### PR TITLE
fix: tolerate source monitor CLI cache fallback

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -171,10 +171,8 @@ jobs:
             if grep -q -- '--checkoutCacheDir' <<<"$MONITOR_HELP"; then
               CMD+=(--checkoutCacheDir "$CHECKOUT_CACHE_DIR")
             else
-              echo "::error::Latest Skillstore CLI does not support --checkoutCacheDir, but checkout_cache_dir is set to '$CHECKOUT_CACHE_DIR'. Publish a latest CLI release with checkout cache support before running source monitor. Older CLI versions re-download upstream checkouts and burn runner/network traffic."
-              echo "Monitor help:"
-              echo "$MONITOR_HELP"
-              exit 1
+              echo "::warning::Downloaded Skillstore CLI does not support --checkoutCacheDir; continuing without checkout cache. This only affects runtime and network usage."
+              CHECKOUT_CACHE_DIR=""
             fi
           fi
 


### PR DESCRIPTION
## Summary
- downgrade missing `--checkoutCacheDir` support from a hard source-monitor failure to a warning
- continue running without checkout cache when the downloaded CLI is older or feature-probe output is stale

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/monitor-skill-sources.yml"); puts "yaml ok"'`
- `git diff --check`

## Context
Recent Monitor Skill Sources run 28908491268 failed before scanning because the downloaded CLI reported version 1.50.14 and lacked `--checkoutCacheDir`. Checkout cache is a performance optimization, not a correctness requirement, so the workflow should fall back instead of failing CI.