### PR TITLE
fix(workflow): accept tagged Skillstore CLI versions

### DIFF
--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -3,7 +3,7 @@ description: Download and setup skillstore-cli binary
 
 inputs:
   version:
-    description: 'CLI version (default: latest)'
+    description: 'CLI version (default: latest; accepts 1.50.3 or cli-v1.50.3)'
     required: false
     default: 'latest'
   token:
@@ -35,6 +35,9 @@ runs:
           echo "Fetching latest release tag..."
           RELEASE_TAG=$(gh release view --repo "$CLI_REPO" --json tagName -q '.tagName')
           echo "Latest release: $RELEASE_TAG"
+        elif [[ "$CLI_VERSION" == cli-v* ]]; then
+          RELEASE_TAG="$CLI_VERSION"
+          echo "Using specified release tag: $RELEASE_TAG"
         else
           RELEASE_TAG="cli-v$CLI_VERSION"
           echo "Using specified version: $RELEASE_TAG"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -336,6 +336,9 @@ test('workflows fail no-success/global scoring failures instead of masking them'
 
 test('download action invalidates stale local CLI cache entries', () => {
 	const action = readFileSync(DOWNLOAD_CLI_ACTION, 'utf8');
+	assert.match(action, /\[\[ "\$CLI_VERSION" == cli-v\* \]\]/, 'download action must accept already-tagged cli-v versions');
+	assert.match(action, /RELEASE_TAG="\$CLI_VERSION"/, 'already-tagged cli-v input must not be prefixed again');
+	assert.match(action, /RELEASE_TAG="cli-v\$CLI_VERSION"/, 'plain semantic versions must still be converted to release tags');
 	assert.match(action, /CACHED_VERSION=/, 'local cache hit must inspect the cached binary version');
 	assert.match(action, /EXPECTED_VERSION=\$\{RELEASE_TAG#cli-v\}/, 'expected version must come from the resolved release tag');
 	assert.match(action, /rm -f "\$CACHE_FILE" "\$GITHUB_WORKSPACE\/skillstore-cli"/, 'stale local cache must be removed so the Download CLI step runs');


### PR DESCRIPTION
## Summary
- normalize Skillstore CLI downloader input so both `1.50.3` and `cli-v1.50.3` resolve to `cli-v1.50.3`
- keep `latest` behavior unchanged
- add a regression guard for already-tagged CLI versions

## Evidence
- Failed run: https://github.com/aiskillstore/marketplace/actions/runs/28666125055 used `version: cli-v1.50.3`, then resolved `cli-vcli-v1.50.3` and failed with `release not found`.
- Successful comparison run: https://github.com/aiskillstore/marketplace/actions/runs/28666181501 used `version: 1.50.3`, resolved `cli-v1.50.3`, and translated 11 packs.

## Tests
- `node --test scripts/tests/recalculate-scores.test.mjs`
- `git diff --check`
- shell resolver sanity check: empty/latest -> latest tag, 1.50.3 -> cli-v1.50.3, cli-v1.50.3 -> cli-v1.50.3