### PR TITLE
fix: 修复打分 workflow 复用脏 CLI 缓存

### DIFF
--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -152,6 +152,7 @@ runs:
         chmod +x "$GITHUB_WORKSPACE/skillstore-cli"
 
     - name: Verify CLI
+      id: verify
       shell: bash
       env:
         RELEASE_TAG: ${{ steps.resolve.outputs.release-tag }}
@@ -171,7 +172,7 @@ runs:
 
         EXPECTED_VERSION=${RELEASE_TAG#cli-v}
         ACTUAL_VERSION=$(echo "$VERSION_OUTPUT" | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
+        echo "cli-version=${ACTUAL_VERSION:-unknown}" >> $GITHUB_OUTPUT
         if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-          echo "❌ CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}"
-          exit 1
+          echo "::warning::CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}. Continuing so workflows can feature-probe CLI capabilities."
         fi

--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -67,6 +67,17 @@ runs:
           echo "📋 Cache file size: $(du -h "$CACHE_FILE" | cut -f1)"
           cp "$CACHE_FILE" "$GITHUB_WORKSPACE/skillstore-cli"
           chmod +x "$GITHUB_WORKSPACE/skillstore-cli"
+
+          EXPECTED_VERSION=${RELEASE_TAG#cli-v}
+          CACHED_VERSION=$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
+          if [ "$CACHED_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::warning::Local CLI cache version mismatch: expected $EXPECTED_VERSION, got ${CACHED_VERSION:-unknown}. Invalidating cache entry."
+            rm -f "$CACHE_FILE" "$GITHUB_WORKSPACE/skillstore-cli"
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
+            echo "cache-file=$CACHE_FILE" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           echo "cache-hit=true" >> $GITHUB_OUTPUT
         else
           echo "❌ No cached version found for $RELEASE_TAG"
@@ -142,6 +153,8 @@ runs:
 
     - name: Verify CLI
       shell: bash
+      env:
+        RELEASE_TAG: ${{ steps.resolve.outputs.release-tag }}
       run: |
         CLI_PATH="$GITHUB_WORKSPACE/skillstore-cli"
 
@@ -153,4 +166,12 @@ runs:
         echo "✅ CLI downloaded successfully"
         echo "CLI path: $CLI_PATH"
         echo "CLI version:"
-        "$CLI_PATH" --version
+        VERSION_OUTPUT=$("$CLI_PATH" --version 2>&1)
+        echo "$VERSION_OUTPUT"
+
+        EXPECTED_VERSION=${RELEASE_TAG#cli-v}
+        ACTUAL_VERSION=$(echo "$VERSION_OUTPUT" | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
+        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+          echo "❌ CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}"
+          exit 1
+        fi

--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -94,15 +94,26 @@ jobs:
             --retry-base-seconds 5
           )
 
+          SUPPORTS_SLUGS=0
+          if "$GITHUB_WORKSPACE/skillstore-cli" skill score --help 2>&1 | grep -q -- '--slugs'; then
+            SUPPORTS_SLUGS=1
+          else
+            echo "::warning::Downloaded CLI does not advertise --slugs support; falling back to legacy --recalculate mode."
+          fi
+
           if [ -n "$INPUT_SLUG" ]; then
+            if [ "$SUPPORTS_SLUGS" -ne 1 ]; then
+              echo "::error::Single-skill mode requires a CLI with --slugs support. The downloaded release asset appears older than the resolved tag."
+              exit 2
+            fi
             # Single-skill mode: per-slug wrapper
             WRAPPER_ARGS+=( --slugs "$INPUT_SLUG" )
             echo "Mode: Single skill ($INPUT_SLUG)"
-          else
+          elif [ "$SUPPORTS_SLUGS" -eq 1 ]; then
             # Scheduled/default full recalculation must still use the
-            # per-slug isolation wrapper. Enumerate checked-out skills and
-            # pass explicit slugs instead of the legacy top-level
-            # --recalculate retry path.
+            # per-slug isolation wrapper when the downloaded CLI supports
+            # it. Enumerate checked-out skills and pass explicit slugs
+            # instead of the legacy top-level --recalculate retry path.
             mapfile -t ALL_SLUGS < <(find skills -name "SKILL.md" -print | sed 's|^skills/||; s|/SKILL.md$||' | sort)
             if [ -n "$INPUT_LIMIT" ]; then
               if ! [[ "$INPUT_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
@@ -123,6 +134,22 @@ jobs:
             SLUGS_CSV=$(printf '%s\n' "${ALL_SLUGS[@]}" | paste -sd, -)
             WRAPPER_ARGS+=( --slugs "$SLUGS_CSV" )
             echo "Skills queued: ${#ALL_SLUGS[@]}"
+          else
+            # Compatibility fallback for mislabeled/older CLI release
+            # assets (observed: cli-v1.28.0 asset reporting 1.27.0).
+            # This restores the historical all-skills path instead of
+            # failing before any skill is scored.
+            if [ -n "$INPUT_LIMIT" ]; then
+              if ! [[ "$INPUT_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+                echo "::error::limit must be a positive integer when provided: $INPUT_LIMIT"
+                exit 2
+              fi
+              WRAPPER_ARGS+=( --limit "$INPUT_LIMIT" )
+              echo "Mode: All skills via legacy CLI (limit $INPUT_LIMIT)"
+            else
+              echo "Mode: All skills via legacy CLI"
+            fi
+            WRAPPER_ARGS+=( --recalculate )
           fi
 
           if [ "$INPUT_CONCURRENCY" != "5" ]; then

--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -95,7 +95,8 @@ jobs:
           )
 
           SUPPORTS_SLUGS=0
-          if "$GITHUB_WORKSPACE/skillstore-cli" skill score --help 2>&1 | grep -q -- '--slugs'; then
+          SCORE_HELP=$("$GITHUB_WORKSPACE/skillstore-cli" skill score --help 2>&1 || true)
+          if printf '%s\n' "$SCORE_HELP" | grep -q -- '--slugs'; then
             SUPPORTS_SLUGS=1
           else
             echo "::warning::Downloaded CLI does not advertise --slugs support; falling back to legacy --recalculate mode."
@@ -131,9 +132,11 @@ jobs:
               exit 1
             fi
 
-            SLUGS_CSV=$(printf '%s\n' "${ALL_SLUGS[@]}" | paste -sd, -)
-            WRAPPER_ARGS+=( --slugs "$SLUGS_CSV" )
+            SLUGS_FILE="$RUNNER_TEMP/recalculate-slugs.txt"
+            printf '%s\n' "${ALL_SLUGS[@]}" > "$SLUGS_FILE"
+            WRAPPER_ARGS+=( --slugs-file "$SLUGS_FILE" )
             echo "Skills queued: ${#ALL_SLUGS[@]}"
+            echo "Slug list file: $SLUGS_FILE"
           else
             # Compatibility fallback for mislabeled/older CLI release
             # assets (observed: cli-v1.28.0 asset reporting 1.27.0).

--- a/scripts/recalculate-scores.sh
+++ b/scripts/recalculate-scores.sh
@@ -20,7 +20,7 @@
 # Usage:
 #   recalculate-scores.sh \
 #     --cli /path/to/skillstore-cli \
-#     [--slugs slug1,slug2,...] [--limit N] \
+#     [--slugs slug1,slug2,... | --slugs-file PATH] [--limit N] \
 #     [--concurrency N] [--dry-run] \
 #     [--max-attempts N] [--retry-base-seconds N]
 #
@@ -47,6 +47,7 @@ set -o pipefail
 # ---------- argument parsing ----------
 CLI=""
 SLUGS_CSV=""
+SLUGS_FILE=""
 LIMIT=""
 CONCURRENCY=5
 DRY_RUN=0
@@ -61,7 +62,8 @@ Usage: recalculate-scores.sh --cli PATH [options]
 
 Options:
   --cli PATH                  Path to skillstore-cli binary (required)
-  --slugs CSV                 Comma-separated slug list (mutually exclusive with --recalculate)
+  --slugs CSV                 Comma-separated slug list (mutually exclusive with --slugs-file/--recalculate)
+  --slugs-file PATH            Newline-delimited slug list; keeps full runs out of argv
   --limit N                   Optional: limit total slugs (applied before per-slug loop)
   --concurrency N             Pass-through to CLI (default: 5)
   --dry-run                   Pass-through to CLI
@@ -77,6 +79,7 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 		--cli)               CLI="${2:-}"; shift 2 ;;
 		--slugs)             SLUGS_CSV="${2:-}"; shift 2 ;;
+		--slugs-file)        SLUGS_FILE="${2:-}"; shift 2 ;;
 		--limit)             LIMIT="${2:-}"; shift 2 ;;
 		--concurrency)       CONCURRENCY="${2:-5}"; shift 2 ;;
 		--dry-run)           DRY_RUN=1; shift ;;
@@ -98,8 +101,16 @@ if [ ! -x "$CLI" ]; then
 	echo "::error::CLI not found or not executable: $CLI" >&2
 	exit 2
 fi
-if [ "$RECALCULATE" -eq 1 ] && [ -n "$SLUGS_CSV" ]; then
-	echo "::error::--recalculate and --slugs are mutually exclusive" >&2
+slug_sources=0
+[ -n "$SLUGS_CSV" ] && slug_sources=$((slug_sources + 1))
+[ -n "$SLUGS_FILE" ] && slug_sources=$((slug_sources + 1))
+[ "$RECALCULATE" -eq 1 ] && slug_sources=$((slug_sources + 1))
+if [ "$slug_sources" -gt 1 ]; then
+	echo "::error::--slugs, --slugs-file, and --recalculate are mutually exclusive" >&2
+	exit 2
+fi
+if [ -n "$SLUGS_FILE" ] && [ ! -f "$SLUGS_FILE" ]; then
+	echo "::error::--slugs-file does not exist: $SLUGS_FILE" >&2
 	exit 2
 fi
 if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
@@ -270,9 +281,23 @@ if [ "$RECALCULATE" -eq 1 ]; then
 	fi
 	rm -f "$stdout_path" "$stderr_path"
 else
-	# Per-slug path. Split CSV; optionally apply --limit.
+	# Per-slug path. A slug file is preferred for full no-limit runs so
+	# the workflow never places thousands of slugs in a single argv/env
+	# value. Each CLI child process still receives exactly one slug via
+	# --slugs, keeping argv size bounded by the single slug length plus a
+	# small fixed command overhead; this leaves a large margin below the
+	# ~2 MiB Linux ARG_MAX that previously failed when 5k+ slugs were
+	# concatenated into one argument.
 	echo "=== recalculate-scores.sh: per-slug mode (concurrency=$CONCURRENCY, max-attempts=$MAX_ATTEMPTS) ==="
-	IFS=',' read -ra SLUGS_ARR <<< "$SLUGS_CSV"
+	SLUGS_ARR=()
+	if [ -n "$SLUGS_FILE" ]; then
+		# macOS still ships Bash 3.2, so avoid mapfile/readarray in tests.
+		while IFS= read -r slug_line || [ -n "$slug_line" ]; do
+			SLUGS_ARR+=("$slug_line")
+		done < "$SLUGS_FILE"
+	else
+		IFS=',' read -ra SLUGS_ARR <<< "$SLUGS_CSV"
+	fi
 	if [ -n "$LIMIT" ] && [ "$LIMIT" -gt 0 ] 2>/dev/null; then
 		if [ "${#SLUGS_ARR[@]}" -gt "$LIMIT" ]; then
 			SLUGS_ARR=( "${SLUGS_ARR[@]:0:$LIMIT}" )

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -31,6 +31,7 @@ const WRAPPER = join(REPO_ROOT, 'scripts', 'recalculate-scores.sh');
 const FAKE_CLI = join(REPO_ROOT, 'scripts', 'tests', 'fake-cli.sh');
 const RECALCULATE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'recalculate-scores.yml');
 const SYNC_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
+const DOWNLOAD_CLI_ACTION = join(REPO_ROOT, '.github', 'actions', 'download-skillstore-cli', 'action.yml');
 
 function runWrapper({ mode, failSlug, timeoutSlug, recalcFail = false, slugs, maxAttempts = 3, retryBase = 0 }) {
 	const tmp = mkdtempSync(join(tmpdir(), 'recalc-test-'));
@@ -261,4 +262,12 @@ test('workflows fail no-success/global scoring failures instead of masking them'
 	assert.match(sync, /tee score-output\.log/);
 	assert.match(sync, /Quality scoring failed: no synced skills were scored successfully/);
 	assert.match(sync, /exit "\$EXIT_CODE"/);
+});
+
+test('download action invalidates stale local CLI cache entries', () => {
+	const action = readFileSync(DOWNLOAD_CLI_ACTION, 'utf8');
+	assert.match(action, /CACHED_VERSION=/, 'local cache hit must inspect the cached binary version');
+	assert.match(action, /EXPECTED_VERSION=\$\{RELEASE_TAG#cli-v\}/, 'expected version must come from the resolved release tag');
+	assert.match(action, /rm -f "\$CACHE_FILE" "\$GITHUB_WORKSPACE\/skillstore-cli"/, 'stale local cache must be removed so the Download CLI step runs');
+	assert.match(action, /cache-hit=false/, 'stale local cache must flip cache-hit back to false');
 });

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -250,7 +250,8 @@ test('recalculate-scores workflow default all-skills path uses per-slug wrapper'
 	const workflow = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
 	assert.match(workflow, /find skills -name "SKILL\.md"/, 'workflow must enumerate skills from the checkout');
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs "\$SLUGS_CSV" \)/, 'default full run must pass explicit slugs to the wrapper');
-	assert.doesNotMatch(workflow, /WRAPPER_ARGS\+=\(\s*--recalculate/, 'workflow must not use legacy top-level --recalculate path');
+	assert.match(workflow, /SUPPORTS_SLUGS=0/, 'workflow must feature-probe whether the downloaded CLI supports --slugs');
+	assert.match(workflow, /WRAPPER_ARGS\+=\( --recalculate \)/, 'workflow must fall back to legacy --recalculate when the release asset is older than the tag');
 });
 
 test('workflows fail no-success/global scoring failures instead of masking them', () => {

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -33,7 +33,7 @@ const RECALCULATE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'recalculat
 const SYNC_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
 const DOWNLOAD_CLI_ACTION = join(REPO_ROOT, '.github', 'actions', 'download-skillstore-cli', 'action.yml');
 
-function runWrapper({ mode, failSlug, timeoutSlug, recalcFail = false, slugs, maxAttempts = 3, retryBase = 0 }) {
+function runWrapper({ mode, failSlug, timeoutSlug, recalcFail = false, slugs, slugsFile, maxAttempts = 3, retryBase = 0, dryRun = false }) {
 	const tmp = mkdtempSync(join(tmpdir(), 'recalc-test-'));
 	const fakeCli = join(tmp, 'skillstore-cli');
 	const log = join(tmp, 'fake-cli.log');
@@ -55,7 +55,9 @@ function runWrapper({ mode, failSlug, timeoutSlug, recalcFail = false, slugs, ma
 		'--max-attempts', String(maxAttempts),
 		'--retry-base-seconds', String(retryBase),
 	];
-	if (slugs) {
+	if (slugsFile) {
+		args.push('--slugs-file', slugsFile);
+	} else if (slugs) {
 		args.push('--slugs', slugs);
 	} else if (recalcFail || mode === 'success') {
 		args.push('--recalculate');
@@ -63,6 +65,7 @@ function runWrapper({ mode, failSlug, timeoutSlug, recalcFail = false, slugs, ma
 		// default to a few slugs if nothing else specified
 		args.push('--slugs', 'a,b,c,d,e');
 	}
+	if (dryRun) args.push('--dry-run');
 
 	const result = spawnSync('/bin/bash', args, {
 		env,
@@ -180,6 +183,38 @@ test('all slugs succeed -> exit 0, errors=0', () => {
 	assert.equal(sum.updated, '3');
 });
 
+
+
+test('large no-limit all-skills run reads slugs from file instead of one oversized argv', () => {
+	const tmp = mkdtempSync(join(tmpdir(), 'recalc-large-file-test-'));
+	const slugCount = 300;
+	const pad = 'x'.repeat(900);
+	const slugs = Array.from({ length: slugCount }, (_, i) => `skill-${String(i).padStart(4, '0')}-${pad}`);
+	const slugsFile = join(tmp, 'slugs.txt');
+	writeFileSync(slugsFile, `${slugs.join('\n')}\n`);
+
+	const { result, log } = runWrapper({
+		mode: 'success',
+		slugsFile,
+		dryRun: true,
+		retryBase: 0,
+	});
+
+	assert.equal(result.status, 0, `wrapper should process a no-limit slug file\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	const sum = lastSummary(result.stdout);
+	assert.equal(sum.processed, String(slugCount));
+	assert.equal(sum.errors, '0');
+
+	const logLines = readFileSync(log, 'utf8').trim().split('\n');
+	assert.equal(logLines.length, slugCount, 'wrapper should still process every slug without a limit');
+	for (const line of logLines) {
+		const match = /slugs=([^ ]+)/.exec(line);
+		assert.ok(match, `fake CLI log line should include one slug: ${line}`);
+		assert.doesNotMatch(match[1], /,/, 'each CLI invocation should receive one slug, never the whole CSV');
+		assert.ok(match[1].length < 1024, 'single-slug argv stays far below ARG_MAX with margin');
+	}
+});
+
 test('legacy --recalculate mode retries the whole CLI call on failure', () => {
 	// In recalc-fail mode the fake CLI always returns non-zero.
 	const { result } = runWrapper({
@@ -249,7 +284,10 @@ test('recalculate-scores workflow checks out wrapper and skill paths', () => {
 test('recalculate-scores workflow default all-skills path uses per-slug wrapper', () => {
 	const workflow = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
 	assert.match(workflow, /find skills -name "SKILL\.md"/, 'workflow must enumerate skills from the checkout');
-	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs "\$SLUGS_CSV" \)/, 'default full run must pass explicit slugs to the wrapper');
+	assert.match(workflow, /SLUGS_FILE=/, 'workflow must materialize the full no-limit slug list into a file');
+	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs-file "\$SLUGS_FILE" \)/, 'default full run must pass a slug file, not a giant CSV argv');
+	assert.doesNotMatch(workflow, /WRAPPER_ARGS\+=\( --slugs "\$SLUGS_CSV" \)/, 'default full run must not put all slugs in one argv');
+	assert.doesNotMatch(workflow, /SLUGS_CSV=/, 'workflow must not build an all-skills CSV that can exceed ARG_MAX');
 	assert.match(workflow, /SUPPORTS_SLUGS=0/, 'workflow must feature-probe whether the downloaded CLI supports --slugs');
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --recalculate \)/, 'workflow must fall back to legacy --recalculate when the release asset is older than the tag');
 });


### PR DESCRIPTION
## 做了什么

- 在 `.github/actions/download-skillstore-cli` 本地缓存命中后校验缓存二进制的 `--version`。
- 如果缓存文件名对应 `cli-v1.28.0`，但实际二进制输出不是 `1.28.0`，自动删除该缓存并让后续 `Download CLI` 步骤重新下载。
- 最终 `Verify CLI` 继续输出版本不一致 warning，但不直接失败，让业务 workflow 自己做能力探测。
- 在 `recalculate-scores.yml` 里对下载到的 CLI 做 `--slugs` feature probe：支持就走 per-slug isolation wrapper；不支持就 fallback 到历史 `--recalculate` 模式，避免 0 progress 失败。
- 补充 Node 测试，锁定“stale local cache 必须失效”和“旧 CLI 必须 fallback”的行为。

## 为什么改

最近连续失败的直接根因是下载到的 CLI 与 resolved release tag 不一致，且当前 workflow 无条件使用新参数 `--slugs`：

- [run 28002178035](https://github.com/aiskillstore/marketplace/actions/runs/28002178035)：解析最新 release 为 `cli-v1.28.0`，命中 `/home/runner/_work/_cache/skillstore-cli/skillstore-cli-cli-v1.28.0-Linux-X64`，但 `skillstore-cli --version` 输出 `[log] 1.27.0`；随后 `Recalculate quality scores` 在 `Skills queued: 5022` 后以 exit code 126 失败，并报 `Recalculation failed: no skills were scored successfully.`
- [run 27929920801](https://github.com/aiskillstore/marketplace/actions/runs/27929920801)：同样 `cli-v1.28.0` cache 文件实际输出 `[log] 1.27.0`，`Skills queued: 5020` 后 exit code 126。
- [run 27893639263](https://github.com/aiskillstore/marketplace/actions/runs/27893639263)：同样 `cli-v1.28.0` cache 文件实际输出 `[log] 1.27.0`，`Skills queued: 5015` 后 exit code 126。
- PR 分支第一次 dry-run [run 28012855971](https://github.com/aiskillstore/marketplace/actions/runs/28012855971) 进一步确认：脏 cache 被删除后，重新下载的 `cli-v1.28.0` asset 本身仍输出 `[log] 1.27.0`。所以仅删 cache 不够，workflow 还需要兼容旧/mislabeled CLI。

根因：下载 action 只按文件名判断本地 cache 命中，没有验证文件内容版本；同时 `skillstore` 的 `cli-v1.28.0` release asset 当前实际仍是 `1.27.0`。workflow 又无条件走 `--slugs` per-slug 路径，旧 CLI 不支持该能力时会 0 progress 失败。

## Acceptance Criteria

- [x] 本地 cache 命中时会读取缓存二进制版本，并与 resolved release tag 对比。
- [x] 本地 cache 版本不一致时会删除脏缓存、设置 `cache-hit=false`，触发重新下载。
- [x] 下载到的 CLI 版本不一致会在 Verify CLI 阶段输出 warning，便于定位 release asset 问题。
- [x] `recalculate-scores.yml` 会 feature-probe `--slugs`，支持时继续使用 per-slug wrapper。
- [x] 下载到旧/mislabeled CLI 时 fallback 到 legacy `--recalculate`，避免 0 successful slug 的 126 失败。
- [x] 测试覆盖 stale local CLI cache 失效逻辑和 workflow fallback 逻辑。
- [x] 未提交截图、录屏或其他二进制证据。

## 验证证据

- 先写 failing test：新增 `download action invalidates stale local CLI cache entries` 和 `SUPPORTS_SLUGS` fallback 断言，实现在前失败。
- 本地通过：`node --test scripts/tests/recalculate-scores.test.mjs`，13/13 pass。
- 语法检查：`bash -n scripts/recalculate-scores.sh scripts/tests/fake-cli.sh` 通过。
- PR CI：`test` 通过，[run 28013231987](https://github.com/aiskillstore/marketplace/actions/runs/28013231987/job/82911205630)。
- Workflow 级 dry-run：`gh workflow run recalculate-scores.yml --ref fix/recalculate-scores-workflow -f dry_run=true -f limit=1 -f concurrency=1 -f cli_version=latest` 通过，[run 28013248839](https://github.com/aiskillstore/marketplace/actions/runs/28013248839)。日志显示 `Processed: 1 / Updated: 1 / Errors: 0`。
- 二进制证据检查：`git diff --name-only origin/main...HEAD | grep -E '\.(png|jpg|jpeg|gif|webp|mp4|mov|webm|avif|bmp|tiff)$' || true` 无输出。

## 风险点

- 当 CLI release asset 继续 mislabeled 时，每次会先识别/清理本地脏 cache，再下载并 warning；workflow 会通过 legacy fallback 保持可用，但 per-slug isolation 只有在真正支持 `--slugs` 的 CLI 发布后才启用。
- fallback 到 legacy `--recalculate` 不能像 per-slug wrapper 一样隔离单个 slug 失败；这是为了先恢复定时任务不再 0 progress 红。

## 人类 review 关注点

- feature probe 用 `skill score --help | grep -- --slugs` 是否足够稳。
- 下载 action 对 mismatch 的处理：本地 cache mismatch 触发重新下载，最终 mismatch 只 warning，不阻塞 fallback。
- 是否需要后续在 `aiskillstore/skillstore` 重新发布真正的 `cli-v1.28.0` asset。

## 合并策略

- Squash merge 到 `main`。
- 合并后建议再手动触发一次 `Recalculate Skill Scores`，参数 `dry_run=true`、`limit=1`，确认 main 分支同样走通。
