### PR TITLE
让 skillstore add 默认自动检测 Codex 和 Claude Code

### DIFF
--- a/packages/skillstore/src/commands/add.ts
+++ b/packages/skillstore/src/commands/add.ts
@@ -10,16 +10,15 @@ import {
 } from '../lib/plugin-api.js';
 import { fetchSkillManifest, downloadSkillZip, SkillApiError } from '../lib/skill-api.js';
 import { verifyManifest, verifySkillManifest, verifyZipHash } from '../lib/plugin-verify.js';
-import { downloadAllSkills, printDownloadSummary } from '../lib/plugin-download.js';
+import { downloadAllSkills, printDownloadSummary, type DownloadSummary } from '../lib/plugin-download.js';
 import { logger } from '../lib/plugin-logger.js';
 import {
 	agents,
-	detectInstalledAgents,
+	detectDefaultInstallAgents,
 	getAgentsByIds,
 	isValidAgentId,
 	CANONICAL_SKILLS_DIR,
 	type AgentConfig,
-	type AgentId,
 } from '../lib/agents.js';
 import { addToLock, getLockEntry } from '../lib/skill-lock.js';
 import { installToAgents, getCanonicalSkillPath } from '../lib/installer.js';
@@ -97,20 +96,20 @@ export default defineCommand({
 		let targetAgents: AgentConfig[];
 		if (agentArg) {
 			// Parse comma-separated agent IDs
-			const agentIds = agentArg.split(',').map((s) => s.trim()) as AgentId[];
+			const agentIds = agentArg.split(',').map((s) => s.trim());
 			const invalidIds = agentIds.filter((id) => !isValidAgentId(id));
 			if (invalidIds.length > 0) {
 				logger.error(`Invalid agent ID(s): ${invalidIds.join(', ')}`);
 				console.log('');
-				console.log('Valid agents: claude-code, cursor, windsurf, cline, codex, continue, etc.');
+				console.log('Valid agents include: claude, codex, claude-code, cursor, windsurf, cline, continue, etc.');
 				process.exit(1);
 			}
 			targetAgents = getAgentsByIds(agentIds);
 		} else {
-			// Auto-detect installed agents
-			targetAgents = detectInstalledAgents();
+			// Auto-detect the default Skillstore targets only.
+			targetAgents = detectDefaultInstallAgents();
 			if (targetAgents.length === 0) {
-				logger.warn('No AI coding agents detected. Installing to Claude Code by default.');
+				logger.warn('No Codex or Claude Code folders detected. Installing to Claude Code by default.');
 				targetAgents = [agents['claude-code']];
 			}
 		}
@@ -129,6 +128,31 @@ interface AddOptions {
 	skipVerify: boolean;
 	dryRun: boolean;
 	overwrite: boolean;
+}
+
+interface PluginInstallTarget {
+	agent: AgentConfig;
+	installDir: string;
+}
+
+function getPluginInstallTargets(targetAgents: AgentConfig[], isGlobal: boolean): PluginInstallTarget[] {
+	return targetAgents.map((agent) => ({
+		agent,
+		installDir: isGlobal ? agent.globalPath : join(process.cwd(), agent.projectPath),
+	}));
+}
+
+function combineDownloadSummaries(summaries: DownloadSummary[]): DownloadSummary {
+	return summaries.reduce<DownloadSummary>(
+		(combined, summary) => ({
+			total: combined.total + summary.total,
+			success: combined.success + summary.success,
+			failed: combined.failed + summary.failed,
+			skipped: combined.skipped + summary.skipped,
+			results: [...combined.results, ...summary.results],
+		}),
+		{ total: 0, success: 0, failed: 0, skipped: 0, results: [] }
+	);
 }
 
 /**
@@ -290,20 +314,20 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
 async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 	const { targetAgents, isGlobal, skipVerify, dryRun, overwrite } = options;
 
-	// For plugins, use first agent's path as install dir (legacy behavior)
-	// TODO: Update plugin download to use multi-agent installation
-	const installDir = isGlobal
-		? targetAgents[0]?.globalPath || agents['claude-code'].globalPath
-		: join(process.cwd(), targetAgents[0]?.projectPath || '.claude/skills');
+	const installTargets = getPluginInstallTargets(targetAgents, isGlobal);
+	const primaryInstallDir = installTargets[0]?.installDir || agents['claude-code'].globalPath;
 
 	const config = getPluginConfig({
-		installDir,
+		installDir: primaryInstallDir,
 		skipVerify,
 		dryRun,
 	});
 
 	logger.info(`Adding plugin: @${slug}`);
-	logger.info(`Target directory: ${config.installDir}`);
+	logger.info(`Target agents: ${targetAgents.map((a) => a.name).join(', ')}`);
+	for (const target of installTargets) {
+		logger.info(`Target directory (${target.agent.name}): ${target.installDir}`);
+	}
 
 	if (dryRun) {
 		logger.warn('Dry run mode - no files will be written');
@@ -343,15 +367,25 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			`Generated: ${new Date(manifest.generatedAt).toLocaleDateString()}`,
 		]);
 
-		// Step 4: Download skills
-		logger.info('');
-		const downloadResult = await downloadAllSkills(config, manifest.skills, {
-			overwrite,
-			verifyHash: !skipVerify,
-		});
+		// Step 4: Download skills to every selected agent directory
+		const downloadSummaries: DownloadSummary[] = [];
+		for (const target of installTargets) {
+			logger.info('');
+			logger.info(`Installing to ${target.agent.name}...`);
+			const targetConfig = getPluginConfig({
+				installDir: target.installDir,
+				skipVerify,
+				dryRun,
+			});
+			const downloadResult = await downloadAllSkills(targetConfig, manifest.skills, {
+				overwrite,
+				verifyHash: !skipVerify,
+			});
+			printDownloadSummary(downloadResult);
+			downloadSummaries.push(downloadResult);
+		}
 
-		// Step 5: Print summary
-		printDownloadSummary(downloadResult);
+		const downloadResult = combineDownloadSummaries(downloadSummaries);
 
 		// Step 6: Report installation (non-blocking)
 		if (!dryRun && downloadResult.success > 0) {
@@ -367,10 +401,12 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			}
 
 			// Report telemetry for each successfully installed skill
-			const successfulSkills = downloadResult.results.filter((r) => r.success && !r.skipped);
-			if (successfulSkills.length > 0) {
+			const successfulSkillSlugs = [
+				...new Set(downloadResult.results.filter((r) => r.success && !r.skipped).map((r) => r.slug)),
+			];
+			if (successfulSkillSlugs.length > 0) {
 				// Report in parallel, non-blocking
-				Promise.all(successfulSkills.map((r) => reportSkillInstall(config, r.slug))).catch(() => {
+				Promise.all(successfulSkillSlugs.map((skillSlug) => reportSkillInstall(config, skillSlug))).catch(() => {
 					logger.debug('Telemetry reporting failed (non-critical)');
 				});
 			}

--- a/packages/skillstore/src/lib/agents.ts
+++ b/packages/skillstore/src/lib/agents.ts
@@ -53,6 +53,12 @@ export type AgentId =
 	| 'zencoder'
 	| 'neovate';
 
+export const DEFAULT_INSTALL_AGENT_IDS = ['codex', 'claude-code'] as const satisfies readonly AgentId[];
+
+const AGENT_ID_ALIASES: Record<string, AgentId> = {
+	claude: 'claude-code',
+};
+
 const home = homedir();
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 
@@ -275,12 +281,24 @@ export function detectInstalledAgents(): AgentConfig[] {
 	return Object.values(agents).filter((agent) => agent.detectInstalled());
 }
 
+/** Detect default Skillstore install targets: Codex and Claude Code only. */
+export function detectDefaultInstallAgents(): AgentConfig[] {
+	return DEFAULT_INSTALL_AGENT_IDS.map((id) => agents[id]).filter((agent) => agent.detectInstalled());
+}
+
+export function normalizeAgentId(id: string): AgentId | null {
+	const normalized = id.trim().toLowerCase();
+	const canonicalId = AGENT_ID_ALIASES[normalized] ?? normalized;
+	return canonicalId in agents ? (canonicalId as AgentId) : null;
+}
+
 /** Get agent configs by IDs */
-export function getAgentsByIds(ids: AgentId[]): AgentConfig[] {
-	return ids.map((id) => agents[id]).filter(Boolean);
+export function getAgentsByIds(ids: string[]): AgentConfig[] {
+	const uniqueIds = [...new Set(ids.map((id) => normalizeAgentId(id)).filter(Boolean))] as AgentId[];
+	return uniqueIds.map((id) => agents[id]).filter(Boolean);
 }
 
 /** Check if an agent ID is valid */
-export function isValidAgentId(id: string): id is AgentId {
-	return id in agents;
+export function isValidAgentId(id: string): boolean {
+	return normalizeAgentId(id) !== null;
 }

--- a/packages/skillstore/tests/agents.test.ts
+++ b/packages/skillstore/tests/agents.test.ts
@@ -4,6 +4,7 @@ import {
 	getAllAgentIds,
 	getAgentById,
 	detectInstalledAgents,
+	detectDefaultInstallAgents,
 	getAgentsByIds,
 	isValidAgentId,
 	CANONICAL_SKILLS_DIR,
@@ -138,6 +139,19 @@ describe('agents', () => {
 		});
 	});
 
+	describe('detectDefaultInstallAgents', () => {
+		it('should return only Codex and Claude Code when both folders exist', () => {
+			vi.mocked(existsSync).mockImplementation((path) => {
+				const p = String(path);
+				return p.includes('.codex') || p.includes('.claude') || p.includes('.cursor');
+			});
+
+			const installed = detectDefaultInstallAgents();
+
+			expect(installed.map((a) => a.id)).toEqual(['codex', 'claude-code']);
+		});
+	});
+
 	describe('getAgentsByIds', () => {
 		it('should return configs for given IDs', () => {
 			const configs = getAgentsByIds(['claude-code', 'cursor']);
@@ -153,11 +167,18 @@ describe('agents', () => {
 			expect(configs.length).toBe(1);
 			expect(configs[0].id).toBe('claude-code');
 		});
+
+		it('should support claude as an alias for claude-code', () => {
+			const configs = getAgentsByIds(['claude', 'codex', 'claude']);
+
+			expect(configs.map((agent) => agent.id)).toEqual(['claude-code', 'codex']);
+		});
 	});
 
 	describe('isValidAgentId', () => {
 		it('should return true for valid agent IDs', () => {
 			expect(isValidAgentId('claude-code')).toBe(true);
+			expect(isValidAgentId('claude')).toBe(true);
 			expect(isValidAgentId('cursor')).toBe(true);
 			expect(isValidAgentId('windsurf')).toBe(true);
 		});
@@ -165,7 +186,6 @@ describe('agents', () => {
 		it('should return false for invalid agent IDs', () => {
 			expect(isValidAgentId('invalid')).toBe(false);
 			expect(isValidAgentId('')).toBe(false);
-			expect(isValidAgentId('CLAUDE-CODE')).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## 改动内容

- `npx skillstore add <slug>` 和 `npx skillstore add @<pack>` 默认只自动检测 Codex 与 Claude Code 这两个目标环境。
- 当本机同时存在 Codex 和 Claude Code 文件夹时，默认安装到两者；只存在一个时安装到可用的那个。
- 保留显式覆盖能力，并支持 `--agent claude` 作为 `claude-code` 的别名。
- 修复 plugin 安装旧逻辑：不再只写入第一个检测到的 agent 目录，而是写入所有选中的目标目录。
- 多目标安装时，对成功 skill 的 telemetry 上报做去重，避免同一个 skill 因安装到两个目录而重复上报。

## 验收方式

本地执行并通过：

- `npm test -- agents.test.ts`
- `npm run check`

## 关联

配合 skillstore 站点 PR，将官网、MCP 和 Markdown 的默认安装命令改为不带 `--agent` 的自动检测模式。
