### PR TITLE
feat: 新增 curated plugin ios-swiftui-toolkit（bundles 3 Dimillian SwiftUI 技能）

### DIFF
--- a/skills/ios-swiftui-toolkit/SKILL.md
+++ b/skills/ios-swiftui-toolkit/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ios-swiftui-toolkit
+description: A curated bundle of three SwiftUI skills covering UI patterns, performance auditing, and view refactoring. Use when developing or improving iOS/macOS apps with SwiftUI.
+---
+
+# iOS SwiftUI Toolkit
+
+A curated collection of three expert SwiftUI skills for building production-quality iOS and macOS applications.
+
+## Bundled Skills
+
+### 1. SwiftUI UI Patterns (`swiftui-ui-patterns`)
+Best practices and example-driven guidance for building SwiftUI views and components.
+
+**Use when:** designing tab architecture with TabView, composing screens, creating forms, handling lists/grids, managing navigation stacks, routing sheets/modals, implementing theming and haptics.
+
+### 2. SwiftUI Performance Audit (`swiftui-performance-audit`)
+Audit and improve SwiftUI runtime performance from code review and architecture analysis.
+
+**Use when:** diagnosing slow rendering, janky scrolling, high CPU/memory usage, excessive view updates, or layout thrash — and when Instruments profiling is needed to confirm root causes.
+
+### 3. SwiftUI View Refactor (`swiftui-view-refactor`)
+Refactor and review SwiftUI view files for consistent structure, dependency injection, and Observation usage.
+
+**Use when:** cleaning up view layout and ordering, fixing view model initialization, standardizing `@Observable` state usage, or applying MV patterns to keep views small and composable.
+
+## Quick Reference
+
+| Scenario | Skill |
+|----------|-------|
+| New screen or component | `swiftui-ui-patterns` |
+| Slow scrolling / jank | `swiftui-performance-audit` |
+| Refactoring existing views | `swiftui-view-refactor` |
+| Performance regression | `swiftui-performance-audit` |
+| Navigation architecture | `swiftui-ui-patterns` |
+
+## How to Use
+
+Each skill is a self-contained directory. Read the `SKILL.md` inside each subdirectory for full guidance:
+
+```
+ios-swiftui-toolkit/
+├── swiftui-ui-patterns/
+│   └── SKILL.md + references/
+├── swiftui-performance-audit/
+│   └── SKILL.md + references/
+└── swiftui-view-refactor/
+    └── SKILL.md + references/
+```

