### PR TITLE
docs: add agent-engineering-starter-kit install command to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The official AI Skills marketplace for Claude Code and Codex. Discover, install,
 
 ## Quick Start
 
+```
+npx skillstore add @agent-engineering-starter-kit
+```
+
 ### Claude Code Installation
 
 #### Method 1: Quick Install (Recommended)


### PR DESCRIPTION
## What

Add `npx skillstore add @agent-engineering-starter-kit` as the first line in the Quick Start section so users can discover and install the plugin with one command.

## Change

```diff
## Quick Start

+```
+npx skillstore add @agent-engineering-starter-kit
+```
+
### Claude Code Installation
```

## Acceptance Criteria

- [ ] `## Quick Start` section shows the npx install command before the existing Claude Code / Codex subsections
- [ ] No other content changed