### PR TITLE
fix: add missing plugin.json manifests for kepano obsidian plugins

### DIFF
--- a/plugins/kepano/obsidian-bases/.claude-plugin/plugin.json
+++ b/plugins/kepano/obsidian-bases/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "kepano-obsidian-bases",
+  "version": "1.0.0",
+  "description": "Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card views, filters, or formulas in Obsidian.",
+  "author": {
+    "name": "kepano"
+  },
+  "repository": "https://github.com/kepano/obsidian-skills/tree/main/obsidian-bases",
+  "license": "MIT",
+  "keywords": [
+    "obsidian",
+    "bases",
+    "database",
+    "yaml",
+    "productivity"
+  ]
+}

--- a/plugins/kepano/obsidian-markdown/.claude-plugin/plugin.json
+++ b/plugins/kepano/obsidian-markdown/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "kepano-obsidian-markdown",
+  "version": "1.0.0",
+  "description": "Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes.",
+  "author": {
+    "name": "kepano"
+  },
+  "repository": "https://github.com/kepano/obsidian-skills/tree/main/obsidian-markdown",
+  "license": "MIT",
+  "keywords": [
+    "Obsidian",
+    "Markdown",
+    "Knowledge Management",
+    "Note-Taking"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add required `.claude-plugin/plugin.json` manifest files for `kepano/obsidian-bases` and `kepano/obsidian-markdown`
- These files were missing after commit 21df407 added the plugins to `marketplace.json` without manifests
- Fixes CI validation failure in "Validate Marketplace" workflow

## Files Added

- `plugins/kepano/obsidian-bases/.claude-plugin/plugin.json`
- `plugins/kepano/obsidian-markdown/.claude-plugin/plugin.json`

## Validation

This PR will trigger the `validate-marketplace.yml` workflow to verify the fix.