### PR TITLE
fix(workflows): tolerate optional manual approval label

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -677,17 +677,23 @@ jobs:
           *Processed by skillstore-cli*
           EOF
 
-          PR_LABELS="pending-review"
-          if [ "${{ inputs.is_manual_approval }}" = "true" ]; then
-            PR_LABELS="$PR_LABELS,manually-approved"
-          fi
-
-          PR_URL=$(gh pr create \
+          PR_CREATE_OUTPUT=""
+          if ! PR_CREATE_OUTPUT=$(gh pr create \
             --title "$PR_TITLE" \
             --body-file pr-body.md \
-            --label "$PR_LABELS" \
+            --label "pending-review" \
             --base main \
-            --head "$BRANCH_NAME" 2>&1 | tail -1)
+            --head "$BRANCH_NAME" 2>&1); then
+            echo "$PR_CREATE_OUTPUT"
+            exit 1
+          fi
+
+          PR_URL=$(printf '%s\n' "$PR_CREATE_OUTPUT" | tail -1)
+
+          if [ "${{ inputs.is_manual_approval }}" = "true" ]; then
+            gh pr edit "$PR_URL" --add-label "manually-approved" || \
+              echo "::warning::Optional label 'manually-approved' could not be applied"
+          fi
 
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "Created PR: $PR_URL"


### PR DESCRIPTION
## Summary
- keep `pending-review` as the required PR creation label
- apply `manually-approved` only after PR creation, and downgrade missing-label failures to a warning
- print the real `gh pr create` error before exiting when PR creation itself fails

## Root cause
Run 28711135636 processed 65 skills successfully and pushed the submission branch, but failed while creating the PR. The manual approval path passed `pending-review,manually-approved` to `gh pr create`, while the repo only has `pending-review`; the missing optional label caused PR creation to fail, and the old command substitution hid the useful error.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reusable-process-skills.yml"); puts "YAML OK"'`\n- `git diff --check`