### PR TITLE
Add openhue, sonoscli, eightctl skills

### DIFF
--- a/skills/mylukin/eightctl/SKILL.md
+++ b/skills/mylukin/eightctl/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: eightctl
+description: Control Eight Sleep pods (status, temperature, alarms, schedules).
+homepage: https://eightctl.sh
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛌",
+        "requires": { "bins": ["eightctl"] },
+        "install":
+          [
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "github.com/steipete/eightctl/cmd/eightctl@latest",
+              "bins": ["eightctl"],
+              "label": "Install eightctl (go)",
+            },
+          ],
+      },
+  }
+---
+
+# eightctl
+
+Use `eightctl` for Eight Sleep pod control. Requires auth.
+
+Auth
+
+- Config: `~/.config/eightctl/config.yaml`
+- Env: `EIGHTCTL_EMAIL`, `EIGHTCTL_PASSWORD`
+
+Quick start
+
+- `eightctl status`
+- `eightctl on|off`
+- `eightctl temp 20`
+
+Common tasks
+
+- Alarms: `eightctl alarm list|create|dismiss`
+- Schedules: `eightctl schedule list|create|update`
+- Audio: `eightctl audio state|play|pause`
+- Base: `eightctl base info|angle`
+
+Notes
+
+- API is unofficial and rate-limited; avoid repeated logins.
+- Confirm before changing temperature or alarms.

--- a/skills/mylukin/openhue/SKILL.md
+++ b/skills/mylukin/openhue/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: openhue
+description: Control Philips Hue lights and scenes via the OpenHue CLI.
+homepage: https://www.openhue.io/cli
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "💡",
+        "requires": { "bins": ["openhue"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "openhue/cli/openhue-cli",
+              "bins": ["openhue"],
+              "label": "Install OpenHue CLI (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# OpenHue CLI
+
+Use `openhue` to control Philips Hue lights and scenes via a Hue Bridge.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- "Turn on/off the lights"
+- "Dim the living room lights"
+- "Set a scene" or "movie mode"
+- Controlling specific Hue rooms or zones
+- Adjusting brightness, color, or color temperature
+
+## When NOT to Use
+
+❌ **DON'T use this skill when:**
+
+- Non-Hue smart devices (other brands) → not supported
+- HomeKit scenes or Shortcuts → use Apple's ecosystem
+- TV or entertainment system control
+- Thermostat or HVAC
+- Smart plugs (unless Hue smart plugs)
+
+## Common Commands
+
+### List Resources
+
+```bash
+openhue get light       # List all lights
+openhue get room        # List all rooms
+openhue get scene       # List all scenes
+```
+
+### Control Lights
+
+```bash
+# Turn on/off
+openhue set light "Bedroom Lamp" --on
+openhue set light "Bedroom Lamp" --off
+
+# Brightness (0-100)
+openhue set light "Bedroom Lamp" --on --brightness 50
+
+# Color temperature (warm to cool: 153-500 mirek)
+openhue set light "Bedroom Lamp" --on --temperature 300
+
+# Color (by name or hex)
+openhue set light "Bedroom Lamp" --on --color red
+openhue set light "Bedroom Lamp" --on --rgb "#FF5500"
+```
+
+### Control Rooms
+
+```bash
+# Turn off entire room
+openhue set room "Bedroom" --off
+
+# Set room brightness
+openhue set room "Bedroom" --on --brightness 30
+```
+
+### Scenes
+
+```bash
+# Activate scene
+openhue set scene "Relax" --room "Bedroom"
+openhue set scene "Concentrate" --room "Office"
+```
+
+## Quick Presets
+
+```bash
+# Bedtime (dim warm)
+openhue set room "Bedroom" --on --brightness 20 --temperature 450
+
+# Work mode (bright cool)
+openhue set room "Office" --on --brightness 100 --temperature 250
+
+# Movie mode (dim)
+openhue set room "Living Room" --on --brightness 10
+```
+
+## Notes
+
+- Bridge must be on local network
+- First run requires button press on Hue bridge to pair
+- Colors only work on color-capable bulbs (not white-only)

--- a/skills/mylukin/sonoscli/SKILL.md
+++ b/skills/mylukin/sonoscli/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: sonoscli
+description: Control Sonos speakers (discover/status/play/volume/group).
+homepage: https://sonoscli.sh
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔊",
+        "requires": { "bins": ["sonos"] },
+        "install":
+          [
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "github.com/steipete/sonoscli/cmd/sonos@latest",
+              "bins": ["sonos"],
+              "label": "Install sonoscli (go)",
+            },
+          ],
+      },
+  }
+---
+
+# Sonos CLI
+
+Use `sonos` to control Sonos speakers on the local network.
+
+## Quick start
+
+- `sonos discover`
+- `sonos status --name "Kitchen"`
+- `sonos play|pause|stop --name "Kitchen"`
+- `sonos volume set 15 --name "Kitchen"`
+
+## Common tasks
+
+- Grouping: `sonos group status|join|unjoin|party|solo`
+- Favorites: `sonos favorites list|open`
+- Queue: `sonos queue list|play|clear`
+- Spotify search (via SMAPI): `sonos smapi search --service "Spotify" --category tracks "query"`
+
+## Notes
+
+- If SSDP fails, specify `--ip <speaker-ip>`.
+- Spotify Web API search is optional and requires `SPOTIFY_CLIENT_ID/SECRET`.
+- If there is an error, check the troubleshooting section and offer advice if there is a decent match.
+
+## Troubleshooting
+
+### `sonos discover` - `no route to host`
+
+- On error `Error: write udp4 0.0.0.0:64326->239.255.255.250:1900: sendto: no route to host (Command exited with code 1)`
+  - Note that the port number after `0.0.0.0:` is ephemeral and will change and the netmask may not match exactly either
+  - The `sendto: no route to host` should stay consistent
+- Advise the user that in `direct` (no Docker sandbox) mode on Mac OS that Settings -> Privacy & Security -> Local Network will need to be enabled for the top-level host parent process of the Gateway
+  - `node` if running via `launchd`
+  - `Terminal` if running the gateway directly in the terminal
+  - `Visual Studio Code` if running via terminal in VS Code
+- An alternative option is to use `sandbox` (docker container) with network access allowed for that sandbox
+
+### `sonos discover` - `bind: operation not permitted`
+
+- On error `Error: listen udp4 0.0.0.0:0: bind: operation not permitted`
+- Advise the user that they may be running via a Codex or other sandbox that does not permit network access (this can be replicated by running `sonos discover` within a Codex CLI session with sandbox enabled and not approving the escalation request)


### PR DESCRIPTION
## Summary
- Add 3 smart home control skills under `skills/mylukin/`:
  - **openhue** — Philips Hue lights/scenes via OpenHue CLI
  - **sonoscli** — Sonos speaker control (discover/play/volume/group)
  - **eightctl** — Eight Sleep pod control (temp/alarms/schedules)

These will be grouped into the `smart-home-controller` plugin.

## Test plan
- [ ] Each SKILL.md has valid frontmatter (name, description, homepage, metadata)
- [ ] No duplicate skill names in the marketplace
- [ ] Skills match source at `openclaw/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)