### PR TITLE
fix(workflows): bound score recalculation slug runtime

### DIFF
--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -35,6 +35,10 @@ on:
         description: 'CLI version (default: latest)'
         type: string
         default: 'latest'
+      timeout_seconds:
+        description: 'Per-skill CLI timeout in seconds (0 disables)'
+        type: string
+        default: '180'
 
 concurrency:
   group: recalculate-scores
@@ -82,6 +86,7 @@ jobs:
           INPUT_LIMIT: ${{ inputs.limit }}
           INPUT_CONCURRENCY: ${{ inputs.concurrency || '5' }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '180' }}
         run: |
           echo "=== Skill Quality Score Recalculation ==="
           echo "Time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
@@ -95,6 +100,7 @@ jobs:
             --concurrency "$INPUT_CONCURRENCY"
             --max-attempts 3
             --retry-base-seconds 5
+            --timeout-seconds "$INPUT_TIMEOUT_SECONDS"
           )
 
           SUPPORTS_SLUGS=0

--- a/scripts/recalculate-scores.sh
+++ b/scripts/recalculate-scores.sh
@@ -23,7 +23,7 @@
 #     --cli /path/to/skillstore-cli \
 #     [--slugs slug1,slug2,... | --slugs-file PATH] [--limit N] \
 #     [--concurrency N] [--dry-run] \
-#     [--max-attempts N] [--retry-base-seconds N]
+#     [--max-attempts N] [--retry-base-seconds N] [--timeout-seconds N]
 #
 # Exit codes:
 #   0  - all slugs processed, no per-slug failures
@@ -54,6 +54,7 @@ CONCURRENCY=5
 DRY_RUN=0
 MAX_ATTEMPTS=3
 RETRY_BASE_SECONDS=2
+TIMEOUT_SECONDS=180
 RECALCULATE=0
 EXTRA_FLAGS=()
 
@@ -70,6 +71,7 @@ Options:
   --dry-run                   Pass-through to CLI
   --max-attempts N            Per-slug retry attempts (default: 3)
   --retry-base-seconds N      Initial backoff seconds (default: 2, doubled each retry)
+  --timeout-seconds N         Per-slug wall-clock timeout in seconds (default: 180; 0 disables)
   --recalculate               Legacy "all skills" mode (no per-slug isolation; wrapped in top-level retry)
   --                          Forwarded as additional CLI flags
   -h | --help                 Show this help
@@ -86,6 +88,7 @@ while [ $# -gt 0 ]; do
 		--dry-run)           DRY_RUN=1; shift ;;
 		--max-attempts)      MAX_ATTEMPTS="${2:-3}"; shift 2 ;;
 		--retry-base-seconds) RETRY_BASE_SECONDS="${2:-2}"; shift 2 ;;
+		--timeout-seconds)   TIMEOUT_SECONDS="${2:-180}"; shift 2 ;;
 		--recalculate)       RECALCULATE=1; shift ;;
 		--)                  shift; while [ $# -gt 0 ]; do EXTRA_FLAGS+=("$1"); shift; done ;;
 		-h|--help)           usage; exit 0 ;;
@@ -120,6 +123,10 @@ if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if ! [[ "$RETRY_BASE_SECONDS" =~ ^[0-9]+$ ]]; then
 	echo "::error::--retry-base-seconds must be a non-negative integer" >&2
+	exit 2
+fi
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+	echo "::error::--timeout-seconds must be a non-negative integer" >&2
 	exit 2
 fi
 if ! [[ "$CONCURRENCY" =~ ^[1-9][0-9]*$ ]]; then
