### PR TITLE
Require source monitor checkout cache support

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -67,7 +67,7 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Skillstore CLI version: latest, 1.50.x, or cli-v1.50.x'
+        description: 'Skillstore CLI version: latest, 1.50.x, or cli-v1.50.x; checkout cache requires >=1.50.15'
         required: false
         type: string
         default: 'latest'
@@ -151,6 +151,9 @@ jobs:
           mkdir -p source-monitor-results "$CHECKOUT_CACHE_DIR"
           JSONL_FILE="source-monitor-results/skill-source-monitor-${GITHUB_RUN_ID}.jsonl"
           SUMMARY_FILE="source-monitor-results/skill-source-monitor-${GITHUB_RUN_ID}.md"
+          CLI_VERSION_OUTPUT="$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 || true)"
+          MONITOR_HELP="$("$GITHUB_WORKSPACE/skillstore-cli" skill monitor-upstream --help 2>&1 || true)"
+          echo "Downloaded CLI version: $CLI_VERSION_OUTPUT"
 
           CMD=(
             "$GITHUB_WORKSPACE/skillstore-cli"
@@ -163,16 +166,21 @@ jobs:
             --maxLocalUpdates "$MAX_UPDATES_PER_RUN"
           )
 
-          if "$GITHUB_WORKSPACE/skillstore-cli" skill monitor-upstream --help 2>&1 | grep -q -- '--writeConcurrency'; then
+          if grep -q -- '--writeConcurrency' <<<"$MONITOR_HELP"; then
             CMD+=(--writeConcurrency "$WRITE_CONCURRENCY")
           else
             echo "::warning::Downloaded Skillstore CLI does not support --writeConcurrency; Supabase writes will use scan concurrency."
           fi
 
-          if "$GITHUB_WORKSPACE/skillstore-cli" skill monitor-upstream --help 2>&1 | grep -q -- '--checkoutCacheDir'; then
-            CMD+=(--checkoutCacheDir "$CHECKOUT_CACHE_DIR")
-          else
-            echo "::warning::Downloaded Skillstore CLI does not support --checkoutCacheDir; upstream checkouts will not use the persistent runner cache."
+          if [ -n "$CHECKOUT_CACHE_DIR" ]; then
+            if grep -q -- '--checkoutCacheDir' <<<"$MONITOR_HELP"; then
+              CMD+=(--checkoutCacheDir "$CHECKOUT_CACHE_DIR")
+            else
+              echo "::error::Downloaded Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Re-run with cli_version=latest or cli_version>=1.50.15. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
+              echo "Monitor help:"
+              echo "$MONITOR_HELP"
+              exit 1
+            fi
           fi
 
           if [ -n "$SLUGS" ]; then

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -31,6 +31,7 @@ const WRAPPER = join(REPO_ROOT, 'scripts', 'recalculate-scores.sh');
 const FAKE_CLI = join(REPO_ROOT, 'scripts', 'tests', 'fake-cli.sh');
 const RECALCULATE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'recalculate-scores.yml');
 const SYNC_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
+const MONITOR_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'monitor-skill-sources.yml');
 const DOWNLOAD_CLI_ACTION = join(REPO_ROOT, '.github', 'actions', 'download-skillstore-cli', 'action.yml');
 
 function runWrapper({
@@ -385,4 +386,14 @@ test('download action invalidates stale local CLI cache entries', () => {
 	assert.match(action, /EXPECTED_VERSION=\$\{RELEASE_TAG#cli-v\}/, 'expected version must come from the resolved release tag');
 	assert.match(action, /rm -f "\$CACHE_FILE" "\$GITHUB_WORKSPACE\/skillstore-cli"/, 'stale local cache must be removed so the Download CLI step runs');
 	assert.match(action, /cache-hit=false/, 'stale local cache must flip cache-hit back to false');
+});
+
+test('source monitor requires checkout-cache-capable CLI before scanning', () => {
+	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
+	assert.match(workflow, /checkout cache requires >=1\.50\.15/, 'operator-facing input text must call out the minimum cache-capable CLI');
+	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');
+	assert.match(workflow, /grep -q -- '--checkoutCacheDir' <<<"\$MONITOR_HELP"/, 'workflow must check for checkout cache support');
+	assert.match(workflow, /Older CLI versions re-download upstream checkouts and burn runner\/network traffic/, 'old CLI must fail before expensive upstream downloads');
+	assert.match(workflow, /exit 1/, 'missing checkout cache support must stop the scan');
+	assert.doesNotMatch(workflow, /upstream checkouts will not use the persistent runner cache/, 'workflow must not silently continue without checkout caching');
 });


### PR DESCRIPTION
## Summary
- require Monitor Skill Sources to use a checkout-cache-capable skillstore CLI when checkout_cache_dir is set
- fail before the expensive scan if an older CLI is pinned, instead of silently running without checkout caching
- add a workflow guard test so this cannot regress back to warning-only behavior

## Evidence
- live run 28897320626 was dispatched with cli_version=1.50.14 in the runner event payload
- the running command on docker-runner-199-7 had --writeConcurrency but no --checkoutCacheDir
- runner cache directory /home/runner/_work/_cache/skill-source-monitor was only 4.0K, so upstream checkout caching was not active
- cli-v1.50.15 release artifact contains checkoutCacheDir support

## Tests
- git diff --check
- ruby YAML parse for monitor workflow and download action
- node --test scripts/tests/recalculate-scores.test.mjs
- node --test scripts/tests/audit-batch-supervisor.test.mjs