### PR TITLE
Pass skills.sh metric slugs by file

### DIFF
--- a/.github/workflows/scrape-skills-sh.yml
+++ b/.github/workflows/scrape-skills-sh.yml
@@ -274,13 +274,16 @@ jobs:
             exit 0
           fi
 
-          SLUG_COUNT=$(echo "$METRIC_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
+          SLUG_FILE="$RUNNER_TEMP/skills-sh-metric-slugs.txt"
+          printf '%s' "$METRIC_SLUGS" | tr ',' '\n' | sed '/^$/d' > "$SLUG_FILE"
+
+          SLUG_COUNT=$(wc -l < "$SLUG_FILE" | tr -d ' ')
           echo "🎯 Recalculating scores for $SLUG_COUNT skills matched from skills.sh metrics"
 
           set +e
           bash scripts/recalculate-scores.sh \
             --cli "$GITHUB_WORKSPACE/skillstore-cli" \
-            --slugs "$METRIC_SLUGS" \
+            --slugs-file "$SLUG_FILE" \
             --concurrency 5 \
             --max-attempts 3 \
             --retry-base-seconds 5 2>&1 | tee score-output.log


### PR DESCRIPTION
## Summary
- write matched skills.sh metric slugs to a runner temp file
- call recalculate-scores.sh with --slugs-file instead of one large inline --slugs value

## Why
Claude Opus review flagged the inline slug list as a scalability risk. The wrapper already supports --slugs-file, so use it in the daily scrape workflow.

## Tests
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/scrape-skills-sh.yml'); puts 'yaml ok'"
- node scripts/tests/recalculate-scores.test.mjs
- git diff --check