### PR TITLE
fix(workflows): collect completed score jobs out of order

### DIFF
--- a/scripts/recalculate-scores.sh
+++ b/scripts/recalculate-scores.sh
@@ -384,6 +384,7 @@ else
 	JOB_RCS=()
 	ACTIVE_PIDS=()
 	ACTIVE_JOBS=()
+	JOB_POLL_SECONDS=0.05
 	NEXT_JOB=0
 
 	collect_finished_job() {
@@ -401,6 +402,52 @@ else
 		ingest_one_slug_output "${JOB_SLUGS[$job_index]}" "$job_rc" "${JOB_OUTPUTS[$job_index]}"
 	}
 
+	remove_active_job() {
+		local remove_index="$1"
+		local active_index
+		local new_pids=()
+		local new_jobs=()
+
+		for active_index in "${!ACTIVE_PIDS[@]}"; do
+			if [ "$active_index" = "$remove_index" ]; then
+				continue
+			fi
+			new_pids+=( "${ACTIVE_PIDS[$active_index]}" )
+			new_jobs+=( "${ACTIVE_JOBS[$active_index]}" )
+		done
+
+		ACTIVE_PIDS=()
+		ACTIVE_JOBS=()
+		if [ "${#new_pids[@]}" -gt 0 ]; then
+			ACTIVE_PIDS=( "${new_pids[@]}" )
+			ACTIVE_JOBS=( "${new_jobs[@]}" )
+		fi
+	}
+
+	collect_next_finished_job() {
+		local active_index pid job_index rc_path
+
+		while [ "${#ACTIVE_PIDS[@]}" -gt 0 ]; do
+			for active_index in "${!ACTIVE_PIDS[@]}"; do
+				pid="${ACTIVE_PIDS[$active_index]}"
+				job_index="${ACTIVE_JOBS[$active_index]}"
+				rc_path="${JOB_RCS[$job_index]}"
+				if [ -f "$rc_path" ]; then
+					collect_finished_job "$pid" "$job_index"
+					remove_active_job "$active_index"
+					return 0
+				fi
+				if ! kill -0 "$pid" 2>/dev/null; then
+					printf '1\n' > "$rc_path"
+					collect_finished_job "$pid" "$job_index"
+					remove_active_job "$active_index"
+					return 0
+				fi
+			done
+			sleep "$JOB_POLL_SECONDS"
+		done
+	}
+
 	for slug in "${SLUGS_ARR[@]}"; do
 		job_index="$NEXT_JOB"
 		NEXT_JOB=$(( NEXT_JOB + 1 ))
@@ -416,16 +463,12 @@ else
 		ACTIVE_JOBS+=( "$job_index" )
 
 		if [ "${#ACTIVE_PIDS[@]}" -ge "$CONCURRENCY" ]; then
-			collect_finished_job "${ACTIVE_PIDS[0]}" "${ACTIVE_JOBS[0]}"
-			ACTIVE_PIDS=( "${ACTIVE_PIDS[@]:1}" )
-			ACTIVE_JOBS=( "${ACTIVE_JOBS[@]:1}" )
+			collect_next_finished_job
 		fi
 	done
 
 	while [ "${#ACTIVE_PIDS[@]}" -gt 0 ]; do
-		collect_finished_job "${ACTIVE_PIDS[0]}" "${ACTIVE_JOBS[0]}"
-		ACTIVE_PIDS=( "${ACTIVE_PIDS[@]:1}" )
-		ACTIVE_JOBS=( "${ACTIVE_JOBS[@]:1}" )
+		collect_next_finished_job
 	done
 fi
 

--- a/scripts/tests/fake-cli.sh
+++ b/scripts/tests/fake-cli.sh
@@ -54,7 +54,9 @@ if [ "$SCORE" -ne 1 ]; then
 	exit 64
 fi
 
-if [ -n "${FAKE_CLI_SLEEP_SECONDS:-}" ]; then
+if [ -n "${FAKE_CLI_SLOW_SLUG:-}" ] && [ "$SLUGS" = "$FAKE_CLI_SLOW_SLUG" ]; then
+	sleep "${FAKE_CLI_SLOW_SECONDS:-2}"
+elif [ -n "${FAKE_CLI_SLEEP_SECONDS:-}" ]; then
 	sleep "$FAKE_CLI_SLEEP_SECONDS"
 fi
 
