### PR TITLE
fix(ci): handle blank skillstore CLI version

### DIFF
--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -30,6 +30,7 @@ runs:
         CLI_VERSION: ${{ inputs.version }}
         CLI_REPO: aiskillstore/skillstore
       run: |
+        CLI_VERSION="${CLI_VERSION:-latest}"
         if [ "$CLI_VERSION" = "latest" ]; then
           echo "Fetching latest release tag..."
           RELEASE_TAG=$(gh release view --repo "$CLI_REPO" --json tagName -q '.tagName')


### PR DESCRIPTION
## Summary
- Fix the shared Skillstore CLI download action so an explicitly blank version falls back to latest.
- Prevent scheduled workflows from resolving the release tag as `cli-v` when they pass `${{ inputs.cli_version }}` outside `workflow_dispatch`.

## Root cause
The failed Generate Pack run 28544049610 was a scheduled run at commit `fc26ab600dc96934494c3319f174d9cb5f4d432a`. The Generate Pack workflow passed `${{ inputs.cli_version }}` to the composite action. On scheduled events that expression is empty, and because the input was explicitly provided, the composite action default did not apply. The download action therefore built `RELEASE_TAG=cli-v`, then `gh release download cli-v` failed with `release not found` before pack generation started.

## Verification
- Parsed `.github/actions/download-skillstore-cli/action.yml` and `.github/workflows/generate-packs.yml` as YAML.
- Ran the resolver with blank `CLI_VERSION`; it resolved to `cli-v1.48.0` instead of `cli-v`.
- Ran the resolver with pinned `CLI_VERSION=1.47.0`; it still resolved to `cli-v1.47.0`.
- Ran `git diff --check`.
