### PR TITLE
fix(workflows): recalc from canonical skill slugs

### DIFF
--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -93,6 +93,35 @@ jobs:
           echo ""
           INVALIDATE_SLUGS_FILE=""
 
+          configure_tls() {
+            if [ ! -s /etc/ssl/certs/ca-certificates.crt ] && command -v apt-get >/dev/null 2>&1; then
+              echo "CA bundle missing; attempting to install ca-certificates"
+              if command -v sudo >/dev/null 2>&1; then
+                sudo apt-get update -y && sudo apt-get install -y ca-certificates || true
+              else
+                apt-get update -y && apt-get install -y ca-certificates || true
+              fi
+            fi
+
+            if command -v update-ca-certificates >/dev/null 2>&1; then
+              if command -v sudo >/dev/null 2>&1; then
+                sudo update-ca-certificates || true
+              else
+                update-ca-certificates || true
+              fi
+            fi
+
+            if [ -s /etc/ssl/certs/ca-certificates.crt ]; then
+              export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+              export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+              export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+              export GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+            fi
+            export NODE_OPTIONS="${NODE_OPTIONS:-} --use-openssl-ca"
+          }
+
+          configure_tls
+
           # Build wrapper args. The wrapper script (scripts/recalculate-scores.sh)
           # runs the CLI in per-slug mode with retry/backoff so a single
           # breakdown update TimeoutError does not take down the whole run.
@@ -125,11 +154,31 @@ jobs:
           elif [ "$SUPPORTS_SLUGS" -eq 1 ]; then
             # Scheduled/default full recalculation must still use the
             # per-slug isolation wrapper when the downloaded CLI supports
-            # it. Enumerate published skills from reports and pass explicit
-            # slugs instead of the legacy top-level --recalculate retry path.
-            # Some packages contain nested/example SKILL.md files that are
-            # resources, not marketplace entries.
-            mapfile -t ALL_SLUGS < <(find skills -name "skill-report.json" -type f -print | sed 's|^skills/||; s|/skill-report.json$||' | sort)
+            # it. Enumerate the canonical DB slug from each report; path
+            # segments are owner-qualified and do not necessarily match
+            # skillstore.skills.slug.
+            mapfile -t ALL_SLUGS < <(node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const slugs = new Set();
+          function walk(dir) {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const fullPath = path.join(dir, entry.name);
+              if (entry.isDirectory()) {
+                walk(fullPath);
+              } else if (entry.isFile() && entry.name === 'skill-report.json') {
+                const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+                const slug = report?.meta?.slug;
+                if (typeof slug === 'string' && slug.trim()) slugs.add(slug.trim());
+              }
+            }
+          }
+
+          walk('skills');
+          for (const slug of [...slugs].sort()) console.log(slug);
+          NODE
+          )
             if [ -n "$INPUT_LIMIT" ]; then
               if ! [[ "$INPUT_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
                 echo "::error::limit must be a positive integer when provided: $INPUT_LIMIT"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -347,7 +347,10 @@ test('recalculate-scores workflow checks out wrapper and skill paths', () => {
 
 test('recalculate-scores workflow default all-skills path uses per-slug wrapper', () => {
 	const workflow = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
-	assert.match(workflow, /find skills -name "skill-report\.json"/, 'workflow must enumerate published skill reports from the checkout');
+	assert.match(workflow, /report\?\.meta\?\.slug/, 'workflow must enumerate canonical DB slugs from skill-report meta.slug');
+	assert.doesNotMatch(workflow, /sed 's\|\^skills\/\|\|; s\|\/skill-report\.json\$\|\|'/, 'workflow must not derive DB slugs from owner-qualified paths');
+	assert.match(workflow, /NODE_EXTRA_CA_CERTS=\/etc\/ssl\/certs\/ca-certificates\.crt/, 'workflow must configure the Node CA bundle before Supabase calls');
+	assert.match(workflow, /--use-openssl-ca/, 'workflow must force Node to use the system OpenSSL CA store');
 	assert.match(workflow, /SLUGS_FILE=/, 'workflow must materialize the full no-limit slug list into a file');
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs-file "\$SLUGS_FILE" \)/, 'default full run must pass a slug file, not a giant CSV argv');
 	assert.match(workflow, /--timeout-seconds "\$INPUT_TIMEOUT_SECONDS"/, 'default full run must bound each per-skill CLI child');


### PR DESCRIPTION
## Summary
- enumerate full recalc targets from `skill-report.json` `meta.slug` instead of owner-qualified repository paths
- configure the system CA bundle for Node before Skillstore CLI Supabase calls
- update workflow guard tests to prevent path-derived slug and missing-CA regressions

## Why
The Marketplace path (`skills/<owner>/<skill>`) is not the Skillstore DB slug. The current workflow spends most of the run launching no-op CLI processes for slugs that do not exist in `skillstore.skills`. The canceled run also showed `unknown certificate verification error` from Supabase fetches, matching the CA setup already used by other Marketplace workflows.

## Verification
- `node --test scripts/tests/recalculate-scores.test.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/recalculate-scores.yml"); puts "yaml ok"'`