### PR TITLE
Update workflows for pack CLI and APIs

### DIFF
--- a/.github/actions/invalidate-cache/action.yml
+++ b/.github/actions/invalidate-cache/action.yml
@@ -1,9 +1,9 @@
 name: Invalidate Cache
-description: Batch invalidate cache for skills/workflows/releases
+description: Batch invalidate cache for skills/packs/workflows/releases
 
 inputs:
   type:
-    description: 'Content type (skills, workflows, releases)'
+    description: 'Content type (skills, packs, workflows, releases)'
     required: true
   slugs:
     description: 'Space or comma-separated list of slugs to invalidate'

--- a/.github/workflows/cover-approval.yml
+++ b/.github/workflows/cover-approval.yml
@@ -63,7 +63,7 @@ jobs:
             }
 
             // Call callback API
-            const callbackUrl = `${process.env.SKILLSTORE_API_URL}/api/plugins/cover/callback`;
+            const callbackUrl = `${process.env.SKILLSTORE_API_URL}/api/packs/cover/callback`;
             const callbackBody = {
               requestId,
               event: isApprove ? 'approved' : 'rejected',

--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -1,11 +1,11 @@
-# Generate a plugin's review content — cover image, description and usage guide —
+# Generate a pack's review content — cover image, description and usage guide —
 # on a clean self-hosted runner. The cover (~15s) and guide (~30s) Helm calls are
 # far too slow for Cloudflare's request window, so the app's /generate flow
 # dispatches this instead of generating anything on the edge.
 # Triggered by `repository_dispatch { event_type: generate-content }` from
-# skillstore's /api/plugins/review/callback.
+# skillstore's /api/packs/review/callback.
 
-name: Generate Plugin Content
+name: Generate Pack Content
 
 on:
   repository_dispatch:
@@ -55,4 +55,4 @@ jobs:
           # lets the CLI post the finished content back onto the review issue
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          "$CLI" plugin generate-content --slug "$SLUG" --issue "$ISSUE"
+          "$CLI" pack generate-content --slug "$SLUG" --issue "$ISSUE"

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -3,7 +3,7 @@
 # behavior) -> best-of-breed verify (PK) -> LLM compose -> whole-pack verify
 # -> optionally write a candidate to Supabase (review_status=generated).
 # Clean runner HOME = accurate used-skill scoring (no personal global skills).
-# Uses `skillstore-cli plugin generate` (CLI >= 1.41.0 for --scenario).
+# Uses `skillstore-cli pack generate` (CLI >= 1.41.0 for --scenario).
 
 name: Generate Pack
 
@@ -110,16 +110,16 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
-          # lets `plugin generate` generate a cover image via Helm (gemini-3.1-flash-image);
+          # lets `pack generate` generate a cover image via Helm (gemini-3.1-flash-image);
           # absent => cover step is skipped (best-effort, never fails the pack)
           HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
-          # lets `plugin generate` dispatch the translate-plugins workflow after writing a pack
+          # lets `pack generate` dispatch the translate-packs workflow after writing a pack
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          set +e  # plugin generate exits non-zero when the pack FAILs verification; that's data, not a job error
+          set +e  # pack generate exits non-zero when the pack FAILs verification; that's data, not a job error
           mkdir -p pack-results
 
-          ARGS=(plugin generate --skills-dir skills --json)
+          ARGS=(pack generate --skills-dir skills --json)
           if [ "$EVENT" = "schedule" ]; then
             # Daily rotation: today's scenario, written as a generated candidate.
             ARGS+=(--scenario daily-rotation --write \
@@ -151,7 +151,7 @@ jobs:
             FIT=$(jq -r '.packFitness.medianScore' "$R")
             PASS=$(jq -r 'if .packFitness.passed then "✅ PASS" else "❌ FAIL" end' "$R")
             USED=$(jq -r '(.packFitness.usedSkillRate*100)|floor' "$R")
-            WRITTEN=$(jq -r 'if .written then (.written.pluginId + " (review_status=generated)" + (if .comparisonOf then " [comparison of " + .comparisonOf + "]" else "" end)) elif .skippedReason then ("skipped — " + .skippedReason) elif .writeError then ("write failed — " + .writeError) else "dry-run" end' "$R")
+            WRITTEN=$(jq -r 'if .written then ((.written.packId // .written.pluginId) + " (review_status=generated)" + (if .comparisonOf then " [comparison of " + .comparisonOf + "]" else "" end)) elif .skippedReason then ("skipped — " + .skippedReason) elif .writeError then ("write failed — " + .writeError) else "dry-run" end' "$R")
             {
               echo "## Pack Generation"
               echo ""

--- a/.github/workflows/pack-review.yml
+++ b/.github/workflows/pack-review.yml
@@ -1,4 +1,4 @@
-name: Plugin Review
+name: Pack Review
 
 on:
   issue_comment:
@@ -11,14 +11,15 @@ jobs:
     # trimmed and command-checked inside the script so leading blank lines before
     # /generate or /approve do not silently skip the workflow.
     if: >-
-      contains(github.event.issue.labels.*.name, 'plugin-review') &&
+      (contains(github.event.issue.labels.*.name, 'pack-review') ||
+       contains(github.event.issue.labels.*.name, 'plugin-review')) &&
       github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - name: Process command
         uses: actions/github-script@v8
         env:
-          CALLBACK_URL: ${{ secrets.SKILLSTORE_API_URL }}/api/plugins/review/callback
+          CALLBACK_URL: ${{ secrets.SKILLSTORE_API_URL }}/api/packs/review/callback
           CALLBACK_SECRET: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
         with:
           script: |
@@ -41,36 +42,34 @@ jobs:
 
             const issueBody = context.payload.issue.body;
 
-            // Extract plugin ID from issue body. Tolerate both the table row
-            // `| Plugin ID | \`<id>\` |` (current buildIssueBody format) and the
-            // older `Plugin ID: \`<id>\`` colon format — match "Plugin ID" then
-            // the first backtick-quoted value after it.
-            const pluginIdMatch = issueBody.match(/Plugin ID[^`]*`([^`]+)`/);
-            if (!pluginIdMatch) {
-              console.log('Plugin ID not found in issue body');
+            // Extract pack ID from issue body. Tolerate legacy Plugin ID rows
+            // from issues opened before the product rename.
+            const packIdMatch = issueBody.match(/(?:Pack|Plugin) ID[^`]*`([^`]+)`/);
+            if (!packIdMatch) {
+              console.log('Pack ID not found in issue body');
               return;
             }
-            const pluginId = pluginIdMatch[1];
-            console.log(`Processing command for plugin: ${pluginId}`);
+            const packId = packIdMatch[1];
+            console.log(`Processing command for pack: ${packId}`);
 
             let event, payload;
 
             if (comment.startsWith('/generate')) {
               event = 'generate';
-              payload = { pluginId };
+              payload = { packId };
             } else if (comment.startsWith('/approve')) {
               event = 'approve';
               // Parse optional modifications
               const guideMatch = comment.match(/--guide\s+"([^"]+)"/);
               payload = {
-                pluginId,
+                packId,
                 approvedBy: context.actor,
                 modifiedGuide: guideMatch ? guideMatch[1] : null
               };
             } else if (comment.startsWith('/regenerate')) {
               event = 'regenerate';
               payload = {
-                pluginId,
+                packId,
                 coverOnly: comment.includes('--cover'),
                 guideOnly: comment.includes('--guide')
               };
@@ -78,7 +77,7 @@ jobs:
               event = 'reject';
               const reason = comment.replace('/reject', '').trim();
               payload = {
-                pluginId,
+                packId,
                 rejectedBy: context.actor,
                 reason: reason || 'No reason provided'
               };

--- a/.github/workflows/translate-packs.yml
+++ b/.github/workflows/translate-packs.yml
@@ -1,17 +1,20 @@
 # GitHub Action Workflow for Marketplace Repository
-# Translates plugin content to supported languages.
-# Simplified single-job workflow (no sharding) since plugin count is small.
-# Sharding support can be added later if plugin count grows significantly.
+# Translates pack content to supported languages.
+# Simplified single-job workflow (no sharding) since pack count is small.
+# Sharding support can be added later if pack count grows significantly.
 
-name: Auto-Translate Plugin Content
+name: Auto-Translate Pack Content
 
 on:
   repository_dispatch:
-    types: [translate-plugins]
+    types: [translate-packs, translate-plugins]
   workflow_dispatch:
     inputs:
+      pack_slugs:
+        description: "Specific packs to translate, comma-separated"
+        required: false
       plugin_slugs:
-        description: "Specific plugins to translate, comma-separated"
+        description: "Deprecated alias for pack_slugs"
         required: false
       model:
         description: "Model to use (e.g., gpt-5.5:high, claude-sonnet-4.6). Auto-detects agent."
@@ -22,7 +25,7 @@ on:
         type: boolean
         default: false
       concurrency:
-        description: "Parallel plugins per language (1-10)"
+        description: "Parallel packs per language (1-10)"
         type: string
         default: "5"
       cli_version:
@@ -31,7 +34,7 @@ on:
         default: "latest"
 
 concurrency:
-  group: translate-plugins
+  group: translate-packs
   cancel-in-progress: false
 
 jobs:
@@ -63,15 +66,15 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Detect plugin slugs
+      - name: Detect pack slugs
         id: detect
         run: |
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            SLUGS_CSV="${{ github.event.client_payload.plugin_slugs }}"
+            SLUGS_CSV="${{ github.event.client_payload.pack_slugs || github.event.client_payload.plugin_slugs }}"
             TRIGGERED_BY="${{ github.event.client_payload.triggered_by }}"
             echo "Triggered by: $TRIGGERED_BY"
           else
-            SLUGS_CSV="${{ inputs.plugin_slugs }}"
+            SLUGS_CSV="${{ inputs.pack_slugs || inputs.plugin_slugs }}"
           fi
 
           if [ -n "$SLUGS_CSV" ]; then
@@ -79,15 +82,15 @@ jobs:
               echo "::error::Invalid slug format in: $SLUGS_CSV (expected: lowercase alphanumeric with hyphens and slashes)"
               exit 1
             fi
-            PLUGIN_COUNT=$(echo "$SLUGS_CSV" | tr ',' '\n' | grep -c . || echo 0)
-            echo "Translating $PLUGIN_COUNT plugin(s): $SLUGS_CSV"
+            PACK_COUNT=$(echo "$SLUGS_CSV" | tr ',' '\n' | grep -c . || echo 0)
+            echo "Translating $PACK_COUNT pack(s): $SLUGS_CSV"
           else
-            echo "No specific slugs provided - will translate all stale/pending plugins"
-            PLUGIN_COUNT=0
+            echo "No specific slugs provided - will translate all stale/pending packs"
+            PACK_COUNT=0
           fi
 
           echo "slugs_csv=$SLUGS_CSV" >> $GITHUB_OUTPUT
-          echo "plugin_count=$PLUGIN_COUNT" >> $GITHUB_OUTPUT
+          echo "pack_count=$PACK_COUNT" >> $GITHUB_OUTPUT
 
       - name: Run translation
         id: translate
@@ -114,7 +117,7 @@ jobs:
           fi
 
           set +e
-          RESULT=$("$GITHUB_WORKSPACE/skillstore-cli" plugin translate-content \
+          RESULT=$("$GITHUB_WORKSPACE/skillstore-cli" pack translate-content \
             $SLUG_FLAG \
             --concurrency "$CONCURRENCY" \
             --output json \
@@ -123,7 +126,7 @@ jobs:
           EXIT_CODE=$?
           set -e
 
-          if echo "$RESULT" | jq -e '.totalPlugins // .totalSkills' > /dev/null 2>&1; then
+          if echo "$RESULT" | jq -e '.totalPacks // .totalPlugins // .totalSkills' > /dev/null 2>&1; then
             TRANSLATED=$(echo "$RESULT" | jq -r '.translated')
             SKIPPED=$(echo "$RESULT" | jq -r '.skipped')
             ERRORS=$(echo "$RESULT" | jq -r '.errors')
@@ -150,7 +153,7 @@ jobs:
             echo "result_json=$RESULT_JSON" >> $GITHUB_OUTPUT
 
             # Extract slugs that were actually translated (for cache invalidation)
-            TRANSLATED_SLUGS=$(echo "$RESULT" | jq -r '[.languages[].plugins[] | select(.status != "skipped") | .slug] | unique | join(",")' 2>/dev/null || echo "")
+            TRANSLATED_SLUGS=$(echo "$RESULT" | jq -r '[.languages[] | (.packs // .plugins // [])[] | select(.status != "skipped") | .slug] | unique | join(",")' 2>/dev/null || echo "")
             echo "translated_slugs=$TRANSLATED_SLUGS" >> $GITHUB_OUTPUT
 
             if [ "$TRANSLATED" -gt 0 ]; then
@@ -187,11 +190,11 @@ jobs:
         with:
           sparse-checkout: .github/actions
 
-      - name: Invalidate cache for translated plugins
+      - name: Invalidate cache for translated packs
         id: invalidate
         uses: ./.github/actions/invalidate-cache
         with:
-          type: plugins
+          type: packs
           slugs: ${{ needs.translate.outputs.translated_slugs }}
           secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           fail-on-error: false
@@ -208,7 +211,7 @@ jobs:
           CACHE_INVALIDATE_TOTAL: ${{ needs.invalidate-cache.outputs.total_count || '0' }}
           CACHE_INVALIDATE_FAILED: ${{ needs.invalidate-cache.outputs.failed_count || '0' }}
         run: |
-          echo "# Plugin Translation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "# Pack Translation Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ -n "$RESULT_JSON" ] && echo "$RESULT_JSON" | jq -e '.translated' > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Switch Marketplace workflows from canonical `skillstore plugin ...` commands to `skillstore pack ...`.
- Move review, cover, translation, and cache invalidation flows to `/api/packs` and `translate-packs`.
- Keep transition compatibility for existing `plugin-review` labels, `Plugin ID` issue bodies, `translate-plugins` dispatches, `plugin_slugs`, and older `.written.pluginId` output.

## Verification
- `git diff --check`
- Ruby YAML parse for updated workflows/action
- Targeted grep confirmed no canonical `plugin` CLI/API workflow calls remain
- Claude Fable review: no self-contained workflow diff bug found; rollout gates documented below

## Rollout gates
- Merge/deploy aiskillstore/skillstore#113 before Marketplace starts requiring canonical `/api/packs` routes, `packId` payloads, and cache `type: packs`.
- Publish a Skillstore CLI release that contains the `skillstore pack ...` subcommands before this workflow branch lands on Marketplace `main`.