### PR TITLE
fix: use source field for directory path in on-pr-merge workflow

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -47,10 +47,14 @@ jobs:
         run: |
           for PENDING_DIR in ${{ steps.find_pending.outputs.plugin_paths }}; do
             if [ -d "$PENDING_DIR" ] && [ -f "$PENDING_DIR/marketplace-entry.json" ]; then
-              NAMESPACED_SLUG=$(jq -r '.name' "$PENDING_DIR/marketplace-entry.json")
-              TARGET_DIR="plugins/$NAMESPACED_SLUG"
+              # Use 'source' field for directory path (e.g., "./payloadcms/payload")
+              # 'name' field must stay hyphenated for plugin.json schema compliance
+              SOURCE_PATH=$(jq -r '.source' "$PENDING_DIR/marketplace-entry.json")
+              # Strip "./" prefix: "./payloadcms/payload" -> "payloadcms/payload"
+              PLUGIN_PATH="${SOURCE_PATH#./}"
+              TARGET_DIR="plugins/$PLUGIN_PATH"
               
-              echo "Moving $PENDING_DIR to $TARGET_DIR (slug: $NAMESPACED_SLUG)"
+              echo "Moving $PENDING_DIR to $TARGET_DIR (source: $SOURCE_PATH)"
               
               mkdir -p "$(dirname "$TARGET_DIR")"
               
@@ -59,10 +63,7 @@ jobs:
               fi
               
               mv "$PENDING_DIR" "$TARGET_DIR"
-              
-              jq --arg source "./$NAMESPACED_SLUG" '.source = $source' \
-                "$TARGET_DIR/marketplace-entry.json" > /tmp/entry.json
-              mv /tmp/entry.json "$TARGET_DIR/marketplace-entry.json"
+              # source field is already correct, no need to update
             fi
           done
 


### PR DESCRIPTION
## Summary

- Use `source` field instead of `name` to determine target directory path
- `name` must stay hyphenated (`payloadcms-payload`) for plugin.json schema compliance
- `source` contains the correct slash-separated path (`./payloadcms/payload`)
- Remove unnecessary source field update (already correct in pending)

## Problem

The workflow was using `name` field to determine where to move files:
```bash
NAMESPACED_SLUG=$(jq -r '.name' "$PENDING_DIR/marketplace-entry.json")
TARGET_DIR="plugins/$NAMESPACED_SLUG"
```

This resulted in `plugins/payloadcms-payload` instead of `plugins/payloadcms/payload`.

## Solution

Use `source` field which already has the correct path:
```bash
SOURCE_PATH=$(jq -r '.source' "$PENDING_DIR/marketplace-entry.json")
PLUGIN_PATH="${SOURCE_PATH#./}"
TARGET_DIR="plugins/$PLUGIN_PATH"
```