@@ -163,6 +170,7 @@ score_one_slug() {
 	trap "rm -f '$stdout_path' '$stderr_path'" RETURN
 
 	while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+		local current_attempt="$attempt"
 		if [ "$attempt" -gt 1 ]; then
 			echo "  [retry $attempt/$MAX_ATTEMPTS for $slug after ${sleep_secs}s]"
 			sleep "$sleep_secs"
@@ -181,8 +189,32 @@ score_one_slug() {
 		if [ "${#EXTRA_FLAGS[@]}" -gt 0 ]; then
 			cli_args+=( "${EXTRA_FLAGS[@]}" )
 		fi
-		"$CLI" "${cli_args[@]}" > "$stdout_path" 2> "$stderr_path"
-		rc=$?
+		if [ "$TIMEOUT_SECONDS" -gt 0 ]; then
+			"$CLI" "${cli_args[@]}" > "$stdout_path" 2> "$stderr_path" &
+			local cli_pid="$!"
+			local elapsed=0
+			local timed_out=0
+			while kill -0 "$cli_pid" 2>/dev/null; do
+				if [ "$elapsed" -ge "$TIMEOUT_SECONDS" ]; then
+					timed_out=1
+					echo "Timed out after ${TIMEOUT_SECONDS}s" >> "$stderr_path"
+					kill "$cli_pid" 2>/dev/null || true
+					sleep 2
+					kill -9 "$cli_pid" 2>/dev/null || true
+					break
+				fi
+				sleep 1
+				elapsed=$(( elapsed + 1 ))
+			done
+			wait "$cli_pid" 2>/dev/null
+			rc=$?
+			if [ "$timed_out" -eq 1 ]; then
+				rc=124
+			fi
+		else
+			"$CLI" "${cli_args[@]}" > "$stdout_path" 2> "$stderr_path"
+			rc=$?
+		fi
 		set -e 2>/dev/null || true
 
 		# Forward CLI output to the caller's stdout (matches single-run
@@ -200,7 +232,10 @@ score_one_slug() {
 		# in GitHub Actions UI without failing the step).
 		local err_summary
 		err_summary="$(_truncate "$(tail -n 5 "$stderr_path" 2>/dev/null | tr '\n' ' ')" 200)"
-		echo "::warning::score failed for slug=$slug attempt=$attempt/$MAX_ATTEMPTS exit=$rc err=$( _truncate "$err_summary" 200 )"
+		if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+			err_summary="timed out after ${TIMEOUT_SECONDS}s ${err_summary}"
+		fi
+		echo "::warning::score failed for slug=$slug attempt=$current_attempt/$MAX_ATTEMPTS exit=$rc err=$( _truncate "$err_summary" 200 )"
 	done
 
 	echo "::error::score ultimately failed for slug=$slug after $MAX_ATTEMPTS attempts"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -45,6 +45,7 @@ function runWrapper({
 	concurrency = 5,
 	dryRun = false,
 	sleepSeconds,
+	timeoutSeconds = 0,
 }) {
 	const tmp = mkdtempSync(join(tmpdir(), 'recalc-test-'));
 	const fakeCli = join(tmp, 'skillstore-cli');
@@ -68,6 +69,7 @@ function runWrapper({
 		'--max-attempts', String(maxAttempts),
 		'--retry-base-seconds', String(retryBase),
 		'--concurrency', String(concurrency),
+		'--timeout-seconds', String(timeoutSeconds),
 	];
 	if (slugsFile) {
 		args.push('--slugs-file', slugsFile);
@@ -317,6 +319,7 @@ test('recalculate-scores workflow default all-skills path uses per-slug wrapper'
 	assert.match(workflow, /find skills -name "skill-report\.json"/, 'workflow must enumerate published skill reports from the checkout');
 	assert.match(workflow, /SLUGS_FILE=/, 'workflow must materialize the full no-limit slug list into a file');
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs-file "\$SLUGS_FILE" \)/, 'default full run must pass a slug file, not a giant CSV argv');
+	assert.match(workflow, /--timeout-seconds "\$INPUT_TIMEOUT_SECONDS"/, 'default full run must bound each per-skill CLI child');
 	assert.doesNotMatch(workflow, /WRAPPER_ARGS\+=\( --slugs "\$SLUGS_CSV" \)/, 'default full run must not put all slugs in one argv');
 	assert.doesNotMatch(workflow, /SLUGS_CSV=/, 'workflow must not build an all-skills CSV that can exceed ARG_MAX');
 	assert.match(workflow, /SUPPORTS_SLUGS=0/, 'workflow must feature-probe whether the downloaded CLI supports --slugs');


### PR DESCRIPTION
## Summary
- add a per-skill timeout to the score recalculation wrapper
- expose the timeout as a workflow_dispatch input
- prevent one stuck CLI child from blocking the full recalculate run indefinitely

## Verification
- bash -n scripts/recalculate-scores.sh
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/recalculate-scores.yml'); puts 'yaml ok'"
- bash scripts/recalculate-scores.sh --cli /bin/echo --slugs smoke/test --concurrency 1 --max-attempts 1 --timeout-seconds 1
- temporary fake CLI timeout smoke test returned Errors: 1 as expected