### PR TITLE
feat: add 3 media capture skills for media-capture-toolkit plugin

### DIFF
--- a/skills/mylukin/camsnap/SKILL.md
+++ b/skills/mylukin/camsnap/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: camsnap
+description: Capture frames or clips from RTSP/ONVIF cameras.
+homepage: https://camsnap.ai
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📸",
+        "requires": { "bins": ["camsnap"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "steipete/tap/camsnap",
+              "bins": ["camsnap"],
+              "label": "Install camsnap (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# camsnap
+
+Use `camsnap` to grab snapshots, clips, or motion events from configured cameras.
+
+Setup
+
+- Config file: `~/.config/camsnap/config.yaml`
+- Add camera: `camsnap add --name kitchen --host 192.168.0.10 --user user --pass pass`
+
+Common commands
+
+- Discover: `camsnap discover --info`
+- Snapshot: `camsnap snap kitchen --out shot.jpg`
+- Clip: `camsnap clip kitchen --dur 5s --out clip.mp4`
+- Motion watch: `camsnap watch kitchen --threshold 0.2 --action '...'`
+- Doctor: `camsnap doctor --probe`
+
+Notes
+
+- Requires `ffmpeg` on PATH.
+- Prefer a short test capture before longer clips.

--- a/skills/mylukin/peekaboo/SKILL.md
+++ b/skills/mylukin/peekaboo/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: peekaboo
+description: Capture and automate macOS UI with the Peekaboo CLI.
+homepage: https://peekaboo.boo
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "👀",
+        "os": ["darwin"],
+        "requires": { "bins": ["peekaboo"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "steipete/tap/peekaboo",
+              "bins": ["peekaboo"],
+              "label": "Install Peekaboo (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Peekaboo
+
+Peekaboo is a full macOS UI automation CLI: capture/inspect screens, target UI
+elements, drive input, and manage apps/windows/menus. Commands share a snapshot
+cache and support `--json`/`-j` for scripting. Run `peekaboo` or
+`peekaboo <cmd> --help` for flags; `peekaboo --version` prints build metadata.
+Tip: run via `polter peekaboo` to ensure fresh builds.
+
+## Features (all CLI capabilities, excluding agent/MCP)
+
+Core
+
+- `bridge`: inspect Peekaboo Bridge host connectivity
+- `capture`: live capture or video ingest + frame extraction
+- `clean`: prune snapshot cache and temp files
+- `config`: init/show/edit/validate, providers, models, credentials
+- `image`: capture screenshots (screen/window/menu bar regions)
+- `learn`: print the full agent guide + tool catalog
+- `list`: apps, windows, screens, menubar, permissions
+- `permissions`: check Screen Recording/Accessibility status
+- `run`: execute `.peekaboo.json` scripts
+- `sleep`: pause execution for a duration
+- `tools`: list available tools with filtering/display options
+
+Interaction
+
+- `click`: target by ID/query/coords with smart waits
+- `drag`: drag & drop across elements/coords/Dock
+- `hotkey`: modifier combos like `cmd,shift,t`
+- `move`: cursor positioning with optional smoothing
+- `paste`: set clipboard -> paste -> restore
+- `press`: special-key sequences with repeats
+- `scroll`: directional scrolling (targeted + smooth)
+- `swipe`: gesture-style drags between targets
+- `type`: text + control keys (`--clear`, delays)
+
+System
+
+- `app`: launch/quit/relaunch/hide/unhide/switch/list apps
+- `clipboard`: read/write clipboard (text/images/files)
+- `dialog`: click/input/file/dismiss/list system dialogs
+- `dock`: launch/right-click/hide/show/list Dock items
+- `menu`: click/list application menus + menu extras
+- `menubar`: list/click status bar items
+- `open`: enhanced `open` with app targeting + JSON payloads
+- `space`: list/switch/move-window (Spaces)
+- `visualizer`: exercise Peekaboo visual feedback animations
+- `window`: close/minimize/maximize/move/resize/focus/list
+
+Vision
+
+- `see`: annotated UI maps, snapshot IDs, optional analysis
+
+Global runtime flags
+
+- `--json`/`-j`, `--verbose`/`-v`, `--log-level <level>`
+- `--no-remote`, `--bridge-socket <path>`
+
+## Quickstart (happy path)
+
+```bash
+peekaboo permissions
+peekaboo list apps --json
+peekaboo see --annotate --path /tmp/peekaboo-see.png
+peekaboo click --on B1
+peekaboo type "Hello" --return
+```
+
+## Common targeting parameters (most interaction commands)
+
+- App/window: `--app`, `--pid`, `--window-title`, `--window-id`, `--window-index`
+- Snapshot targeting: `--snapshot` (ID from `see`; defaults to latest)
+- Element/coords: `--on`/`--id` (element ID), `--coords x,y`
+- Focus control: `--no-auto-focus`, `--space-switch`, `--bring-to-current-space`,
+  `--focus-timeout-seconds`, `--focus-retry-count`
+
+## Common capture parameters
+
+- Output: `--path`, `--format png|jpg`, `--retina`
+- Targeting: `--mode screen|window|frontmost`, `--screen-index`,
+  `--window-title`, `--window-id`
+- Analysis: `--analyze "prompt"`, `--annotate`
+- Capture engine: `--capture-engine auto|classic|cg|modern|sckit`
+
+## Common motion/typing parameters
+
+- Timing: `--duration` (drag/swipe), `--steps`, `--delay` (type/scroll/press)
+- Human-ish movement: `--profile human|linear`, `--wpm` (typing)
+- Scroll: `--direction up|down|left|right`, `--amount <ticks>`, `--smooth`
+
+## Examples
+
+### See -> click -> type (most reliable flow)
+
+```bash
+peekaboo see --app Safari --window-title "Login" --annotate --path /tmp/see.png
+peekaboo click --on B3 --app Safari
+peekaboo type "user@example.com" --app Safari
+peekaboo press tab --count 1 --app Safari
+peekaboo type "supersecret" --app Safari --return
+```
+
+### Target by window id
+
+```bash
+peekaboo list windows --app "Visual Studio Code" --json
+peekaboo click --window-id 12345 --coords 120,160
+peekaboo type "Hello from Peekaboo" --window-id 12345
+```
+
+### Capture screenshots + analyze
+
+```bash
+peekaboo image --mode screen --screen-index 0 --retina --path /tmp/screen.png
+peekaboo image --app Safari --window-title "Dashboard" --analyze "Summarize KPIs"
+peekaboo see --mode screen --screen-index 0 --analyze "Summarize the dashboard"
+```
+
+### Live capture (motion-aware)
+
+```bash
+peekaboo capture live --mode region --region 100,100,800,600 --duration 30 \
+  --active-fps 8 --idle-fps 2 --highlight-changes --path /tmp/capture
+```
+
+### App + window management
+
+```bash
+peekaboo app launch "Safari" --open https://example.com
+peekaboo window focus --app Safari --window-title "Example"
+peekaboo window set-bounds --app Safari --x 50 --y 50 --width 1200 --height 800
+peekaboo app quit --app Safari
+```
+
+### Menus, menubar, dock
+
+```bash
+peekaboo menu click --app Safari --item "New Window"
+peekaboo menu click --app TextEdit --path "Format > Font > Show Fonts"
+peekaboo menu click-extra --title "WiFi"
+peekaboo dock launch Safari
+peekaboo menubar list --json
+```
+
+### Mouse + gesture input
+
+```bash
+peekaboo move 500,300 --smooth
+peekaboo drag --from B1 --to T2
+peekaboo swipe --from-coords 100,500 --to-coords 100,200 --duration 800
+peekaboo scroll --direction down --amount 6 --smooth
+```
+
+### Keyboard input
+
+```bash
+peekaboo hotkey --keys "cmd,shift,t"
+peekaboo press escape
+peekaboo type "Line 1\nLine 2" --delay 10
+```
+
+Notes
+
+- Requires Screen Recording + Accessibility permissions.
+- Use `peekaboo see --annotate` to identify targets before clicking.

--- a/skills/mylukin/video-frames/SKILL.md
+++ b/skills/mylukin/video-frames/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: video-frames
+description: Extract frames or short clips from videos using ffmpeg.
+homepage: https://ffmpeg.org
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🎞️",
+        "requires": { "bins": ["ffmpeg"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "ffmpeg",
+              "bins": ["ffmpeg"],
+              "label": "Install ffmpeg (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Video Frames (ffmpeg)
+
+Extract a single frame from a video, or create quick thumbnails for inspection.
+
+## Quick start
+
+First frame:
+
+```bash
+{baseDir}/scripts/frame.sh /path/to/video.mp4 --out /tmp/frame.jpg
+```
+
+At a timestamp:
+
+```bash
+{baseDir}/scripts/frame.sh /path/to/video.mp4 --time 00:00:10 --out /tmp/frame-10s.jpg
+```
+
+## Notes
+
+- Prefer `--time` for “what is happening around here?”.
+- Use a `.jpg` for quick share; use `.png` for crisp UI frames.

--- a/skills/mylukin/video-frames/scripts/frame.sh
+++ b/skills/mylukin/video-frames/scripts/frame.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  frame.sh <video-file> [--time HH:MM:SS] [--index N] --out /path/to/frame.jpg
+
+Examples:
+  frame.sh video.mp4 --out /tmp/frame.jpg
+  frame.sh video.mp4 --time 00:00:10 --out /tmp/frame-10s.jpg
+  frame.sh video.mp4 --index 0 --out /tmp/frame0.png
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+in="${1:-}"
+shift || true
+
+time=""
+index=""
+out=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --time)
+      time="${2:-}"
+      shift 2
+      ;;
+    --index)
+      index="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ ! -f "$in" ]]; then
+  echo "File not found: $in" >&2
+  exit 1
+fi
+
+if [[ "$out" == "" ]]; then
+  echo "Missing --out" >&2
+  usage
+fi
+
+mkdir -p "$(dirname "$out")"
+
+if [[ "$index" != "" ]]; then
+  ffmpeg -hide_banner -loglevel error -y \
+    -i "$in" \
+    -vf "select=eq(n\\,${index})" \
+    -vframes 1 \
+    "$out"
+elif [[ "$time" != "" ]]; then
+  ffmpeg -hide_banner -loglevel error -y \
+    -ss "$time" \
+    -i "$in" \
+    -frames:v 1 \
+    "$out"
+else
+  ffmpeg -hide_banner -loglevel error -y \
+    -i "$in" \
+    -vf "select=eq(n\\,0)" \
+    -vframes 1 \
+    "$out"
+fi
+
+echo "$out"


### PR DESCRIPTION
## Summary

Add 3 OpenClaw skills for the upcoming **media-capture-toolkit** plugin bundle:

- **camsnap** — Capture frames/clips from RTSP/ONVIF cameras via `camsnap` CLI
- **video-frames** — Extract frames from video files using ffmpeg (includes `frame.sh` helper)
- **peekaboo** — macOS UI automation and screen capture via `peekaboo` CLI

## Files Added

- `skills/mylukin/camsnap/SKILL.md`
- `skills/mylukin/video-frames/SKILL.md`
- `skills/mylukin/video-frames/scripts/frame.sh`
- `skills/mylukin/peekaboo/SKILL.md`

## Plugin Context

These skills will be bundled into the `media-capture-toolkit` plugin:
> *Capture anything visual — cameras, videos, screens. One toolkit for all your agent's visual inputs.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)