### PR TITLE
feat: add cross-platform messaging skills

### DIFF
--- a/skills/mylukin/bluebubbles/SKILL.md
+++ b/skills/mylukin/bluebubbles/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: bluebubbles
+description: Use when you need to send or manage iMessages via BlueBubbles (recommended iMessage integration). Calls go through the generic message tool with channel="bluebubbles".
+metadata: { "openclaw": { "emoji": "🫧", "requires": { "config": ["channels.bluebubbles"] } } }
+---
+
+# BlueBubbles Actions
+
+## Overview
+
+BlueBubbles is OpenClaw’s recommended iMessage integration. Use the `message` tool with `channel: "bluebubbles"` to send messages and manage iMessage conversations: send texts and attachments, react (tapbacks), edit/unsend, reply in threads, and manage group participants/names/icons.
+
+## Inputs to collect
+
+- `target` (prefer `chat_guid:...`; also `+15551234567` in E.164 or `user@example.com`)
+- `message` text for send/edit/reply
+- `messageId` for react/edit/unsend/reply
+- Attachment `path` for local files, or `buffer` + `filename` for base64
+
+If the user is vague ("text my mom"), ask for the recipient handle or chat guid and the exact message content.
+
+## Actions
+
+### Send a message
+
+```json
+{
+  "action": "send",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "message": "hello from OpenClaw"
+}
+```
+
+### React (tapback)
+
+```json
+{
+  "action": "react",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "messageId": "<message-guid>",
+  "emoji": "❤️"
+}
+```
+
+### Remove a reaction
+
+```json
+{
+  "action": "react",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "messageId": "<message-guid>",
+  "emoji": "❤️",
+  "remove": true
+}
+```
+
+### Edit a previously sent message
+
+```json
+{
+  "action": "edit",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "messageId": "<message-guid>",
+  "message": "updated text"
+}
+```
+
+### Unsend a message
+
+```json
+{
+  "action": "unsend",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "messageId": "<message-guid>"
+}
+```
+
+### Reply to a specific message
+
+```json
+{
+  "action": "reply",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "replyTo": "<message-guid>",
+  "message": "replying to that"
+}
+```
+
+### Send an attachment
+
+```json
+{
+  "action": "sendAttachment",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "path": "/tmp/photo.jpg",
+  "caption": "here you go"
+}
+```
+
+### Send with an iMessage effect
+
+```json
+{
+  "action": "sendWithEffect",
+  "channel": "bluebubbles",
+  "target": "+15551234567",
+  "message": "big news",
+  "effect": "balloons"
+}
+```
+
+## Notes
+
+- Requires gateway config `channels.bluebubbles` (serverUrl/password/webhookPath).
+- Prefer `chat_guid` targets when you have them (especially for group chats).
+- BlueBubbles supports rich actions, but some are macOS-version dependent (for example, edit may be broken on macOS 26 Tahoe).
+- The gateway may expose both short and full message ids; full ids are more durable across restarts.
+- Developer reference for the underlying plugin lives in `extensions/bluebubbles/README.md`.
+
+## Ideas to try
+
+- React with a tapback to acknowledge a request.
+- Reply in-thread when a user references a specific message.
+- Send a file attachment with a short caption.

--- a/skills/mylukin/discord/SKILL.md
+++ b/skills/mylukin/discord/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: discord
+description: "Discord ops via the message tool (channel=discord)."
+metadata: { "openclaw": { "emoji": "🎮", "requires": { "config": ["channels.discord.token"] } } }
+allowed-tools: ["message"]
+---
+
+# Discord (Via `message`)
+
+Use the `message` tool. No provider-specific `discord` tool exposed to the agent.
+
+## Musts
+
+- Always: `channel: "discord"`.
+- Respect gating: `channels.discord.actions.*` (some default off: `roles`, `moderation`, `presence`, `channels`).
+- Prefer explicit ids: `guildId`, `channelId`, `messageId`, `userId`.
+- Multi-account: optional `accountId`.
+
+## Guidelines
+
+- Avoid Markdown tables in outbound Discord messages.
+- Mention users as `<@USER_ID>`.
+- Prefer Discord components v2 (`components`) for rich UI; use legacy `embeds` only when you must.
+
+## Targets
+
+- Send-like actions: `to: "channel:<id>"` or `to: "user:<id>"`.
+- Message-specific actions: `channelId: "<id>"` (or `to`) + `messageId: "<id>"`.
+
+## Common Actions (Examples)
+
+Send message:
+
+```json
+{
+  "action": "send",
+  "channel": "discord",
+  "to": "channel:123",
+  "message": "hello",
+  "silent": true
+}
+```
+
+Send with media:
+
+```json
+{
+  "action": "send",
+  "channel": "discord",
+  "to": "channel:123",
+  "message": "see attachment",
+  "media": "file:///tmp/example.png"
+}
+```
+
+- Optional `silent: true` to suppress Discord notifications.
+
+Send with components v2 (recommended for rich UI):
+
+```json
+{
+  "action": "send",
+  "channel": "discord",
+  "to": "channel:123",
+  "message": "Status update",
+  "components": "[Carbon v2 components]"
+}
+```
+
+- `components` expects Carbon component instances (Container, TextDisplay, etc.) from JS/TS integrations.
+- Do not combine `components` with `embeds` (Discord rejects v2 + embeds).
+
+Legacy embeds (not recommended):
+
+```json
+{
+  "action": "send",
+  "channel": "discord",
+  "to": "channel:123",
+  "message": "Status update",
+  "embeds": [{ "title": "Legacy", "description": "Embeds are legacy." }]
+}
+```
+
+- `embeds` are ignored when components v2 are present.
+
+React:
+
+```json
+{
+  "action": "react",
+  "channel": "discord",
+  "channelId": "123",
+  "messageId": "456",
+  "emoji": "✅"
+}
+```
+
+Read:
+
+```json
+{
+  "action": "read",
+  "channel": "discord",
+  "to": "channel:123",
+  "limit": 20
+}
+```
+
+Edit / delete:
+
+```json
+{
+  "action": "edit",
+  "channel": "discord",
+  "channelId": "123",
+  "messageId": "456",
+  "message": "fixed typo"
+}
+```
+
+```json
+{
+  "action": "delete",
+  "channel": "discord",
+  "channelId": "123",
+  "messageId": "456"
+}
+```
+
+Poll:
+
+```json
+{
+  "action": "poll",
+  "channel": "discord",
+  "to": "channel:123",
+  "pollQuestion": "Lunch?",
+  "pollOption": ["Pizza", "Sushi", "Salad"],
+  "pollMulti": false,
+  "pollDurationHours": 24
+}
+```
+
+Pins:
+
+```json
+{
+  "action": "pin",
+  "channel": "discord",
+  "channelId": "123",
+  "messageId": "456"
+}
+```
+
+Threads:
+
+```json
+{
+  "action": "thread-create",
+  "channel": "discord",
+  "channelId": "123",
+  "messageId": "456",
+  "threadName": "bug triage"
+}
+```
+
+Search:
+
+```json
+{
+  "action": "search",
+  "channel": "discord",
+  "guildId": "999",
+  "query": "release notes",
+  "channelIds": ["123", "456"],
+  "limit": 10
+}
+```
+
+Presence (often gated):
+
+```json
+{
+  "action": "set-presence",
+  "channel": "discord",
+  "activityType": "playing",
+  "activityName": "with fire",
+  "status": "online"
+}
+```
+
+## Writing Style (Discord)
+
+- Short, conversational, low ceremony.
+- No markdown tables.
+- Mention users as `<@USER_ID>`.

