### PR TITLE
Use latest for source monitor CLI guidance

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -67,7 +67,7 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Skillstore CLI version: latest, 1.50.x, or cli-v1.50.x; checkout cache requires >=1.50.15'
+        description: 'Skillstore CLI version. Use latest for source monitor runs.'
         required: false
         type: string
         default: 'latest'
@@ -176,7 +176,7 @@ jobs:
             if grep -q -- '--checkoutCacheDir' <<<"$MONITOR_HELP"; then
               CMD+=(--checkoutCacheDir "$CHECKOUT_CACHE_DIR")
             else
-              echo "::error::Downloaded Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Re-run with cli_version=latest or cli_version>=1.50.15. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
+              echo "::error::Downloaded Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Re-run with cli_version=latest. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
               echo "Monitor help:"
               echo "$MONITOR_HELP"
               exit 1

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -390,9 +390,10 @@ test('download action invalidates stale local CLI cache entries', () => {
 
 test('source monitor requires checkout-cache-capable CLI before scanning', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /checkout cache requires >=1\.50\.15/, 'operator-facing input text must call out the minimum cache-capable CLI');
+	assert.match(workflow, /Use latest for source monitor runs/, 'operator-facing input text must tell operators to use latest');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');
 	assert.match(workflow, /grep -q -- '--checkoutCacheDir' <<<"\$MONITOR_HELP"/, 'workflow must check for checkout cache support');
+	assert.match(workflow, /Re-run with cli_version=latest/, 'old CLI must direct operators back to latest');
 	assert.match(workflow, /Older CLI versions re-download upstream checkouts and burn runner\/network traffic/, 'old CLI must fail before expensive upstream downloads');
 	assert.match(workflow, /exit 1/, 'missing checkout cache support must stop the scan');
 	assert.doesNotMatch(workflow, /upstream checkouts will not use the persistent runner cache/, 'workflow must not silently continue without checkout caching');


### PR DESCRIPTION
## Summary
- remove fixed CLI version guidance from Monitor Skill Sources
- keep the checkout-cache capability guard, but direct operators to rerun with cli_version=latest
- update the workflow guard test so it enforces latest guidance instead of a fixed version number

## Tests
- rg fixed source-monitor CLI version strings in changed files
- git diff --check
- ruby YAML parse for monitor workflow
- node --test scripts/tests/recalculate-scores.test.mjs