### PR TITLE
Fix draft-commit skill frontmatter

### DIFF
--- a/skills/abejitsu/draft-commit/SKILL.md
+++ b/skills/abejitsu/draft-commit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: draft-commit
+description: Create a thoughtful, supportive commit message from your staged changes.
+---
+
 # Draft a Commit
 
 Create a thoughtful, supportive commit message from your staged changes.


### PR DESCRIPTION
## Summary
- restore required YAML frontmatter for `abejitsu/draft-commit`
- unblock incremental Supabase sync after source-monitor PR #2247

## Validation
- `git diff --check`

This is a narrow follow-up to the bulk source-monitor sync failure where 49/50 skills synced and `abejitsu-draft-commit` failed validation.
