### PR TITLE
fix: 修复插件审核命令空白跳过

### DIFF
--- a/.github/workflows/plugin-review.yml
+++ b/.github/workflows/plugin-review.yml
@@ -6,20 +6,29 @@ on:
 
 jobs:
   process-command:
-    # Only real human slash-commands. Skip bot comments (the callback posts its own
-    # "⏳ Generation started" notice as the App, which would otherwise re-trigger this
-    # job and fail the permission check) and ordinary non-command chatter.
+    # Skip bot comments (the callback posts its own "⏳ Generation started" notice as
+    # the App, which would otherwise re-trigger this job). Human comments are
+    # trimmed and command-checked inside the script so leading blank lines before
+    # /generate or /approve do not silently skip the workflow.
     if: >-
       contains(github.event.issue.labels.*.name, 'plugin-review') &&
-      startsWith(github.event.comment.body, '/') &&
       github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
-      - name: Check permissions
-        id: check-perm
+      - name: Process command
         uses: actions/github-script@v8
+        env:
+          CALLBACK_URL: ${{ secrets.SKILLSTORE_API_URL }}/api/plugins/review/callback
+          CALLBACK_SECRET: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
         with:
           script: |
+            const comment = context.payload.comment.body.trim();
+            const knownCommands = ['/generate', '/approve', '/regenerate', '/reject'];
+            if (!knownCommands.some((command) => comment.startsWith(command))) {
+              console.log(`Not a recognized command: ${comment.substring(0, 50)}`);
+              return;
+            }
+
             const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -29,17 +38,7 @@ jobs:
               core.setFailed('Insufficient permissions');
               return;
             }
-            core.setOutput('permission', perm.permission);
 
-      - name: Process command
-        if: success()
-        uses: actions/github-script@v8
-        env:
-          CALLBACK_URL: ${{ secrets.SKILLSTORE_API_URL }}/api/plugins/review/callback
-          CALLBACK_SECRET: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
-        with:
-          script: |
-            const comment = context.payload.comment.body.trim();
             const issueBody = context.payload.issue.body;
 
             // Extract plugin ID from issue body. Tolerate both the table row


### PR DESCRIPTION
## 做了什么
- 调整 `Plugin Review` workflow：不再用未 trim 的 `github.event.comment.body` 判断是否以 `/` 开头。
- 将命令识别移到脚本内，对 comment body 先 `trim()`，再判断 `/generate`、`/approve`、`/regenerate`、`/reject`。
- 权限检查只在确认为审核命令后执行，普通评论不会因为没有权限而失败。

## 为什么改
- 失败现场的 #2135 第一条 `/generate` comment 实际 body 是 `\n/generate`，旧 job-level `startsWith(github.event.comment.body, '/')` 直接跳过，导致生成流程没跑。
- 后续 `/approve` 才触发 workflow，但后端又因为 DB 未记录 issue number 报 `Issue number mismatch`。后端修复在 aiskillstore/skillstore#110，本 PR 修 workflow 侧的空白跳过问题。

## Acceptance Criteria
- [x] `\n/generate` 这类带前导空白的审核命令不会被 job-level if 静默跳过。
- [x] 非 bot 的普通评论不会触发权限失败，只会在脚本内识别为非命令并退出成功。
- [x] bot comment 仍然被 job-level if 跳过，避免回调机器人评论递归触发。

## 验证证据
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/plugin-review.yml"); puts "yaml ok"'`

## 风险点
- plugin-review issue 下的人类普通评论会多启动一个很短的 workflow job，但脚本会立即退出，不调后端。

## 人类 review 关注点
- 是否接受把命令过滤从 job-level if 下沉到 github-script 内。

## 合并策略
- Squash merge。