### PR TITLE
fix: correct typo in agentic-jujutsu skill-report.json FAQ

### DIFF
--- a/plugins/ruvnet/agentic-jujutsu/skill-report.json
+++ b/plugins/ruvnet/agentic-jujutsu/skill-report.json
@@ -156,7 +156,7 @@
       },
       {
         "question": "How does it integrate with existing Git repos?",
-        "answer:": "The package wraps Git operations. You can use it alongside existing Git workflows. It tracks operations in AgentDB separately."
+        "answer": "The package wraps Git operations. You can use it alongside existing Git workflows. It tracks operations in AgentDB separately."
       },
       {
         "question": "Is my data safe with the quantum-resistant features?",


### PR DESCRIPTION
## Summary

- Fix JSON key typo in `plugins/ruvnet/agentic-jujutsu/skill-report.json`
- The third FAQ entry had `"answer:"` (with extra colon) instead of `"answer"`

## Problem

The CI validation workflow failed because schema validation detected:
```
instancePath: "/content/faq/2"
message: "must have required property 'answer'"
```

## Root Cause

Typo in JSON key name at line 159:
```diff
- "answer:": "The package wraps Git operations..."
+ "answer": "The package wraps Git operations..."
```

## Related

Fixes failed run: https://github.com/aiskillstore/marketplace/actions/runs/20771930768