### PR TITLE
Skip bulk source monitor follow-up fan-out

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -749,7 +749,7 @@ jobs:
   # ============================================================
   trigger-cache-warm:
     needs: [sync, calculate-scores, cache-invalidate]
-    if: needs.sync.outputs.skip_sync != 'true' && inputs.skip_cache_warm != true
+    if: needs.sync.outputs.skip_sync != 'true' && inputs.skip_cache_warm != true && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
@@ -822,7 +822,7 @@ jobs:
   # ============================================================
   trigger-translate:
     needs: [sync]
-    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != ''
+    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != '' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- Skip per-batch cache warming when a sync push commit contains `[bulk-source-monitor]`
- Skip per-batch translation fan-out for the same marker
- Keep the core Supabase sync and quality score calculation intact

## Why
Bulk source monitor updates are being processed in many PRs. Running translation/cache warming after every batch saturates self-hosted runners. For the bulk run, we will merge batch PRs with the marker and run follow-up warming/translation separately after the bulk sync is complete.

## Validation
- Parsed `.github/workflows/sync-to-supabase.yml` with Ruby YAML loader