### PR TITLE
fix(workflow): detect plugins at any directory depth

### DIFF
--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -98,7 +98,8 @@ jobs:
 
           SLUGS=""
           for file in $CHANGED; do
-            PLUGIN=$(echo "$file" | sed -n 's|plugins/\([^/]*/[^/]*\)/skill-report.json|\1|p')
+            # Extract plugin path: supports both single-level (plugin-name) and multi-level (org/plugin-name)
+            PLUGIN=$(echo "$file" | sed -n 's|plugins/\(.*\)/skill-report.json|\1|p')
             if [ -n "$PLUGIN" ]; then
               SLUG=$(echo "$PLUGIN" | tr '/' '-')
               [ -n "$SLUGS" ] && SLUGS="$SLUGS,$SLUG" || SLUGS="$SLUG"


### PR DESCRIPTION
## Summary

- Fix regex in `translate-skills.yml` that only matched 2-level plugin paths
- Now correctly detects both single-level (`plugins/docx/`) and multi-level (`plugins/k-dense-ai/adaptyv/`) paths

## Problem

PR #84 modified **40 skill-report.json files**, but the workflow [only detected 29](https://github.com/aiskillstore/marketplace/actions/runs/20692438682).

**Root Cause**: The regex pattern `plugins/\([^/]*/[^/]*\)/skill-report.json` requires exactly 2 path levels after `plugins/`.

### Files that were MISSED (11):
```
plugins/agent-development/skill-report.json
plugins/algorithmic-art/skill-report.json
plugins/brand-guidelines/skill-report.json
plugins/canvas-design/skill-report.json
plugins/claude-opus-4-5-migration/skill-report.json
plugins/command-development/skill-report.json
plugins/doc-coauthoring/skill-report.json
plugins/docx/skill-report.json
plugins/frontend-design/skill-report.json
plugins/hook-development/skill-report.json
plugins/internal-comms/skill-report.json
```

## Fix

```diff
- PLUGIN=$(echo "$file" | sed -n 's|plugins/\([^/]*/[^/]*\)/skill-report.json|\1|p')
+ PLUGIN=$(echo "$file" | sed -n 's|plugins/\(.*\)/skill-report.json|\1|p')
```

## Verification

```bash
# Before (only 2-level paths match)
✗ plugins/agent-development/skill-report.json
✓ plugins/jetbrains/changelog/skill-report.json -> jetbrains/changelog

# After (all paths match)
✓ plugins/agent-development/skill-report.json -> agent-development
✓ plugins/jetbrains/changelog/skill-report.json -> jetbrains/changelog
```