### PR TITLE
Force source monitor to use latest CLI

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -66,11 +66,6 @@ on:
         required: false
         type: string
         default: ''
-      cli_version:
-        description: 'Skillstore CLI version. Use latest for source monitor runs.'
-        required: false
-        type: string
-        default: 'latest'
       checkout_cache_dir:
         description: 'Persistent upstream checkout cache directory on self-hosted runners'
         required: false
@@ -111,7 +106,7 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version || 'latest' }}
+          version: latest
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
@@ -176,7 +171,7 @@ jobs:
             if grep -q -- '--checkoutCacheDir' <<<"$MONITOR_HELP"; then
               CMD+=(--checkoutCacheDir "$CHECKOUT_CACHE_DIR")
             else
-              echo "::error::Downloaded Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Re-run with cli_version=latest. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
+              echo "::error::Latest Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Publish a latest CLI release with checkout cache support before running source monitor. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
               echo "Monitor help:"
               echo "$MONITOR_HELP"
               exit 1

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -390,10 +390,12 @@ test('download action invalidates stale local CLI cache entries', () => {
 
 test('source monitor requires checkout-cache-capable CLI before scanning', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /Use latest for source monitor runs/, 'operator-facing input text must tell operators to use latest');
+	assert.match(workflow, /version: latest/, 'source monitor must always download the latest CLI');
+	assert.doesNotMatch(workflow, /cli_version:/, 'source monitor must not expose a fixed CLI version input');
+	assert.doesNotMatch(workflow, /inputs\.cli_version/, 'source monitor must not consume a fixed CLI version input');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');
 	assert.match(workflow, /grep -q -- '--checkoutCacheDir' <<<"\$MONITOR_HELP"/, 'workflow must check for checkout cache support');
-	assert.match(workflow, /Re-run with cli_version=latest/, 'old CLI must direct operators back to latest');
+	assert.match(workflow, /Latest Skillstore CLI does not support --checkoutCacheDir/, 'old latest CLI must fail before expensive upstream downloads');
 	assert.match(workflow, /Older CLI versions re-download upstream checkouts and burn runner\/network traffic/, 'old CLI must fail before expensive upstream downloads');
 	assert.match(workflow, /exit 1/, 'missing checkout cache support must stop the scan');
 	assert.doesNotMatch(workflow, /upstream checkouts will not use the persistent runner cache/, 'workflow must not silently continue without checkout caching');


### PR DESCRIPTION
## Summary
- remove the Monitor Skill Sources cli_version workflow_dispatch input
- download skillstore-cli with version: latest unconditionally
- keep the checkout cache capability guard so latest must support --checkoutCacheDir before the scan starts
- update the guard test to prevent reintroducing fixed CLI version inputs

## Tests
- rg fixed CLI version strings in .github/workflows/monitor-skill-sources.yml
- git diff --check
- ruby YAML parse for monitor workflow
- node --test scripts/tests/recalculate-scores.test.mjs