### PR TITLE
chore(skillstore): bump npm package version to 0.1.5

### DIFF
--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## 改动内容

- 将 `packages/skillstore/package.json` 里的 npm 包版本从 `0.1.4` 提升到 `0.1.5`。
- 这是为发布包含 #2083 的 `npx skillstore add` 自动检测行为准备的新 npm 版本。

## 验收方式

本地执行并通过：

- `node -p "require('./packages/skillstore/package.json').version"` 输出 `0.1.5`
- `git diff --check`

## 合并后的发布步骤

发布 workflow 会校验 tag 版本和 `packages/skillstore/package.json` 版本一致。合并本 PR 后，可使用其中一种方式发布：

- 推送 tag：`skillstore-v0.1.5`
- 或手动触发 `Release Skillstore NPM` workflow，输入版本 `0.1.5`

两种方式都会走 GitHub Actions Trusted Publishing，不需要本地手动 `npm publish`。
