### PR TITLE
Add ralyodio job automation skills

### DIFF
--- a/skills/ralyodio/dice-easy-apply-automation/SKILL.md
+++ b/skills/ralyodio/dice-easy-apply-automation/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: dice-easy-apply
+description: Automate Dice.com Easy Apply searches and applications with Puppeteer/Chromium, resume and cover-letter uploads, remote-role filtering, and conservative application guardrails.
+when_to_use: Use when you need an AI agent to search Dice.com jobs and submit Dice Easy Apply applications from a verified resume and cover letter.
+license: MIT
+metadata:
+  supported_agents:
+    - claude-code
+    - openclaw
+    - hermes
+    - codex
+    - cursor
+    - windsurf
+    - goose
+    - aider
+    - roo-code
+    - cline
+  tags: [jobs, dice, automation, puppeteer, easy-apply]
+---
+
+# Dice Easy Apply Automation
+
+This skill helps an AI coding/operations agent build and run a repeatable Dice.com Easy Apply workflow.
+
+It is intentionally public and credential-free. It contains no usernames, passwords, cookies, private profile paths, or user-specific secrets.
+
+## What it does
+
+- Searches Dice jobs using the explicit Remote workplace filter.
+- Focuses on software, web, full-stack, frontend/backend, AI, GenAI, LLM, Claude/OpenAI/Codex-style roles.
+- Uses Dice in-site Easy Apply flows only, unless the operator explicitly approves external ATS applications.
+- Uploads a verified resume PDF and optional cover-letter PDF.
+- Uses a persistent Chromium profile so login can be performed manually once and reused safely.
+- Keeps state/log files so daily reruns avoid duplicates.
+- Skips roles with explicit onsite/hybrid/local/travel/clearance constraints or unknown required questions.
+
+## Safety rules
+
+- Do not store job-board credentials in scripts, skills, memory, logs, or reports.
+- Pass credentials only via one-off environment variables if absolutely necessary, or use a pre-authenticated browser profile.
+- Stop for CAPTCHA, MFA, suspicious-login checks, identity verification, or account-security prompts.
+- Do not fabricate answers. Skip forms requiring salary expectations, essays, custom cover letters, relocation preferences, travel, or unverifiable facts.
+- Treat Dice match percentages as advisory only. Do not skip a role solely because Dice reports a low match score if the role title is inside the resume's wheelhouse.
+- Gen AI / Generative AI Engineer should be treated as a software-engineering role when the resume supports web/software/AI work.
+
+## Recommended search URL
+
+Use Dice's remote filter directly, not a radius search:
+
+```text
+https://www.dice.com/jobs?filters.workplaceTypes=Remote&filters.easyApply=true&q=<QUERY>
+```
+
+For contract/direct-hire filtered searches, add Dice's employment and employer filters:
+
+```text
+https://www.dice.com/jobs?filters.easyApply=true&filters.employmentType=CONTRACTS&filters.employerType=Direct+Hire&filters.workplaceTypes=Remote&q=<QUERY>
+```
+
+Useful query set:
+
+```text
+gen ai engineer
+generative ai engineer
+llm engineer
+ai full stack engineer
+frontend ai engineer
+web developer
+full stack engineer
+node react engineer
+javascript engineer
+typescript engineer
+react developer
+node.js developer
+svelte developer
+software engineer
+```
+
+## Environment variables
+
+```bash
+RESUME_PDF=/absolute/path/to/resume.pdf
+COVER_PDF=/absolute/path/to/cover.pdf
+CHROME_PROFILE=$HOME/.cache/dice-chrome
+STATE_DIR=/tmp/dice-easyapply-daily
+MAX_SCAN=120
+MAX_APPLY=15
+DRY_RUN=1
+SEARCHES='gen ai engineer|llm engineer|full stack engineer|react developer'
+EMPLOYMENT_FILTER=CONTRACTS
+EMPLOYER_TYPE='Direct Hire'
+```
+
+## Puppeteer launch pattern
+
+```js
+const puppeteer = require('puppeteer');
+
+const browser = await puppeteer.launch({
+  headless: false,
+  executablePath: process.env.CHROME_BIN || '/snap/bin/chromium',
+  userDataDir: process.env.CHROME_PROFILE || `${process.env.HOME}/.cache/dice-chrome`,
+  defaultViewport: null,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--start-maximized']
+});
+
+let page = await browser.newPage();
+page.setDefaultTimeout(30000);
+page.on('dialog', async d => {
+  try {
+    if (d.type() === 'beforeunload') await d.accept();
+    else await d.dismiss();
+  } catch {}
+});
+```
+
+## Core workflow
+
+1. Verify local files exist:
+
+```bash
+test -f "$RESUME_PDF"
+test -f "$COVER_PDF"
+```
+
+2. Open Dice with a persistent browser profile and verify login.
+3. Search remote Easy Apply roles using the query list.
+4. Extract Dice job IDs from `/job-detail/<id>` URLs.
+5. Open each job detail page and inspect only the main job description, not footer/recommended-job/sidebar text.
+6. Skip explicit onsite/hybrid/local/travel/clearance constraints.
+7. Open the wizard:
+
+```text
+https://www.dice.com/job-applications/<job-id>/wizard
+```
+
+8. Replace any stale/default resume with the verified resume PDF.
+9. Upload the cover-letter PDF where Dice supports it.
+10. Continue to the review screen.
+11. Confirm expected filenames and work authorization are visible.
+12. Submit only if no unknown required questions remain.
+13. Append a JSONL audit row and save state.
+
+## Suggested state
+
+```json
+{
+  "seen": {},
+  "applied": {},
+  "skipped": {},
+  "alreadySubmitted": {}
+}
+```
+
+Write state and logs to:
+
+```text
+/tmp/dice-easyapply-daily/state.json
+/tmp/dice-easyapply-daily/results.jsonl
+```
+
+## Skip reasons
+
+Common skip reasons:
+
+- `not_remote_only_or_has_hybrid_location_text`
+- `outside_resume_wheelhouse`
+- `external_ats_not_approved`
+- `unknown_required_question`
+- `captcha_or_verification_required`
+- `could_not_attach_resume`
+- `could_not_attach_cover_letter`
+- `already_submitted`
+
+## Reporting
+
+Report concise results:
+
+```text
+Submitted:
+- Title — Company — URL
+
+Skipped:
+- Title — Company — URL — reason
+
+State: /tmp/dice-easyapply-daily/state.json
+Log: /tmp/dice-easyapply-daily/results.jsonl
+```
+
+## Pitfalls
+
+- Dice may preselect an older profile resume. Always verify the filename before submitting.
+- Dice pages can fire native `beforeunload` dialogs; register a Puppeteer dialog handler and accept beforeunload dialogs.
+- Dice may close/detach a page after a submit attempt. If navigation reports `Target closed`, `Session closed`, or `frame was detached`, create a fresh page, re-register the dialog handler, and continue from state.
+- Do not let unrelated recommendation/sidebar/footer text cause false remote/hybrid skips.
+- Do not overfit to a single resume. Keep search queries and skip rules configurable.

