### PR TITLE
fix(workflow): prevent stderr/stdout mixing in translate workflow

### DIFF
--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -255,13 +255,14 @@ jobs:
             FORCE_FLAG="--force"
           fi
 
+          # Run CLI: stdout=JSON, stderr=progress logs (visible in Actions log)
           set +e
           RESULT=$(./skillstore-cli skill translate-content \
             $SLUGS_FLAG \
             --concurrency "$CONCURRENCY" \
             --output json \
             $MODEL_FLAG \
-            $FORCE_FLAG 2>&1)
+            $FORCE_FLAG)
           EXIT_CODE=$?
           set -e
 
@@ -385,8 +386,8 @@ jobs:
           echo "total_errors=$TOTAL_ERRORS" >> $GITHUB_OUTPUT
           echo "total_duration=$TOTAL_DURATION" >> $GITHUB_OUTPUT
           
-          # Create combined result JSON
-          RESULT_JSON=$(jq -n \
+          # Create combined result JSON (compact for GITHUB_OUTPUT compatibility)
+          RESULT_JSON=$(jq -cn \
             --argjson translated "$TOTAL_TRANSLATED" \
             --argjson skipped "$TOTAL_SKIPPED" \
             --argjson errors "$TOTAL_ERRORS" \


### PR DESCRIPTION
## Summary

Fixes the `translate-skills.yml` workflow failure caused by mixing stderr (progress logs) with stdout (JSON result).

**Related:** https://github.com/aiskillstore/marketplace/actions/runs/20692438682

## Root Cause

The CLI correctly outputs:
- Progress logs → stderr (e.g., `[11:48:05] 📦 skill...`)
- JSON result → stdout

But the workflow used `2>&1` which combined both streams, causing `$RESULT` to start with log lines instead of `{`, making `jq` parsing fail.

## Changes

1. **Removed `2>&1`** from CLI invocation (line 263) - stdout captured cleanly, stderr flows to CI logs naturally
2. **Changed `jq -n` to `jq -cn`** (line 388) - compact single-line JSON for GITHUB_OUTPUT compatibility

## Testing

Re-run the translate workflow after merging to verify the fix.