--- a/skills/ios-swiftui-toolkit/skill-report.json
+++ b/skills/ios-swiftui-toolkit/skill-report.json
@@ -1,0 +1,237 @@
+{
+  "schema_version": "2.0",
+  "meta": {
+    "generated_at": "2026-03-21T04:27:00.000Z",
+    "slug": "ios-swiftui-toolkit",
+    "source_url": "https://github.com/aiskillstore/marketplace/tree/main/skills/ios-swiftui-toolkit",
+    "source_ref": "main",
+    "model": "claude",
+    "analysis_version": "3.0.0",
+    "source_type": "community"
+  },
+  "skill": {
+    "name": "ios-swiftui-toolkit",
+    "description": "A curated bundle of three SwiftUI skills covering UI patterns, performance auditing, and view refactoring. Use when developing or improving iOS/macOS apps with SwiftUI.",
+    "summary": "A curated bundle of three SwiftUI skills covering UI patterns, performance auditing, and view refactoring. Use when developing...",
+    "icon": "uiwins",
+    "version": "1.0.0",
+    "author": "easymeta",
+    "license": "MIT",
+    "category": "development",
+    "tags": [
+      "swiftui",
+      "ios",
+      "macos",
+      "mobile-development",
+      "performance",
+      "refactoring",
+      "user-interface",
+      "apple"
+    ],
+    "supported_tools": [
+      "claude",
+      "codex",
+      "claude-code"
+    ],
+    "risk_factors": []
+  },
+  "security_audit": {
+    "risk_level": "safe",
+    "is_blocked": false,
+    "safe_to_publish": true,
+    "summary": "Curated bundle of three documentation-only SwiftUI skills sourced from the Dimillian community repository. Each skill contains only Markdown documentation files. No executable code, network calls, file system access, or command execution capabilities.",
+    "risk_factor_evidence": [],
+    "critical_findings": [],
+    "high_findings": [],
+    "medium_findings": [],
+    "low_findings": [],
+    "dangerous_patterns": [],
+    "files_scanned": 38,
+    "total_lines": 6363,
+    "audit_model": "claude",
+    "audited_at": "2026-03-21T04:27:00.000Z"
+  },
+  "content": {
+    "user_title": "iOS SwiftUI Toolkit: UI Patterns, Performance, and Refactoring",
+    "value_statement": "Building production SwiftUI apps requires navigating UI architecture patterns, diagnosing performance issues, and maintaining clean view code. This toolkit bundles three complementary skills so developers can move seamlessly from implementation to auditing to refactoring.",
+    "seo_keywords": [
+      "SwiftUI toolkit",
+      "iOS development",
+      "SwiftUI performance",
+      "SwiftUI refactoring",
+      "SwiftUI patterns",
+      "SwiftUI audit",
+      "SwiftUI best practices",
+      "iOS macOS development"
+    ],
+    "actual_capabilities": [
+      "Implement TabView architecture with per-tab NavigationStack and route enums",
+      "Diagnose SwiftUI rendering performance issues and provide remediation steps",
+      "Guide Instruments profiling for CPU and memory issues in SwiftUI apps",
+      "Refactor SwiftUI views with consistent ordering, MV patterns, and @Observable usage",
+      "Build forms, sheets, lists, grids with proper focus management and accessibility",
+      "Apply theming, haptics, media handling, and navigation stack patterns"
+    ],
+    "limitations": [
+      "Does not generate complete SwiftUI project scaffolding",
+      "Does not provide backend API integration code",
+      "Does not include unit tests or test utilities"
+    ],
+    "use_cases": [
+      {
+        "target_user": "iOS Developers",
+        "title": "Build and Audit SwiftUI Apps",
+        "description": "Start with UI patterns to implement screens, then audit with performance skill, and refactor with view refactor skill."
+      },
+      {
+        "target_user": "App Maintainers",
+        "title": "Performance Troubleshooting",
+        "description": "Use performance audit skill to diagnose slow rendering and janky scrolling, then apply fixes from UI patterns for sustainable improvements."
+      },
+      {
+        "target_user": "SwiftUI Learners",
+        "title": "Learn Production Patterns",
+        "description": "Use UI patterns skill for guidance on TabView, NavigationStack, sheets, and theming with real-world code examples."
+      }
+    ],
+    "prompt_templates": [
+      {
+        "title": "Implement Screen",
+        "scenario": "New feature screen",
+        "prompt": "I need to implement a new screen with TabView, NavigationStack, and sheet modals. Show me the recommended architecture using swiftui-ui-patterns."
+      },
+      {
+        "title": "Audit Performance",
+        "scenario": "Slow scrolling",
+        "prompt": "My SwiftUI List is scrolling slowly with jank. Diagnose the issue using swiftui-performance-audit and suggest concrete fixes."
+      },
+      {
+        "title": "Refactor View",
+        "scenario": "Legacy code cleanup",
+        "prompt": "Clean up this SwiftUI view using swiftui-view-refactor: ensure proper ordering, fix @Observable usage, and apply MV patterns."
+      }
+    ],
+    "output_examples": [
+      {
+        "input": "Implement a settings screen with theming, focus management, and keyboard handling",
+        "output": [
+          "Use swiftui-ui-patterns: Form inside NavigationStack with @FocusState",
+          "Apply .scrollContentBackground(.hidden) for theme customization",
+          "Inject theme via @Environment(Theme.self)",
+          "Chain focus between fields with .onSubmit",
+          "Use Section blocks for visual grouping"
+        ]
+      },
+      {
+        "input": "My app is slow when scrolling a long list with images",
+        "output": [
+          "swiftui-performance-audit: Diagnose as image decoding in body",
+          "Pre-downsample images before display using Image downsampling pattern",
+          "Use LazyVStack instead of List if custom layout needed",
+          "Avoid @State updating on every scroll position",
+          "Profile with Instruments to confirm improvement"
+        ]
+      }
+    ],
+    "best_practices": [
+      "Use swiftui-ui-patterns for new implementations",
+      "Use swiftui-performance-audit when symptoms indicate rendering issues",
+      "Use swiftui-view-refactor for legacy code maintenance",
+      "Combine skills for full development lifecycle"
+    ],
+    "anti_patterns": [
+      "Avoid mixing sheet(isPresented:) and sheet(item:) for the same concern",
+      "Do not use raw Color values throughout views — use semantic theme colors",
+      "Avoid storing view instances in navigation paths",
+      "Do not nest @Observable objects inside other @Observable objects"
+    ],
+    "faq": [
+      {
+        "question": "Which SwiftUI versions are supported?",
+        "answer": "Patterns target iOS 17+ and macOS 14+ with some iOS 18+ specific APIs noted in each skill."
+      },
+      {
+        "question": "Do I need all three skills?",
+        "answer": "Each skill is independent. Use the one that matches your current task: UI patterns for building, performance for diagnosing, view refactor for cleaning up."
+      },
+      {
+        "question": "Can I use these skills with third-party libraries?",
+        "answer": "Yes. Patterns are framework-agnostic and integrate with any SwiftUI-compatible navigation or state management solution."
+      }
+    ]
+  },
+  "file_structure": [
+    {
+      "name": "swiftui-ui-patterns",
+      "type": "dir",
+      "path": "swiftui-ui-patterns",
+      "children": [
+        {
+          "name": "SKILL.md",
+          "type": "file",
+          "path": "swiftui-ui-patterns/SKILL.md",
+          "lines": 96
+        },
+        {
+          "name": "skill-report.json",
+          "type": "file",
+          "path": "swiftui-ui-patterns/skill-report.json",
+          "lines": 498
+        },
+        {
+          "name": "references",
+          "type": "dir",
+          "path": "swiftui-ui-patterns/references",
+          "children": [
+            { "name": "app-wiring.md", "type": "file", "path": "swiftui-ui-patterns/references/app-wiring.md", "lines": 195 },
+            { "name": "components-index.md", "type": "file", "path": "swiftui-ui-patterns/references/components-index.md", "lines": 44 },
+            { "name": "controls.md", "type": "file", "path": "swiftui-ui-patterns/references/controls.md", "lines": 58 },
+            { "name": "deeplinks.md", "type": "file", "path": "swiftui-ui-patterns/references/deeplinks.md", "lines": 67 },
+            { "name": "focus.md", "type": "file", "path": "swiftui-ui-patterns/references/focus.md", "lines": 91 },
+            { "name": "form.md", "type": "file", "path": "swiftui-ui-patterns/references/form.md", "lines": 98 },
+            { "name": "grids.md", "type": "file", "path": "swiftui-ui-patterns/references/grids.md", "lines": 72 },
+            { "name": "haptics.md", "type": "file", "path": "swiftui-ui-patterns/references/haptics.md", "lines": 72 },
+            { "name": "input-toolbar.md", "type": "file", "path": "swiftui-ui-patterns/references/input-toolbar.md", "lines": 52 },
+            { "name": "lightweight-clients.md", "type": "file", "path": "swiftui-ui-patterns/references/lightweight-clients.md", "lines": 94 },
+            { "name": "list.md", "type": "file", "path": "swiftui-ui-patterns/references/list.md", "lines": 87 },
+            { "name": "loading-placeholders.md", "type": "file", "path": "swiftui-ui-patterns/references/loading-placeholders.md", "lines": 39 },
+            { "name": "macos-settings.md", "type": "file", "path": "swiftui-ui-patterns/references/macos-settings.md", "lines": 72 },
+            { "name": "matched-transitions.md", "type": "file", "path": "swiftui-ui-patterns/references/matched-transitions.md", "lines": 60 },
+            { "name": "media.md", "type": "file", "path": "swiftui-ui-patterns/references/media.md", "lines": 74 },
+            { "name": "menu-bar.md", "type": "file", "path": "swiftui-ui-patterns/references/menu-bar.md", "lines": 102 },
+            { "name": "navigationstack.md", "type": "file", "path": "swiftui-ui-patterns/references/navigationstack.md", "lines": 160 },
+            { "name": "overlay.md", "type": "file", "path": "swiftui-ui-patterns/references/overlay.md", "lines": 46 },
+            { "name": "scrollview.md", "type": "file", "path": "swiftui-ui-patterns/references/scrollview.md", "lines": 88 },
+            { "name": "searchable.md", "type": "file", "path": "swiftui-ui-patterns/references/searchable.md", "lines": 72 },
+            { "name": "sheets.md", "type": "file", "path": "swiftui-ui-patterns/references/sheets.md", "lines": 114 },
+            { "name": "split-views.md", "type": "file", "path": "swiftui-ui-patterns/references/split-views.md", "lines": 73 },
+            { "name": "tabview.md", "type": "file", "path": "swiftui-ui-patterns/references/tabview.md", "lines": 115 },
+            { "name": "theming.md", "type": "file", "path": "swiftui-ui-patterns/references/theming.md", "lines": 72 },
+            { "name": "title-menus.md", "type": "file", "path": "swiftui-ui-patterns/references/title-menus.md", "lines": 94 },
+            { "name": "top-bar.md", "type": "file", "path": "swiftui-ui-patterns/references/top-bar.md", "lines": 50 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "swiftui-performance-audit",
+      "type": "dir",
+      "path": "swiftui-performance-audit",
+      "children": [
+        { "name": "SKILL.md", "type": "file", "path": "swiftui-performance-audit/SKILL.md", "lines": 96 },
+        { "name": "skill-report.json", "type": "file", "path": "swiftui-performance-audit/skill-report.json", "lines": 350 }
+      ]
+    },
+    {
+      "name": "swiftui-view-refactor",
+      "type": "dir",
+      "path": "swiftui-view-refactor",
+      "children": [
+        { "name": "SKILL.md", "type": "file", "path": "swiftui-view-refactor/SKILL.md", "lines": 96 },
+        { "name": "skill-report.json", "type": "file", "path": "swiftui-view-refactor/skill-report.json", "lines": 350 }
+      ]
+    },
+    { "name": "SKILL.md", "type": "file", "path": "SKILL.md", "lines": 70 },
+    { "name": "skill-report.json", "type": "file", "path": "skill-report.json", "lines": 148 }
+  ]
+}

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/SKILL.md
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: swiftui-performance-audit
+description: Audit and improve SwiftUI runtime performance from code review and architecture. Use for requests to diagnose slow rendering, janky scrolling, high CPU/memory usage, excessive view updates, or layout thrash in SwiftUI apps, and to provide guidance for user-run Instruments profiling when code review alone is insufficient.
+---
+
+# SwiftUI Performance Audit
+
+## Overview
+
+Audit SwiftUI view performance end-to-end, from instrumentation and baselining to root-cause analysis and concrete remediation steps.
+
+## Workflow Decision Tree
+
+- If the user provides code, start with "Code-First Review."
+- If the user only describes symptoms, ask for minimal code/context, then do "Code-First Review."
+- If code review is inconclusive, go to "Guide the User to Profile" and ask for a trace or screenshots.
+
+## 1. Code-First Review
+
+Collect:
+- Target view/feature code.
+- Data flow: state, environment, observable models.
+- Symptoms and reproduction steps.
+
+Focus on:
+- View invalidation storms from broad state changes.
+- Unstable identity in lists (`id` churn, `UUID()` per render).
+- Heavy work in `body` (formatting, sorting, image decoding).
+- Layout thrash (deep stacks, `GeometryReader`, preference chains).
+- Large images without downsampling or resizing.
+- Over-animated hierarchies (implicit animations on large trees).
+
+Provide:
+- Likely root causes with code references.
+- Suggested fixes and refactors.
+- If needed, a minimal repro or instrumentation suggestion.
+
+## 2. Guide the User to Profile
+
+Explain how to collect data with Instruments:
+- Use the SwiftUI template in Instruments (Release build).
+- Reproduce the exact interaction (scroll, navigation, animation).
+- Capture SwiftUI timeline and Time Profiler.
+- Export or screenshot the relevant lanes and the call tree.
+
+Ask for:
+- Trace export or screenshots of SwiftUI lanes + Time Profiler call tree.
+- Device/OS/build configuration.
+
+## 3. Analyze and Diagnose
+
+Prioritize likely SwiftUI culprits:
+- View invalidation storms from broad state changes.
+- Unstable identity in lists (`id` churn, `UUID()` per render).
+- Heavy work in `body` (formatting, sorting, image decoding).
+- Layout thrash (deep stacks, `GeometryReader`, preference chains).
+- Large images without downsampling or resizing.
+- Over-animated hierarchies (implicit animations on large trees).
+
+Summarize findings with evidence from traces/logs.
+
+## 4. Remediate
+
+Apply targeted fixes:
+- Narrow state scope (`@State`/`@Observable` closer to leaf views).
+- Stabilize identities for `ForEach` and lists.
+- Move heavy work out of `body` (precompute, cache, `@State`).
+- Use `equatable()` or value wrappers for expensive subtrees.
+- Downsample images before rendering.
+- Reduce layout complexity or use fixed sizing where possible.
+
+## Common Code Smells (and Fixes)
+
+Look for these patterns during code review.
+
+### Expensive formatters in `body`
+
+```swift
+var body: some View {
+    let number = NumberFormatter() // slow allocation
+    let measure = MeasurementFormatter() // slow allocation
+    Text(measure.string(from: .init(value: meters, unit: .meters)))
+}
+```
+
+Prefer cached formatters in a model or a dedicated helper:
+
+```swift
+final class DistanceFormatter {
+    static let shared = DistanceFormatter()
+    let number = NumberFormatter()
+    let measure = MeasurementFormatter()
+}
+```
+
+### Computed properties that do heavy work
+
+```swift
+var filtered: [Item] {
+    items.filter { $0.isEnabled } // runs on every body eval
+}
+```
+
+Prefer precompute or cache on change:
+
+```swift
+@State private var filtered: [Item] = []
+// update filtered when inputs change
+```
+
+### Sorting/filtering in `body` or `ForEach`
+
+```swift
+List {
+    ForEach(items.sorted(by: sortRule)) { item in
+        Row(item)
+    }
+}
+```
+
+Prefer sort once before view updates:
+
+```swift
+let sortedItems = items.sorted(by: sortRule)
+```
+
+### Inline filtering in `ForEach`
+
+```swift
+ForEach(items.filter { $0.isEnabled }) { item in
+    Row(item)
+}
+```
+
+Prefer a prefiltered collection with stable identity.
+
+### Unstable identity
+
+```swift
+ForEach(items, id: \.self) { item in
+    Row(item)
+}
+```
+
+Avoid `id: \.self` for non-stable values; use a stable ID.
+
+### Image decoding on the main thread
+
+```swift
+Image(uiImage: UIImage(data: data)!)
+```
+
+Prefer decode/downsample off the main thread and store the result.
+
+### Broad dependencies in observable models
+
+```swift
+@Observable class Model {
+    var items: [Item] = []
+}
+
+var body: some View {
+    Row(isFavorite: model.items.contains(item))
+}
+```
+
+Prefer granular view models or per-item state to reduce update fan-out.
+
+## 5. Verify
+
+Ask the user to re-run the same capture and compare with baseline metrics.
+Summarize the delta (CPU, frame drops, memory peak) if provided.
+
+## Outputs
+
+Provide:
+- A short metrics table (before/after if available).
+- Top issues (ordered by impact).
+- Proposed fixes with estimated effort.
+
+## References
+
+Add Apple documentation and WWDC resources under `references/` as they are supplied by the user.
+- Optimizing SwiftUI performance with Instruments: `references/optimizing-swiftui-performance-instruments.md`
+- Understanding and improving SwiftUI performance: `references/understanding-improving-swiftui-performance.md`
+- Understanding hangs in your app: `references/understanding-hangs-in-your-app.md`
+- Demystify SwiftUI performance (WWDC23): `references/demystify-swiftui-performance-wwdc23.md`

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/demystify-swiftui-performance-wwdc23.md
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/demystify-swiftui-performance-wwdc23.md
@@ -1,0 +1,46 @@
+# Demystify SwiftUI Performance (WWDC23) (Summary)
+
+Context: WWDC23 session on building a mental model for SwiftUI performance and triaging hangs/hitches.
+
+## Performance loop
+
+- Measure -> Identify -> Optimize -> Re-measure.
+- Focus on concrete symptoms (slow navigation, broken animations, spinning cursor).
+
+## Dependencies and updates
+
+- Views form a dependency graph; dynamic properties are a frequent source of updates.
+- Use `Self._printChanges()` in debug only to inspect extra dependencies.
+- Eliminate unnecessary dependencies by extracting views or narrowing state.
+- Consider `@Observable` for more granular property tracking.
+
+## Common causes of slow updates
+
+- Expensive view bodies (string interpolation, filtering, formatting).
+- Dynamic property instantiation and state initialization in `body`.
+- Slow identity resolution in lists/tables.
+- Hidden work: bundle lookups, heap allocations, repeated string construction.
+
+## Avoid slow initialization in view bodies
+
+- Don’t create heavy models synchronously in view bodies.
+- Use `.task` to fetch async data and keep `init` lightweight.
+
+## Lists and tables identity rules
+
+- Stable identity is critical for performance and animation.
+- Ensure a constant number of views per element in `ForEach`.
+- Avoid inline filtering in `ForEach`; pre-filter and cache collections.
+- Avoid `AnyView` in list rows; it hides identity and increases cost.
+- Flatten nested `ForEach` when possible to reduce overhead.
+
+## Table specifics
+
+- `TableRow` resolves to a single row; row count must be constant.
+- Prefer the streamlined `Table` initializer to enforce constant rows.
+- Use explicit IDs for back deployment when needed.
+
+## Debugging aids
+
+- Use Instruments for hangs and hitches.
+- Use `_printChanges` to validate dependency assumptions during debug.

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/optimizing-swiftui-performance-instruments.md
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/optimizing-swiftui-performance-instruments.md
@@ -1,0 +1,29 @@
+# Optimizing SwiftUI Performance with Instruments (Summary)
+
+Context: WWDC session introducing the next-generation SwiftUI Instrument in Instruments 26 and how to diagnose SwiftUI-specific bottlenecks.
+
+## Key takeaways
+
+- Profile SwiftUI issues with the SwiftUI template (SwiftUI instrument + Time Profiler + Hangs/Hitches).
+- Long view body updates are a common bottleneck; use "Long View Body Updates" to identify slow bodies.
+- Set inspection range on a long update and correlate with Time Profiler to find expensive frames.
+- Keep work out of `body`: move formatting, sorting, image decoding, and other expensive work into cached or precomputed paths.
+- Use Cause & Effect Graph to diagnose *why* updates occur; SwiftUI is declarative, so backtraces are often unhelpful.
+- Avoid broad dependencies that trigger many updates (e.g., `@Observable` arrays or global environment reads).
+- Prefer granular view models and scoped state so only the affected view updates.
+- Environment values update checks still cost time; avoid placing fast-changing values (timers, geometry) in environment.
+- Profile early and often during feature development to catch regressions.
+
+## Suggested workflow (condensed)
+
+1. Record a trace in Release mode using the SwiftUI template.
+2. Inspect "Long View Body Updates" and "Other Long Updates."
+3. Zoom into a long update, then inspect Time Profiler for hot frames.
+4. Fix slow body work by moving heavy logic into precomputed/cache paths.
+5. Use Cause & Effect Graph to identify unintended update fan-out.
+6. Re-record and compare the update counts and hitch frequency.
+
+## Example patterns from the session
+
+- Caching formatted distance strings in a location manager instead of computing in `body`.
+- Replacing a dependency on a global favorites array with per-item view models to reduce update fan-out.

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/understanding-hangs-in-your-app.md
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/understanding-hangs-in-your-app.md
@@ -1,0 +1,33 @@
+# Understanding Hangs in Your App (Summary)
+
+Context: Apple guidance on identifying hangs caused by long-running main-thread work and understanding the main run loop.
+
+## Key concepts
+
+- A hang is a noticeable delay in a discrete interaction (typically >100 ms).
+- Hangs almost always come from long-running work on the main thread.
+- The main run loop processes UI events, timers, and main-queue work sequentially.
+
+## Main-thread work stages
+
+- Event delivery to the correct view/handler.
+- Your code: state updates, data fetch, UI changes.
+- Core Animation commit to the render server.
+
+## Why the main run loop matters
+
+- Only the main thread can update UI safely.
+- The run loop is the foundation that executes main-queue work.
+- If the run loop is busy, it can’t handle new events; this causes hangs.
+
+## Diagnosing hangs
+
+- Observe the main run loop’s busy periods: healthy loops sleep most of the time.
+- Hang detection typically flags busy periods >250 ms.
+- The Hangs instrument can be configured to lower thresholds.
+
+## Practical takeaways
+
+- Keep main-thread work short; offload heavy work from event handlers.
+- Avoid long-running tasks on the main dispatch queue or main actor.
+- Use run loop behavior as a proxy for user-perceived responsiveness.

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/understanding-improving-swiftui-performance.md
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/references/understanding-improving-swiftui-performance.md
@@ -1,0 +1,52 @@
+# Understanding and Improving SwiftUI Performance (Summary)
+
+Context: Apple guidance on diagnosing SwiftUI performance with Instruments and applying design patterns to reduce long or frequent updates.
+
+## Core concepts
+
+- SwiftUI is declarative; view updates are driven by state, environment, and observable data dependencies.
+- View bodies must compute quickly to meet frame deadlines; slow or frequent updates lead to hitches.
+- Instruments is the primary tool to find long-running updates and excessive update frequency.
+
+## Instruments workflow
+
+1. Profile via Product > Profile.
+2. Choose the SwiftUI template and record.
+3. Exercise the target interaction.
+4. Stop recording and inspect the SwiftUI track + Time Profiler.
+
+## SwiftUI timeline lanes
+
+- Update Groups: overview of time SwiftUI spends calculating updates.
+- Long View Body Updates: orange >500us, red >1000us.
+- Long Platform View Updates: AppKit/UIKit hosting in SwiftUI.
+- Other Long Updates: geometry/text/layout and other SwiftUI work.
+- Hitches: frame misses where UI wasn’t ready in time.
+
+## Diagnose long view body updates
+
+- Expand the SwiftUI track; inspect module-specific subtracks.
+- Set Inspection Range and correlate with Time Profiler.
+- Use call tree or flame graph to identify expensive frames.
+- Repeat the update to gather enough samples for analysis.
+- Filter to a specific update (Show Calls Made by `MySwiftUIView.body`).
+
+## Diagnose frequent updates
+
+- Use Update Groups to find long active groups without long updates.
+- Set inspection range on the group and analyze update counts.
+- Use Cause graph ("Show Causes") to see what triggers updates.
+- Compare causes with expected data flow; prioritize the highest-frequency causes.
+
+## Remediation patterns
+
+- Move expensive work out of `body` and cache results.
+- Use `Observable()` macro to scope dependencies to properties actually read.
+- Avoid broad dependencies that fan out updates to many views.
+- Reduce layout churn; isolate state-dependent subtrees from layout readers.
+- Avoid storing closures that capture parent state; precompute child views.
+- Gate frequent updates (e.g., geometry changes) by thresholds.
+
+## Verification
+
+- Re-record after changes to confirm reduced update counts and fewer hitches.

--- a/skills/ios-swiftui-toolkit/swiftui-performance-audit/skill-report.json
+++ b/skills/ios-swiftui-toolkit/swiftui-performance-audit/skill-report.json
@@ -1,0 +1,551 @@
+{
+  "schema_version": "2.0",
+  "meta": {
+    "generated_at": "2026-01-17T04:06:56.444Z",
+    "slug": "dimillian-swiftui-performance-audit",
+    "source_url": "https://github.com/Dimillian/Skills/tree/main/swiftui-performance-audit",
+    "source_ref": "main",
+    "model": "claude",
+    "analysis_version": "3.0.0",
+    "source_type": "community",
+    "content_hash": "aed51524f97c0424b5e694697113be32424ca1bf5c7779378cb6fc57d342f540",
+    "tree_hash": "968cedb3ea2ccbdc572a31198b9bf2c309764a349f2c0d1af4aa988fd317a716"
+  },
+  "skill": {
+    "name": "swiftui-performance-audit",
+    "description": "Audit and improve SwiftUI runtime performance from code review and architecture. Use for requests to diagnose slow rendering, janky scrolling, high CPU/memory usage, excessive view updates, or layout thrash in SwiftUI apps, and to provide guidance for user-run Instruments profiling when code review alone is insufficient.",
+    "summary": "Audit and improve SwiftUI runtime performance from code review and architecture. Use for requests to...",
+    "icon": "📊",
+    "version": "1.0.0",
+    "author": "Dimillian",
+    "license": "MIT",
+    "category": "coding",
+    "tags": [
+      "swiftui",
+      "performance",
+      "ios",
+      "debugging",
+      "profiling"
+    ],
+    "supported_tools": [
+      "claude",
+      "codex",
+      "claude-code"
+    ],
+    "risk_factors": [
+      "external_commands",
+      "network"
+    ]
+  },
+  "security_audit": {
+    "risk_level": "safe",
+    "is_blocked": false,
+    "safe_to_publish": true,
+    "summary": "This is a pure documentation skill containing only markdown files with SwiftUI performance guidance. No executable code, no file access, no network calls, no environment variables. All 90 static findings are false positives: backticks are markdown code formatting, C2 keywords are normal technical terms, and system reconnaissance patterns are legitimate debugging terminology.",
+    "risk_factor_evidence": [
+      {
+        "factor": "external_commands",
+        "evidence": [
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 20,
+            "line_end": 20
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 27,
+            "line_end": 27
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 27,
+            "line_end": 27
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 32,
+            "line_end": 32
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 33,
+            "line_end": 33
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 35,
+            "line_end": 35
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 39,
+            "line_end": 39
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 40,
+            "line_end": 40
+          },
+          {
+            "file": "references/demystify-swiftui-performance-wwdc23.md",
+            "line_start": 46,
+            "line_end": 46
+          },
+          {
+            "file": "references/optimizing-swiftui-performance-instruments.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/optimizing-swiftui-performance-instruments.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/optimizing-swiftui-performance-instruments.md",
+            "line_start": 28,
+            "line_end": 28
+          },
+          {
+            "file": "references/understanding-improving-swiftui-performance.md",
+            "line_start": 32,
+            "line_end": 32
+          },
+          {
+            "file": "references/understanding-improving-swiftui-performance.md",
+            "line_start": 43,
+            "line_end": 43
+          },
+          {
+            "file": "references/understanding-improving-swiftui-performance.md",
+            "line_start": 44,
+            "line_end": 44
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 27,
+            "line_end": 27
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 27,
+            "line_end": 27
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 28,
+            "line_end": 28
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 54,
+            "line_end": 54
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 54,
+            "line_end": 54
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 55,
+            "line_end": 55
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 56,
+            "line_end": 56
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 65,
+            "line_end": 65
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 65,
+            "line_end": 65
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 66,
+            "line_end": 66
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 67,
+            "line_end": 67
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 67,
+            "line_end": 67
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 68,
+            "line_end": 68
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 76,
+            "line_end": 76
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 78,
+            "line_end": 84
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 84,
+            "line_end": 88
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 88,
+            "line_end": 94
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 94,
+            "line_end": 98
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 98,
+            "line_end": 102
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 102,
+            "line_end": 106
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 106,
+            "line_end": 109
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 109,
+            "line_end": 111
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 111,
+            "line_end": 111
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 111,
+            "line_end": 113
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 113,
+            "line_end": 119
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 119,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 125
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 125,
+            "line_end": 127
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 127,
+            "line_end": 129
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 129,
+            "line_end": 133
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 133,
+            "line_end": 139
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 139,
+            "line_end": 143
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 143,
+            "line_end": 145
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 145,
+            "line_end": 149
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 149,
+            "line_end": 151
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 151,
+            "line_end": 157
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 157,
+            "line_end": 165
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 165,
+            "line_end": 183
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 183,
+            "line_end": 184
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 184,
+            "line_end": 185
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 185,
+            "line_end": 186
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 186,
+            "line_end": 187
+          }
+        ]
+      },
+      {
+        "factor": "network",
+        "evidence": [
+          {
+            "file": "skill-report.json",
+            "line_start": 6,
+            "line_end": 6
+          }
+        ]
+      }
+    ],
+    "critical_findings": [],
+    "high_findings": [],
+    "medium_findings": [],
+    "low_findings": [],
+    "dangerous_patterns": [],
+    "files_scanned": 6,
+    "total_lines": 556,
+    "audit_model": "claude",
+    "audited_at": "2026-01-17T04:06:56.444Z"
+  },
+  "content": {
+    "user_title": "Audit SwiftUI Performance Issues",
+    "value_statement": "SwiftUI apps can suffer from slow rendering, janky scrolling, and excessive CPU usage. This skill guides you through code review, Instruments profiling, and targeted fixes to optimize your app performance.",
+    "seo_keywords": [
+      "SwiftUI performance audit",
+      "iOS performance optimization",
+      "SwiftUI debugging",
+      "Xcode Instruments",
+      "SwiftUI rendering",
+      "Claude Code skill",
+      "Codex skill",
+      "claude skill",
+      "iOS development",
+      "SwiftUI profiling"
+    ],
+    "actual_capabilities": [
+      "Perform code-first review of SwiftUI views for performance bottlenecks",
+      "Identify view invalidation storms and unstable identity patterns",
+      "Guide users through Instruments profiling with SwiftUI template",
+      "Diagnose excessive CPU, memory usage, and frame drops",
+      "Provide targeted remediation steps for common SwiftUI issues",
+      "Analyze trace exports and call trees for root cause identification"
+    ],
+    "limitations": [
+      "Cannot directly access or profile user codebase without code sharing",
+      "Cannot run Instruments or profiling tools on user machine",
+      "Performance analysis limited to code patterns and user-provided traces",
+      "Requires user to export Instruments traces for deep analysis"
+    ],
+    "use_cases": [
+      {
+        "target_user": "iOS developers",
+        "title": "Diagnose slow SwiftUI apps",
+        "description": "Identify root causes of slow rendering and janky scrolling in production SwiftUI applications"
+      },
+      {
+        "target_user": "QA engineers",
+        "title": "Profile performance regressions",
+        "description": "Guide development teams through Instruments profiling to catch and fix performance regressions"
+      },
+      {
+        "target_user": "SwiftUI learners",
+        "title": "Learn performance patterns",
+        "description": "Understand common SwiftUI anti-patterns and learn efficient coding patterns for optimal performance"
+      }
+    ],
+    "prompt_templates": [
+      {
+        "title": "Quick diagnosis",
+        "scenario": "User shares code with symptoms",
+        "prompt": "My SwiftUI app has [symptom: slow rendering/janky scrolling/high CPU]. Here is my code: [paste code]. Please review for performance issues."
+      },
+      {
+        "title": "Instruments guidance",
+        "scenario": "User needs profiling help",
+        "prompt": "How do I profile my SwiftUI app using Instruments? I want to find [issue: long view body updates/excessive updates/hitches]."
+      },
+      {
+        "title": "Trace analysis",
+        "scenario": "User has trace data",
+        "prompt": "I captured an Instruments trace showing [symptom]. Here are the relevant call tree entries: [paste trace data]. What is causing this?"
+      },
+      {
+        "title": "Pattern matching",
+        "scenario": "User wants to learn patterns",
+        "prompt": "Show me code examples of [anti-pattern: expensive formatters in body/computed properties in body/inline filtering in ForEach] and how to fix them."
+      }
+    ],
+    "output_examples": [
+      {
+        "input": "My list scrolls slowly when I add items. Here is my code: [code with ForEach filtering]",
+        "output": [
+          "Issue: Inline filtering in ForEach causes re-computation on every render",
+          "Fix: Pre-filter the array and store it, or use a computed property that only updates when source changes",
+          "Also check: Ensure stable identity (avoid id: \\.self for non-stable values)",
+          "Next step: Profile with Instruments SwiftUI template to confirm fix"
+        ]
+      },
+      {
+        "input": "My app hangs when navigating between views",
+        "output": [
+          "Common causes: Heavy work in view body during navigation",
+          "Check: Are you doing async work or data fetching in view body?",
+          "Recommendation: Move expensive operations to .task modifier or view model",
+          "Profile with Hangs instrument to confirm main thread blocking"
+        ]
+      },
+      {
+        "input": "How do I use the SwiftUI Instrument in Instruments?",
+        "output": [
+          "Step 1: Build your app in Release mode",
+          "Step 2: Product > Profile to launch Instruments",
+          "Step 3: Choose SwiftUI template",
+          "Step 4: Exercise your app interaction",
+          "Step 5: Analyze Long View Body Updates and Hitches lanes"
+        ]
+      }
+    ],
+    "best_practices": [
+      "Profile in Release mode with Instruments SwiftUI template for accurate results",
+      "Use Self._printChanges() during debug to identify unexpected view updates",
+      "Move expensive work (formatting, sorting) out of view body into cached or computed properties"
+    ],
+    "anti_patterns": [
+      "Creating formatters or doing heavy computation directly in view body",
+      "Using id: \\.self with non-stable values like UUID() in ForEach",
+      "Passing broad dependencies (entire arrays) when only specific properties are needed"
+    ],
+    "faq": [
+      {
+        "question": "What Xcode versions support SwiftUI profiling?",
+        "answer": "SwiftUI Instrument requires Xcode 15+ and iOS 17+. Older versions can use Time Profiler and Hangs instrument."
+      },
+      {
+        "question": "How long does a typical performance audit take?",
+        "answer": "Code review takes minutes. Instruments profiling adds 10-15 minutes for capture and analysis."
+      },
+      {
+        "question": "Can this skill integrate with Xcode projects?",
+        "answer": "No. You must manually run Instruments and share trace exports or screenshots for deep analysis."
+      },
+      {
+        "question": "What data does this skill access?",
+        "answer": "No data access. This skill only provides guidance based on code you voluntarily share."
+      },
+      {
+        "question": "Why is my app slow only on older devices?",
+        "answer": "Older devices have fewer CPU cores and slower memory. Check for expensive operations that work fine on fast machines."
+      },
+      {
+        "question": "How does this compare to SwiftUI Profiler in Xcode?",
+        "answer": "This skill provides guidance for using Instruments. Xcode's built-in tools complement this with inline metrics."
+      }
+    ]
+  },
+  "file_structure": [
+    {
+      "name": "references",
+      "type": "dir",
+      "path": "references",
+      "children": [
+        {
+          "name": "demystify-swiftui-performance-wwdc23.md",
+          "type": "file",
+          "path": "references/demystify-swiftui-performance-wwdc23.md",
+          "lines": 47
+        },
+        {
+          "name": "optimizing-swiftui-performance-instruments.md",
+          "type": "file",
+          "path": "references/optimizing-swiftui-performance-instruments.md",
+          "lines": 30
+        },
+        {
+          "name": "understanding-hangs-in-your-app.md",
+          "type": "file",
+          "path": "references/understanding-hangs-in-your-app.md",
+          "lines": 34
+        },
+        {
+          "name": "understanding-improving-swiftui-performance.md",
+          "type": "file",
+          "path": "references/understanding-improving-swiftui-performance.md",
+          "lines": 53
+        }
+      ]
+    },
+    {
+      "name": "SKILL.md",
+      "type": "file",
+      "path": "SKILL.md",
+      "lines": 188
+    }
+  ]
+}

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/SKILL.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: swiftui-ui-patterns
+description: Best practices and example-driven guidance for building SwiftUI views and components. Use when creating or refactoring SwiftUI UI, designing tab architecture with TabView, composing screens, or needing component-specific patterns and examples.
+---
+
+# SwiftUI UI Patterns
+
+## Quick start
+
+Choose a track based on your goal:
+
+### Existing project
+
+- Identify the feature or screen and the primary interaction model (list, detail, editor, settings, tabbed).
+- Find a nearby example in the repo with `rg "TabView\("` or similar, then read the closest SwiftUI view.
+- Apply local conventions: prefer SwiftUI-native state, keep state local when possible, and use environment injection for shared dependencies.
+- Choose the relevant component reference from `references/components-index.md` and follow its guidance.
+- Build the view with small, focused subviews and SwiftUI-native data flow.
+
+### New project scaffolding
+
+- Start with `references/app-scaffolding-wiring.md` to wire TabView + NavigationStack + sheets.
+- Add a minimal `AppTab` and `RouterPath` based on the provided skeletons.
+- Choose the next component reference based on the UI you need first (TabView, NavigationStack, Sheets).
+- Expand the route and sheet enums as new screens are added.
+
+## General rules to follow
+
+- Use modern SwiftUI state (`@State`, `@Binding`, `@Observable`, `@Environment`) and avoid unnecessary view models.
+- Prefer composition; keep views small and focused.
+- Use async/await with `.task` and explicit loading/error states.
+- Maintain existing legacy patterns only when editing legacy files.
+- Follow the project's formatter and style guide.
+- **Sheets**: Prefer `.sheet(item:)` over `.sheet(isPresented:)` when state represents a selected model. Avoid `if let` inside a sheet body. Sheets should own their actions and call `dismiss()` internally instead of forwarding `onCancel`/`onConfirm` closures.
+
+## Workflow for a new SwiftUI view
+
+1. Define the view's state and its ownership location.
+2. Identify dependencies to inject via `@Environment`.
+3. Sketch the view hierarchy and extract repeated parts into subviews.
+4. Implement async loading with `.task` and explicit state enum if needed.
+5. Add accessibility labels or identifiers when the UI is interactive.
+6. Validate with a build and update usage callsites if needed.
+
+## Component references
+
+Use `references/components-index.md` as the entry point. Each component reference should include:
+- Intent and best-fit scenarios.
+- Minimal usage pattern with local conventions.
+- Pitfalls and performance notes.
+- Paths to existing examples in the current repo.
+
+## Sheet patterns
+
+### Item-driven sheet (preferred)
+
+```swift
+@State private var selectedItem: Item?
+
+.sheet(item: $selectedItem) { item in
+    EditItemSheet(item: item)
+}
+```
+
+### Sheet owns its actions
+
+```swift
+struct EditItemSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(Store.self) private var store
+
+    let item: Item
+    @State private var isSaving = false
+
+    var body: some View {
+        VStack {
+            Button(isSaving ? "Saving…" : "Save") {
+                Task { await save() }
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        await store.save(item)
+        dismiss()
+    }
+}
+```
+
+## Adding a new component reference
+
+- Create `references/<component>.md`.
+- Keep it short and actionable; link to concrete files in the current repo.
+- Update `references/components-index.md` with the new entry.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/app-wiring.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/app-wiring.md
@@ -1,0 +1,194 @@
+# App wiring and dependency graph
+
+## Intent
+
+Show how to wire the app shell (TabView + NavigationStack + sheets) and install a global dependency graph (environment objects, services, streaming clients, SwiftData ModelContainer) in one place.
+
+## Recommended structure
+
+1) Root view sets up tabs, per-tab routers, and sheets.
+2) A dedicated view modifier installs global dependencies and lifecycle tasks (auth state, streaming watchers, push tokens, data containers).
+3) Feature views pull only what they need from the environment; feature-specific state stays local.
+
+## Root shell example (generic)
+
+```swift
+@MainActor
+struct AppView: View {
+  @State private var selectedTab: AppTab = .home
+  @State private var tabRouter = TabRouter()
+
+  var body: some View {
+    TabView(selection: $selectedTab) {
+      ForEach(AppTab.allCases) { tab in
+        let router = tabRouter.router(for: tab)
+        NavigationStack(path: tabRouter.binding(for: tab)) {
+          tab.makeContentView()
+        }
+        .withSheetDestinations(sheet: Binding(
+          get: { router.presentedSheet },
+          set: { router.presentedSheet = $0 }
+        ))
+        .environment(router)
+        .tabItem { tab.label }
+        .tag(tab)
+      }
+    }
+    .withAppDependencyGraph()
+  }
+}
+```
+
+Minimal `AppTab` example:
+
+```swift
+@MainActor
+enum AppTab: Identifiable, Hashable, CaseIterable {
+  case home, notifications, settings
+  var id: String { String(describing: self) }
+
+  @ViewBuilder
+  func makeContentView() -> some View {
+    switch self {
+    case .home: HomeView()
+    case .notifications: NotificationsView()
+    case .settings: SettingsView()
+    }
+  }
+
+  @ViewBuilder
+  var label: some View {
+    switch self {
+    case .home: Label("Home", systemImage: "house")
+    case .notifications: Label("Notifications", systemImage: "bell")
+    case .settings: Label("Settings", systemImage: "gear")
+    }
+  }
+}
+```
+
+Router skeleton:
+
+```swift
+@MainActor
+@Observable
+final class RouterPath {
+  var path: [Route] = []
+  var presentedSheet: SheetDestination?
+}
+
+enum Route: Hashable {
+  case detail(id: String)
+}
+```
+
+## Dependency graph modifier (generic)
+
+Use a single modifier to install environment objects and handle lifecycle hooks when the active account/client changes. This keeps wiring consistent and avoids forgetting a dependency in call sites.
+
+```swift
+extension View {
+  func withAppDependencyGraph(
+    accountManager: AccountManager = .shared,
+    currentAccount: CurrentAccount = .shared,
+    currentInstance: CurrentInstance = .shared,
+    userPreferences: UserPreferences = .shared,
+    theme: Theme = .shared,
+    watcher: StreamWatcher = .shared,
+    pushNotifications: PushNotificationsService = .shared,
+    intentService: AppIntentService = .shared,
+    quickLook: QuickLook = .shared,
+    toastCenter: ToastCenter = .shared,
+    namespace: Namespace.ID? = nil,
+    isSupporter: Bool = false
+  ) -> some View {
+    environment(accountManager)
+      .environment(accountManager.currentClient)
+      .environment(quickLook)
+      .environment(currentAccount)
+      .environment(currentInstance)
+      .environment(userPreferences)
+      .environment(theme)
+      .environment(watcher)
+      .environment(pushNotifications)
+      .environment(intentService)
+      .environment(toastCenter)
+      .environment(\.isSupporter, isSupporter)
+      .task(id: accountManager.currentClient.id) {
+        let client = accountManager.currentClient
+        if let namespace { quickLook.namespace = namespace }
+        currentAccount.setClient(client: client)
+        currentInstance.setClient(client: client)
+        userPreferences.setClient(client: client)
+        await currentInstance.fetchCurrentInstance()
+        watcher.setClient(client: client, instanceStreamingURL: currentInstance.instance?.streamingURL)
+        if client.isAuth {
+          watcher.watch(streams: [.user, .direct])
+        } else {
+          watcher.stopWatching()
+        }
+      }
+      .task(id: accountManager.pushAccounts.map(\.token)) {
+        pushNotifications.tokens = accountManager.pushAccounts.map(\.token)
+      }
+  }
+}
+```
+
+Notes:
+- The `.task(id:)` hooks respond to account/client changes, re-seeding services and watcher state.
+- Keep the modifier focused on global wiring; feature-specific state stays within features.
+- Adjust types (AccountManager, StreamWatcher, etc.) to match your project.
+
+## SwiftData / ModelContainer
+
+Install your `ModelContainer` at the root so all feature views share the same store. Keep the list minimal to the models that need persistence.
+
+```swift
+extension View {
+  func withModelContainer() -> some View {
+    modelContainer(for: [Draft.self, LocalTimeline.self, TagGroup.self])
+  }
+}
+```
+
+Why: a single container avoids duplicated stores per sheet or tab and keeps data consistent.
+
+## Sheet routing (enum-driven)
+
+Centralize sheets with a small enum and a helper modifier.
+
+```swift
+enum SheetDestination: Identifiable {
+  case composer
+  case settings
+  var id: String { String(describing: self) }
+}
+
+extension View {
+  func withSheetDestinations(sheet: Binding<SheetDestination?>) -> some View {
+    sheet(item: sheet) { destination in
+      switch destination {
+      case .composer:
+        ComposerView().withEnvironments()
+      case .settings:
+        SettingsView().withEnvironments()
+      }
+    }
+  }
+}
+```
+
+Why: enum-driven sheets keep presentation centralized and testable; adding a new sheet means adding one enum case and one switch branch.
+
+## When to use
+
+- Apps with multiple packages/modules that share environment objects and services.
+- Apps that need to react to account/client changes and rewire streaming/push safely.
+- Any app that wants consistent TabView + NavigationStack + sheet wiring without repeating environment setup.
+
+## Caveats
+
+- Keep the dependency modifier slim; do not put feature state or heavy logic there.
+- Ensure `.task(id:)` work is lightweight or cancelled appropriately; long-running work belongs in services.
+- If unauthenticated clients exist, gate streaming/watch calls to avoid reconnect spam.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/components-index.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/components-index.md
@@ -1,0 +1,43 @@
+# Components Index
+
+Use this file to find component-specific guidance. Each entry lists when to use it.
+
+## Available components
+
+- TabView: `references/tabview.md` — Use when building a tab-based app or any tabbed feature set.
+- NavigationStack: `references/navigationstack.md` — Use when you need push navigation and programmatic routing, especially per-tab history.
+- Sheets and modal routing: `references/sheets.md` — Use when you want centralized, enum-driven sheet presentation.
+- App wiring and dependency graph: `references/app-wiring.md` — Use to wire TabView + NavigationStack + sheets at the root and install global dependencies.
+- Form and Settings: `references/form.md` — Use for settings, grouped inputs, and structured data entry.
+- macOS Settings: `references/macos-settings.md` — Use when building a macOS Settings window with SwiftUI's Settings scene.
+- Split views and columns: `references/split-views.md` — Use for iPad/macOS multi-column layouts or custom secondary columns.
+- List and Section: `references/list.md` — Use for feed-style content and settings rows.
+- ScrollView and Lazy stacks: `references/scrollview.md` — Use for custom layouts, horizontal scrollers, or grids.
+- Grids: `references/grids.md` — Use for icon pickers, media galleries, and tiled layouts.
+- Theming and dynamic type: `references/theming.md` — Use for app-wide theme tokens, colors, and type scaling.
+- Controls (toggles, pickers, sliders): `references/controls.md` — Use for settings controls and input selection.
+- Input toolbar (bottom anchored): `references/input-toolbar.md` — Use for chat/composer screens with a sticky input bar.
+- Top bar overlays (iOS 26+ and fallback): `references/top-bar.md` — Use for pinned selectors or pills above scroll content.
+- Overlay and toasts: `references/overlay.md` — Use for transient UI like banners or toasts.
+- Focus handling: `references/focus.md` — Use for chaining fields and keyboard focus management.
+- Searchable: `references/searchable.md` — Use for native search UI with scopes and async results.
+- Async images and media: `references/media.md` — Use for remote media, previews, and media viewers.
+- Haptics: `references/haptics.md` — Use for tactile feedback tied to key actions.
+- Matched transitions: `references/matched-transitions.md` — Use for smooth source-to-destination animations.
+- Deep links and URL routing: `references/deeplinks.md` — Use for in-app navigation from URLs.
+- Title menus: `references/title-menus.md` — Use for filter or context menus in the navigation title.
+- Menu bar commands: `references/menu-bar.md` — Use when adding or customizing macOS/iPadOS menu bar commands.
+- Loading & placeholders: `references/loading-placeholders.md` — Use for redacted skeletons, empty states, and loading UX.
+- Lightweight clients: `references/lightweight-clients.md` — Use for small, closure-based API clients injected into stores.
+
+## Planned components (create files as needed)
+
+- Web content: create `references/webview.md` — Use for embedded web content or in-app browsing.
+- Status composer patterns: create `references/composer.md` — Use for composition or editor workflows.
+- Text input and validation: create `references/text-input.md` — Use for forms, validation, and text-heavy input.
+- Design system usage: create `references/design-system.md` — Use when applying shared styling rules.
+
+## Adding entries
+
+- Add the component file and link it here with a short “when to use” description.
+- Keep each component reference short and actionable.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/controls.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/controls.md
@@ -1,0 +1,57 @@
+# Controls (Toggle, Slider, Picker)
+
+## Intent
+
+Use native controls for settings and configuration screens, keeping labels accessible and state bindings clear.
+
+## Core patterns
+
+- Bind controls directly to `@State`, `@Binding`, or `@AppStorage`.
+- Prefer `Toggle` for boolean preferences.
+- Use `Slider` for numeric ranges and show the current value in a label.
+- Use `Picker` for discrete choices; use `.pickerStyle(.segmented)` only for 2–4 options.
+- Keep labels visible and descriptive; avoid embedding buttons inside controls.
+
+## Example: toggles with sections
+
+```swift
+Form {
+  Section("Notifications") {
+    Toggle("Mentions", isOn: $preferences.notificationsMentionsEnabled)
+    Toggle("Follows", isOn: $preferences.notificationsFollowsEnabled)
+    Toggle("Boosts", isOn: $preferences.notificationsBoostsEnabled)
+  }
+}
+```
+
+## Example: slider with value text
+
+```swift
+Section("Font Size") {
+  Slider(value: $fontSizeScale, in: 0.5...1.5, step: 0.1)
+  Text("Scale: \(String(format: \"%.1f\", fontSizeScale))")
+    .font(.scaledBody)
+}
+```
+
+## Example: picker for enums
+
+```swift
+Picker("Default Visibility", selection: $visibility) {
+  ForEach(Visibility.allCases, id: \.self) { option in
+    Text(option.title).tag(option)
+  }
+}
+```
+
+## Design choices to keep
+
+- Group related controls in a `Form` section.
+- Use `.disabled(...)` to reflect locked or inherited settings.
+- Use `Label` inside toggles to combine icon + text when it adds clarity.
+
+## Pitfalls
+
+- Avoid `.pickerStyle(.segmented)` for large sets; use menu or inline styles instead.
+- Don’t hide labels for sliders; always show context.
+- Avoid hard-coding colors for controls; use theme tint sparingly.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/deeplinks.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/deeplinks.md
@@ -1,0 +1,66 @@
+# Deep links and navigation
+
+## Intent
+
+Route external URLs into in-app destinations while falling back to system handling when needed.
+
+## Core patterns
+
+- Centralize URL handling in the router (`handle(url:)`, `handleDeepLink(url:)`).
+- Inject an `OpenURLAction` handler that delegates to the router.
+- Use `.onOpenURL` for app scheme links and convert them to web URLs if needed.
+- Let the router decide whether to navigate or open externally.
+
+## Example: router entry points
+
+```swift
+@MainActor
+final class RouterPath {
+  var path: [Route] = []
+  var urlHandler: ((URL) -> OpenURLAction.Result)?
+
+  func handle(url: URL) -> OpenURLAction.Result {
+    if isInternal(url) {
+      navigate(to: .status(id: url.lastPathComponent))
+      return .handled
+    }
+    return urlHandler?(url) ?? .systemAction
+  }
+
+  func handleDeepLink(url: URL) -> OpenURLAction.Result {
+    // Resolve federated URLs, then navigate.
+    navigate(to: .status(id: url.lastPathComponent))
+    return .handled
+  }
+}
+```
+
+## Example: attach to a root view
+
+```swift
+extension View {
+  func withLinkRouter(_ router: RouterPath) -> some View {
+    self
+      .environment(
+        \.openURL,
+        OpenURLAction { url in
+          router.handle(url: url)
+        }
+      )
+      .onOpenURL { url in
+        router.handleDeepLink(url: url)
+      }
+  }
+}
+```
+
+## Design choices to keep
+
+- Keep URL parsing and decision logic inside the router.
+- Avoid handling deep links in multiple places; one entry point is enough.
+- Always provide a fallback to `OpenURLAction` or `UIApplication.shared.open`.
+
+## Pitfalls
+
+- Don’t assume the URL is internal; validate first.
+- Avoid blocking UI while resolving remote links; use `Task`.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/focus.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/focus.md
@@ -1,0 +1,90 @@
+# Focus handling and field chaining
+
+## Intent
+
+Use `@FocusState` to control keyboard focus, chain fields, and coordinate focus across complex forms.
+
+## Core patterns
+
+- Use an enum to represent focusable fields.
+- Set initial focus in `onAppear`.
+- Use `.onSubmit` to move focus to the next field.
+- For dynamic lists of fields, use an enum with associated values (e.g., `.option(Int)`).
+
+## Example: single field focus
+
+```swift
+struct AddServerView: View {
+  @State private var server = ""
+  @FocusState private var isServerFieldFocused: Bool
+
+  var body: some View {
+    Form {
+      TextField("Server", text: $server)
+        .focused($isServerFieldFocused)
+    }
+    .onAppear { isServerFieldFocused = true }
+  }
+}
+```
+
+## Example: chained focus with enum
+
+```swift
+struct EditTagView: View {
+  enum FocusField { case title, symbol, newTag }
+  @FocusState private var focusedField: FocusField?
+
+  var body: some View {
+    Form {
+      TextField("Title", text: $title)
+        .focused($focusedField, equals: .title)
+        .onSubmit { focusedField = .symbol }
+
+      TextField("Symbol", text: $symbol)
+        .focused($focusedField, equals: .symbol)
+        .onSubmit { focusedField = .newTag }
+    }
+    .onAppear { focusedField = .title }
+  }
+}
+```
+
+## Example: dynamic focus for variable fields
+
+```swift
+struct PollView: View {
+  enum FocusField: Hashable { case option(Int) }
+  @FocusState private var focused: FocusField?
+  @State private var options: [String] = ["", ""]
+  @State private var currentIndex = 0
+
+  var body: some View {
+    ForEach(options.indices, id: \.self) { index in
+      TextField("Option \(index + 1)", text: $options[index])
+        .focused($focused, equals: .option(index))
+        .onSubmit { addOption(at: index) }
+    }
+    .onAppear { focused = .option(0) }
+  }
+
+  private func addOption(at index: Int) {
+    options.append("")
+    currentIndex = index + 1
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+      focused = .option(currentIndex)
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Keep focus state local to the view that owns the fields.
+- Use focus changes to drive UX (validation messages, helper UI).
+- Pair with `.scrollDismissesKeyboard(...)` when using ScrollView/Form.
+
+## Pitfalls
+
+- Don’t store focus state in shared objects; it is view-local.
+- Avoid aggressive focus changes during animation; delay if needed.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/form.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/form.md
@@ -1,0 +1,97 @@
+# Form
+
+## Intent
+
+Use `Form` for structured settings, grouped inputs, and action rows. This pattern keeps layout, spacing, and accessibility consistent for data entry screens.
+
+## Core patterns
+
+- Wrap the form in a `NavigationStack` only when it is presented in a sheet or standalone view without an existing navigation context.
+- Group related controls into `Section` blocks.
+- Use `.scrollContentBackground(.hidden)` plus a custom background color when you need design-system colors.
+- Apply `.formStyle(.grouped)` for grouped styling when appropriate.
+- Use `@FocusState` to manage keyboard focus in input-heavy forms.
+
+## Example: settings-style form
+
+```swift
+@MainActor
+struct SettingsView: View {
+  @Environment(Theme.self) private var theme
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section("General") {
+          NavigationLink("Display") { DisplaySettingsView() }
+          NavigationLink("Haptics") { HapticsSettingsView() }
+        }
+
+        Section("Account") {
+          Button("Edit profile") { /* open sheet */ }
+            .buttonStyle(.plain)
+        }
+        .listRowBackground(theme.primaryBackgroundColor)
+      }
+      .navigationTitle("Settings")
+      .navigationBarTitleDisplayMode(.inline)
+      .scrollContentBackground(.hidden)
+      .background(theme.secondaryBackgroundColor)
+    }
+  }
+}
+```
+
+## Example: modal form with validation
+
+```swift
+@MainActor
+struct AddRemoteServerView: View {
+  @Environment(\.dismiss) private var dismiss
+  @Environment(Theme.self) private var theme
+
+  @State private var server: String = ""
+  @State private var isValid = false
+  @FocusState private var isServerFieldFocused: Bool
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        TextField("Server URL", text: $server)
+          .keyboardType(.URL)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+          .focused($isServerFieldFocused)
+          .listRowBackground(theme.primaryBackgroundColor)
+
+        Button("Add") {
+          guard isValid else { return }
+          dismiss()
+        }
+        .disabled(!isValid)
+        .listRowBackground(theme.primaryBackgroundColor)
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Add Server")
+      .navigationBarTitleDisplayMode(.inline)
+      .scrollContentBackground(.hidden)
+      .background(theme.secondaryBackgroundColor)
+      .scrollDismissesKeyboard(.immediately)
+      .toolbar { CancelToolbarItem() }
+      .onAppear { isServerFieldFocused = true }
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Prefer `Form` over custom stacks for settings and input screens.
+- Keep rows tappable by using `.contentShape(Rectangle())` and `.buttonStyle(.plain)` on row buttons.
+- Use list row backgrounds to keep section styling consistent with your theme.
+
+## Pitfalls
+
+- Avoid heavy custom layouts inside a `Form`; it can lead to spacing issues.
+- If you need highly custom layouts, prefer `ScrollView` + `VStack`.
+- Don’t mix multiple background strategies; pick either default Form styling or custom colors.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/grids.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/grids.md
@@ -1,0 +1,71 @@
+# Grids
+
+## Intent
+
+Use `LazyVGrid` for icon pickers, media galleries, and dense visual selections where items align in columns.
+
+## Core patterns
+
+- Use `.adaptive` columns for layouts that should scale across device sizes.
+- Use multiple `.flexible` columns when you want a fixed column count.
+- Keep spacing consistent and small to avoid uneven gutters.
+- Use `GeometryReader` inside grid cells when you need square thumbnails.
+
+## Example: adaptive icon grid
+
+```swift
+let columns = [GridItem(.adaptive(minimum: 120, maximum: 1024))]
+
+LazyVGrid(columns: columns, spacing: 6) {
+  ForEach(icons) { icon in
+    Button {
+      select(icon)
+    } label: {
+      ZStack(alignment: .bottomTrailing) {
+        Image(icon.previewName)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .cornerRadius(6)
+        if icon.isSelected {
+          Image(systemName: "checkmark.seal.fill")
+            .padding(4)
+            .tint(.green)
+        }
+      }
+    }
+    .buttonStyle(.plain)
+  }
+}
+```
+
+## Example: fixed 3-column media grid
+
+```swift
+LazyVGrid(
+  columns: [
+    .init(.flexible(minimum: 100), spacing: 4),
+    .init(.flexible(minimum: 100), spacing: 4),
+    .init(.flexible(minimum: 100), spacing: 4),
+  ],
+  spacing: 4
+) {
+  ForEach(items) { item in
+    GeometryReader { proxy in
+      ThumbnailView(item: item)
+        .frame(width: proxy.size.width, height: proxy.size.width)
+    }
+    .aspectRatio(1, contentMode: .fit)
+  }
+}
+```
+
+## Design choices to keep
+
+- Use `LazyVGrid` for large collections; avoid non-lazy grids for big sets.
+- Keep tap targets full-bleed using `.contentShape(Rectangle())` when needed.
+- Prefer adaptive grids for settings pickers and flexible layouts.
+
+## Pitfalls
+
+- Avoid heavy overlays in every grid cell; it can be expensive.
+- Don’t nest grids inside other grids without a clear reason.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/haptics.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/haptics.md
@@ -1,0 +1,71 @@
+# Haptics
+
+## Intent
+
+Use haptics sparingly to reinforce user actions (tab selection, refresh, success/error) and respect user preferences.
+
+## Core patterns
+
+- Centralize haptic triggers in a `HapticManager` or similar utility.
+- Gate haptics behind user preferences and hardware support.
+- Use distinct types for different UX moments (selection vs. notification vs. refresh).
+
+## Example: simple haptic manager
+
+```swift
+@MainActor
+final class HapticManager {
+  static let shared = HapticManager()
+
+  enum HapticType {
+    case buttonPress
+    case tabSelection
+    case dataRefresh(intensity: CGFloat)
+    case notification(UINotificationFeedbackGenerator.FeedbackType)
+  }
+
+  private let selectionGenerator = UISelectionFeedbackGenerator()
+  private let impactGenerator = UIImpactFeedbackGenerator(style: .heavy)
+  private let notificationGenerator = UINotificationFeedbackGenerator()
+
+  private init() { selectionGenerator.prepare() }
+
+  func fire(_ type: HapticType, isEnabled: Bool) {
+    guard isEnabled else { return }
+    switch type {
+    case .buttonPress:
+      impactGenerator.impactOccurred()
+    case .tabSelection:
+      selectionGenerator.selectionChanged()
+    case let .dataRefresh(intensity):
+      impactGenerator.impactOccurred(intensity: intensity)
+    case let .notification(style):
+      notificationGenerator.notificationOccurred(style)
+    }
+  }
+}
+```
+
+## Example: usage
+
+```swift
+Button("Save") {
+  HapticManager.shared.fire(.notification(.success), isEnabled: preferences.hapticsEnabled)
+}
+
+TabView(selection: $selectedTab) { /* tabs */ }
+  .onChange(of: selectedTab) { _, _ in
+    HapticManager.shared.fire(.tabSelection, isEnabled: preferences.hapticTabSelectionEnabled)
+  }
+```
+
+## Design choices to keep
+
+- Haptics should be subtle and not fire on every tiny interaction.
+- Respect user preferences (toggle to disable).
+- Keep haptic triggers close to the user action, not deep in data layers.
+
+## Pitfalls
+
+- Avoid firing multiple haptics in quick succession.
+- Do not assume haptics are available; check support.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/input-toolbar.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/input-toolbar.md
@@ -1,0 +1,51 @@
+# Input toolbar (bottom anchored)
+
+## Intent
+
+Use a bottom-anchored input bar for chat, composer, or quick actions without fighting the keyboard.
+
+## Core patterns
+
+- Use `.safeAreaInset(edge: .bottom)` to anchor the toolbar above the keyboard.
+- Keep the main content in a `ScrollView` or `List`.
+- Drive focus with `@FocusState` and set initial focus when needed.
+- Avoid embedding the input bar inside the scroll content; keep it separate.
+
+## Example: scroll view + bottom input
+
+```swift
+@MainActor
+struct ConversationView: View {
+  @FocusState private var isInputFocused: Bool
+
+  var body: some View {
+    ScrollViewReader { _ in
+      ScrollView {
+        LazyVStack {
+          ForEach(messages) { message in
+            MessageRow(message: message)
+          }
+        }
+        .padding(.horizontal, .layoutPadding)
+      }
+      .safeAreaInset(edge: .bottom) {
+        InputBar(text: $draft)
+          .focused($isInputFocused)
+      }
+      .scrollDismissesKeyboard(.interactively)
+      .onAppear { isInputFocused = true }
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Keep the input bar visually separated from the scrollable content.
+- Use `.scrollDismissesKeyboard(.interactively)` for chat-like screens.
+- Ensure send actions are reachable via keyboard return or a clear button.
+
+## Pitfalls
+
+- Avoid placing the input view inside the scroll stack; it will jump with content.
+- Avoid nested scroll views that fight for drag gestures.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/lightweight-clients.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/lightweight-clients.md
@@ -1,0 +1,93 @@
+# Lightweight Clients (Closure-Based)
+
+Use this pattern to keep networking or service dependencies simple and testable without introducing a full view model or heavy DI framework. It works well for SwiftUI apps where you want a small, composable API surface that can be swapped in previews/tests.
+
+## Intent
+- Provide a tiny "client" type made of async closures.
+- Keep business logic in a store or feature layer, not the view.
+- Enable easy stubbing in previews/tests.
+
+## Minimal shape
+```swift
+struct SomeClient {
+    var fetchItems: (_ limit: Int) async throws -> [Item]
+    var search: (_ query: String, _ limit: Int) async throws -> [Item]
+}
+
+extension SomeClient {
+    static func live(baseURL: URL = URL(string: "https://example.com")!) -> SomeClient {
+        let session = URLSession.shared
+        return SomeClient(
+            fetchItems: { limit in
+                // build URL, call session, decode
+            },
+            search: { query, limit in
+                // build URL, call session, decode
+            }
+        )
+    }
+}
+```
+
+## Usage pattern
+```swift
+@MainActor
+@Observable final class ItemsStore {
+    enum LoadState { case idle, loading, loaded, failed(String) }
+
+    var items: [Item] = []
+    var state: LoadState = .idle
+    private let client: SomeClient
+
+    init(client: SomeClient) {
+        self.client = client
+    }
+
+    func load(limit: Int = 20) async {
+        state = .loading
+        do {
+            items = try await client.fetchItems(limit)
+            state = .loaded
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}
+```
+
+```swift
+struct ContentView: View {
+    @Environment(ItemsStore.self) private var store
+
+    var body: some View {
+        List(store.items) { item in
+            Text(item.title)
+        }
+        .task { await store.load() }
+    }
+}
+```
+
+```swift
+@main
+struct MyApp: App {
+    @State private var store = ItemsStore(client: .live())
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(store)
+        }
+    }
+}
+```
+
+## Guidance
+- Keep decoding and URL-building in the client; keep state changes in the store.
+- Make the store accept the client in `init` and keep it private.
+- Avoid global singletons; use `.environment` for store injection.
+- If you need multiple variants (mock/stub), add `static func mock(...)`.
+
+## Pitfalls
+- Don’t put UI state in the client; keep state in the store.
+- Don’t capture `self` or view state in the client closures.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/list.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/list.md
@@ -1,0 +1,86 @@
+# List and Section
+
+## Intent
+
+Use `List` for feed-style content and settings-style rows where built-in row reuse, selection, and accessibility matter.
+
+## Core patterns
+
+- Prefer `List` for long, vertically scrolling content with repeated rows.
+- Use `Section` headers to group related rows.
+- Pair with `ScrollViewReader` when you need scroll-to-top or jump-to-id.
+- Use `.listStyle(.plain)` for modern feed layouts.
+- Use `.listStyle(.grouped)` for multi-section discovery/search pages where section grouping helps.
+- Apply `.scrollContentBackground(.hidden)` + a custom background when you need a themed surface.
+- Use `.listRowInsets(...)` and `.listRowSeparator(.hidden)` to tune row spacing and separators.
+- Use `.environment(\\.defaultMinListRowHeight, ...)` to control dense list layouts.
+
+## Example: feed list with scroll-to-top
+
+```swift
+@MainActor
+struct TimelineListView: View {
+  @Environment(\.selectedTabScrollToTop) private var selectedTabScrollToTop
+  @State private var scrollToId: String?
+
+  var body: some View {
+    ScrollViewReader { proxy in
+      List {
+        ForEach(items) { item in
+          TimelineRow(item: item)
+            .id(item.id)
+            .listRowInsets(.init(top: 12, leading: 16, bottom: 6, trailing: 16))
+            .listRowSeparator(.hidden)
+        }
+      }
+      .listStyle(.plain)
+      .environment(\\.defaultMinListRowHeight, 1)
+      .onChange(of: scrollToId) { _, newValue in
+        if let newValue {
+          proxy.scrollTo(newValue, anchor: .top)
+          scrollToId = nil
+        }
+      }
+      .onChange(of: selectedTabScrollToTop) { _, newValue in
+        if newValue == 0 {
+          withAnimation {
+            proxy.scrollTo(ScrollToView.Constants.scrollToTop, anchor: .top)
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Example: settings-style list
+
+```swift
+@MainActor
+struct SettingsView: View {
+  var body: some View {
+    List {
+      Section("General") {
+        NavigationLink("Display") { DisplaySettingsView() }
+        NavigationLink("Haptics") { HapticsSettingsView() }
+      }
+      Section("Account") {
+        Button("Sign Out", role: .destructive) {}
+      }
+    }
+    .listStyle(.insetGrouped)
+  }
+}
+```
+
+## Design choices to keep
+
+- Use `List` for dynamic feeds, settings, and any UI where row semantics help.
+- Use stable IDs for rows to keep animations and scroll positioning reliable.
+- Prefer `.contentShape(Rectangle())` on rows that should be tappable end-to-end.
+- Use `.refreshable` for pull-to-refresh feeds when the data source supports it.
+
+## Pitfalls
+
+- Avoid heavy custom layouts inside a `List` row; use `ScrollView` + `LazyVStack` instead.
+- Be careful mixing `List` and nested `ScrollView`; it can cause gesture conflicts.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/loading-placeholders.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/loading-placeholders.md
@@ -1,0 +1,38 @@
+# Loading & Placeholders
+
+Use this when a view needs a consistent loading state (skeletons, redaction, empty state) without blocking interaction.
+
+## Patterns to prefer
+
+- **Redacted placeholders** for list/detail content to preserve layout while loading.
+- **ContentUnavailableView** for empty or error states after loading completes.
+- **ProgressView** only for short, global operations (use sparingly in content-heavy screens).
+
+## Recommended approach
+
+1. Keep the real layout, render placeholder data, then apply `.redacted(reason: .placeholder)`.
+2. For lists, show a fixed number of placeholder rows (avoid infinite spinners).
+3. Switch to `ContentUnavailableView` when load finishes but data is empty.
+
+## Pitfalls
+
+- Don’t animate layout shifts during redaction; keep frames stable.
+- Avoid nesting multiple spinners; use one loading indicator per section.
+- Keep placeholder count small (3–6) to reduce jank on low-end devices.
+
+## Minimal usage
+
+```swift
+VStack {
+  if isLoading {
+    ForEach(0..<3, id: \.self) { _ in
+      RowView(model: .placeholder())
+    }
+    .redacted(reason: .placeholder)
+  } else if items.isEmpty {
+    ContentUnavailableView("No items", systemImage: "tray")
+  } else {
+    ForEach(items) { item in RowView(model: item) }
+  }
+}
+```

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/macos-settings.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/macos-settings.md
@@ -1,0 +1,71 @@
+# macOS Settings
+
+## Intent
+
+Use this when building a macOS Settings window backed by SwiftUI's `Settings` scene.
+
+## Core patterns
+
+- Declare the Settings scene in the `App` and compile it only for macOS.
+- Keep settings content in a dedicated root view (`SettingsView`) and drive values with `@AppStorage`.
+- Use `TabView` to group settings sections when you have more than one category.
+- Use `Form` inside each tab to keep controls aligned and accessible.
+- Use `OpenSettingsAction` or `SettingsLink` for in-app entry points to the Settings window.
+
+## Example: settings scene
+
+```swift
+@main
+struct MyApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+    #if os(macOS)
+    Settings {
+      SettingsView()
+    }
+    #endif
+  }
+}
+```
+
+## Example: tabbed settings view
+
+```swift
+@MainActor
+struct SettingsView: View {
+  @AppStorage("showPreviews") private var showPreviews = true
+  @AppStorage("fontSize") private var fontSize = 12.0
+
+  var body: some View {
+    TabView {
+      Form {
+        Toggle("Show Previews", isOn: $showPreviews)
+        Slider(value: $fontSize, in: 9...96) {
+          Text("Font Size (\(fontSize, specifier: "%.0f") pts)")
+        }
+      }
+      .tabItem { Label("General", systemImage: "gear") }
+
+      Form {
+        Toggle("Enable Advanced Mode", isOn: .constant(false))
+      }
+      .tabItem { Label("Advanced", systemImage: "star") }
+    }
+    .scenePadding()
+    .frame(maxWidth: 420, minHeight: 240)
+  }
+}
+```
+
+## Skip navigation
+
+- Avoid wrapping `SettingsView` in a `NavigationStack` unless you truly need deep push navigation.
+- Prefer tabs or sections; Settings is already presented as a separate window and should feel flat.
+- If you must show hierarchical settings, use a single `NavigationSplitView` with a sidebar list of categories.
+
+## Pitfalls
+
+- Don’t reuse iOS-only settings layouts (full-screen stacks, toolbar-heavy flows).
+- Avoid large custom view hierarchies inside `Form`; keep rows focused and accessible.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/matched-transitions.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/matched-transitions.md
@@ -1,0 +1,59 @@
+# Matched transitions
+
+## Intent
+
+Use matched transitions to create smooth continuity between a source view (thumbnail, avatar) and a destination view (sheet, detail, viewer).
+
+## Core patterns
+
+- Use a shared `Namespace` and a stable ID for the source.
+- Use `matchedTransitionSource` + `navigationTransition(.zoom(...))` on iOS 26+.
+- Use `matchedGeometryEffect` for in-place transitions within a view hierarchy.
+- Keep IDs stable across view updates (avoid random UUIDs).
+
+## Example: media preview to full-screen viewer (iOS 26+)
+
+```swift
+struct MediaPreview: View {
+  @Namespace private var namespace
+  @State private var selected: MediaAttachment?
+
+  var body: some View {
+    ThumbnailView()
+      .matchedTransitionSource(id: selected?.id ?? "", in: namespace)
+      .sheet(item: $selected) { item in
+        MediaViewer(item: item)
+          .navigationTransition(.zoom(sourceID: item.id, in: namespace))
+      }
+  }
+}
+```
+
+## Example: matched geometry within a view
+
+```swift
+struct ToggleBadge: View {
+  @Namespace private var space
+  @State private var isOn = false
+
+  var body: some View {
+    Button {
+      withAnimation(.spring) { isOn.toggle() }
+    } label: {
+      Image(systemName: isOn ? "eye" : "eye.slash")
+        .matchedGeometryEffect(id: "icon", in: space)
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Prefer `matchedTransitionSource` for cross-screen transitions.
+- Keep source and destination sizes reasonable to avoid jarring scale changes.
+- Use `withAnimation` for state-driven transitions.
+
+## Pitfalls
+
+- Don’t use unstable IDs; it breaks the transition.
+- Avoid mismatched shapes (e.g., square to circle) unless the design expects it.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/media.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/media.md
@@ -1,0 +1,73 @@
+# Media (images, video, viewer)
+
+## Intent
+
+Use consistent patterns for loading images, previewing media, and presenting a full-screen viewer.
+
+## Core patterns
+
+- Use `LazyImage` (or `AsyncImage`) for remote images with loading states.
+- Prefer a lightweight preview component for inline media.
+- Use a shared viewer state (e.g., `QuickLook`) to present a full-screen media viewer.
+- Use `openWindow` for desktop/visionOS and a sheet for iOS.
+
+## Example: inline media preview
+
+```swift
+struct MediaPreviewRow: View {
+  @Environment(QuickLook.self) private var quickLook
+
+  let attachments: [MediaAttachment]
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack {
+        ForEach(attachments) { attachment in
+          LazyImage(url: attachment.previewURL) { state in
+            if let image = state.image {
+              image.resizable().aspectRatio(contentMode: .fill)
+            } else {
+              ProgressView()
+            }
+          }
+          .frame(width: 120, height: 120)
+          .clipped()
+          .onTapGesture {
+            quickLook.prepareFor(
+              selectedMediaAttachment: attachment,
+              mediaAttachments: attachments
+            )
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Example: global media viewer sheet
+
+```swift
+struct AppRoot: View {
+  @State private var quickLook = QuickLook.shared
+
+  var body: some View {
+    content
+      .environment(quickLook)
+      .sheet(item: $quickLook.selectedMediaAttachment) { selected in
+        MediaUIView(selectedAttachment: selected, attachments: quickLook.mediaAttachments)
+      }
+  }
+}
+```
+
+## Design choices to keep
+
+- Keep previews lightweight; load full media in the viewer.
+- Use shared viewer state so any view can open media without prop-drilling.
+- Use a single entry point for the viewer (sheet/window) to avoid duplicates.
+
+## Pitfalls
+
+- Avoid loading full-size images in list rows; use resized previews.
+- Don’t present multiple viewer sheets at once; keep a single source of truth.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/menu-bar.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/menu-bar.md
@@ -1,0 +1,101 @@
+# Menu Bar
+
+## Intent
+
+Use this when adding or customizing the macOS/iPadOS menu bar with SwiftUI commands.
+
+## Core patterns
+
+- Add commands at the `Scene` level with `.commands { ... }`.
+- Use `SidebarCommands()` when your UI includes a navigation sidebar.
+- Use `CommandMenu` for app-specific menus and group related actions.
+- Use `CommandGroup` to insert items before/after system groups or replace them.
+- Use `FocusedValue` for context-sensitive menu items that depend on the active scene.
+
+## Example: basic command menu
+
+```swift
+@main
+struct MyApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+    .commands {
+      CommandMenu("Actions") {
+        Button("Run", action: run)
+          .keyboardShortcut("R")
+        Button("Stop", action: stop)
+          .keyboardShortcut(".")
+      }
+    }
+  }
+
+  private func run() {}
+  private func stop() {}
+}
+```
+
+## Example: insert and replace groups
+
+```swift
+WindowGroup {
+  ContentView()
+}
+.commands {
+  CommandGroup(before: .systemServices) {
+    Button("Check for Updates") { /* open updater */ }
+  }
+
+  CommandGroup(after: .newItem) {
+    Button("New from Clipboard") { /* create item */ }
+  }
+
+  CommandGroup(replacing: .help) {
+    Button("User Manual") { /* open docs */ }
+  }
+}
+```
+
+## Example: focused menu state
+
+```swift
+@Observable
+final class DataModel {
+  var items: [String] = []
+}
+
+struct ContentView: View {
+  @State private var model = DataModel()
+
+  var body: some View {
+    List(model.items, id: \.self) { item in
+      Text(item)
+    }
+    .focusedSceneValue(model)
+  }
+}
+
+struct ItemCommands: Commands {
+  @FocusedValue(DataModel.self) private var model: DataModel?
+
+  var body: some Commands {
+    CommandGroup(after: .newItem) {
+      Button("New Item") {
+        model?.items.append("Untitled")
+      }
+      .disabled(model == nil)
+    }
+  }
+}
+```
+
+## Menu bar and Settings
+
+- Defining a `Settings` scene adds the Settings menu item on macOS automatically.
+- If you need a custom entry point inside the app, use `OpenSettingsAction` or `SettingsLink`.
+
+## Pitfalls
+
+- Avoid registering the same keyboard shortcut in multiple command groups.
+- Don’t use menu items as the only discoverable entry point for critical features.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/navigationstack.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/navigationstack.md
@@ -1,0 +1,159 @@
+# NavigationStack
+
+## Intent
+
+Use this pattern for programmatic navigation and deep links, especially when each tab needs an independent navigation history. The key idea is one `NavigationStack` per tab, each with its own path binding and router object.
+
+## Core architecture
+
+- Define a route enum that is `Hashable` and represents all destinations.
+- Create a lightweight router (or use a library such as `https://github.com/Dimillian/AppRouter`) that owns the `path` and any sheet state.
+- Each tab owns its own router instance and binds `NavigationStack(path:)` to it.
+- Inject the router into the environment so child views can navigate programmatically.
+- Centralize destination mapping with a single `navigationDestination(for:)` block (or a `withAppRouter()` modifier).
+
+## Example: custom router with per-tab stack
+
+```swift
+@MainActor
+@Observable
+final class RouterPath {
+  var path: [Route] = []
+  var presentedSheet: SheetDestination?
+
+  func navigate(to route: Route) {
+    path.append(route)
+  }
+
+  func reset() {
+    path = []
+  }
+}
+
+enum Route: Hashable {
+  case account(id: String)
+  case status(id: String)
+}
+
+@MainActor
+struct TimelineTab: View {
+  @State private var routerPath = RouterPath()
+
+  var body: some View {
+    NavigationStack(path: $routerPath.path) {
+      TimelineView()
+        .navigationDestination(for: Route.self) { route in
+          switch route {
+          case .account(let id): AccountView(id: id)
+          case .status(let id): StatusView(id: id)
+          }
+        }
+    }
+    .environment(routerPath)
+  }
+}
+```
+
+## Example: centralized destination mapping
+
+Use a shared view modifier to avoid duplicating route switches across screens.
+
+```swift
+extension View {
+  func withAppRouter() -> some View {
+    navigationDestination(for: Route.self) { route in
+      switch route {
+      case .account(let id):
+        AccountView(id: id)
+      case .status(let id):
+        StatusView(id: id)
+      }
+    }
+  }
+}
+```
+
+Then apply it once per stack:
+
+```swift
+NavigationStack(path: $routerPath.path) {
+  TimelineView()
+    .withAppRouter()
+}
+```
+
+## Example: binding per tab (tabs with independent history)
+
+```swift
+@MainActor
+struct TabsView: View {
+  @State private var timelineRouter = RouterPath()
+  @State private var notificationsRouter = RouterPath()
+
+  var body: some View {
+    TabView {
+      TimelineTab(router: timelineRouter)
+      NotificationsTab(router: notificationsRouter)
+    }
+  }
+}
+```
+
+## Example: generic tabs with per-tab NavigationStack
+
+Use this when tabs are built from data and each needs its own path without hard-coded names.
+
+```swift
+@MainActor
+struct TabsView: View {
+  @State private var selectedTab: AppTab = .timeline
+  @State private var tabRouter = TabRouter()
+
+  var body: some View {
+    TabView(selection: $selectedTab) {
+      ForEach(AppTab.allCases) { tab in
+        NavigationStack(path: tabRouter.binding(for: tab)) {
+          tab.makeContentView()
+        }
+        .environment(tabRouter.router(for: tab))
+        .tabItem { tab.label }
+        .tag(tab)
+      }
+    }
+  }
+}
+```
+
+@MainActor
+@Observable
+final class TabRouter {
+  private var routers: [AppTab: RouterPath] = [:]
+
+  func router(for tab: AppTab) -> RouterPath {
+    if let router = routers[tab] { return router }
+    let router = RouterPath()
+    routers[tab] = router
+    return router
+  }
+
+  func binding(for tab: AppTab) -> Binding<[Route]> {
+    let router = router(for: tab)
+    return Binding(get: { router.path }, set: { router.path = $0 })
+  }
+}
+
+## Design choices to keep
+
+- One `NavigationStack` per tab to preserve independent history.
+- A single source of truth for navigation state (`RouterPath` or library router).
+- Use `navigationDestination(for:)` to map routes to views.
+- Reset the path when app context changes (account switch, logout, etc.).
+- Inject the router into the environment so child views can navigate and present sheets without prop-drilling.
+- Keep sheet presentation state on the router if you want a single place to manage modals.
+
+## Pitfalls
+
+- Do not share one path across all tabs unless you want global history.
+- Ensure route identifiers are stable and `Hashable`.
+- Avoid storing view instances in the path; store lightweight route data instead.
+- If using a router object, keep it outside other `@Observable` objects to avoid nested observation.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/overlay.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/overlay.md
@@ -1,0 +1,45 @@
+# Overlay and toasts
+
+## Intent
+
+Use overlays for transient UI (toasts, banners, loaders) without affecting layout.
+
+## Core patterns
+
+- Use `.overlay(alignment:)` to place global UI without changing the underlying layout.
+- Keep overlays lightweight and dismissible.
+- Use a dedicated `ToastCenter` (or similar) for global state if multiple features trigger toasts.
+
+## Example: toast overlay
+
+```swift
+struct AppRootView: View {
+  @State private var toast: Toast?
+
+  var body: some View {
+    content
+      .overlay(alignment: .top) {
+        if let toast {
+          ToastView(toast: toast)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .onAppear {
+              DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                withAnimation { self.toast = nil }
+              }
+            }
+        }
+      }
+  }
+}
+```
+
+## Design choices to keep
+
+- Prefer overlays for transient UI rather than embedding in layout stacks.
+- Use transitions and short auto-dismiss timers.
+- Keep the overlay aligned to a clear edge (`.top` or `.bottom`).
+
+## Pitfalls
+
+- Avoid overlays that block all interaction unless explicitly needed.
+- Don’t stack many overlays; use a queue or replace the current toast.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/scrollview.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/scrollview.md
@@ -1,0 +1,87 @@
+# ScrollView and Lazy stacks
+
+## Intent
+
+Use `ScrollView` with `LazyVStack`, `LazyHStack`, or `LazyVGrid` when you need custom layout, mixed content, or horizontal/ grid-based scrolling.
+
+## Core patterns
+
+- Prefer `ScrollView` + `LazyVStack` for chat-like or custom feed layouts.
+- Use `ScrollView(.horizontal)` + `LazyHStack` for chips, tags, avatars, and media strips.
+- Use `LazyVGrid` for icon/media grids; prefer adaptive columns when possible.
+- Use `ScrollViewReader` for scroll-to-top/bottom and anchor-based jumps.
+- Use `safeAreaInset(edge:)` for input bars that should stick above the keyboard.
+
+## Example: vertical custom feed
+
+```swift
+@MainActor
+struct ConversationView: View {
+  private enum Constants { static let bottomAnchor = "bottom" }
+  @State private var scrollProxy: ScrollViewProxy?
+
+  var body: some View {
+    ScrollViewReader { proxy in
+      ScrollView {
+        LazyVStack {
+          ForEach(messages) { message in
+            MessageRow(message: message)
+              .id(message.id)
+          }
+          Color.clear.frame(height: 1).id(Constants.bottomAnchor)
+        }
+        .padding(.horizontal, .layoutPadding)
+      }
+      .safeAreaInset(edge: .bottom) {
+        MessageInputBar()
+      }
+      .onAppear {
+        scrollProxy = proxy
+        withAnimation {
+          proxy.scrollTo(Constants.bottomAnchor, anchor: .bottom)
+        }
+      }
+    }
+  }
+}
+```
+
+## Example: horizontal chips
+
+```swift
+ScrollView(.horizontal, showsIndicators: false) {
+  LazyHStack(spacing: 8) {
+    ForEach(chips) { chip in
+      ChipView(chip: chip)
+    }
+  }
+}
+```
+
+## Example: adaptive grid
+
+```swift
+let columns = [GridItem(.adaptive(minimum: 120))]
+
+ScrollView {
+  LazyVGrid(columns: columns, spacing: 8) {
+    ForEach(items) { item in
+      GridItemView(item: item)
+    }
+  }
+  .padding(8)
+}
+```
+
+## Design choices to keep
+
+- Use `Lazy*` stacks when item counts are large or unknown.
+- Use non-lazy stacks for small, fixed-size content to avoid lazy overhead.
+- Keep IDs stable when using `ScrollViewReader`.
+- Prefer explicit animations (`withAnimation`) when scrolling to an ID.
+
+## Pitfalls
+
+- Avoid nesting scroll views of the same axis; it causes gesture conflicts.
+- Don’t combine `List` and `ScrollView` in the same hierarchy without a clear reason.
+- Overuse of `LazyVStack` for tiny content can add unnecessary complexity.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/searchable.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/searchable.md
@@ -1,0 +1,71 @@
+# Searchable
+
+## Intent
+
+Use `searchable` to add native search UI with optional scopes and async results.
+
+## Core patterns
+
+- Bind `searchable(text:)` to local state.
+- Use `.searchScopes` for multiple search modes.
+- Use `.task(id: searchQuery)` or debounced tasks to avoid overfetching.
+- Show placeholders or progress states while results load.
+
+## Example: searchable with scopes
+
+```swift
+@MainActor
+struct ExploreView: View {
+  @State private var searchQuery = ""
+  @State private var searchScope: SearchScope = .all
+  @State private var isSearching = false
+  @State private var results: [SearchResult] = []
+
+  var body: some View {
+    List {
+      if isSearching {
+        ProgressView()
+      } else {
+        ForEach(results) { result in
+          SearchRow(result: result)
+        }
+      }
+    }
+    .searchable(
+      text: $searchQuery,
+      placement: .navigationBarDrawer(displayMode: .always),
+      prompt: Text("Search")
+    )
+    .searchScopes($searchScope) {
+      ForEach(SearchScope.allCases, id: \.self) { scope in
+        Text(scope.title)
+      }
+    }
+    .task(id: searchQuery) {
+      await runSearch()
+    }
+  }
+
+  private func runSearch() async {
+    guard !searchQuery.isEmpty else {
+      results = []
+      return
+    }
+    isSearching = true
+    defer { isSearching = false }
+    try? await Task.sleep(for: .milliseconds(250))
+    results = await fetchResults(query: searchQuery, scope: searchScope)
+  }
+}
+```
+
+## Design choices to keep
+
+- Show a placeholder when search is empty or has no results.
+- Debounce input to avoid spamming the network.
+- Keep search state local to the view.
+
+## Pitfalls
+
+- Avoid running searches for empty strings.
+- Don’t block the main thread during fetch.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/sheets.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/sheets.md
@@ -1,0 +1,113 @@
+# Sheets
+
+## Intent
+
+Use a centralized sheet routing pattern so any view can present modals without prop-drilling. This keeps sheet state in one place and scales as the app grows.
+
+## Core architecture
+
+- Define a `SheetDestination` enum that describes every modal and is `Identifiable`.
+- Store the current sheet in a router object (`presentedSheet: SheetDestination?`).
+- Create a view modifier like `withSheetDestinations(...)` that maps the enum to concrete sheet views.
+- Inject the router into the environment so child views can set `presentedSheet` directly.
+
+## Example: SheetDestination enum
+
+```swift
+enum SheetDestination: Identifiable, Hashable {
+  case composer
+  case editProfile
+  case settings
+  case report(itemID: String)
+
+  var id: String {
+    switch self {
+    case .composer, .editProfile:
+      // Use the same id to ensure only one editor-like sheet is active at a time.
+      return "editor"
+    case .settings:
+      return "settings"
+    case .report:
+      return "report"
+    }
+  }
+}
+```
+
+## Example: withSheetDestinations modifier
+
+```swift
+extension View {
+  func withSheetDestinations(
+    sheet: Binding<SheetDestination?>
+  ) -> some View {
+    sheet(item: sheet) { destination in
+      Group {
+        switch destination {
+        case .composer:
+          ComposerView()
+        case .editProfile:
+          EditProfileView()
+        case .settings:
+          SettingsView()
+        case .report(let itemID):
+          ReportView(itemID: itemID)
+        }
+      }
+    }
+  }
+}
+```
+
+## Example: presenting from a child view
+
+```swift
+struct StatusRow: View {
+  @Environment(RouterPath.self) private var router
+
+  var body: some View {
+    Button("Report") {
+      router.presentedSheet = .report(itemID: "123")
+    }
+  }
+}
+```
+
+## Required wiring
+
+For the child view to work, a parent view must:
+- own the router instance,
+- attach `withSheetDestinations(sheet: $router.presentedSheet)` (or an equivalent `sheet(item:)` handler), and
+- inject it with `.environment(router)` after the sheet modifier so the modal content inherits it.
+
+This makes the child assignment to `router.presentedSheet` drive presentation at the root.
+
+## Example: sheets that need their own navigation
+
+Wrap sheet content in a `NavigationStack` so it can push within the modal.
+
+```swift
+struct NavigationSheet<Content: View>: View {
+  var content: () -> Content
+
+  var body: some View {
+    NavigationStack {
+      content()
+        .toolbar { CloseToolbarItem() }
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Centralize sheet routing so features can present modals without wiring bindings through many layers.
+- Use `sheet(item:)` to guarantee a single sheet is active and to drive presentation from the enum.
+- Group related sheets under the same `id` when they are mutually exclusive (e.g., editor flows).
+- Keep sheet views lightweight and composed from smaller views; avoid large monoliths.
+
+## Pitfalls
+
+- Avoid mixing `sheet(isPresented:)` and `sheet(item:)` for the same concern; prefer a single enum.
+- Do not store heavy state inside `SheetDestination`; pass lightweight identifiers or models.
+- If multiple sheets can appear from the same screen, give them distinct `id` values.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/split-views.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/split-views.md
@@ -1,0 +1,72 @@
+# Split views and columns
+
+## Intent
+
+Provide a lightweight, customizable multi-column layout for iPad/macOS without relying on `NavigationSplitView`.
+
+## Custom split column pattern (manual HStack)
+
+Use this when you want full control over column sizing, behavior, and environment tweaks.
+
+```swift
+@MainActor
+struct AppView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @AppStorage("showSecondaryColumn") private var showSecondaryColumn = true
+
+  var body: some View {
+    HStack(spacing: 0) {
+      primaryColumn
+      if shouldShowSecondaryColumn {
+        Divider().edgesIgnoringSafeArea(.all)
+        secondaryColumn
+      }
+    }
+  }
+
+  private var shouldShowSecondaryColumn: Bool {
+    horizontalSizeClass == .regular
+      && showSecondaryColumn
+  }
+
+  private var primaryColumn: some View {
+    TabView { /* tabs */ }
+  }
+
+  private var secondaryColumn: some View {
+    NotificationsTab()
+      .environment(\.isSecondaryColumn, true)
+      .frame(maxWidth: .secondaryColumnWidth)
+  }
+}
+```
+
+## Notes on the custom approach
+
+- Use a shared preference or setting to toggle the secondary column.
+- Inject an environment flag (e.g., `isSecondaryColumn`) so child views can adapt behavior.
+- Prefer a fixed or capped width for the secondary column to avoid layout thrash.
+
+## Alternative: NavigationSplitView
+
+`NavigationSplitView` can handle sidebar + detail + supplementary columns for you, but is harder to customize in cases like:\n- a dedicated notification column independent of selection,\n- custom sizing, or\n- different toolbar behaviors per column.
+
+```swift
+@MainActor
+struct AppView: View {
+  var body: some View {
+    NavigationSplitView {
+      SidebarView()
+    } content: {
+      MainContentView()
+    } detail: {
+      NotificationsView()
+    }
+  }
+}
+```
+
+## When to choose which
+
+- Use the manual HStack split when you need full control or a non-standard secondary column.
+- Use `NavigationSplitView` when you want a standard system layout with minimal customization.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/tabview.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/tabview.md
@@ -1,0 +1,114 @@
+# TabView
+
+## Intent
+
+Use this pattern for a scalable, multi-platform tab architecture with:
+- a single source of truth for tab identity and content,
+- platform-specific tab sets and sidebar sections,
+- dynamic tabs sourced from data,
+- an interception hook for special tabs (e.g., compose).
+
+## Core architecture
+
+- `AppTab` enum defines identity, labels, icons, and content builder.
+- `SidebarSections` enum groups tabs for sidebar sections.
+- `AppView` owns the `TabView` and selection binding, and routes tab changes through `updateTab`.
+
+## Example: custom binding with side effects
+
+Use this when tab selection needs side effects, like intercepting a special tab to perform an action instead of changing selection.
+
+```swift
+@MainActor
+struct AppView: View {
+  @Binding var selectedTab: AppTab
+
+  var body: some View {
+    TabView(selection: .init(
+      get: { selectedTab },
+      set: { updateTab(with: $0) }
+    )) {
+      ForEach(availableSections) { section in
+        TabSection(section.title) {
+          ForEach(section.tabs) { tab in
+            Tab(value: tab) {
+              tab.makeContentView(
+                homeTimeline: $timeline,
+                selectedTab: $selectedTab,
+                pinnedFilters: $pinnedFilters
+              )
+            } label: {
+              tab.label
+            }
+            .tabPlacement(tab.tabPlacement)
+          }
+        }
+        .tabPlacement(.sidebarOnly)
+      }
+    }
+  }
+
+  private func updateTab(with newTab: AppTab) {
+    if newTab == .post {
+      // Intercept special tabs (compose) instead of changing selection.
+      presentComposer()
+      return
+    }
+    selectedTab = newTab
+  }
+}
+```
+
+## Example: direct binding without side effects
+
+Use this when selection is purely state-driven.
+
+```swift
+@MainActor
+struct AppView: View {
+  @Binding var selectedTab: AppTab
+
+  var body: some View {
+    TabView(selection: $selectedTab) {
+      ForEach(availableSections) { section in
+        TabSection(section.title) {
+          ForEach(section.tabs) { tab in
+            Tab(value: tab) {
+              tab.makeContentView(
+                homeTimeline: $timeline,
+                selectedTab: $selectedTab,
+                pinnedFilters: $pinnedFilters
+              )
+            } label: {
+              tab.label
+            }
+            .tabPlacement(tab.tabPlacement)
+          }
+        }
+        .tabPlacement(.sidebarOnly)
+      }
+    }
+  }
+}
+```
+
+## Design choices to keep
+
+- Centralize tab identity and content in `AppTab` with `makeContentView(...)`.
+- Use `Tab(value:)` with `selection` binding for state-driven tab selection.
+- Route selection changes through `updateTab` to handle special tabs and scroll-to-top behavior.
+- Use `TabSection` + `.tabPlacement(.sidebarOnly)` for sidebar structure.
+- Use `.tabPlacement(.pinned)` in `AppTab.tabPlacement` for a single pinned tab; this is commonly used for iOS 26 `.searchable` tab content, but can be used for any tab.
+
+## Dynamic tabs pattern
+
+- `SidebarSections` handles dynamic data tabs.
+- `AppTab.anyTimelineFilter(filter:)` wraps dynamic tabs in a single enum case.
+- The enum provides label/icon/title for dynamic tabs via the filter type.
+
+## Pitfalls
+
+- Avoid adding ViewModels for tabs; keep state local or in `@Observable` services.
+- Do not nest `@Observable` objects inside other `@Observable` objects.
+- Ensure `AppTab.id` values are stable; dynamic cases should hash on stable IDs.
+- Special tabs (compose) should not change selection.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/theming.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/theming.md
@@ -1,0 +1,71 @@
+# Theming and dynamic type
+
+## Intent
+
+Provide a clean, scalable theming approach that keeps view code semantic and consistent.
+
+## Core patterns
+
+- Use a single `Theme` object as the source of truth (colors, fonts, spacing).
+- Inject theme at the app root and read it via `@Environment(Theme.self)` in views.
+- Prefer semantic colors (`primaryBackground`, `secondaryBackground`, `label`, `tint`) instead of raw colors.
+- Keep user-facing theme controls in a dedicated settings screen.
+- Apply Dynamic Type scaling through custom fonts or `.font(.scaled...)`.
+
+## Example: Theme object
+
+```swift
+@MainActor
+@Observable
+final class Theme {
+  var tintColor: Color = .blue
+  var primaryBackground: Color = .white
+  var secondaryBackground: Color = .gray.opacity(0.1)
+  var labelColor: Color = .primary
+  var fontSizeScale: Double = 1.0
+}
+```
+
+## Example: inject at app root
+
+```swift
+@main
+struct MyApp: App {
+  @State private var theme = Theme()
+
+  var body: some Scene {
+    WindowGroup {
+      AppView()
+        .environment(theme)
+    }
+  }
+}
+```
+
+## Example: view usage
+
+```swift
+struct ProfileView: View {
+  @Environment(Theme.self) private var theme
+
+  var body: some View {
+    VStack {
+      Text("Profile")
+        .foregroundStyle(theme.labelColor)
+    }
+    .background(theme.primaryBackground)
+  }
+}
+```
+
+## Design choices to keep
+
+- Keep theme values semantic and minimal; avoid duplicating system colors.
+- Store user-selected theme values in persistent storage if needed.
+- Ensure contrast between text and backgrounds.
+
+## Pitfalls
+
+- Avoid sprinkling raw `Color` values in views; it breaks consistency.
+- Do not tie theme to a single view’s local state.
+- Avoid using `@Environment(\\.colorScheme)` as the only theme control; it should complement your theme.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/title-menus.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/title-menus.md
@@ -1,0 +1,93 @@
+# Title menus
+
+## Intent
+
+Use a title menu in the navigation bar to provide context‑specific filtering or quick actions without adding extra chrome.
+
+## Core patterns
+
+- Use `ToolbarTitleMenu` to attach a menu to the navigation title.
+- Keep the menu content compact and grouped with dividers.
+
+## Example: title menu for filters
+
+```swift
+@ToolbarContentBuilder
+private var toolbarView: some ToolbarContent {
+  ToolbarTitleMenu {
+    Button("Latest") { timeline = .latest }
+    Button("Resume") { timeline = .resume }
+    Divider()
+    Button("Local") { timeline = .local }
+    Button("Federated") { timeline = .federated }
+  }
+}
+```
+
+## Example: attach to a view
+
+```swift
+NavigationStack {
+  TimelineView()
+    .toolbar {
+      toolbarView
+    }
+}
+```
+
+## Example: title + menu together
+
+```swift
+struct TimelineScreen: View {
+  @State private var timeline: TimelineFilter = .home
+
+  var body: some View {
+    NavigationStack {
+      TimelineView()
+        .toolbar {
+          ToolbarItem(placement: .principal) {
+            VStack(spacing: 2) {
+              Text(timeline.title)
+                .font(.headline)
+              Text(timeline.subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          ToolbarTitleMenu {
+            Button("Home") { timeline = .home }
+            Button("Local") { timeline = .local }
+            Button("Federated") { timeline = .federated }
+          }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+  }
+}
+```
+
+## Example: title + subtitle with menu
+
+```swift
+ToolbarItem(placement: .principal) {
+  VStack(spacing: 2) {
+    Text(title)
+      .font(.headline)
+    Text(subtitle)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+  }
+}
+```
+
+## Design choices to keep
+
+- Only show the title menu when filtering or context switching is available.
+- Keep the title readable; avoid long labels that truncate.
+- Use secondary text below the title if extra context is needed.
+
+## Pitfalls
+
+- Don’t overload the menu with too many options.
+- Avoid using title menus for destructive actions.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/top-bar.md
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/references/top-bar.md
@@ -1,0 +1,49 @@
+# Top bar overlays (iOS 26+ and fallback)
+
+## Intent
+
+Provide a custom top selector or pill row that sits above scroll content, using `safeAreaBar(.top)` on iOS 26 and a compatible fallback on earlier OS versions.
+
+## iOS 26+ approach
+
+Use `safeAreaBar(edge: .top)` to attach the view to the safe area bar.
+
+```swift
+if #available(iOS 26.0, *) {
+  content
+    .safeAreaBar(edge: .top) {
+      TopSelectorView()
+        .padding(.horizontal, .layoutPadding)
+    }
+}
+```
+
+## Fallback for earlier iOS
+
+Use `.safeAreaInset(edge: .top)` and hide the toolbar background to avoid double layers.
+
+```swift
+content
+  .toolbarBackground(.hidden, for: .navigationBar)
+  .safeAreaInset(edge: .top, spacing: 0) {
+    VStack(spacing: 0) {
+      TopSelectorView()
+        .padding(.vertical, 8)
+        .padding(.horizontal, .layoutPadding)
+        .background(Color.primary.opacity(0.06))
+        .background(Material.ultraThin)
+      Divider()
+    }
+  }
+```
+
+## Design choices to keep
+
+- Use `safeAreaBar` when available; it integrates better with the navigation bar.
+- Use a subtle background + divider in the fallback to keep separation from content.
+- Keep the selector height compact to avoid pushing content too far down.
+
+## Pitfalls
+
+- Don’t stack multiple top insets; it can create extra padding.
+- Avoid heavy, opaque backgrounds that fight the navigation bar.

--- a/skills/ios-swiftui-toolkit/swiftui-ui-patterns/skill-report.json
+++ b/skills/ios-swiftui-toolkit/swiftui-ui-patterns/skill-report.json
@@ -1,0 +1,2152 @@
+{
+  "schema_version": "2.0",
+  "meta": {
+    "generated_at": "2026-01-17T04:11:46.146Z",
+    "slug": "dimillian-swiftui-ui-patterns",
+    "source_url": "https://github.com/Dimillian/Skills/tree/main/swiftui-ui-patterns",
+    "source_ref": "main",
+    "model": "claude",
+    "analysis_version": "3.0.0",
+    "source_type": "community",
+    "content_hash": "fa53c6b11cb374c6bc0c07cba245fd56d9f4d684054cdec89eeae29c1cce910d",
+    "tree_hash": "bf94913f86f97a1f06aae03e5540dec61d1fd65d3f5e82624f856062cfb6bb9b"
+  },
+  "skill": {
+    "name": "swiftui-ui-patterns",
+    "description": "Best practices and example-driven guidance for building SwiftUI views and components. Use when creating or refactoring SwiftUI UI, designing tab architecture with TabView, composing screens, or needing component-specific patterns and examples.",
+    "summary": "Best practices and example-driven guidance for building SwiftUI views and components. Use when creat...",
+    "icon": "uiwins",
+    "version": "1.0.0",
+    "author": "Dimillian",
+    "license": "MIT",
+    "category": "design",
+    "tags": [
+      "swiftui",
+      "ios",
+      "macos",
+      "mobile-development",
+      "user-interface"
+    ],
+    "supported_tools": [
+      "claude",
+      "codex",
+      "claude-code"
+    ],
+    "risk_factors": [
+      "external_commands",
+      "network"
+    ]
+  },
+  "security_audit": {
+    "risk_level": "safe",
+    "is_blocked": false,
+    "safe_to_publish": true,
+    "summary": "Pure documentation skill containing only Markdown files with SwiftUI best practices and code examples. No executable code, scripts, network calls, file system access, or command execution capabilities. All 498 static findings are false positives from markdown documentation being misinterpreted by pattern-based scanning.",
+    "risk_factor_evidence": [
+      {
+        "factor": "external_commands",
+        "evidence": [
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 15,
+            "line_end": 40
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 40,
+            "line_end": 42
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 42,
+            "line_end": 44
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 44,
+            "line_end": 68
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 68,
+            "line_end": 72
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 72,
+            "line_end": 83
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 83,
+            "line_end": 89
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 89,
+            "line_end": 136
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 136,
+            "line_end": 139
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 139,
+            "line_end": 145
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 145,
+            "line_end": 147
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 147,
+            "line_end": 153
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 153,
+            "line_end": 161
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 161,
+            "line_end": 180
+          },
+          {
+            "file": "references/app-wiring.md",
+            "line_start": 180,
+            "line_end": 193
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 7,
+            "line_end": 7
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 8,
+            "line_end": 8
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 14,
+            "line_end": 14
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 16,
+            "line_end": 16
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 17,
+            "line_end": 17
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 18,
+            "line_end": 18
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 19,
+            "line_end": 19
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 20,
+            "line_end": 20
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 21,
+            "line_end": 21
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 22,
+            "line_end": 22
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 23,
+            "line_end": 23
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 24,
+            "line_end": 24
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 26,
+            "line_end": 26
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 27,
+            "line_end": 27
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 28,
+            "line_end": 28
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 30,
+            "line_end": 30
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 31,
+            "line_end": 31
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 35,
+            "line_end": 35
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 36,
+            "line_end": 36
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 37,
+            "line_end": 37
+          },
+          {
+            "file": "references/components-index.md",
+            "line_start": 38,
+            "line_end": 38
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 17,
+            "line_end": 25
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 25,
+            "line_end": 29
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 29,
+            "line_end": 35
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 35,
+            "line_end": 39
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 39,
+            "line_end": 45
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 45,
+            "line_end": 49
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 49,
+            "line_end": 50
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 50,
+            "line_end": 51
+          },
+          {
+            "file": "references/controls.md",
+            "line_start": 51,
+            "line_end": 55
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 16,
+            "line_end": 36
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 36,
+            "line_end": 40
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 40,
+            "line_end": 55
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 55,
+            "line_end": 61
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 61,
+            "line_end": 61
+          },
+          {
+            "file": "references/deeplinks.md",
+            "line_start": 61,
+            "line_end": 66
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 16,
+            "line_end": 29
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 29,
+            "line_end": 33
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 33,
+            "line_end": 51
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 51,
+            "line_end": 55
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 55,
+            "line_end": 79
+          },
+          {
+            "file": "references/focus.md",
+            "line_start": 79,
+            "line_end": 85
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 17,
+            "line_end": 43
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 43,
+            "line_end": 47
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 47,
+            "line_end": 85
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 85,
+            "line_end": 89
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 89,
+            "line_end": 90
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 90,
+            "line_end": 90
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 90,
+            "line_end": 95
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 95,
+            "line_end": 96
+          },
+          {
+            "file": "references/form.md",
+            "line_start": 96,
+            "line_end": 96
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 16,
+            "line_end": 39
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 39,
+            "line_end": 43
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 43,
+            "line_end": 60
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 60,
+            "line_end": 64
+          },
+          {
+            "file": "references/grids.md",
+            "line_start": 64,
+            "line_end": 65
+          },
+          {
+            "file": "references/haptics.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/haptics.md",
+            "line_start": 15,
+            "line_end": 47
+          },
+          {
+            "file": "references/haptics.md",
+            "line_start": 47,
+            "line_end": 51
+          },
+          {
+            "file": "references/haptics.md",
+            "line_start": 51,
+            "line_end": 60
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 16,
+            "line_end": 40
+          },
+          {
+            "file": "references/input-toolbar.md",
+            "line_start": 40,
+            "line_end": 45
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 11,
+            "line_end": 30
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 30,
+            "line_end": 33
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 33,
+            "line_end": 56
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 56,
+            "line_end": 58
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 58,
+            "line_end": 69
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 69,
+            "line_end": 71
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 71,
+            "line_end": 83
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 83,
+            "line_end": 87
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 87,
+            "line_end": 88
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 88,
+            "line_end": 89
+          },
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 89,
+            "line_end": 93
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 14,
+            "line_end": 14
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 16,
+            "line_end": 16
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 20,
+            "line_end": 54
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 54,
+            "line_end": 58
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 58,
+            "line_end": 74
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 74,
+            "line_end": 78
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 78,
+            "line_end": 80
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 80,
+            "line_end": 81
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 81,
+            "line_end": 85
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 85,
+            "line_end": 85
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 85,
+            "line_end": 85
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 85,
+            "line_end": 86
+          },
+          {
+            "file": "references/list.md",
+            "line_start": 86,
+            "line_end": 86
+          },
+          {
+            "file": "references/loading-placeholders.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/loading-placeholders.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/loading-placeholders.md",
+            "line_start": 25,
+            "line_end": 38
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 17,
+            "line_end": 31
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 31,
+            "line_end": 35
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 35,
+            "line_end": 60
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 60,
+            "line_end": 64
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 64,
+            "line_end": 64
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 64,
+            "line_end": 66
+          },
+          {
+            "file": "references/macos-settings.md",
+            "line_start": 66,
+            "line_end": 71
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 16,
+            "line_end": 30
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 30,
+            "line_end": 34
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 34,
+            "line_end": 48
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 48,
+            "line_end": 52
+          },
+          {
+            "file": "references/matched-transitions.md",
+            "line_start": 52,
+            "line_end": 54
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 16,
+            "line_end": 46
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 46,
+            "line_end": 50
+          },
+          {
+            "file": "references/media.md",
+            "line_start": 50,
+            "line_end": 62
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 17,
+            "line_end": 37
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 37,
+            "line_end": 41
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 41,
+            "line_end": 58
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 58,
+            "line_end": 62
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 62,
+            "line_end": 91
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 91,
+            "line_end": 95
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 95,
+            "line_end": 96
+          },
+          {
+            "file": "references/menu-bar.md",
+            "line_start": 96,
+            "line_end": 96
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 17,
+            "line_end": 55
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 55,
+            "line_end": 61
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 61,
+            "line_end": 74
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 74,
+            "line_end": 78
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 78,
+            "line_end": 83
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 83,
+            "line_end": 87
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 87,
+            "line_end": 100
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 100,
+            "line_end": 106
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 106,
+            "line_end": 125
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 125,
+            "line_end": 147
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 147,
+            "line_end": 148
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 148,
+            "line_end": 149
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 149,
+            "line_end": 157
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 157,
+            "line_end": 159
+          },
+          {
+            "file": "references/overlay.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/overlay.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/overlay.md",
+            "line_start": 15,
+            "line_end": 34
+          },
+          {
+            "file": "references/overlay.md",
+            "line_start": 34,
+            "line_end": 40
+          },
+          {
+            "file": "references/overlay.md",
+            "line_start": 40,
+            "line_end": 40
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 17,
+            "line_end": 47
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 47,
+            "line_end": 51
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 51,
+            "line_end": 59
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 59,
+            "line_end": 63
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 63,
+            "line_end": 74
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 74,
+            "line_end": 78
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 78,
+            "line_end": 80
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 80,
+            "line_end": 81
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 81,
+            "line_end": 86
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 86,
+            "line_end": 86
+          },
+          {
+            "file": "references/scrollview.md",
+            "line_start": 86,
+            "line_end": 87
+          },
+          {
+            "file": "references/searchable.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/searchable.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/searchable.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/searchable.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/searchable.md",
+            "line_start": 16,
+            "line_end": 60
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 12,
+            "line_end": 12
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 16,
+            "line_end": 35
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 35,
+            "line_end": 39
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 39,
+            "line_end": 60
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 60,
+            "line_end": 64
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 64,
+            "line_end": 74
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 74,
+            "line_end": 80
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 80,
+            "line_end": 80
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 80,
+            "line_end": 81
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 81,
+            "line_end": 83
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 83,
+            "line_end": 87
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 87,
+            "line_end": 89
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 89,
+            "line_end": 100
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 100,
+            "line_end": 105
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 105,
+            "line_end": 106
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 106,
+            "line_end": 111
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 111,
+            "line_end": 111
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 111,
+            "line_end": 112
+          },
+          {
+            "file": "references/sheets.md",
+            "line_start": 112,
+            "line_end": 113
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 11,
+            "line_end": 42
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 42,
+            "line_end": 47
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 47,
+            "line_end": 52
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 52,
+            "line_end": 54
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 54,
+            "line_end": 67
+          },
+          {
+            "file": "references/split-views.md",
+            "line_start": 67,
+            "line_end": 72
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 14,
+            "line_end": 14
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 21,
+            "line_end": 60
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 60,
+            "line_end": 66
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 66,
+            "line_end": 93
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 93,
+            "line_end": 97
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 97,
+            "line_end": 97
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 97,
+            "line_end": 98
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 98,
+            "line_end": 98
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 98,
+            "line_end": 99
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 99,
+            "line_end": 100
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 100,
+            "line_end": 100
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 100,
+            "line_end": 101
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 101,
+            "line_end": 101
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 101,
+            "line_end": 101
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 101,
+            "line_end": 105
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 105,
+            "line_end": 106
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 106,
+            "line_end": 111
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 111,
+            "line_end": 112
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 112,
+            "line_end": 112
+          },
+          {
+            "file": "references/tabview.md",
+            "line_start": 112,
+            "line_end": 113
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 11,
+            "line_end": 11
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 13,
+            "line_end": 13
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 17,
+            "line_end": 27
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 27,
+            "line_end": 31
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 31,
+            "line_end": 43
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 43,
+            "line_end": 47
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 47,
+            "line_end": 59
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 59,
+            "line_end": 69
+          },
+          {
+            "file": "references/theming.md",
+            "line_start": 69,
+            "line_end": 71
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 14,
+            "line_end": 25
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 25,
+            "line_end": 29
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 29,
+            "line_end": 36
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 36,
+            "line_end": 40
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 40,
+            "line_end": 68
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 68,
+            "line_end": 72
+          },
+          {
+            "file": "references/title-menus.md",
+            "line_start": 72,
+            "line_end": 82
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 5,
+            "line_end": 5
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 11,
+            "line_end": 19
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 19,
+            "line_end": 23
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 23,
+            "line_end": 25
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 25,
+            "line_end": 38
+          },
+          {
+            "file": "references/top-bar.md",
+            "line_start": 38,
+            "line_end": 42
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 17,
+            "line_end": 17
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 22,
+            "line_end": 22
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 23,
+            "line_end": 23
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 23,
+            "line_end": 23
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 29,
+            "line_end": 29
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 31,
+            "line_end": 31
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 34,
+            "line_end": 34
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 39,
+            "line_end": 39
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 41,
+            "line_end": 41
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 47,
+            "line_end": 47
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 57,
+            "line_end": 63
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 63,
+            "line_end": 67
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 67,
+            "line_end": 89
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 89,
+            "line_end": 93
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 93,
+            "line_end": 95
+          }
+        ]
+      },
+      {
+        "factor": "network",
+        "evidence": [
+          {
+            "file": "references/lightweight-clients.md",
+            "line_start": 18,
+            "line_end": 18
+          },
+          {
+            "file": "references/navigationstack.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "skill-report.json",
+            "line_start": 6,
+            "line_end": 6
+          }
+        ]
+      }
+    ],
+    "critical_findings": [],
+    "high_findings": [],
+    "medium_findings": [],
+    "low_findings": [],
+    "dangerous_patterns": [],
+    "files_scanned": 28,
+    "total_lines": 2574,
+    "audit_model": "claude",
+    "audited_at": "2026-01-17T04:11:46.146Z"
+  },
+  "content": {
+    "user_title": "Build SwiftUI Views with Best Patterns",
+    "value_statement": "Creating SwiftUI views requires understanding navigation architecture, component patterns, and state management. This skill provides ready-to-use patterns for tabs, sheets, lists, grids, and more so you can ship faster with fewer bugs.",
+    "seo_keywords": [
+      "SwiftUI patterns",
+      "SwiftUI components",
+      "iOS development",
+      "macOS development",
+      "SwiftUI navigation",
+      "TabView patterns",
+      "Claude Code",
+      "Claude",
+      "Codex",
+      "SwiftUI best practices"
+    ],
+    "actual_capabilities": [
+      "Provide patterns for TabView architecture with per-tab navigation stacks",
+      "Show sheet routing with enum-driven centralized sheet presentation",
+      "Demonstrate form and settings patterns with proper focus management",
+      "Guide on grids, lists, and scroll views for efficient layouts",
+      "Explain deep link routing and programmatic navigation",
+      "Show theming, haptics, and media handling patterns"
+    ],
+    "limitations": [
+      "Does not generate complete SwiftUI project files",
+      "Does not provide backend API integration code",
+      "Does not include unit tests or test utilities",
+      "Does not cover SwiftUI accessibility beyond basic labels"
+    ],
+    "use_cases": [
+      {
+        "target_user": "iOS Developers",
+        "title": "Architect Tab Navigation",
+        "description": "Set up scalable TabView with per-tab NavigationStack and route enums for clean navigation state."
+      },
+      {
+        "target_user": "SwiftUI Beginners",
+        "title": "Implement Sheets Properly",
+        "description": "Replace prop-drilling sheet bindings with centralized enum-driven sheet routing pattern."
+      },
+      {
+        "target_user": "App Maintainers",
+        "title": "Refactor Legacy Views",
+        "description": "Modernize older SwiftUI code using modern state primitives like @Observable and @Environment."
+      }
+    ],
+    "prompt_templates": [
+      {
+        "title": "Basic Tab Setup",
+        "scenario": "Need tab architecture",
+        "prompt": "Show me how to set up a TabView with multiple tabs that each have their own NavigationStack and independent navigation history."
+      },
+      {
+        "title": "Sheet Routing",
+        "scenario": "Centralize modals",
+        "prompt": "How do I create a centralized sheet routing pattern using an enum so any view can present modals without passing bindings through many layers?"
+      },
+      {
+        "title": "List Performance",
+        "scenario": "Optimize scrolling",
+        "prompt": "What are the best patterns for building efficient Lists and ScrollViews with pull-to-refresh, scroll-to-top, and proper row reuse?"
+      },
+      {
+        "title": "Form Validation",
+        "scenario": "Input handling",
+        "prompt": "Show me how to implement form validation with proper focus state management, keyboard handling, and accessibility in SwiftUI."
+      }
+    ],
+    "output_examples": [
+      {
+        "input": "How do I implement a settings form with proper theming and keyboard focus management?",
+        "output": [
+          "Use a Form inside NavigationStack with @FocusState for field management",
+          "Apply .scrollContentBackground(.hidden) to customize the background",
+          "Group controls in Section blocks for visual organization",
+          "Use .onSubmit to chain focus between fields",
+          "Inject theme via @Environment(Theme.self) for consistent styling"
+        ]
+      },
+      {
+        "input": "How do I handle deep links in a multi-tab app?",
+        "output": [
+          "Define a Route enum that maps URL paths to destination views",
+          "Create a router per tab that maintains independent NavigationStack path",
+          "Use NavigationPath for type-erased navigation state",
+          "Handle incoming URLs by parsing path and selecting appropriate tab and route",
+          "Call router.navigate(to:) to programmatically push destinations"
+        ]
+      }
+    ],
+    "best_practices": [
+      "Keep views small and focused on a single responsibility",
+      "Use @Environment for shared dependencies instead of prop-drilling",
+      "Prefer @Observable and modern state over older view models",
+      "Centralize navigation state in a router object per tab"
+    ],
+    "anti_patterns": [
+      "Avoid mixing sheet(isPresented:) and sheet(item:) for the same concern",
+      "Do not nest @Observable objects inside other @Observable objects",
+      "Avoid storing view instances in navigation paths; use lightweight route data",
+      "Do not use raw Color values throughout views; use semantic theme colors"
+    ],
+    "faq": [
+      {
+        "question": "Which SwiftUI versions are supported?",
+        "answer": "Patterns target iOS 17+ and macOS 14+ with some iOS 18+ specific APIs noted."
+      },
+      {
+        "question": "How many items can Lists handle efficiently?",
+        "answer": "Use List for long content with built-in row reuse. For custom layouts prefer ScrollView + LazyVStack."
+      },
+      {
+        "question": "Can I use these patterns with third-party libraries?",
+        "answer": "Patterns are framework-agnostic and integrate with any SwiftUI-compatible navigation solution."
+      },
+      {
+        "question": "Is my data safe when using these patterns?",
+        "answer": "These are view-layer patterns with no network or storage access. Data safety depends on your implementation."
+      },
+      {
+        "question": "Why does my sheet not dismiss properly?",
+        "answer": "Use .sheet(item:) instead of .sheet(isPresented:) when state represents a selected model. Avoid if let inside sheet body."
+      },
+      {
+        "question": "How do these patterns compare to UIKit?",
+        "answer": "SwiftUI patterns favor declarative state over imperative updates. NavigationStack replaces UINavigationController."
+      }
+    ]
+  },
+  "file_structure": [
+    {
+      "name": "references",
+      "type": "dir",
+      "path": "references",
+      "children": [
+        {
+          "name": "app-wiring.md",
+          "type": "file",
+          "path": "references/app-wiring.md",
+          "lines": 195
+        },
+        {
+          "name": "components-index.md",
+          "type": "file",
+          "path": "references/components-index.md",
+          "lines": 44
+        },
+        {
+          "name": "controls.md",
+          "type": "file",
+          "path": "references/controls.md",
+          "lines": 58
+        },
+        {
+          "name": "deeplinks.md",
+          "type": "file",
+          "path": "references/deeplinks.md",
+          "lines": 67
+        },
+        {
+          "name": "focus.md",
+          "type": "file",
+          "path": "references/focus.md",
+          "lines": 91
+        },
+        {
+          "name": "form.md",
+          "type": "file",
+          "path": "references/form.md",
+          "lines": 98
+        },
+        {
+          "name": "grids.md",
+          "type": "file",
+          "path": "references/grids.md",
+          "lines": 72
+        },
+        {
+          "name": "haptics.md",
+          "type": "file",
+          "path": "references/haptics.md",
+          "lines": 72
+        },
+        {
+          "name": "input-toolbar.md",
+          "type": "file",
+          "path": "references/input-toolbar.md",
+          "lines": 52
+        },
+        {
+          "name": "lightweight-clients.md",
+          "type": "file",
+          "path": "references/lightweight-clients.md",
+          "lines": 94
+        },
+        {
+          "name": "list.md",
+          "type": "file",
+          "path": "references/list.md",
+          "lines": 87
+        },
+        {
+          "name": "loading-placeholders.md",
+          "type": "file",
+          "path": "references/loading-placeholders.md",
+          "lines": 39
+        },
+        {
+          "name": "macos-settings.md",
+          "type": "file",
+          "path": "references/macos-settings.md",
+          "lines": 72
+        },
+        {
+          "name": "matched-transitions.md",
+          "type": "file",
+          "path": "references/matched-transitions.md",
+          "lines": 60
+        },
+        {
+          "name": "media.md",
+          "type": "file",
+          "path": "references/media.md",
+          "lines": 74
+        },
+        {
+          "name": "menu-bar.md",
+          "type": "file",
+          "path": "references/menu-bar.md",
+          "lines": 102
+        },
+        {
+          "name": "navigationstack.md",
+          "type": "file",
+          "path": "references/navigationstack.md",
+          "lines": 160
+        },
+        {
+          "name": "overlay.md",
+          "type": "file",
+          "path": "references/overlay.md",
+          "lines": 46
+        },
+        {
+          "name": "scrollview.md",
+          "type": "file",
+          "path": "references/scrollview.md",
+          "lines": 88
+        },
+        {
+          "name": "searchable.md",
+          "type": "file",
+          "path": "references/searchable.md",
+          "lines": 72
+        },
+        {
+          "name": "sheets.md",
+          "type": "file",
+          "path": "references/sheets.md",
+          "lines": 114
+        },
+        {
+          "name": "split-views.md",
+          "type": "file",
+          "path": "references/split-views.md",
+          "lines": 73
+        },
+        {
+          "name": "tabview.md",
+          "type": "file",
+          "path": "references/tabview.md",
+          "lines": 115
+        },
+        {
+          "name": "theming.md",
+          "type": "file",
+          "path": "references/theming.md",
+          "lines": 72
+        },
+        {
+          "name": "title-menus.md",
+          "type": "file",
+          "path": "references/title-menus.md",
+          "lines": 94
+        },
+        {
+          "name": "top-bar.md",
+          "type": "file",
+          "path": "references/top-bar.md",
+          "lines": 50
+        }
+      ]
+    },
+    {
+      "name": "SKILL.md",
+      "type": "file",
+      "path": "SKILL.md",
+      "lines": 96
+    }
+  ]
+}

--- a/skills/ios-swiftui-toolkit/swiftui-view-refactor/SKILL.md
+++ b/skills/ios-swiftui-toolkit/swiftui-view-refactor/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: swiftui-view-refactor
+description: Refactor and review SwiftUI view files for consistent structure, dependency injection, and Observation usage. Use when asked to clean up a SwiftUI view’s layout/ordering, handle view models safely (non-optional when possible), or standardize how dependencies and @Observable state are initialized and passed.
+---
+
+# SwiftUI View Refactor
+
+## Overview
+Apply a consistent structure and dependency pattern to SwiftUI views, with a focus on ordering, Model-View (MV) patterns, careful view model handling, and correct Observation usage.
+
+## Core Guidelines
+
+### 1) View ordering (top → bottom)
+- Environment
+- `private`/`public` `let`
+- `@State` / other stored properties
+- computed `var` (non-view)
+- `init`
+- `body`
+- computed view builders / other view helpers
+- helper / async functions
+
+### 2) Prefer MV (Model-View) patterns
+- Default to MV: Views are lightweight state expressions; models/services own business logic.
+- Favor `@State`, `@Environment`, `@Query`, and `task`/`onChange` for orchestration.
+- Inject services and shared models via `@Environment`; keep views small and composable.
+- Split large views into subviews rather than introducing a view model.
+
+### 3) Split large bodies and view properties
+- If `body` grows beyond a screen or has multiple logical sections, split it into smaller subviews.
+- Extract large computed view properties (`var header: some View { ... }`) into dedicated `View` types when they carry state or complex branching.
+- It's fine to keep related subviews as computed view properties in the same file; extract to a standalone `View` struct only when it structurally makes sense or when reuse is intended.
+- Prefer passing small inputs (data, bindings, callbacks) over reusing the entire parent view state.
+
+Example (extracting a section):
+
+```swift
+var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+        HeaderSection(title: title, isPinned: isPinned)
+        DetailsSection(details: details)
+        ActionsSection(onSave: onSave, onCancel: onCancel)
+    }
+}
+```
+
+Example (long body → shorter body + computed views in the same file):
+
+```swift
+var body: some View {
+    List {
+        header
+        filters
+        results
+        footer
+    }
+}
+
+private var header: some View {
+    VStack(alignment: .leading, spacing: 6) {
+        Text(title).font(.title2)
+        Text(subtitle).font(.subheadline)
+    }
+}
+
+private var filters: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+        HStack {
+            ForEach(filterOptions, id: \.self) { option in
+                FilterChip(option: option, isSelected: option == selectedFilter)
+                    .onTapGesture { selectedFilter = option }
+            }
+        }
+    }
+}
+```
+
+Example (extracting a complex computed view):
+
+```swift
+private var header: some View {
+    HeaderSection(title: title, subtitle: subtitle, status: status)
+}
+
+private struct HeaderSection: View {
+    let title: String
+    let subtitle: String?
+    let status: Status
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.headline)
+            if let subtitle { Text(subtitle).font(.subheadline) }
+            StatusBadge(status: status)
+        }
+    }
+}
+```
+
+### 4) View model handling (only if already present)
+- Do not introduce a view model unless the request or existing code clearly calls for one.
+- If a view model exists, make it non-optional when possible.
+- Pass dependencies to the view via `init`, then pass them into the view model in the view's `init`.
+- Avoid `bootstrapIfNeeded` patterns.
+
+Example (Observation-based):
+
+```swift
+@State private var viewModel: SomeViewModel
+
+init(dependency: Dependency) {
+    _viewModel = State(initialValue: SomeViewModel(dependency: dependency))
+}
+```
+
+### 5) Observation usage
+- For `@Observable` reference types, store them as `@State` in the root view.
+- Pass observables down explicitly as needed; avoid optional state unless required.
+
+## Workflow
+
+1) Reorder the view to match the ordering rules.
+2) Favor MV: move lightweight orchestration into the view using `@State`, `@Environment`, `@Query`, `task`, and `onChange`.
+3) If a view model exists, replace optional view models with a non-optional `@State` view model initialized in `init` by passing dependencies from the view.
+4) Confirm Observation usage: `@State` for root `@Observable` view models, no redundant wrappers.
+5) Keep behavior intact: do not change layout or business logic unless requested.
+
+## Notes
+
+- Prefer small, explicit helpers over large conditional blocks.
+- Keep computed view builders below `body` and non-view computed vars above `init`.
+- For MV-first guidance and rationale, see `references/mv-patterns.md`.
+
+## Large-view handling
+
+- When a SwiftUI view file exceeds ~300 lines, split it using extensions to group related helpers. Move async functions and helper functions into dedicated `private` extensions, separated with `// MARK: -` comments that describe their purpose (e.g., `// MARK: - Actions`, `// MARK: - Subviews`, `// MARK: - Helpers`). Keep the main `struct` focused on stored properties, init, and `body`, with view-building computed vars also grouped via marks when the file is long.

--- a/skills/ios-swiftui-toolkit/swiftui-view-refactor/references/mv-patterns.md
+++ b/skills/ios-swiftui-toolkit/swiftui-view-refactor/references/mv-patterns.md
@@ -1,0 +1,314 @@
+# MV Patterns Reference
+
+Source provided by user: "SwiftUI in 2025: Forget MVVM" (Thomas Ricouard).
+
+Use this as guidance when deciding whether to introduce a view model.
+
+Key points:
+- Default to MV: views are lightweight state expressions and orchestration points.
+- Prefer `@State`, `@Environment`, `@Query`, `task`, and `onChange` over view models.
+- Inject services and shared models via `@Environment`; keep logic in services/models.
+- Split large views into smaller views instead of moving logic into a view model.
+- Avoid manual data fetching that duplicates SwiftUI/SwiftData mechanisms.
+- Test models/services and business logic; views should stay simple and declarative.
+
+# SwiftUI in 2025: Forget MVVM
+
+*Let me tell you why*
+
+**Thomas Ricouard**
+10 min read · Jun 2, 2025
+
+---
+
+It’s 2025, and I’m still getting asked the same question:
+
+> “Where are your ViewModels?”
+
+Every time I share this opinion or code from my open-source projects like my BlueSky client **IcySky**, or even the Medium iOS app, developers are surprised to see clean, simple views without a single ViewModel in sight.
+
+Let me be clear:
+
+You don’t need ViewModels in SwiftUI.
+You never did.
+You never will.
+
+---
+
+## The MVVM Trap
+
+When SwiftUI launched in 2019, many developers brought their UIKit baggage with them. We were so used to the *Massive View Controller* problem that we immediately reached for MVVM as our savior.
+
+But SwiftUI isn’t UIKit.
+
+It was designed from the ground up with a different philosophy, highlighted in multiple WWDC sessions like:
+
+- *Data Flow Through SwiftUI (WWDC19)*
+- *Data Essentials in SwiftUI (WWDC20)*
+- *Discover Observation in SwiftUI (WWDC23)*
+
+Those sessions barely mention ViewModels.
+
+Why? Because ViewModels are almost alien to SwiftUI’s data flow model.
+
+SwiftUI views are **structs**, not classes. They are lightweight, disposable, and recreated frequently. Adding a ViewModel means fighting the framework’s core design.
+
+---
+
+## Views as Pure State Expressions
+
+In my latest IcySky app, every view follows the same pattern I’ve advocated for years.
+
+```swift
+struct FeedView: View {
+
+    @Environment(BlueSkyClient.self) private var client
+    @Environment(AppTheme.self) private var theme
+
+    enum ViewState {
+        case loading
+        case error(String)
+        case loaded([Post])
+    }
+
+    @State private var viewState: ViewState = .loading
+    @State private var isRefreshing = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                switch viewState {
+                case .loading:
+                    ProgressView("Loading feed...")
+                        .frame(maxWidth: .infinity)
+                        .listRowSeparator(.hidden)
+
+                case .error(let message):
+                    ErrorStateView(
+                        message: message,
+                        retryAction: { await loadFeed() }
+                    )
+                    .listRowSeparator(.hidden)
+
+                case .loaded(let posts):
+                    ForEach(posts) { post in
+                        PostRowView(post: post)
+                            .listRowInsets(.init())
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .refreshable { await refreshFeed() }
+            .task { await loadFeed() }
+        }
+    }
+}
+```
+
+The state is defined inside the view, using an enum.
+
+No ViewModel.
+No indirection.
+The view is a direct expression of state.
+
+## The Magic of Environment
+
+Instead of dependency injection through ViewModels, SwiftUI gives us @Environment.
+
+```swift
+@Environment(BlueSkyClient.self) private var client
+
+private func loadFeed() async {
+    do {
+        let posts = try await client.getFeed()
+        viewState = .loaded(posts)
+    } catch {
+        viewState = .error(error.localizedDescription)
+    }
+}
+```
+
+Your services live in the environment, are testable in isolation, and encapsulate complexity.
+
+The view orchestrates UI flow — nothing else.
+
+Real-World Complexity
+“This only works for simple apps.”
+
+No.
+
+IcySky handles authentication, complex feeds, navigation, and user interaction — without ViewModels.
+
+The Medium iOS app (millions of users) is now mostly SwiftUI and uses very few ViewModels, most of them legacy from 2019.
+
+For new features, we inject services into the environment and build lightweight views with local state.
+
+Using `.task(id:)` and `.onChange()`
+
+## SwiftUI’s modifiers act as small state reducers.
+
+```swift
+.task(id: searchText) {
+    guard !searchText.isEmpty else { return }
+    await searchFeed(query: searchText)
+}
+.onChange(of: isInSearch, initial: false) {
+    guard !isInSearch else { return }
+    Task { await fetchSuggestedFeed() }
+}
+```
+
+Readable. Local. Explicit.
+
+## App-Level Environment Setup
+
+```swift
+@main
+struct IcySkyApp: App {
+
+    @Environment(\.scenePhase) var scenePhase
+
+    @State var client: BSkyClient?
+    @State var auth: Auth = .init()
+    @State var currentUser: CurrentUser?
+    @State var router: AppRouter = .init(initialTab: .feed)
+
+    var body: some Scene {
+        WindowGroup {
+            TabView(selection: $router.selectedTab) {
+                if client != nil && currentUser != nil {
+                    ForEach(AppTab.allCases) { tab in
+                        AppTabRootView(tab: tab)
+                            .tag(tab)
+                            .toolbarVisibility(.hidden, for: .tabBar)
+                    }
+                } else {
+                    ProgressView()
+                        .containerRelativeFrame([.horizontal, .vertical])
+                }
+            }
+            .environment(client)
+            .environment(currentUser)
+            .environment(auth)
+            .environment(router)
+        }
+    }
+}
+```
+
+All dependencies are injected once and available everywhere.
+
+## SwiftData: The Perfect Example
+SwiftData was built to work directly in views.
+
+```swift
+struct BookListView: View {
+
+    @Query private var books: [Book]
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        List {
+            ForEach(books) { book in
+                BookRowView(book: book)
+                    .swipeActions {
+                        Button("Delete", role: .destructive) {
+                            modelContext.delete(book)
+                        }
+                    }
+            }
+        }
+    }
+}
+```
+
+Now compare that to forcing a ViewModel:
+
+```swift
+@Observable
+class BookListViewModel {
+    private var modelContext: ModelContext
+    var books: [Book] = []
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        fetchBooks()
+    }
+
+    func fetchBooks() {
+        let descriptor = FetchDescriptor<Book>()
+        books = try! modelContext.fetch(descriptor)
+    }
+}
+```
+
+Manual fetching. Manual refresh. Boilerplate everywhere.
+
+You’re fighting the framework.
+
+## Testing Reality
+Testing SwiftUI views provides minimal value.
+
+Instead:
+
+* Unit test services and business logic
+
+* Test models and transformations
+
+* Use SwiftUI previews for visual regression
+
+* Use UI automation for E2E tests
+
+* If needed, use `ViewInspector` for view introspection.
+
+## The 2025 Reality
+
+SwiftUI is mature:
+
+* `@Observable`
+
+* Better Environment
+
+* Improved async & task lifecycle
+
+* Almost everything you need lives inside the view.
+
+I’ll reconsider ViewModels when Apple lets us access Environment outside views.
+
+Until then, vanilla SwiftUI is the canon.
+
+## Why This Matters
+
+Every ViewModel adds:
+
+* More complexity
+
+* More objects to sync
+
+* More indirection
+
+* More cognitive overhead
+
+SwiftUI gives you:
+
+* `@State`
+
+* `@Environment`
+
+* `@Observable`
+
+* Binding
+
+Use them. Trust the framework.
+
+## The Bottom Line
+In 2025, there’s no excuse for cluttering SwiftUI apps with unnecessary ViewModels.
+
+Let views be pure expressions of state.
+
+Focus complexity where it belongs: services and business logic.
+
+Goodbye MVVM 🚮
+Long live the View 👑
+
+Happy coding 🚀

--- a/skills/ios-swiftui-toolkit/swiftui-view-refactor/skill-report.json
+++ b/skills/ios-swiftui-toolkit/swiftui-view-refactor/skill-report.json
@@ -1,0 +1,584 @@
+{
+  "schema_version": "2.0",
+  "meta": {
+    "generated_at": "2026-01-17T04:14:16.842Z",
+    "slug": "dimillian-swiftui-view-refactor",
+    "source_url": "https://github.com/Dimillian/Skills/tree/main/swiftui-view-refactor",
+    "source_ref": "main",
+    "model": "claude",
+    "analysis_version": "3.0.0",
+    "source_type": "community",
+    "content_hash": "252a62d05fa0243ac7450c0ac31db3fec18061b40981f175c60f1406d32df36d",
+    "tree_hash": "bd6af9717148b0942f3cac6eb7c30cbe943c91ffc48818ef1b9bdaa0f47a6877"
+  },
+  "skill": {
+    "name": "swiftui-view-refactor",
+    "description": "Refactor and review SwiftUI view files for consistent structure, dependency injection, and Observation usage. Use when asked to clean up a SwiftUI view’s layout/ordering, handle view models safely (non-optional when possible), or standardize how dependencies and @Observable state are initialized and passed.",
+    "summary": "Refactor and review SwiftUI view files for consistent structure, dependency injection, and Observati...",
+    "icon": "🔄",
+    "version": "1.0.0",
+    "author": "Dimillian",
+    "license": "MIT",
+    "category": "coding",
+    "tags": [
+      "swift",
+      "swiftui",
+      "ios",
+      "refactoring",
+      "apple"
+    ],
+    "supported_tools": [
+      "claude",
+      "codex",
+      "claude-code"
+    ],
+    "risk_factors": [
+      "external_commands",
+      "network"
+    ]
+  },
+  "security_audit": {
+    "risk_level": "safe",
+    "is_blocked": false,
+    "safe_to_publish": true,
+    "summary": "Pure documentation skill containing only markdown files with Swift code examples. No executable code, network calls, file system access, or external command execution. All 94 static findings are false positives triggered by markdown syntax (backticks in code fences, WWDC session titles, SwiftData API names) misidentified as security patterns.",
+    "risk_factor_evidence": [
+      {
+        "factor": "external_commands",
+        "evidence": [
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 9,
+            "line_end": 9
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 10,
+            "line_end": 10
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 62,
+            "line_end": 106
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 106,
+            "line_end": 118
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 118,
+            "line_end": 129
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 129,
+            "line_end": 146
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 146,
+            "line_end": 146
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 146,
+            "line_end": 150
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 150,
+            "line_end": 159
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 159,
+            "line_end": 165
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 165,
+            "line_end": 197
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 197,
+            "line_end": 204
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 204,
+            "line_end": 223
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 223,
+            "line_end": 227
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 227,
+            "line_end": 243
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 243,
+            "line_end": 262
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 262,
+            "line_end": 268
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 268,
+            "line_end": 294
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 294,
+            "line_end": 296
+          },
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 296,
+            "line_end": 298
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 15,
+            "line_end": 15
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 16,
+            "line_end": 16
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 17,
+            "line_end": 17
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 18,
+            "line_end": 18
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 19,
+            "line_end": 19
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 25,
+            "line_end": 25
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 26,
+            "line_end": 26
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 30,
+            "line_end": 30
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 31,
+            "line_end": 31
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 31,
+            "line_end": 31
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 32,
+            "line_end": 32
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 37,
+            "line_end": 45
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 45,
+            "line_end": 49
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 49,
+            "line_end": 76
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 76,
+            "line_end": 80
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 80,
+            "line_end": 98
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 98,
+            "line_end": 103
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 103,
+            "line_end": 103
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 103,
+            "line_end": 104
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 104,
+            "line_end": 108
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 108,
+            "line_end": 114
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 114,
+            "line_end": 117
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 117,
+            "line_end": 117
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 117,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 123
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 123,
+            "line_end": 124
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 124,
+            "line_end": 124
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 124,
+            "line_end": 125
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 125,
+            "line_end": 125
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 125,
+            "line_end": 131
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 131,
+            "line_end": 131
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 131,
+            "line_end": 132
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 132,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          },
+          {
+            "file": "SKILL.md",
+            "line_start": 136,
+            "line_end": 136
+          }
+        ]
+      },
+      {
+        "factor": "network",
+        "evidence": [
+          {
+            "file": "references/mv-patterns.md",
+            "line_start": 240,
+            "line_end": 240
+          },
+          {
+            "file": "skill-report.json",
+            "line_start": 6,
+            "line_end": 6
+          }
+        ]
+      }
+    ],
+    "critical_findings": [],
+    "high_findings": [],
+    "medium_findings": [],
+    "low_findings": [],
+    "dangerous_patterns": [],
+    "files_scanned": 3,
+    "total_lines": 642,
+    "audit_model": "claude",
+    "audited_at": "2026-01-17T04:14:16.842Z"
+  },
+  "content": {
+    "user_title": "Refactor SwiftUI Views",
+    "value_statement": "SwiftUI views often become disorganized with inconsistent property ordering and mixed responsibilities. This skill applies a consistent structure to views by enforcing proper ordering, favoring MV patterns over view models, and ensuring correct Observation usage.",
+    "seo_keywords": [
+      "SwiftUI",
+      "refactoring",
+      "Swift",
+      "iOS development",
+      "view refactor",
+      "Claude",
+      "Codex",
+      "Claude Code",
+      "MV pattern",
+      "Observation"
+    ],
+    "actual_capabilities": [
+      "Reorder SwiftUI view properties according to documented hierarchy (Environment, let, @State, computed vars, init, body, helpers)",
+      "Apply MV (Model-View) patterns favoring @State, @Environment, and @Query over traditional view models",
+      "Split large view bodies into smaller subviews and computed view properties",
+      "Handle existing view models by making them non-optional and properly initialized",
+      "Verify correct @Observable state usage with proper @State storage in root views",
+      "Organize large files using Swift extensions with MARK comments"
+    ],
+    "limitations": [
+      "Does not modify business logic or layout unless explicitly requested",
+      "Does not introduce view models when none exist; only refactors existing patterns",
+      "Does not generate new SwiftUI code from scratch; only refactors provided code",
+      "Does not handle cross-file refactoring or dependency graph analysis"
+    ],
+    "use_cases": [
+      {
+        "target_user": "iOS Developers",
+        "title": "Clean Codebase",
+        "description": "Standardize SwiftUI view structure across an existing iOS codebase for team consistency."
+      },
+      {
+        "target_user": "Code Reviewers",
+        "title": "Review Patterns",
+        "description": "Validate that submitted views follow established MV patterns and observation best practices."
+      },
+      {
+        "target_user": "Migration Teams",
+        "title": "Modernize Views",
+        "description": "Update legacy SwiftUI code to use modern @Observable patterns instead of Combine-based view models."
+      }
+    ],
+    "prompt_templates": [
+      {
+        "title": "Basic Refactor",
+        "scenario": "Clean a single view",
+        "prompt": "Refactor this SwiftUI view using the MV pattern. Reorder properties, split large body sections, and ensure proper @State usage for @Observable models."
+      },
+      {
+        "title": "View Model Cleanup",
+        "scenario": "Fix view model handling",
+        "prompt": "Review this view's view model usage. Replace optional view models with non-optional @State, initialize properly in init, and verify dependency injection."
+      },
+      {
+        "title": "Large View Split",
+        "scenario": "Split complex views",
+        "prompt": "This view is over 300 lines. Split it into subviews using computed properties and extensions with MARK comments. Keep the original behavior intact."
+      },
+      {
+        "title": "Full Audit",
+        "scenario": "Complete pattern review",
+        "prompt": "Perform a complete review: verify view ordering, confirm MV patterns, check Observation usage, ensure no redundant wrappers, and validate dependency injection via @Environment."
+      }
+    ],
+    "output_examples": [
+      {
+        "input": "Refactor this SwiftUI view to follow MV patterns and split the body.",
+        "output": [
+          "✓ Reordered properties: Environment → let → @State → computed vars → init → body → helpers",
+          "✓ Extracted List sections into computed view properties: header, filters, results, footer",
+          "✓ Changed optional @StateObject to @State with non-optional @Observable view model",
+          "✓ Verified dependencies injected via init, not bootstrapIfNeeded",
+          "✓ Split file into extensions: Main View, Subviews, Actions, Helpers with MARK comments"
+        ]
+      },
+      {
+        "input": "Review this view for proper Observation usage and suggest improvements.",
+        "output": [
+          "✓ @Observable model correctly stored in @State at root view level",
+          "✓ No redundant @StateObject or @ObservedObject wrappers needed",
+          "✓ Dependencies properly injected via @Environment",
+          "✓ Local state enums used for view state instead of view model properties"
+        ]
+      }
+    ],
+    "best_practices": [
+      "Keep views small and composable; extract sections when body exceeds one screen of content",
+      "Use @Environment for shared services rather than passing dependencies through multiple view levels",
+      "Store @Observable reference types in @State at the root; pass down explicitly as needed"
+    ],
+    "anti_patterns": [
+      "Introducing view models when local @State, @Environment, or @Query would suffice",
+      "Using optional view models with bootstrapIfNeeded patterns instead of proper initialization",
+      "Storing business logic in views rather than services/models"
+    ],
+    "faq": [
+      {
+        "question": "Which SwiftUI versions are supported?",
+        "answer": "Supports iOS 17+ with @Observable. Legacy Combine-based patterns can be modernized during refactor."
+      },
+      {
+        "question": "What are the file size limits?",
+        "answer": "Handles files of any size. Views over 300 lines are automatically split using extensions with MARK comments."
+      },
+      {
+        "question": "Does this integrate with Xcode?",
+        "answer": "This skill works with Claude, Codex, and Claude Code. Use it to generate refactored code that you paste into Xcode."
+      },
+      {
+        "question": "Is my code data safe?",
+        "answer": "Yes. This is a prompt-only skill. Code is processed by the AI model only and never stored externally."
+      },
+      {
+        "question": "Why is my refactor failing?",
+        "answer": "Check that the input is valid SwiftUI code with proper View struct definition. Complex generics or Combine publishers may need manual handling."
+      },
+      {
+        "question": "How is this different from MVVM?",
+        "answer": "This skill follows the MV pattern which is the recommended 2025 approach. Views own local state via @State and use @Environment for dependencies instead of traditional view models."
+      }
+    ]
+  },
+  "file_structure": [
+    {
+      "name": "references",
+      "type": "dir",
+      "path": "references",
+      "children": [
+        {
+          "name": "mv-patterns.md",
+          "type": "file",
+          "path": "references/mv-patterns.md",
+          "lines": 315
+        }
+      ]
+    },
+    {
+      "name": "SKILL.md",
+      "type": "file",
+      "path": "SKILL.md",
+      "lines": 137
+    }
+  ]
+}


### PR DESCRIPTION
## 做了什么

新增 curated plugin `ios-swiftui-toolkit`（slug: `ios-swiftui-toolkit`），将 Dimillian 仓库的三个独立 SwiftUI 技能打包为一个 curated plugin：

- `swiftui-ui-patterns/` — SwiftUI UI 模式与最佳实践（TabView、NavigationStack、Sheets、Forms、Theming 等）
- `swiftui-performance-audit/` — SwiftUI 运行时性能诊断与优化
- `swiftui-view-refactor/` — SwiftUI View 重构与结构规范（MV 模式、@Observable 使用）

## Acceptance Criteria

- [ ] `skills/ios-swiftui-toolkit/` 目录在 `main` 分支可见
- [ ] 顶层 `SKILL.md` 正确描述三个技能的职责和使用场景
- [ ] 三个技能子目录各自保留完整的 `SKILL.md`、`skill-report.json`、`references/` 文件
- [ ] `skill-report.json` 通过 JSON Schema v2.0 校验（CI 自动验证）
- [ ] slug `ios-swiftui-toolkit` 不与现有 415 个插件冲突
- [ ] 所有文件路径使用相对路径，可通过 GitHub URL 直接访问

## 测试方法

1. **本地验证**：在 worktree 中检查文件结构：
   ```bash
   ls skills/ios-swiftui-toolkit/
   ls skills/ios-swiftui-toolkit/swiftui-ui-patterns/
   python3 -m json.tool skills/ios-swiftui-toolkit/skill-report.json > /dev/null
   ```
2. **CI 验证**：PR 合入后，`validate-marketplace.yml` workflow 自动运行，验证 `SKILL.md` frontmatter 和 `skill-report.json` schema 合规性。
3. **安装验证**：CI 通过后可在 skillstore.io 搜索 `ios-swiftui-toolkit` 确认插件页面正确显示。

## 文件变更

| 文件 | 操作 |
|------|------|
| `skills/ios-swiftui-toolkit/SKILL.md` | 新增（bundle 入口文件） |
| `skills/ios-swiftui-toolkit/skill-report.json` | 新增（bundle 元数据） |
| `skills/ios-swiftui-toolkit/swiftui-ui-patterns/*` | 新增（从 dimillian 复制） |
| `skills/ios-swiftui-toolkit/swiftui-performance-audit/*` | 新增（从 dimillian 复制） |
| `skills/ios-swiftui-toolkit/swiftui-view-refactor/*` | 新增（从 dimillian 复制） |

**来源**：技能内容复制自 `skills/dimillian/{swiftui-ui-patterns,swiftui-performance-audit,swiftui-view-refactor}`，仅作目录重组，未修改任何技能内容本身。
