### PR TITLE
fix(actions): support comma-separated slugs in invalidate-cache

### DIFF
--- a/.github/actions/invalidate-cache/action.yml
+++ b/.github/actions/invalidate-cache/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'Content type (skills, workflows, releases)'
     required: true
   slugs:
-    description: 'Space-separated list of slugs to invalidate'
+    description: 'Space or comma-separated list of slugs to invalidate'
     required: true
   site-url:
     description: 'Site URL'
@@ -32,6 +32,8 @@ runs:
         CONTENT_TYPE: ${{ inputs.type }}
         SLUGS_STR: ${{ inputs.slugs }}
       run: |
+        # Normalize: support both comma-separated and space-separated input
+        SLUGS_STR="${SLUGS_STR//,/ }"
         read -ra SLUGS <<< "$SLUGS_STR"
         TOTAL=${#SLUGS[@]}
 
@@ -79,3 +81,8 @@ runs:
         done
 
         echo "✅ Complete: $SUCCESS succeeded, $FAILED failed"
+
+        # Fail the job if any invalidations failed
+        if [ "$FAILED" -gt 0 ]; then
+          exit 1
+        fi


### PR DESCRIPTION
## Summary

- Fix IFS parsing bug where comma-separated slugs were treated as a single item
- Add `exit 1` when any cache invalidations fail for proper CI feedback

## Problem

The `invalidate-cache` action used `read -ra SLUGS <<< "$SLUGS_STR"` which splits on **whitespace**.
However, `translate-skills.yml` passes `slugs_csv` which is **comma-separated**.

**Result**: 40 slugs → 1 "slug" containing commas → API rejection → silent failure

```
SLUGS_STR: agent-development,algorithmic-art,brand-guidelines,...
Invalidating 1 skills in 1 batch(es)...   ← Should be 40!
  Batch 1/1 (1 items)... ✗ (retrying)
    Retry ✗ (skipping)
✅ Complete: 0 succeeded, 1 failed       ← But job shows "succeeded" ✓
```

## Solution

1. **Normalize input**: `SLUGS_STR="${SLUGS_STR//,/ }"` - replaces commas with spaces
2. **Proper failure**: `exit 1` when `FAILED > 0`

This is **backward-compatible**:
- `translate-skills.yml` (comma-separated) → ✅ now works
- `warm-cache.yml` (space-separated) → ✅ still works