### PR TITLE
fix(schema): change dangerous_patterns to SecurityFinding-only format

### DIFF
--- a/schemas/skill-report.schema.json
+++ b/schemas/skill-report.schema.json
@@ -153,8 +153,8 @@
         },
         "dangerous_patterns": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Detected dangerous code patterns"
+          "items": { "$ref": "#/$defs/SecurityFinding" },
+          "description": "Detected dangerous code patterns with title, description, and locations"
         },
         "files_scanned": {
           "type": "integer",


### PR DESCRIPTION
## Summary

- Change `dangerous_patterns` field from `string[]` to `SecurityFinding[]` format only
- No backward compatibility for string format (per user requirement - no historical data exists)

## Changes

**Before:**
```json
"dangerous_patterns": ["pattern1", "pattern2"]
```

**After:**
```json
"dangerous_patterns": [
  {
    "title": "Pattern Title",
    "description": "What this pattern does and why it's dangerous",
    "locations": [{"file": "path/to/file.ts", "line_start": 10, "line_end": 15}]
  }
]
```

## Related Changes

Skillstore frontend has been updated to render the new object format properly.