### PR TITLE
Allow parallel source monitor slug batches

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -77,7 +77,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: skill-source-monitor
+  # Full scans stay singleton. Manual slug-scoped batches can run in parallel
+  # because the operator controls non-overlapping slug lists.
+  group: ${{ github.event_name == 'workflow_dispatch' && inputs.slugs != '' && format('skill-source-monitor-{0}', github.run_id) || 'skill-source-monitor' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- keep full source monitor scans serialized under the existing global lock
- allow workflow_dispatch runs with explicit `slugs` to use a per-run concurrency group
- this lets controlled, non-overlapping update batches run in parallel while preserving singleton full scans

## Validation
- `git diff --check`
- `actionlint` was not available locally