### PR TITLE
fix: use contains() for AUTO_FIX_ENABLED boolean evaluation

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   # Enable auto-fix for both push and PRs (set to 'false' to disable)
-  AUTO_FIX_ENABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+  AUTO_FIX_ENABLED: ${{ contains(fromJSON('["pull_request", "push"]'), github.event_name) }}
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

Fix the `AUTO_FIX_ENABLED` environment variable evaluation in the validate-marketplace workflow.

## Problem

The `||` operator in GitHub Actions `env:` context doesn't reliably evaluate to string `'true'`. 

In run [#20748193641](https://github.com/aiskillstore/marketplace/actions/runs/20748193641), the expression:
```yaml
AUTO_FIX_ENABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
```

Evaluated to `false` even on a `push` event, causing auto-fix steps to be skipped.

## Solution

Use `contains(fromJSON(...))` for reliable boolean string output:
```yaml
AUTO_FIX_ENABLED: ${{ contains(fromJSON('["pull_request", "push"]'), github.event_name) }}
```

This ensures the env variable correctly evaluates to `'true'` for both `push` and `pull_request` events.