### PR TITLE
fix(ci): remove approval requirement from translate workflow

### DIFF
--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -235,7 +235,6 @@ jobs:
     needs: detect-and-plan
     if: needs.detect-and-plan.outputs.has_changes == 'true' && needs.detect-and-plan.outputs.shard_count != '0'
     runs-on: self-hosted
-    environment: production
     timeout-minutes: 120
     continue-on-error: true
     strategy:
@@ -479,7 +478,6 @@ jobs:
     needs: [detect-and-plan, translate, merge-results]
     if: always() && needs.translate.result == 'success'
     runs-on: self-hosted
-    environment: production
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removed `environment: production` from `translate` job
- Removed `environment: production` from `invalidate-cache` job

## Problem

Translation workflow was incorrectly requiring manual approval for **every** run, even for small translations triggered by PR merges. This was because both jobs used the `production` environment which has deployment protection rules.

## Solution

Translation is a **safe, internal operation** that:
- Only writes to the database (translations)
- Is triggered automatically after sync-to-supabase completes
- Does not deploy any code or modify infrastructure

The approval gate should only exist for **submission workflows** to protect against malicious PRs, not for internal translation operations.

## Changes

| Job | Before | After |
|-----|--------|-------|
| `translate` | `environment: production` | (none) |
| `invalidate-cache` | `environment: production` | (none) |

---

Generated with [Claude Code](https://claude.ai/code)