@@ -80,7 +82,7 @@ IFS=',' read -ra ARR <<< "$SLUGS"
 # Count how many times this exact slug has been seen so far in the log.
 slug_call_count() {
 	local target="$1"
-	grep -c "|slugs=$target" "$LOG" 2>/dev/null || true
+	grep -F -c -- "slugs=$target " "$LOG" 2>/dev/null || true
 }
 
 for slug in "${ARR[@]}"; do

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -45,6 +45,8 @@ function runWrapper({
 	concurrency = 5,
 	dryRun = false,
 	sleepSeconds,
+	slowSlug,
+	slowSeconds,
 	timeoutSeconds = 0,
 }) {
 	const tmp = mkdtempSync(join(tmpdir(), 'recalc-test-'));
@@ -61,6 +63,8 @@ function runWrapper({
 	if (failSlug) env.FAKE_CLI_FAIL_SLUG = failSlug;
 	if (timeoutSlug) env.FAKE_CLI_TIMEOUT_SLUG = timeoutSlug;
 	if (sleepSeconds) env.FAKE_CLI_SLEEP_SECONDS = String(sleepSeconds);
+	if (slowSlug) env.FAKE_CLI_SLOW_SLUG = slowSlug;
+	if (slowSeconds) env.FAKE_CLI_SLOW_SECONDS = String(slowSeconds);
 	if (recalcFail) env.FAKE_CLI_MODE = 'recalc-fail';
 
 	const args = [
@@ -125,10 +129,10 @@ test('single slug timeout does not abort the whole run; others succeed', () => {
 	const s = lastSummary(result.stdout);
 	assert.ok(s, 'summary block must be present');
 	assert.equal(s.processed, '5', 'all 5 slugs should be processed');
-	// bad-slug ultimately succeeds after retry, so it counts as
-	// updated too. 5 processed = 4 updated + 1 error.
-	assert.equal(s.updated, '4', '4 slugs updated (1 error + 4 ok incl. retry success)');
-	assert.equal(s.errors, '1', 'only the timed-out slug should be in errors');
+	// bad-slug ultimately succeeds after retry, so the final aggregate
+	// should count it as a success, not a terminal error.
+	assert.equal(s.updated, '5', 'all 5 slugs updated after transient timeout retry');
+	assert.equal(s.errors, '0', 'transient timeout should not be counted as a terminal error');
 
 	// Verify retry happened: bad-slug should be called multiple times
 	// (1 fail + 1 success) per the fake CLI's mode=timeout contract.
@@ -145,7 +149,7 @@ test('single slug timeout does not abort the whole run; others succeed', () => {
 
 test('a slug that fails repeatedly lets the run finish; partial success -> exit 0', () => {
 	const { result } = runWrapper({
-		mode: 'fail-slug',
+		mode: 'fail-slug-always',
 		failSlug: 'doomed',
 		slugs: 'a,doomed,b',
 		maxAttempts: 3,
@@ -216,6 +220,33 @@ test('per-slug mode honors wrapper-level concurrency', () => {
 	assert.equal(sum.updated, '6');
 	assert.equal(sum.errors, '0');
 	assert.ok(elapsedMs < 4500, `expected bounded parallelism to finish well below sequential runtime; elapsed=${elapsedMs}ms`);
+});
+
+test('per-slug mode does not let a slow oldest child block ready work', () => {
+	const { result, log } = runWrapper({
+		mode: 'success',
+		slugs: 'slow,fast-a,fast-b,fast-c',
+		concurrency: 2,
+		slowSlug: 'slow',
+		slowSeconds: 3,
+		retryBase: 0,
+	});
+
+	assert.equal(result.status, 0, `wrapper should succeed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	const logLines = readFileSync(log, 'utf8').trim().split('\n');
+	const startedAt = (slug) => {
+		const line = logLines.find((l) => l.includes(`slugs=${slug}`));
+		assert.ok(line, `expected ${slug} to be launched`);
+		return BigInt(line.split('|')[0]);
+	};
+
+	const slowStart = startedAt('slow');
+	const fastCStart = startedAt('fast-c');
+	const elapsedSeconds = Number(fastCStart - slowStart) / 1_000_000_000;
+	assert.ok(
+		elapsedSeconds < 2,
+		`fast-c should launch before the slow first child finishes; elapsed=${elapsedSeconds}s`
+	);
 });
 
 test('large no-limit all-skills run reads slugs from file instead of one oversized argv', () => {


### PR DESCRIPTION
## Summary
- collect per-slug score jobs as soon as their completion marker is written instead of waiting in launch order
- avoid Bash `set -u` empty-array crashes while removing completed jobs from the active queue
- extend fake CLI/tests for slow-first-child scheduling and transient timeout retry semantics

## Verification
- `bash -n scripts/recalculate-scores.sh`
- `node --test scripts/tests/recalculate-scores.test.mjs`