### PR TITLE
fix: correct source paths to include plugins/ prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "payloadcms-payload",
-      "source": "./payloadcms-payload",
+      "source": "./plugins/payloadcms-payload",
       "description": "Use when working with Payload CMS projects (payload.config.ts, collections, fields, hooks, access control, Payload API). Use when debugging validation errors, security issues, relationship queries, transactions, or hook behavior.",
       "version": "3.0.0",
       "author": {

--- a/plugins/payloadcms-payload/marketplace-entry.json
+++ b/plugins/payloadcms-payload/marketplace-entry.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-payload",
-  "source": "./payloadcms-payload",
+  "source": "./plugins/payloadcms-payload",
   "description": "Use when working with Payload CMS projects (payload.config.ts, collections, fields, hooks, access control, Payload API). Use when debugging validation errors, security issues, relationship queries, transactions, or hook behavior.",
   "version": "3.0.0",
   "author": {


### PR DESCRIPTION
## Summary

The `source` field in `marketplace.json` and `marketplace-entry.json` was missing the `plugins/` prefix, causing validation to fail.

## Changes

- `.claude-plugin/marketplace.json`: `./payloadcms-payload` → `./plugins/payloadcms-payload`
- `plugins/payloadcms-payload/marketplace-entry.json`: same fix

## Root Cause

Earlier merge (PR #46) fixed the workflow but the corrupted data was already in main branch from a previous merge.