--- a/skills/mylukin/wacli/SKILL.md
+++ b/skills/mylukin/wacli/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: wacli
+description: Send WhatsApp messages to other people or search/sync WhatsApp history via the wacli CLI (not for normal user chats).
+homepage: https://wacli.sh
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📱",
+        "requires": { "bins": ["wacli"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "steipete/tap/wacli",
+              "bins": ["wacli"],
+              "label": "Install wacli (brew)",
+            },
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "github.com/steipete/wacli/cmd/wacli@latest",
+              "bins": ["wacli"],
+              "label": "Install wacli (go)",
+            },
+          ],
+      },
+  }
+---
+
+# wacli
+
+Use `wacli` only when the user explicitly asks you to message someone else on WhatsApp or when they ask to sync/search WhatsApp history.
+Do NOT use `wacli` for normal user chats; OpenClaw routes WhatsApp conversations automatically.
+If the user is chatting with you on WhatsApp, you should not reach for this tool unless they ask you to contact a third party.
+
+Safety
+
+- Require explicit recipient + message text.
+- Confirm recipient + message before sending.
+- If anything is ambiguous, ask a clarifying question.
+
+Auth + sync
+
+- `wacli auth` (QR login + initial sync)
+- `wacli sync --follow` (continuous sync)
+- `wacli doctor`
+
+Find chats + messages
+
+- `wacli chats list --limit 20 --query "name or number"`
+- `wacli messages search "query" --limit 20 --chat <jid>`
+- `wacli messages search "invoice" --after 2025-01-01 --before 2025-12-31`
+
+History backfill
+
+- `wacli history backfill --chat <jid> --requests 2 --count 50`
+
+Send
+
+- Text: `wacli send text --to "+14155551212" --message "Hello! Are you free at 3pm?"`
+- Group: `wacli send text --to "1234567890-123456789@g.us" --message "Running 5 min late."`
+- File: `wacli send file --to "+14155551212" --file /path/agenda.pdf --caption "Agenda"`
+
+Notes
+
+- Store dir: `~/.wacli` (override with `--store`).
+- Use `--json` for machine-readable output when parsing.
+- Backfill requires your phone online; results are best-effort.
+- WhatsApp CLI is not needed for routine user chats; it’s for messaging other people.
+- JIDs: direct chats look like `<number>@s.whatsapp.net`; groups look like `<id>@g.us` (use `wacli chats list` to find).


### PR DESCRIPTION
## Summary

- Add **bluebubbles** skill: iMessage management via BlueBubbles API (send, react, tapback, edit, unsend, reply, attachments, effects)
- Add **wacli** skill: WhatsApp messaging via wacli CLI (send text/files, search messages, sync/backfill history)
- Add **discord** skill: Discord operations via message tool (send, react, poll, threads, pins, search, presence, components v2)

These 3 skills will be bundled into the `messaging-multi-platform-toolkit` plugin on skillstore.io — a unified cross-platform messaging toolkit covering iMessage, WhatsApp, and Discord.

## Test plan

- [ ] Verify each SKILL.md has valid YAML frontmatter (name, description, metadata)
- [ ] Confirm skills pass automated security analysis
- [ ] Validate plugin bundle after merge via skillstore-plugin-publisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)