### PR TITLE
Pass pack regeneration flags to content runner

### DIFF
--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -47,6 +47,8 @@ jobs:
           CLI: ${{ steps.cli.outputs.cli-path }}
           SLUG: ${{ github.event.client_payload.slug }}
           ISSUE: ${{ github.event.client_payload.issueNumber }}
+          COVER_ONLY: ${{ github.event.client_payload.coverOnly || 'false' }}
+          GUIDE_ONLY: ${{ github.event.client_payload.guideOnly || 'false' }}
           # CLI reads these names; map from the repo's existing secrets
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -55,4 +57,11 @@ jobs:
           # lets the CLI post the finished content back onto the review issue
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          "$CLI" pack generate-content --slug "$SLUG" --issue "$ISSUE"
+          FLAGS=()
+          if [ "$COVER_ONLY" = "true" ]; then
+            FLAGS+=(--cover-only)
+          fi
+          if [ "$GUIDE_ONLY" = "true" ]; then
+            FLAGS+=(--guide-only)
+          fi
+          "$CLI" pack generate-content --slug "$SLUG" --issue "$ISSUE" "${FLAGS[@]}"


### PR DESCRIPTION
## Summary
- forward coverOnly and guideOnly repository_dispatch payload fields to the Skillstore CLI
- make /regenerate --cover run the CLI in cover-only mode instead of regenerating all content

## Verification
- git diff --check