--- a/skills/ralyodio/dice-easy-apply-automation/skill-report.json
+++ b/skills/ralyodio/dice-easy-apply-automation/skill-report.json
@@ -1,0 +1,6 @@
+{
+  "status": "pending-review",
+  "source": "https://github.com/ralyodio/agent-skills/tree/main/skills/dice-easy-apply-automation",
+  "submittedBy": "ralyodio",
+  "notes": "Public credential-free SKILL.md submitted for Skillstore review."
+}

--- a/skills/ralyodio/linkedin-easy-apply-automation/SKILL.md
+++ b/skills/ralyodio/linkedin-easy-apply-automation/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: linkedin-easy-apply
+description: Automate LinkedIn Easy Apply searches and applications with Puppeteer/Chromium, a verified resume PDF, remote/job-title filtering, stateful daily reruns, and conservative answer guardrails.
+when_to_use: Use when you need an AI agent to search LinkedIn jobs and submit LinkedIn Easy Apply applications from a verified resume PDF.
+license: MIT
+metadata:
+  supported_agents:
+    - claude-code
+    - openclaw
+    - hermes
+    - codex
+    - cursor
+    - windsurf
+    - goose
+    - aider
+    - roo-code
+    - cline
+  tags: [jobs, linkedin, automation, puppeteer, easy-apply]
+---
+
+# LinkedIn Easy Apply Automation
+
+This skill helps an AI coding/operations agent build and run a repeatable LinkedIn Easy Apply workflow.
+
+It is intentionally public and credential-free. It contains no usernames, passwords, cookies, private profile paths, or user-specific secrets.
+
+## What it does
+
+- Searches LinkedIn Jobs with Easy Apply enabled.
+- Supports remote-only and location-constrained searches.
+- Focuses on configurable role keywords such as AI, LLM, Claude, OpenAI, Codex, full-stack, frontend, backend, web, software, JavaScript, TypeScript, Node, React, and Svelte.
+- Opens the LinkedIn Easy Apply flow reliably with a direct apply URL when possible.
+- Uploads a verified resume PDF.
+- Answers only verified applicant facts.
+- Skips unknown required questions, compensation questions, custom essays, or subjective fields.
+- Keeps state and JSONL logs so daily reruns avoid duplicates.
+
+## Safety rules
+
+- Do not store LinkedIn credentials in scripts, skills, memory, logs, or reports.
+- Prefer a persistent browser profile where the operator logs in manually once.
+- Stop for CAPTCHA, MFA, suspicious-login checks, identity verification, or account-security prompts.
+- Do not fabricate applicant facts.
+- Do not answer custom freeform questions or compensation expectations without operator-provided answers.
+- Re-check full job descriptions for hybrid/location constraints before submitting remote-only applications.
+
+## Environment variables
+
+```bash
+RESUME_PDF=/absolute/path/to/resume.pdf
+CHROME_PROFILE=$HOME/.cache/linkedin-chrome
+STATE_DIR=/tmp/linkedin-easyapply-daily
+MAX_SCAN=80
+MAX_APPLY=10
+DRY_RUN=1
+SEARCHES='Claude|OpenAI|Codex|LLM engineer|AI engineer|full stack engineer|software engineer'
+LOCATION='United States'
+REMOTE_ONLY=1
+```
+
+## Puppeteer launch pattern
+
+```js
+const puppeteer = require('puppeteer');
+
+const browser = await puppeteer.launch({
+  headless: false,
+  executablePath: process.env.CHROME_BIN || '/snap/bin/chromium',
+  userDataDir: process.env.CHROME_PROFILE || `${process.env.HOME}/.cache/linkedin-chrome`,
+  defaultViewport: null,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--start-maximized']
+});
+
+const page = await browser.newPage();
+page.setDefaultTimeout(30000);
+page.on('dialog', async d => {
+  try {
+    if (d.type() === 'beforeunload') await d.accept();
+    else await d.dismiss();
+  } catch {}
+});
+```
+
+## Search workflow
+
+Build LinkedIn Jobs URLs using explicit filters:
+
+- `f_AL=true` for Easy Apply.
+- Remote filter when remote-only is required.
+- Location such as `United States` when requested.
+- Configurable keywords matching the resume and target market.
+
+Keep candidates only when the card/page supports the requested constraints and the title/description matches the target role family.
+
+## Direct Easy Apply URL
+
+When a LinkedIn job ID is known, try the direct flow first:
+
+```js
+const applyUrl = `https://www.linkedin.com/jobs/view/${jobId}/apply/?openSDUIApplyFlow=true`;
+await page.goto(applyUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+```
+
+If the modal does not open, fall back to clicking visible `Easy Apply` controls across buttons and links.
+
+## Conservative answer rules
+
+Answer only facts that are verified by the resume, profile, or explicit operator instruction:
+
+- Work authorization / eligible to work: yes only if verified.
+- Visa sponsorship required: no only if verified.
+- Remote willingness: yes only for remote-only searches.
+- Years of experience: use resume-backed values or a user-approved mapping.
+- Email/phone/location: use existing profile/resume facts.
+- Middle name: blank if none provided.
+
+Skip:
+
+- Salary/compensation expectations.
+- Cover-letter text prompts.
+- Custom essays.
+- Relocation/hybrid/travel if not approved.
+- Unclear required inputs, radios, or selects.
+
+## Multi-step apply loop
+
+1. Open the apply flow.
+2. Detect already-submitted applications.
+3. Upload/select the verified resume PDF if needed.
+4. Inspect each step's visible inputs/selects/radios.
+5. Fill only safe verified answers.
+6. Click `Next`, `Review`, then `Submit application` only when no unknown required fields remain.
+7. Log submitted/skipped state.
+
+## Suggested state
+
+```json
+{
+  "seen": {},
+  "applied": {},
+  "skipped": {},
+  "alreadySubmitted": {}
+}
+```
+
+Write state and logs to:
+
+```text
+/tmp/linkedin-easyapply-daily/state.json
+/tmp/linkedin-easyapply-daily/results.jsonl
+```
+
+## Reporting
+
+Report concise results:
+
+```text
+Submitted:
+- Title — Company — URL
+
+Skipped:
+- Title — Company — URL — reason
+
+State: /tmp/linkedin-easyapply-daily/state.json
+Log: /tmp/linkedin-easyapply-daily/results.jsonl
+```
+
+## Pitfalls
+
+- Built-in browser tools often time out on LinkedIn. Puppeteer with Chromium and Xvfb is usually more reliable.
+- LinkedIn search cards can say Remote while the description includes hybrid/local constraints. Inspect the full page before applying.
+- Broad keyword matching can create bad answers. Avoid treating generic words like `United States` or `comfortable` as approval.
+- Direct DOM value assignment may not update React forms. Prefer click/type and dispatch input/change events.
+- If a page detaches or a modal closes unexpectedly, create a new page and continue from the state file.

--- a/skills/ralyodio/linkedin-easy-apply-automation/skill-report.json
+++ b/skills/ralyodio/linkedin-easy-apply-automation/skill-report.json
@@ -1,0 +1,6 @@
+{
+  "status": "pending-review",
+  "source": "https://github.com/ralyodio/agent-skills/tree/main/skills/linkedin-easy-apply-automation",
+  "submittedBy": "ralyodio",
+  "notes": "Public credential-free SKILL.md submitted for Skillstore review."
+}

--- a/skills/ralyodio/promote-skill/SKILL.md
+++ b/skills/ralyodio/promote-skill/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: promote-skill
+description: Use when publishing a SKILL.md-style agent skill across uGig, sh1pt, GitHub/gists, and follow-on skill marketplaces such as ClawHub, Goose, LobeHub, Kilo, Skillstore, FreeMyGent, ClawMart, Manus, VS Code Agent Skills, and Moltbook.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+when_to_use: Use when publishing, promoting, or packaging SKILL.md-style agent skills for uGig, sh1pt, GitHub/gists, ClawHub, Goose, LobeHub, Kilo, Skillstore, FreeMyGent, ClawMart, Manus, VS Code Agent Skills, or Moltbook.
+metadata:
+  supported_agents:
+    - hermes
+    - openclaw
+    - claude-code
+    - codex
+    - cursor
+    - windsurf
+    - goose
+  hermes:
+    tags: [skills, marketplace, ugig, sh1pt, publishing, promotion]
+    related_skills: [skill-marketplace-publishing, hermes-agent-skill-authoring, github-repo-management]
+---
+
+# Promote Skill
+
+## Overview
+
+Use this skill to turn a local `SKILL.md` into a public marketplace listing and promotion checklist. The workflow is agent-friendly:
+
+1. Validate and sanitize the skill source.
+2. Create a public source URL, preferably a GitHub repo or public gist raw URL.
+3. Publish to uGig first because uGig imports the raw `SKILL.md`, scans it, and exposes a "Publish Everywhere" checklist.
+4. Use sh1pt as the cross-marketplace promotion manifest/command generator.
+5. Work through other marketplaces by CLI, PR, account submission, or manual upload depending on the platform.
+
+Never include credentials, cookies, private env values, or personal secrets in a public skill file or marketplace listing.
+
+## When to Use
+
+Use this when the user says:
+
+- "publish this skill"
+- "promote this skill"
+- "put it on uGig / ClawHub / LobeHub / Goose / Kilo"
+- "make a public SKILL.md"
+- "publish everywhere"
+- "create a promote-skill workflow"
+
+Do not use this for job applications themselves; use job-board specific skills for that.
+
+## Inputs to collect or infer
+
+Required:
+
+- Local `SKILL.md` path or directory containing it.
+- Public-safe title, slug, tagline, description, category, tags.
+- Price in sats; `0` means free.
+
+Optional:
+
+- Existing public raw `SKILL.md` URL.
+- GitHub repo/gist preference.
+- uGig credentials or already-authenticated browser profile.
+- Marketplace-specific credentials/API keys for platforms that need them.
+
+## Safety checklist before publishing
+
+Run a secrets scan before any public upload:
+
+```bash
+grep -RInE 'password|passwd|secret|token|api[_-]?key|BEGIN .*PRIVATE|private[_-]?key|cookie|credential' SKILL.md . 2>/dev/null || true
+```
+
+Then manually inspect hits. Mentions of environment variable names are fine; real values are not.
+
+For paid listings, remember: marketplaces that import from a public raw URL may expose the artifact publicly. If the artifact is not intended to be free, verify access-gating from an anonymous browser before claiming it is paywalled.
+
+## uGig workflow
+
+Preferred CLI path once `ugig` supports `skills new`:
+
+```bash
+ugig skills new \
+  --title "My Skill" \
+  --description "Public credential-free SKILL.md for ..." \
+  --tagline "Short marketplace tagline" \
+  --category Automation \
+  --price 0 \
+  --tags "skills,automation,agents" \
+  --source-url "https://raw-or-gist-url/SKILL.md"
+```
+
+`ugig skills create` is an alias for `ugig skills new`. If the installed CLI is older or does not support the needed fields, use the uGig browser form:
+
+```text
+https://ugig.net/dashboard/skills/new
+```
+
+Known form fields:
+
+- Skill File URL: raw/direct public `SKILL.md` URL.
+- Title.
+- Tagline.
+- Description.
+- Price: `0` for free.
+- Category.
+- Tags: keep combined tags short; supported-agent chips may count toward the maximum.
+- ClawHub URL: fill after publishing to ClawHub.
+
+Verification:
+
+- Listing URL is `/skills/<slug>`.
+- Page says `Free` or the expected price.
+- Security scan says `Clean`.
+- Medium warning for environment variable access is expected if the skill documents env vars.
+- Source URL is correct and contains no secrets.
+
+## sh1pt workflow
+
+The sh1pt CLI should provide top-level skill promotion commands:
+
+```bash
+sh1pt skills new --skill-file ./SKILL.md --source-url "https://raw-or-gist-url/SKILL.md" --price 0
+sh1pt skills publish --all --dry-run
+sh1pt skills publish --marketplace ugig clawhub goose
+sh1pt skills marketplaces
+```
+
+Expected behavior:
+
+- `sh1pt skills new` creates `sh1pt.skill.json` by reading frontmatter from the local `SKILL.md` and filling title/slug/description/tags/price/source URL.
+- `sh1pt skills publish --all --dry-run` prints exact commands or manual steps for every known marketplace.
+- Non-dry runs should not blindly execute unknown third-party CLIs until credentials/API setup is verified; print commands and mark manual/action-required states.
+
+Implementation locations vary by project. In a typical sh1pt-style monorepo, add the command module under the CLI package and register it from the CLI entrypoint.
+
+## Marketplace matrix
+
+| Marketplace | Method | Publish pattern |
+|---|---|---|
+| uGig | CLI/API or browser | `ugig skills new ... --source-url <raw SKILL.md>` |
+| ClawHub | CLI | `clawhub publish . --slug <slug> --version 1.0.0` |
+| skills.sh | Auto-indexed | Push public GitHub repo containing `SKILL.md` |
+| LobeHub Skills | Submit | Use site submission; install command shown as `npx @lobehub/cli skill install <slug>` |
+| Goose Skills | PR / install URL | `goose skill add <raw SKILL.md URL>`; submit PR if directory requires it |
+| Kilo Marketplace | PR | Fork + PR with valid `SKILL.md`; install command `kilo skill install <slug>` |
+| Skillstore | GitHub repo | Submit repo/raw URL for security analysis |
+| FreeMyGent | Upload | Upload `skill.md`, set price, connect wallet |
+| ClawMart | API | `clawmart publish . --name <slug>` |
+| Manus Agent Skills | Account | Free account required; submit through account UI |
+| VS Code Agent Skills | GitHub | Publish via extension-indexed GitHub repo/PR |
+| Moltbook / NormieClaw | Submit | Submit, set price, pass quality check |
+
+## Public source choices
+
+Quick gist:
+
+```bash
+gh gist create ./SKILL.md --public --desc "<skill title>"
+gh api gists/<gist-id> --jq '.files["SKILL.md"].raw_url'
+```
+
+Better for auto-indexers:
+
+```bash
+mkdir -p /tmp/<slug>
+cp ./SKILL.md /tmp/<slug>/SKILL.md
+cd /tmp/<slug>
+git init
+git add SKILL.md
+git commit -m "Add <slug> skill"
+gh repo create <owner>/<slug>-skill --public --source=. --push
+```
+
+Prefer a repo over a gist when targeting skills.sh, VS Code Agent Skills, Goose/Kilo PRs, or marketplaces that require repository metadata.
+
+## Common pitfalls
+
+1. Using a human gist page instead of the raw URL. Use `gist.githubusercontent.com/.../raw/.../SKILL.md` for import.
+2. Publishing credentials in examples. Use placeholder env var names only.
+3. Too many tags on uGig. Keep tags under 10 and leave supported-agent chips blank if validation complains.
+4. Assuming "Publish Everywhere" means automatic publication. It is a per-marketplace checklist; many require account registration, API keys, or PRs.
+5. Calling unknown CLIs live without checking auth. Prefer dry-run until `command -v`, login status, and target repo/account are verified.
+
+## Final report format
+
+```text
+Published:
+- uGig: https://ugig.net/skills/<slug>
+- GitHub source: https://github.com/<owner>/<repo>
+- Raw SKILL.md: https://...
+
+Ready/manual next:
+- ClawHub: <command or login needed>
+- Goose: <PR/command>
+- LobeHub: <submission URL>
+
+Security:
+- Secret scan: clean / reviewed
+- uGig scan: Clean; env-var warning expected
+```

--- a/skills/ralyodio/promote-skill/skill-report.json
+++ b/skills/ralyodio/promote-skill/skill-report.json
@@ -1,0 +1,6 @@
+{
+  "status": "pending-review",
+  "source": "https://github.com/ralyodio/agent-skills/tree/main/skills/promote-skill",
+  "submittedBy": "ralyodio",
+  "notes": "Public credential-free SKILL.md submitted for Skillstore review."
+}


### PR DESCRIPTION
Adds three public credential-free SKILL.md skills for Skillstore review:\n\n- Dice Easy Apply Automation\n- LinkedIn Easy Apply Automation\n- Promote Skill\n\nCanonical source: https://github.com/ralyodio/agent-skills