### PR TITLE
fix: verify production cache warming

### DIFF
--- a/.github/actions/invalidate-cache/action.yml
+++ b/.github/actions/invalidate-cache/action.yml
@@ -1,9 +1,9 @@
 name: Invalidate Cache
-description: Batch invalidate cache for skills/packs/workflows/releases
+description: Batch invalidate cache for skills/packs/plugins/releases
 
 inputs:
   type:
-    description: 'Content type (skills, packs, workflows, releases)'
+    description: 'Content type (skills, packs, plugins, releases)'
     required: true
   slugs:
     description: 'Space or comma-separated list of slugs to invalidate'
@@ -61,6 +61,14 @@ runs:
           echo "::error::fail-on-error must be true or false"
           exit 1
         fi
+
+        case "$CONTENT_TYPE" in
+          skills|packs|plugins|releases) ;;
+          *)
+            echo "::error::Unsupported cache content type: $CONTENT_TYPE"
+            exit 1
+            ;;
+        esac
 
         if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ]; then
           echo "::error::batch-size must be a positive integer"

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -844,7 +844,6 @@ jobs:
     steps:
       - name: Invalidate cache for synced skills
         id: invalidate
-        continue-on-error: true
         env:
           SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
           SITE_URL: https://skillstore.io
@@ -869,27 +868,19 @@ jobs:
           set -e
 
           if [ $EXIT_CODE -ne 0 ]; then
-            echo "::warning::Cache invalidation failed (non-critical, continuing workflow)"
+            echo "::error::Cache invalidation failed; cache warming is blocked"
             echo "Response: $RESPONSE"
-            echo "invalidation_failed=true" >> $GITHUB_OUTPUT
-            exit 0
+            cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          ## ❌ Cache invalidation failed
+
+          Skill data was synced, but the long-lived production detail cache was not invalidated. Detail API entries can live for **365 days**, so cache warming must not continue with stale data.
+
+          **Action required**: fix the invalidation error, rerun cache invalidation for the synced slugs, then rerun the scoped warm workflow.
+          EOF
+            exit "$EXIT_CODE"
           fi
 
           echo "✅ Cache invalidated: $RESPONSE"
-          echo "invalidation_failed=false" >> $GITHUB_OUTPUT
-
-      - name: Report cache invalidation failure
-        if: steps.invalidate.outputs.invalidation_failed == 'true'
-        run: |
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          ## ⚠️ Cache Invalidation Warning
-
-          Cache invalidation failed for synced skills. This is non-critical and the workflow continued.
-          Skills were synced successfully but may take longer to appear on the website.
-
-          **Impact**: Low - Cache will expire naturally within 24 hours
-          **Action Required**: None - Monitor next sync cycle
-          EOF
 
   # ============================================================
   # CACHE WARMING JOB
@@ -897,7 +888,7 @@ jobs:
   # ============================================================
   trigger-cache-warm:
     needs: [sync, calculate-scores, cache-invalidate]
-    if: needs.sync.outputs.skip_sync != 'true' && inputs.skip_cache_warm != true && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
+    if: needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && inputs.skip_cache_warm != true && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
@@ -920,34 +911,36 @@ jobs:
 
           SLUG_COUNT=$(echo "$SYNCED_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
           THRESHOLD=500
+          REQUEST_BUDGET=$((SLUG_COUNT * 80 + 20))
+          BYTE_BUDGET=$((SLUG_COUNT * 10485760 + 10485760))
 
           echo "🔥 Triggering warm-cache workflow for $SLUG_COUNT synced skills"
+          echo "   Request budget: $REQUEST_BUDGET"
+          echo "   Byte budget: $BYTE_BUDGET"
 
           if [ "$SLUG_COUNT" -le "$THRESHOLD" ]; then
             # Small batch: pass slugs directly via input
             echo "   Mode: direct (≤$THRESHOLD slugs)"
-            if ! gh workflow run warm-cache.yml \
+            gh workflow run warm-cache.yml \
               --repo "${{ github.repository }}" \
               -f mode=warm \
-              -f type=skills \
+              -f scope=changed \
               -f slugs="$SYNCED_SLUGS" \
-              -f warm_zip=false; then
-              echo "::warning::Could not trigger warm-cache workflow for synced skills; sync already completed and cache will refresh naturally."
-              exit 0
-            fi
+              -f request_budget="$REQUEST_BUDGET" \
+              -f byte_budget="$BYTE_BUDGET" \
+              -f warm_zip=false
             MODE="direct"
           else
             # Large batch: use artifact to avoid input size limits
             echo "   Mode: artifact (>$THRESHOLD slugs)"
-            if ! gh workflow run warm-cache.yml \
+            gh workflow run warm-cache.yml \
               --repo "${{ github.repository }}" \
               -f mode=warm \
-              -f type=skills \
+              -f scope=changed \
               -f source_run_id=${{ github.run_id }} \
-              -f warm_zip=false; then
-              echo "::warning::Could not trigger warm-cache workflow for synced skills; sync already completed and cache will refresh naturally."
-              exit 0
-            fi
+              -f request_budget="$REQUEST_BUDGET" \
+              -f byte_budget="$BYTE_BUDGET" \
+              -f warm_zip=false
             MODE="artifact (source: ${{ github.run_id }})"
           fi
 
@@ -958,6 +951,9 @@ jobs:
           ## 🔥 Cache Warming Triggered
 
           Triggered \`warm-cache.yml\` workflow for **$SLUG_COUNT synced skills** (mode: $MODE).
+
+          - Request budget: \`$REQUEST_BUDGET\`
+          - Byte budget: \`$BYTE_BUDGET\`
 
           [View workflow runs →](https://github.com/${{ github.repository }}/actions/workflows/warm-cache.yml)
           EOF

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -4,38 +4,57 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'warm = fill missing cache, force = clear all and regenerate'
+        description: 'warm = verify/fill cache, force = invalidate selected skills first'
         required: true
         type: choice
         options:
           - warm
           - force
         default: warm
-      type:
-        description: 'Content type to warm'
+      scope:
+        description: 'Changed/high-traffic scopes require explicit slugs; full catalog requires separate approval and larger budgets'
         required: true
         type: choice
         options:
-          - skills
-          - workflows
-          - releases
-          - all
-        default: skills
+          - changed
+          - high-traffic
+          - full-catalog
+        default: changed
       slugs:
-        description: 'Specific slugs to warm (comma-separated, optional). If empty, warm all items.'
+        description: 'Changed or high-traffic skill slugs (comma/space separated)'
+        required: false
+        type: string
+        default: ''
+      source_run_id:
+        description: 'Source workflow run containing the synced-slugs artifact (changed scope only)'
+        required: false
+        type: string
+        default: ''
+      approve_full_catalog:
+        description: 'I explicitly approve full-catalog warming within the request and byte budgets below'
+        required: false
+        type: boolean
+        default: false
+      request_budget:
+        description: 'Hard cap for warm verification HTTP requests, including retries and build probes'
+        required: true
+        type: string
+        default: '5000'
+      byte_budget:
+        description: 'Hard cap for downloaded response bytes'
+        required: true
+        type: string
+        default: '536870912'
+      expected_build_token:
+        description: 'Optional exact x-skillstore-build value for deployment-specific warming'
         required: false
         type: string
         default: ''
       warm_zip:
-        description: 'Warm ZIP download cache for skills'
+        description: 'Also verify the ZIP cache after API and HTML caches'
         required: false
         type: boolean
         default: false
-      source_run_id:
-        description: 'Source workflow run ID to download slugs artifact from (alternative to slugs input)'
-        required: false
-        type: string
-        default: ''
 
 concurrency:
   group: warm-cache
@@ -46,482 +65,189 @@ env:
   LOCALES: 'en zh-hans zh-hant ja ko de fr es pt ru ar'
   CONCURRENCY: 10
   INVALIDATE_BATCH_SIZE: 10
+  BUILD_HEADER: x-skillstore-build
+  API_CACHE_HEADER: x-api-kv-cache
+  PAGE_CACHE_HEADER: x-page-kv-cache
 
 jobs:
   warm:
     runs-on: self-hosted
     timeout-minutes: 1440
     steps:
-      - name: Checkout repository
+      - name: Checkout cache tooling
         uses: actions/checkout@v5
         with:
-          sparse-checkout: .github/actions
+          sparse-checkout: |
+            .github/actions
+            scripts
 
-      - name: Download slugs from source workflow
-        if: inputs.source_run_id != ''
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          package-manager-cache: false
+
+      - name: Download changed slugs from source workflow
+        if: inputs.source_run_id != '' && inputs.scope != 'full-catalog'
         uses: actions/download-artifact@v7
         with:
           name: synced-slugs
           run-id: ${{ inputs.source_run_id }}
           github-token: ${{ github.token }}
 
-      - name: Fetch all slugs from Supabase
-        id: fetch
+      - name: Resolve and validate warm scope
+        id: scope
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          CONTENT_TYPE: ${{ inputs.type }}
+          SCOPE: ${{ inputs.scope }}
+          MODE: ${{ inputs.mode }}
           INPUT_SLUGS: ${{ inputs.slugs }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          APPROVE_FULL_CATALOG: ${{ inputs.approve_full_catalog }}
+          REQUEST_BUDGET: ${{ inputs.request_budget }}
+          BYTE_BUDGET: ${{ inputs.byte_budget }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: |
           set -euo pipefail
 
+          if ! [[ "$REQUEST_BUDGET" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::request_budget must be a positive integer"
+            exit 1
+          fi
+          if ! [[ "$BYTE_BUDGET" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::byte_budget must be a positive integer"
+            exit 1
+          fi
+
           WORK_DIR="$RUNNER_TEMP/warm-cache"
           mkdir -p "$WORK_DIR"
+          SLUGS_FILE="$WORK_DIR/skills-slugs.txt"
+          : > "$SLUGS_FILE"
 
-          SKILLS_FILE="$WORK_DIR/skills-slugs.txt"
-          WORKFLOWS_FILE="$WORK_DIR/workflows-slugs.txt"
-          RELEASES_FILE="$WORK_DIR/releases-tags.txt"
-          : > "$SKILLS_FILE"
-          : > "$WORKFLOWS_FILE"
-          : > "$RELEASES_FILE"
-
-          normalize_items() {
+          normalize_slugs() {
             tr ',[:space:]' '\n' | sed '/^$/d' | sort -u
           }
 
-          write_items_from_string() {
-            local file="$1"
-            local items="$2"
-            printf '%s\n' "$items" | normalize_items > "$file"
-          }
-
-          fetch_all_from_supabase() {
-            local table=$1
-            local column=${2:-slug}
-            local output_file=$3
-            local offset=0
-            local limit=1000
-
-            : > "$output_file"
-            
-            while true; do
-              response=$(curl -sf "${SUPABASE_URL}/rest/v1/${table}?select=${column}&offset=${offset}&limit=${limit}" \
-                -H "apikey: ${SUPABASE_SERVICE_KEY}" \
-                -H "Authorization: Bearer ${SUPABASE_SERVICE_KEY}" \
-                -H "Accept-Profile: skillstore")
-              
-              items_file=$(mktemp)
-              echo "$response" | jq -r ".[].${column}" | sed '/^$/d' > "$items_file"
-              count=$(grep -c . "$items_file" || true)
-              
-              if [ "$count" -eq 0 ]; then
-                rm -f "$items_file"
-                break
-              fi
-              
-              cat "$items_file" >> "$output_file"
-              rm -f "$items_file"
-              offset=$((offset + limit))
-              echo "  Fetched $count items (offset: $((offset - limit)))" >&2
-            done
-
-            sort -u -o "$output_file" "$output_file"
-          }
-
-          count_file() {
-            grep -c . "$1" 2>/dev/null || true
-          }
-
-          emit_file_output() {
-            local name="$1"
-            local file="$2"
-            local count
-            count=$(count_file "$file")
-            echo "${name}_file=$file" >> "$GITHUB_OUTPUT"
-            echo "${name}_count=$count" >> "$GITHUB_OUTPUT"
-          }
-
-          USING_SPECIFIC_SKILLS=false
-
-          if [ "$CONTENT_TYPE" = "skills" ] || [ "$CONTENT_TYPE" = "all" ]; then
-            if [ -n "$SOURCE_RUN_ID" ]; then
-              if [ ! -f synced-slugs.txt ]; then
-                echo "::error::synced-slugs.txt not found in source workflow artifact"
-                exit 1
-              fi
-              echo "Using skill slugs from source workflow artifact"
-              normalize_items < synced-slugs.txt > "$SKILLS_FILE"
-              USING_SPECIFIC_SKILLS=true
-            elif [ -n "$INPUT_SLUGS" ]; then
-              echo "Using provided skill slugs"
-              write_items_from_string "$SKILLS_FILE" "$INPUT_SLUGS"
-              USING_SPECIFIC_SKILLS=true
-            else
-              echo "Fetching all skills from Supabase..."
-              fetch_all_from_supabase "skills" "slug" "$SKILLS_FILE"
+          if [ "$SCOPE" = "full-catalog" ]; then
+            if [ "$APPROVE_FULL_CATALOG" != "true" ]; then
+              echo "::error::Full-catalog warming requires approve_full_catalog=true"
+              exit 1
+            fi
+            if [ -n "$INPUT_SLUGS" ] || [ -n "$SOURCE_RUN_ID" ]; then
+              echo "::error::Full-catalog scope cannot be combined with slugs or source_run_id"
+              exit 1
+            fi
+            if [ "$MODE" = "force" ]; then
+              echo "::error::Full-catalog force invalidation is intentionally unsupported; use warm mode with explicit budgets or invalidate a bounded slug set"
+              exit 1
+            fi
+            if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_KEY" ]; then
+              echo "::error::Supabase credentials are required to resolve the full catalog"
+              exit 1
             fi
 
-            SKILLS_COUNT=$(count_file "$SKILLS_FILE")
-            echo "Found $SKILLS_COUNT skills"
-          fi
-          
-          if [ "$CONTENT_TYPE" = "workflows" ] || { [ "$CONTENT_TYPE" = "all" ] && [ "$USING_SPECIFIC_SKILLS" != "true" ]; }; then
-            echo "Fetching all workflows from Supabase..."
-            fetch_all_from_supabase "workflows" "slug" "$WORKFLOWS_FILE"
-            WORKFLOWS_COUNT=$(count_file "$WORKFLOWS_FILE")
-            echo "Found $WORKFLOWS_COUNT workflows"
-          fi
-          
-          if [ "$CONTENT_TYPE" = "releases" ] || { [ "$CONTENT_TYPE" = "all" ] && [ "$USING_SPECIFIC_SKILLS" != "true" ]; }; then
-            echo "Fetching all releases from Supabase..."
-            fetch_all_from_supabase "releases" "tag" "$RELEASES_FILE"
-            RELEASES_COUNT=$(count_file "$RELEASES_FILE")
-            echo "Found $RELEASES_COUNT releases"
+            echo "Resolving the explicitly approved full public Skill catalog..."
+            offset=0
+            limit=1000
+            while true; do
+              response=$(curl -fsS \
+                "${SUPABASE_URL}/rest/v1/skills?select=slug&status=eq.approved&public_eligible=eq.true&order=slug.asc&offset=${offset}&limit=${limit}" \
+                -H "apikey: ${SUPABASE_SERVICE_KEY}" \
+                -H "Authorization: Bearer ${SUPABASE_SERVICE_KEY}" \
+                -H "Accept-Profile: skillstore" \
+                --connect-timeout 10 \
+                --max-time 90)
+              page_file=$(mktemp)
+              printf '%s' "$response" | jq -r 'if type == "array" then .[].slug else error("expected array") end' > "$page_file"
+              count=$(grep -c . "$page_file" || true)
+              cat "$page_file" >> "$SLUGS_FILE"
+              rm -f "$page_file"
+              echo "Resolved $count approved skills at offset $offset"
+              if [ "$count" -lt "$limit" ]; then
+                break
+              fi
+              offset=$((offset + limit))
+            done
+            sort -u -o "$SLUGS_FILE" "$SLUGS_FILE"
+          elif [ -n "$SOURCE_RUN_ID" ]; then
+            if [ "$SCOPE" != "changed" ]; then
+              echo "::error::source_run_id is only valid for changed scope"
+              exit 1
+            fi
+            if [ ! -f synced-slugs.txt ]; then
+              echo "::error::synced-slugs artifact is missing synced-slugs.txt"
+              exit 1
+            fi
+            normalize_slugs < synced-slugs.txt > "$SLUGS_FILE"
+          else
+            printf '%s\n' "$INPUT_SLUGS" | normalize_slugs > "$SLUGS_FILE"
           fi
 
-          emit_file_output "skills" "$SKILLS_FILE"
-          emit_file_output "workflows" "$WORKFLOWS_FILE"
-          emit_file_output "releases" "$RELEASES_FILE"
+          SLUG_COUNT=$(grep -c . "$SLUGS_FILE" || true)
+          if [ "$SLUG_COUNT" -eq 0 ]; then
+            echo "::error::Warm scope is empty. Supply changed/high-traffic slugs or explicitly approve full-catalog mode."
+            exit 1
+          fi
 
-      - name: Invalidate skills cache (force mode only)
-        if: inputs.mode == 'force' && (inputs.type == 'skills' || inputs.type == 'all') && steps.fetch.outputs.skills_count != '0'
+          echo "Resolved $SLUG_COUNT skill(s) for scope $SCOPE"
+          echo "slugs_file=$SLUGS_FILE" >> "$GITHUB_OUTPUT"
+          echo "slug_count=$SLUG_COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Invalidate selected skill caches
+        if: inputs.mode == 'force'
         uses: ./.github/actions/invalidate-cache
         with:
           type: skills
-          slugs-file: ${{ steps.fetch.outputs.skills_file }}
+          slugs-file: ${{ steps.scope.outputs.slugs_file }}
           secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           batch-size: ${{ env.INVALIDATE_BATCH_SIZE }}
+          fail-on-error: 'true'
 
-      - name: Invalidate workflows cache (force mode only)
-        if: inputs.mode == 'force' && (inputs.type == 'workflows' || inputs.type == 'all') && steps.fetch.outputs.workflows_count != '0'
-        uses: ./.github/actions/invalidate-cache
-        with:
-          type: workflows
-          slugs-file: ${{ steps.fetch.outputs.workflows_file }}
-          secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
-          batch-size: ${{ env.INVALIDATE_BATCH_SIZE }}
-
-      - name: Invalidate releases cache (force mode only)
-        if: inputs.mode == 'force' && (inputs.type == 'releases' || inputs.type == 'all') && steps.fetch.outputs.releases_count != '0'
-        uses: ./.github/actions/invalidate-cache
-        with:
-          type: releases
-          slugs-file: ${{ steps.fetch.outputs.releases_file }}
-          secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
-          batch-size: ${{ env.INVALIDATE_BATCH_SIZE }}
-
-      - name: Warm skills page cache
-        if: inputs.type == 'skills' || inputs.type == 'all'
+      - name: Warm and verify API, HTML, and optional ZIP caches
         env:
-          SLUGS_FILE: ${{ steps.fetch.outputs.skills_file }}
-          SKILL_COUNT: ${{ steps.fetch.outputs.skills_count }}
-        run: |
-          if [ ! -s "$SLUGS_FILE" ]; then
-            echo "No skills to warm"
-            exit 0
-          fi
-
-          generate_urls() {
-            while IFS= read -r slug; do
-              [ -z "$slug" ] && continue
-              for locale in $LOCALES; do
-                if [ "$locale" = "en" ]; then
-                  echo "$SITE_URL/skills/$slug"
-                else
-                  echo "$SITE_URL/$locale/skills/$slug"
-                fi
-              done
-            done < "$SLUGS_FILE"
-          }
-
-          LOCALE_COUNT=$(echo "$LOCALES" | wc -w | tr -d ' ')
-          URL_COUNT=$((SKILL_COUNT * LOCALE_COUNT))
-
-          echo "Warming $URL_COUNT skill URLs ($SKILL_COUNT skills × $LOCALE_COUNT locales)..."
-          echo "Progress will be reported every 500 URLs..."
-          echo ""
-
-          COUNTER=0
-          SUCCESS=0
-          FAILED=0
-          START_TIME=$(date +%s)
-
-          generate_urls | xargs -r -P "$CONCURRENCY" -n 1 sh -c '
-            url="$1"
-            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 60 -H "User-Agent: GitHub-Actions/SkillstoreBot" -H "X-Skillstore-Callback: true" "$url" 2>/dev/null || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "success"
-            else
-              echo "failed:$url"
-            fi
-          ' sh | while read -r result; do
-            COUNTER=$((COUNTER + 1))
-            if [ "$result" = "success" ]; then
-              SUCCESS=$((SUCCESS + 1))
-            else
-              FAILED=$((FAILED + 1))
-            fi
-
-            if [ $((COUNTER % 500)) -eq 0 ]; then
-              ELAPSED=$(($(date +%s) - START_TIME))
-              [ "$ELAPSED" -gt 0 ] || ELAPSED=1
-              RATE=$(awk "BEGIN {printf \"%.1f\", $COUNTER / $ELAPSED}")
-              echo "Progress: $COUNTER/$URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Rate: ${RATE} URLs/s"
-            fi
-          done
-
-          END_TIME=$(date +%s)
-          TOTAL_TIME=$((END_TIME - START_TIME))
-          [ "$TOTAL_TIME" -gt 0 ] || TOTAL_TIME=1
-          AVG_RATE=$(awk "BEGIN {printf \"%.1f\", $URL_COUNT / $TOTAL_TIME}")
-
-          echo ""
-          echo "✅ Skills page cache warming complete"
-          echo "Total: $URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Time: ${TOTAL_TIME}s | Avg: ${AVG_RATE} URLs/s"
-
-      - name: Warm skills ZIP download cache
-        if: inputs.warm_zip && (inputs.type == 'skills' || inputs.type == 'all')
-        env:
-          SLUGS_FILE: ${{ steps.fetch.outputs.skills_file }}
-          SLUG_COUNT: ${{ steps.fetch.outputs.skills_count }}
-        run: |
-          if [ ! -s "$SLUGS_FILE" ]; then
-            echo "No skills to warm ZIP cache"
-            exit 0
-          fi
-
-          echo "Warming ZIP cache for $SLUG_COUNT skills..."
-          echo "Progress will be reported every 100 skills..."
-          echo ""
-
-          COUNTER=0
-          SUCCESS=0
-          FAILED=0
-          START_TIME=$(date +%s)
-
-          while IFS= read -r slug; do
-            [ -z "$slug" ] && continue
-            URL="$SITE_URL/api/skills/$slug/download"
-            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 120 -H "User-Agent: GitHub-Actions/SkillstoreBot" -H "X-Skillstore-Callback: true" "$URL" 2>/dev/null || echo "000")
-
-            COUNTER=$((COUNTER + 1))
-            if [ "$STATUS" = "200" ]; then
-              SUCCESS=$((SUCCESS + 1))
-            else
-              FAILED=$((FAILED + 1))
-            fi
-
-            if [ $((COUNTER % 100)) -eq 0 ]; then
-              ELAPSED=$(($(date +%s) - START_TIME))
-              [ "$ELAPSED" -gt 0 ] || ELAPSED=1
-              RATE=$(awk "BEGIN {printf \"%.1f\", $COUNTER / $ELAPSED}")
-              echo "Progress: $COUNTER/$SLUG_COUNT ZIPs | Success: $SUCCESS | Failed: $FAILED | Rate: ${RATE} ZIPs/s"
-            fi
-          done < "$SLUGS_FILE"
-
-          END_TIME=$(date +%s)
-          TOTAL_TIME=$((END_TIME - START_TIME))
-          [ "$TOTAL_TIME" -gt 0 ] || TOTAL_TIME=1
-          AVG_RATE=$(awk "BEGIN {printf \"%.1f\", $SLUG_COUNT / $TOTAL_TIME}")
-
-          echo ""
-          echo "✅ Skills ZIP cache warming complete"
-          echo "Total: $SLUG_COUNT ZIPs | Success: $SUCCESS | Failed: $FAILED | Time: ${TOTAL_TIME}s | Avg: ${AVG_RATE} ZIPs/s"
-
-      - name: Warm workflows cache
-        if: inputs.type == 'workflows' || inputs.type == 'all'
-        env:
-          SLUGS_FILE: ${{ steps.fetch.outputs.workflows_file }}
-          WORKFLOW_COUNT: ${{ steps.fetch.outputs.workflows_count }}
-        run: |
-          if [ ! -s "$SLUGS_FILE" ]; then
-            echo "No workflows to warm"
-            exit 0
-          fi
-
-          generate_urls() {
-            while IFS= read -r slug; do
-              [ -z "$slug" ] && continue
-              for locale in $LOCALES; do
-                if [ "$locale" = "en" ]; then
-                  echo "$SITE_URL/workflows/$slug"
-                else
-                  echo "$SITE_URL/$locale/workflows/$slug"
-                fi
-              done
-            done < "$SLUGS_FILE"
-          }
-
-          LOCALE_COUNT=$(echo "$LOCALES" | wc -w | tr -d ' ')
-          URL_COUNT=$((WORKFLOW_COUNT * LOCALE_COUNT))
-
-          echo "Warming $URL_COUNT workflow URLs ($WORKFLOW_COUNT workflows × $LOCALE_COUNT locales)..."
-          echo "Progress will be reported every 500 URLs..."
-          echo ""
-
-          COUNTER=0
-          SUCCESS=0
-          FAILED=0
-          START_TIME=$(date +%s)
-
-          generate_urls | xargs -r -P "$CONCURRENCY" -n 1 sh -c '
-            url="$1"
-            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 60 -H "User-Agent: GitHub-Actions/SkillstoreBot" -H "X-Skillstore-Callback: true" "$url" 2>/dev/null || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "success"
-            else
-              echo "failed:$url"
-            fi
-          ' sh | while read -r result; do
-            COUNTER=$((COUNTER + 1))
-            if [ "$result" = "success" ]; then
-              SUCCESS=$((SUCCESS + 1))
-            else
-              FAILED=$((FAILED + 1))
-            fi
-
-            if [ $((COUNTER % 500)) -eq 0 ]; then
-              ELAPSED=$(($(date +%s) - START_TIME))
-              [ "$ELAPSED" -gt 0 ] || ELAPSED=1
-              RATE=$(awk "BEGIN {printf \"%.1f\", $COUNTER / $ELAPSED}")
-              echo "Progress: $COUNTER/$URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Rate: ${RATE} URLs/s"
-            fi
-          done
-
-          END_TIME=$(date +%s)
-          TOTAL_TIME=$((END_TIME - START_TIME))
-          [ "$TOTAL_TIME" -gt 0 ] || TOTAL_TIME=1
-          AVG_RATE=$(awk "BEGIN {printf \"%.1f\", $URL_COUNT / $TOTAL_TIME}")
-
-          echo ""
-          echo "✅ Workflows cache warming complete"
-          echo "Total: $URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Time: ${TOTAL_TIME}s | Avg: ${AVG_RATE} URLs/s"
-
-      - name: Warm releases cache
-        if: inputs.type == 'releases' || inputs.type == 'all'
-        env:
-          TAGS_FILE: ${{ steps.fetch.outputs.releases_file }}
-          RELEASE_COUNT: ${{ steps.fetch.outputs.releases_count }}
-        run: |
-          if [ ! -s "$TAGS_FILE" ]; then
-            echo "No releases to warm"
-            exit 0
-          fi
-
-          generate_urls() {
-            while IFS= read -r tag; do
-              [ -z "$tag" ] && continue
-              for locale in $LOCALES; do
-                if [ "$locale" = "en" ]; then
-                  echo "$SITE_URL/releases/$tag"
-                else
-                  echo "$SITE_URL/$locale/releases/$tag"
-                fi
-              done
-            done < "$TAGS_FILE"
-          }
-
-          LOCALE_COUNT=$(echo "$LOCALES" | wc -w | tr -d ' ')
-          URL_COUNT=$((RELEASE_COUNT * LOCALE_COUNT))
-
-          echo "Warming $URL_COUNT release URLs ($RELEASE_COUNT releases × $LOCALE_COUNT locales)..."
-          echo "Progress will be reported every 500 URLs..."
-          echo ""
-
-          COUNTER=0
-          SUCCESS=0
-          FAILED=0
-          START_TIME=$(date +%s)
-
-          generate_urls | xargs -r -P "$CONCURRENCY" -n 1 sh -c '
-            url="$1"
-            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 60 -H "User-Agent: GitHub-Actions/SkillstoreBot" -H "X-Skillstore-Callback: true" "$url" 2>/dev/null || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "success"
-            else
-              echo "failed:$url"
-            fi
-          ' sh | while read -r result; do
-            COUNTER=$((COUNTER + 1))
-            if [ "$result" = "success" ]; then
-              SUCCESS=$((SUCCESS + 1))
-            else
-              FAILED=$((FAILED + 1))
-            fi
-
-            if [ $((COUNTER % 500)) -eq 0 ]; then
-              ELAPSED=$(($(date +%s) - START_TIME))
-              [ "$ELAPSED" -gt 0 ] || ELAPSED=1
-              RATE=$(awk "BEGIN {printf \"%.1f\", $COUNTER / $ELAPSED}")
-              echo "Progress: $COUNTER/$URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Rate: ${RATE} URLs/s"
-            fi
-          done
-
-          END_TIME=$(date +%s)
-          TOTAL_TIME=$((END_TIME - START_TIME))
-          [ "$TOTAL_TIME" -gt 0 ] || TOTAL_TIME=1
-          AVG_RATE=$(awk "BEGIN {printf \"%.1f\", $URL_COUNT / $TOTAL_TIME}")
-
-          echo ""
-          echo "✅ Releases cache warming complete"
-          echo "Total: $URL_COUNT URLs | Success: $SUCCESS | Failed: $FAILED | Time: ${TOTAL_TIME}s | Avg: ${AVG_RATE} URLs/s"
-
-      - name: Summary
-        env:
-          MODE: ${{ inputs.mode }}
-          CONTENT_TYPE: ${{ inputs.type }}
+          SLUGS_FILE: ${{ steps.scope.outputs.slugs_file }}
+          REQUEST_BUDGET: ${{ inputs.request_budget }}
+          BYTE_BUDGET: ${{ inputs.byte_budget }}
+          EXPECTED_BUILD_TOKEN: ${{ inputs.expected_build_token }}
           WARM_ZIP: ${{ inputs.warm_zip }}
-          SKILLS_COUNT: ${{ steps.fetch.outputs.skills_count }}
-          WORKFLOWS_COUNT: ${{ steps.fetch.outputs.workflows_count }}
-          RELEASES_COUNT: ${{ steps.fetch.outputs.releases_count }}
+          WARM_MODE: ${{ inputs.mode }}
+          WARM_SCOPE: ${{ inputs.scope }}
         run: |
-          LOCALE_COUNT=11
-          
-          SKILLS_URLS=$((SKILLS_COUNT * LOCALE_COUNT))
+          set -euo pipefail
+
+          REPORT="$RUNNER_TEMP/warm-cache-report.jsonl"
+          SUMMARY="$RUNNER_TEMP/warm-cache-summary.json"
+          args=(
+            --slugs-file "$SLUGS_FILE"
+            --site-url "$SITE_URL"
+            --locales "$LOCALES"
+            --concurrency "$CONCURRENCY"
+            --request-budget "$REQUEST_BUDGET"
+            --byte-budget "$BYTE_BUDGET"
+            --mode "$WARM_MODE"
+            --scope "$WARM_SCOPE"
+            --build-header "$BUILD_HEADER"
+            --api-cache-header "$API_CACHE_HEADER"
+            --page-cache-header "$PAGE_CACHE_HEADER"
+            --report "$REPORT"
+            --summary "$SUMMARY"
+          )
+          if [ -n "$EXPECTED_BUILD_TOKEN" ]; then
+            args+=(--expected-build-token "$EXPECTED_BUILD_TOKEN")
+          fi
           if [ "$WARM_ZIP" = "true" ]; then
-            SKILLS_ZIPS=$SKILLS_COUNT
-          else
-            SKILLS_ZIPS=0
+            args+=(--warm-zip)
           fi
-          WORKFLOWS_URLS=$((WORKFLOWS_COUNT * LOCALE_COUNT))
-          RELEASES_URLS=$((RELEASES_COUNT * LOCALE_COUNT))
-          TOTAL_URLS=$((SKILLS_URLS + SKILLS_ZIPS + WORKFLOWS_URLS + RELEASES_URLS))
-          
-          echo "## Cache Warming Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Mode | \`$MODE\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Content Type | \`$CONTENT_TYPE\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "$MODE" = "force" ]; then
-            echo "> **Force mode**: All caches were invalidated before warming" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "$CONTENT_TYPE" = "skills" ] || [ "$CONTENT_TYPE" = "all" ]; then
-            echo "| Skills | $SKILLS_COUNT |" >> $GITHUB_STEP_SUMMARY
-            echo "| Skill Page URLs | $SKILLS_URLS |" >> $GITHUB_STEP_SUMMARY
-            if [ "$WARM_ZIP" = "true" ]; then
-              echo "| Skill ZIP Downloads | $SKILLS_COUNT |" >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
-          
-          if [ "$CONTENT_TYPE" = "workflows" ] || [ "$CONTENT_TYPE" = "all" ]; then
-            echo "| Workflows | $WORKFLOWS_COUNT |" >> $GITHUB_STEP_SUMMARY
-            echo "| Workflow URLs | $WORKFLOWS_URLS |" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          if [ "$CONTENT_TYPE" = "releases" ] || [ "$CONTENT_TYPE" = "all" ]; then
-            echo "| Releases | $RELEASES_COUNT |" >> $GITHUB_STEP_SUMMARY
-            echo "| Release URLs | $RELEASES_URLS |" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "| **Total URLs** | **$TOTAL_URLS** |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Cache warming completed" >> $GITHUB_STEP_SUMMARY
+
+          node scripts/warm-skill-cache.mjs "${args[@]}"
+
+      - name: Upload warm verification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: warm-cache-verification-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/warm-cache-report.jsonl
+            ${{ runner.temp }}/warm-cache-summary.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -1,0 +1,564 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { normalizeSlugs, runWarm, WarmError } from '../warm-skill-cache.mjs';
+
+const BUILD_A = `${'a'.repeat(40)}.deploy-a`;
+const BUILD_B = `${'b'.repeat(40)}.deploy-b`;
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function response({
+  status = 200,
+  build = BUILD_A,
+  apiCache,
+  pageCache,
+  zipCache,
+  body = 'ok',
+  ray = 'abc123-SJC',
+  contentLength,
+  responseBytes,
+  omitLength = false,
+} = {}) {
+  const headers = new Headers({
+    'x-skillstore-build': build,
+    'cf-ray': ray,
+  });
+  if (apiCache) headers.set('x-api-kv-cache', apiCache);
+  if (pageCache) headers.set('x-page-kv-cache', pageCache);
+  if (zipCache) headers.set('x-cache', zipCache);
+  const actualBytes = new TextEncoder().encode(body).byteLength;
+  if (!omitLength) headers.set('content-length', String(contentLength ?? actualBytes));
+  if (responseBytes !== undefined) {
+    headers.set('x-skillstore-response-bytes', String(responseBytes));
+  }
+  return new Response(body, { status, headers });
+}
+
+function versionResponse(build = BUILD_A) {
+  return response({ build, body: JSON.stringify({ version: build }) });
+}
+
+function streamingResponse({
+  build = BUILD_A,
+  apiCache,
+  pageCache,
+  chunks = [],
+  contentLength,
+  responseBytes,
+  pending = false,
+  onCancel = () => {},
+} = {}) {
+  const headers = new Headers({
+    'x-skillstore-build': build,
+    'cf-ray': 'stream-SJC',
+  });
+  if (apiCache) headers.set('x-api-kv-cache', apiCache);
+  if (pageCache) headers.set('x-page-kv-cache', pageCache);
+  if (contentLength !== undefined) headers.set('content-length', String(contentLength));
+  if (responseBytes !== undefined) {
+    headers.set('x-skillstore-response-bytes', String(responseBytes));
+  }
+  const encoded = chunks.map((chunk) => new TextEncoder().encode(chunk));
+  let cursor = 0;
+  const body = new ReadableStream({
+    pull(controller) {
+      if (pending) return;
+      if (cursor < encoded.length) controller.enqueue(encoded[cursor++]);
+      else controller.close();
+    },
+    cancel: onCancel,
+  }, { highWaterMark: 0 });
+  return new Response(body, { headers });
+}
+
+function versionBodyBytes(build = BUILD_A) {
+  return new TextEncoder().encode(JSON.stringify({ version: build })).byteLength;
+}
+
+function sequencedFetch(steps, calls) {
+  let cursor = 0;
+  return async (url, init) => {
+    calls.push({ url, init });
+    const step = steps[cursor++];
+    assert(step, `unexpected request ${cursor}: ${url}`);
+    if (step.assert) step.assert(url, init);
+    return typeof step.response === 'function' ? step.response(url, init) : step.response;
+  };
+}
+
+function baseOptions(fetchImpl, records = [], overrides = {}) {
+  return {
+    slugs: ['alpha'],
+    siteUrl: 'https://skillstore.test',
+    locales: ['en'],
+    concurrency: 2,
+    maxAttempts: 3,
+    retryWindowMinMs: 120_000,
+    retryWindowMaxMs: 120_000,
+    timeoutMs: 1_000,
+    requestBudget: 100,
+    byteBudget: 1_000_000,
+    fetchImpl,
+    sleep: async () => {},
+    report: (record) => records.push(record),
+    ...overrides,
+  };
+}
+
+test('normalizes and rejects empty warm scopes', async () => {
+  assert.deepEqual(normalizeSlugs(' beta,alpha\nalpha '), ['alpha', 'beta']);
+  await assert.rejects(
+    runWarm(baseOptions(async () => versionResponse(), [], { slugs: [] })),
+    (error) => error instanceof WarmError && /scope is empty/i.test(error.message)
+  );
+});
+
+test('enforces request and byte budgets before unbounded warming can continue', async () => {
+  await assert.rejects(
+    runWarm(baseOptions(async () => versionResponse(), [], { requestBudget: 7 })),
+    /below the minimum 8/i
+  );
+
+  const summary = await runWarm(baseOptions(async () => versionResponse(), [], { byteBudget: 10 }));
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /byte budget.*exceed/i);
+  assert.equal(summary.budget.requests, 1);
+});
+
+test('rejects an oversized Content-Length before reading and cancels the body', async () => {
+  let cancelled = false;
+  let calls = 0;
+  const summary = await runWarm(baseOptions(async (url) => {
+    calls++;
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return streamingResponse({
+      apiCache: 'HIT',
+      contentLength: 10,
+      pending: true,
+      onCancel: () => { cancelled = true; },
+    });
+  }, [], {
+    byteBudget: versionBodyBytes() + 5,
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /before reading/i);
+  assert.equal(summary.budget.bytes, versionBodyBytes());
+  assert.equal(summary.budget.reservedBytes, 0);
+  assert.equal(cancelled, true);
+  assert.equal(calls, 2);
+});
+
+test('enforces the hard byte limit while streaming one chunked response', async () => {
+  let cancelled = false;
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return streamingResponse({
+      apiCache: 'HIT',
+      chunks: ['1234', '5678'],
+      contentLength: 4,
+      onCancel: () => { cancelled = true; },
+    });
+  }, [], {
+    byteBudget: versionBodyBytes() + 6,
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /exceeded its declared/i);
+  assert.equal(summary.budget.bytes, versionBodyBytes() + 4);
+  assert.ok(summary.budget.bytes <= summary.budget.byteLimit);
+  assert.equal(summary.budget.reservedBytes, 0);
+  assert.equal(cancelled, true);
+});
+
+test('atomically reserves Content-Length across concurrent responses', async () => {
+  const cancelled = [];
+  let apiCalls = 0;
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    const index = apiCalls++;
+    return streamingResponse({
+      apiCache: 'HIT',
+      contentLength: 60,
+      pending: true,
+      onCancel: () => { cancelled[index] = true; },
+    });
+  }, [], {
+    slugs: ['alpha', 'beta'],
+    concurrency: 2,
+    byteBudget: versionBodyBytes() + 100,
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /byte budget/i);
+  assert.ok(summary.budget.bytes <= summary.budget.byteLimit);
+  assert.equal(summary.budget.reservedBytes, 0);
+  assert.deepEqual(cancelled, [true, true]);
+  assert.equal(apiCalls, 2);
+});
+
+test('fails closed when both response-size headers are missing', async () => {
+  let cancelled = false;
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return streamingResponse({
+      apiCache: 'HIT',
+      chunks: ['ok'],
+      onCancel: () => { cancelled = true; },
+    });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /missing Content-Length/i);
+  assert.equal(cancelled, true);
+});
+
+test('fails closed on an invalid Skillstore response-size header', async () => {
+  let cancelled = false;
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return streamingResponse({
+      apiCache: 'HIT',
+      chunks: ['ok'],
+      responseBytes: 'invalid',
+      onCancel: () => { cancelled = true; },
+    });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /x-skillstore-response-bytes must be/i);
+  assert.equal(cancelled, true);
+});
+
+test('fails closed when Content-Length conflicts with the Skillstore size header', async () => {
+  let cancelled = false;
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return streamingResponse({
+      apiCache: 'HIT',
+      chunks: ['ok'],
+      contentLength: 2,
+      responseBytes: 3,
+      onCancel: () => { cancelled = true; },
+    });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /Conflicting response sizes/i);
+  assert.equal(cancelled, true);
+});
+
+test('accepts the trusted Skillstore response-size header for dynamic pages', async () => {
+  const calls = [];
+  const html = '<html>cached</html>';
+  const htmlBytes = new TextEncoder().encode(html).byteLength;
+  const pageHit = () => response({
+    pageCache: 'HIT',
+    body: html,
+    omitLength: true,
+    responseBytes: htmlBytes,
+  });
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: pageHit() },
+    { response: pageHit() },
+    { response: pageHit() },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl));
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.completedEndpoints.page, 1);
+  assert.equal(summary.budget.requests, 8);
+  assert.equal(new Headers(calls[4].init.headers).get('accept-encoding'), 'identity');
+});
+
+test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HITs', async () => {
+  const calls = [];
+  const records = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'MISS', body: '{"data":{}}' }) },
+    { response: response({ apiCache: 'HIT', body: '{"data":{}}' }) },
+    {
+      assert: (url, init) => {
+        assert.match(url, /__skillstore_build=/);
+        assert.equal(new Headers(init.headers).has('cache-control'), false);
+      },
+      response: response({ apiCache: 'HIT', body: '{"data":{}}' }),
+    },
+    {
+      assert: (url, init) => {
+        assert.match(url, /__skillstore_build=/);
+        assert.equal(new Headers(init.headers).has('cache-control'), false);
+      },
+      response: response({ apiCache: 'HIT', body: '{"data":{}}' }),
+    },
+    { response: response({ pageCache: 'MISS', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    {
+      assert: (url, init) => {
+        assert.match(url, /__skillstore_build=/);
+        assert.equal(new Headers(init.headers).has('cache-control'), false);
+      },
+      response: response({ pageCache: 'HIT', body: '<html></html>' }),
+    },
+    {
+      assert: (url, init) => {
+        assert.match(url, /__skillstore_build=/);
+        assert.equal(new Headers(init.headers).has('cache-control'), false);
+      },
+      response: response({ pageCache: 'HIT', body: '<html></html>' }),
+    },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, records));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(summary.completedEndpoints, { api: 1, page: 1, zip: 0 });
+  assert.equal(summary.failedEndpoints, 0);
+  assert.equal(summary.skippedEndpoints, 0);
+  assert.equal(summary.budget.requests, 10);
+  assert.match(calls[1].url, /\/api\/skills\/alpha/);
+  assert.match(calls[5].url, /\/skills\/alpha/);
+  assert.equal(new Headers(calls[1].init.headers).get('cache-control'), 'no-cache');
+  const innerRecord = records.find((record) => record.phase === 'inner-cache');
+  assert.equal(innerRecord?.colo, 'SJC');
+  for (const field of ['url', 'attempt', 'status', 'cache', 'bytes', 'cfRay', 'colo']) {
+    assert.equal(Object.hasOwn(innerRecord, field), true, `JSONL evidence must include ${field}`);
+  }
+  assert.deepEqual(
+    records
+      .filter((record) => record.kind === 'api' && record.phase === 'ordinary-verification')
+      .map((record) => record.attempt),
+    [1, 2]
+  );
+  assert.deepEqual(
+    records
+      .filter((record) => record.kind === 'page' && record.phase === 'ordinary-verification')
+      .map((record) => record.attempt),
+    [1, 2]
+  );
+});
+
+test('fails a persistent MISS and does not start HTML warming', async () => {
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'MISS' }) },
+    { response: response({ apiCache: 'MISS' }) },
+    { response: response({ apiCache: 'MISS' }) },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl));
+
+  assert.equal(summary.success, false);
+  assert.equal(summary.completedEndpoints.api, 0);
+  assert.equal(summary.completedEndpoints.page, 0);
+  assert.equal(summary.failedEndpoints, 1);
+  assert.equal(summary.skippedEndpoints, 1);
+  assert.match(summary.failures.join('\n'), /never reached.*HIT/i);
+  assert.equal(calls.some((call) => new URL(call.url).pathname === '/skills/alpha'), false);
+});
+
+test('retries 429 and 5xx responses before accepting HIT', async () => {
+  const calls = [];
+  const records = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ status: 429 }) },
+    { response: response({ status: 503 }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, records, { maxAttempts: 4 }));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(
+    records.filter((record) => record.kind === 'api').map((record) => record.status),
+    [429, 503, 200, 200, 200]
+  );
+  assert.equal(summary.budget.requests, 10);
+});
+
+test('never exceeds the hard 120 second deadline for one endpoint', async () => {
+  let clock = 0;
+  const fetchImpl = async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return response({ apiCache: 'MISS' });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    maxAttempts: 100,
+    retryWindowMinMs: 120_000,
+    retryWindowMaxMs: 120_000,
+    requestBudget: 500,
+    now: () => clock,
+    sleep: async (milliseconds) => {
+      clock += milliseconds;
+    },
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /endpoint deadline/i);
+  assert.ok(clock <= 120_000, `endpoint elapsed ${clock}ms exceeded 120000ms`);
+});
+
+test('aborts immediately when a response build differs from the pinned deployment', async () => {
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse(BUILD_A) },
+    { response: response({ build: BUILD_B, apiCache: 'HIT' }) },
+    { response: versionResponse(BUILD_A) },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], { maxAttempts: 5 }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /deployment changed/i);
+  assert.equal(calls.length, 2, 'fatal deployment mismatch must skip retries and the final probe');
+});
+
+test('a fatal deployment mismatch aborts another in-flight fetch', async () => {
+  let apiCalls = 0;
+  let inFlightAborted = false;
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    apiCalls++;
+    if (apiCalls === 1) return response({ build: BUILD_B, apiCache: 'HIT' });
+    return new Promise((_, reject) => {
+      const abort = () => {
+        inFlightAborted = true;
+        reject(init.signal.reason || new Error('aborted'));
+      };
+      if (init.signal.aborted) abort();
+      else init.signal.addEventListener('abort', abort, { once: true });
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    slugs: ['alpha', 'beta'],
+    concurrency: 2,
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /deployment changed/i);
+  assert.equal(inFlightAborted, true);
+  assert.equal(apiCalls, 2);
+  assert.equal(
+    calls.some((call) => new URL(call.url).pathname === '/skills/alpha'),
+    false,
+    'fatal abort must prevent the page phase'
+  );
+});
+
+test('rejects a version document that does not exactly match its build header', async () => {
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    {
+      response: response({
+        build: BUILD_A,
+        body: JSON.stringify({ version: BUILD_B }),
+      }),
+    },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /build probe mismatch/i);
+  assert.equal(calls.length, 1);
+});
+
+test('fails if the active deployment changes at the final build probe', async () => {
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse(BUILD_A) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse(BUILD_B) },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /changed before completion/i);
+});
+
+test('reports exact counts for multiple slugs and locales', async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({ pageCache: 'HIT', body: '<html></html>' });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    slugs: ['alpha', 'beta'],
+    locales: ['en', 'zh-hans'],
+    concurrency: 3,
+  }));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(summary.plannedEndpoints, { api: 2, page: 4, zip: 0 });
+  assert.deepEqual(summary.completedEndpoints, { api: 2, page: 4, zip: 0 });
+  assert.equal(summary.budget.requests, 20);
+  assert.equal(summary.failedEndpoints, 0);
+  assert.equal(summary.skippedEndpoints, 0);
+  assert.equal(calls.length, 20);
+});
+
+test('workflow checks out scripts, requires bounded skill scope, and has no retired content branches', () => {
+  const workflow = readFileSync(resolve(REPO_ROOT, '.github/workflows/warm-cache.yml'), 'utf8');
+  const invalidateAction = readFileSync(resolve(REPO_ROOT, '.github/actions/invalidate-cache/action.yml'), 'utf8');
+
+  assert.match(workflow, /sparse-checkout: \|\n\s+\.github\/actions\n\s+scripts/);
+  assert.match(workflow, /approve_full_catalog/);
+  assert.match(workflow, /request_budget/);
+  assert.match(workflow, /byte_budget/);
+  assert.match(workflow, /Warm scope is empty/);
+  assert.match(workflow, /node scripts\/warm-skill-cache\.mjs/);
+  assert.match(workflow, /status=eq\.approved&public_eligible=eq\.true/);
+  assert.doesNotMatch(workflow, /Warm workflows cache|Warm releases cache|type=skills/);
+  assert.doesNotMatch(invalidateAction, /packs\/workflows/);
+  assert.match(invalidateAction, /skills\|packs\|plugins\|releases/);
+});
+
+test('sync propagates invalidation failures and cannot warm stale 365-day detail entries', () => {
+  const workflow = readFileSync(resolve(REPO_ROOT, '.github/workflows/sync-to-supabase.yml'), 'utf8');
+  const invalidationSection = workflow.slice(
+    workflow.indexOf('cache-invalidate:'),
+    workflow.indexOf('# TRIGGER TRANSLATION')
+  );
+
+  assert.doesNotMatch(invalidationSection, /continue-on-error:\s*true/);
+  assert.match(invalidationSection, /cache warming is blocked/);
+  assert.match(invalidationSection, /365 days/);
+  assert.match(invalidationSection, /needs\.cache-invalidate\.result == 'success'/);
+  assert.match(invalidationSection, /-f scope=changed/);
+  assert.match(invalidationSection, /-f request_budget=/);
+  assert.match(invalidationSection, /-f byte_budget=/);
+});

--- a/scripts/warm-skill-cache.mjs
+++ b/scripts/warm-skill-cache.mjs
@@ -1,0 +1,952 @@
+#!/usr/bin/env node
+
+import { createWriteStream } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULTS = {
+  siteUrl: 'https://skillstore.io',
+  locales: ['en', 'zh-hans', 'zh-hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'ru', 'ar'],
+  concurrency: 10,
+  maxAttempts: 5,
+  retryWindowMinMs: 90_000,
+  retryWindowMaxMs: 120_000,
+  timeoutMs: 60_000,
+  buildHeader: 'x-skillstore-build',
+  apiCacheHeader: 'x-api-kv-cache',
+  pageCacheHeader: 'x-page-kv-cache',
+  zipCacheHeader: 'x-cache',
+};
+
+const BUILD_TOKEN_RE = /^[0-9a-f]{40}\.[a-z0-9-]+$/i;
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const RETRYABLE_CACHE_STATES = new Set(['MISS', 'STALE']);
+const RETRY_BASE_DELAY_MS = 1_000;
+const RETRY_MAX_DELAY_MS = 15_000;
+const VERIFICATION_RESERVE_PER_REQUEST_MS = 10_000;
+
+export class WarmError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'WarmError';
+    this.details = details;
+  }
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new WarmError(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function normalizeSiteUrl(value) {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new WarmError('site URL must use HTTP or HTTPS');
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+export function normalizeSlugs(input) {
+  const values = Array.isArray(input) ? input : String(input || '').split(/[\s,]+/);
+  const slugs = [...new Set(values.map((value) => String(value).trim()).filter(Boolean))].sort();
+  if (slugs.length === 0) {
+    throw new WarmError('Warm scope is empty; provide changed/high-traffic slugs or explicitly approve full-catalog mode');
+  }
+  return slugs;
+}
+
+function buildSkillApiUrl(siteUrl, slug) {
+  const url = new URL(`/api/skills/${encodeURIComponent(slug)}`, `${siteUrl}/`);
+  url.searchParams.set('lang', 'en');
+  return url;
+}
+
+function buildSkillPageUrl(siteUrl, slug, locale) {
+  const prefix = locale === 'en' ? '' : `/${locale}`;
+  return new URL(`${prefix}/skills/${encodeURIComponent(slug)}`, `${siteUrl}/`);
+}
+
+function buildSkillZipUrl(siteUrl, slug) {
+  return new URL(`/api/skills/${encodeURIComponent(slug)}/download`, `${siteUrl}/`);
+}
+
+function withBuildToken(url, token) {
+  const result = new URL(url);
+  result.searchParams.set('__skillstore_build', token);
+  return result;
+}
+
+function coloFromRay(cfRay) {
+  if (!cfRay) return null;
+  const separator = cfRay.lastIndexOf('-');
+  return separator >= 0 ? cfRay.slice(separator + 1) || null : null;
+}
+
+function stableHash(value, seed = 0) {
+  let hash = seed >>> 0;
+  for (const character of value) hash = (hash * 33 + character.charCodeAt(0)) >>> 0;
+  return hash;
+}
+
+function endpointWindow(url, minimum, maximum) {
+  if (maximum <= minimum) return minimum;
+  return minimum + (stableHash(url) % (maximum - minimum + 1));
+}
+
+function retryDelay(url, attempt) {
+  const exponent = Math.max(0, attempt - 2);
+  const base = Math.min(RETRY_MAX_DELAY_MS, RETRY_BASE_DELAY_MS * (2 ** exponent));
+  const jitterPercent = 75 + (stableHash(url, attempt) % 51);
+  return Math.max(1, Math.floor(base * jitterPercent / 100));
+}
+
+function timeoutSignal(timeoutMs, runSignal) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error('request timed out')), timeoutMs);
+  const abortFromRun = () => controller.abort(runSignal.reason || new Error('warm run aborted'));
+  if (runSignal.aborted) abortFromRun();
+  else runSignal.addEventListener('abort', abortFromRun, { once: true });
+  return {
+    signal: controller.signal,
+    clear: () => {
+      clearTimeout(timeout);
+      runSignal.removeEventListener('abort', abortFromRun);
+    },
+  };
+}
+
+function contentBytes(buffer) {
+  return buffer?.byteLength || 0;
+}
+
+function requireBuildToken(value, source) {
+  if (!value || !BUILD_TOKEN_RE.test(value)) {
+    throw new WarmError(`${source} did not provide a valid exact Skillstore build token`, {
+      buildToken: value || null,
+    });
+  }
+  return value;
+}
+
+class Budget {
+  constructor(requestLimit, byteLimit) {
+    this.requestLimit = requestLimit;
+    this.byteLimit = byteLimit;
+    this.requests = 0;
+    this.bytes = 0;
+    this.reservedBytes = 0;
+  }
+
+  reserveRequest(url) {
+    if (this.requests >= this.requestLimit) {
+      throw new WarmError(`Request budget exhausted before ${url}`, {
+        ...this.snapshot(),
+        fatal: true,
+      });
+    }
+    this.requests += 1;
+  }
+
+  reserveResponseBytes(bytes, url) {
+    if (this.bytes + this.reservedBytes + bytes > this.byteLimit) {
+      throw new WarmError(`Byte budget would be exceeded before reading ${url}`, {
+        ...this.snapshot(),
+        contentLength: bytes,
+        responseBytes: 0,
+        fatal: true,
+      });
+    }
+    this.reservedBytes += bytes;
+    return { remaining: bytes, released: false };
+  }
+
+  consumeBytes(bytes, url, reservation, responseBytes) {
+    const covered = reservation ? Math.min(bytes, reservation.remaining) : 0;
+    const extra = bytes - covered;
+    if (this.bytes + this.reservedBytes + extra > this.byteLimit) {
+      throw new WarmError(`Byte budget would be exceeded while reading ${url}`, {
+        ...this.snapshot(),
+        chunkBytes: bytes,
+        responseBytes,
+        fatal: true,
+      });
+    }
+    if (reservation) {
+      reservation.remaining -= covered;
+      this.reservedBytes -= covered;
+    }
+    this.bytes += bytes;
+  }
+
+  releaseResponseBytes(reservation) {
+    if (!reservation || reservation.released) return;
+    this.reservedBytes -= reservation.remaining;
+    reservation.remaining = 0;
+    reservation.released = true;
+  }
+
+  snapshot() {
+    return {
+      requests: this.requests,
+      requestLimit: this.requestLimit,
+      bytes: this.bytes,
+      reservedBytes: this.reservedBytes,
+      byteLimit: this.byteLimit,
+    };
+  }
+}
+
+function parseDeclaredBytes(value, headerName) {
+  if (value === null) return null;
+  if (!/^\d+$/.test(value)) {
+    throw new WarmError(`${headerName} must be a non-negative integer`, {
+      fatal: true,
+      responseBytes: 0,
+    });
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new WarmError(`${headerName} exceeds the safe integer range`, {
+      fatal: true,
+      responseBytes: 0,
+    });
+  }
+  return parsed;
+}
+
+function declaredResponseBytes(response) {
+  const contentLength = parseDeclaredBytes(
+    response.headers.get('content-length'),
+    'Content-Length'
+  );
+  const skillstoreLength = parseDeclaredBytes(
+    response.headers.get('x-skillstore-response-bytes'),
+    'x-skillstore-response-bytes'
+  );
+  if (contentLength === null && skillstoreLength === null) {
+    throw new WarmError(
+      'Response is missing Content-Length and x-skillstore-response-bytes',
+      { fatal: true, responseBytes: 0 }
+    );
+  }
+  if (contentLength !== null && skillstoreLength !== null && contentLength !== skillstoreLength) {
+    throw new WarmError(
+      `Conflicting response sizes: Content-Length=${contentLength}, x-skillstore-response-bytes=${skillstoreLength}`,
+      { fatal: true, responseBytes: 0 }
+    );
+  }
+  return contentLength ?? skillstoreLength;
+}
+
+async function cancelBody(body, reason) {
+  if (!body) return;
+  try {
+    await body.cancel(reason);
+  } catch {
+    // The body may already be locked/cancelled by fetch abort propagation.
+  }
+}
+
+async function readResponseBody(response, context, url, signal) {
+  const body = response.body;
+  let reservation = null;
+  let declaredBytes;
+  try {
+    declaredBytes = declaredResponseBytes(response);
+    // This synchronous reservation occurs before getReader()/reader.read(), so
+    // concurrent responses cannot collectively cross the hard run budget.
+    reservation = context.budget.reserveResponseBytes(declaredBytes, url);
+  } catch (error) {
+    const fatal = context.abortRun(error);
+    await cancelBody(body, fatal);
+    throw fatal;
+  }
+
+  if (!body) {
+    context.budget.releaseResponseBytes(reservation);
+    if (declaredBytes === 0) return new Uint8Array();
+    const fatal = context.abortRun(new WarmError(
+      `Response body ended before its declared ${declaredBytes} bytes for ${url}`,
+      { fatal: true, responseBytes: 0 }
+    ));
+    throw fatal;
+  }
+
+  const reader = body.getReader();
+  const chunks = [];
+  let bytesRead = 0;
+  const cancelReader = () => {
+    reader.cancel(signal.reason || new Error('request aborted')).catch(() => {});
+  };
+  signal.addEventListener('abort', cancelReader, { once: true });
+
+  try {
+    while (true) {
+      if (signal.aborted) throw signal.reason || new Error('request aborted');
+      const { done, value } = await reader.read();
+      if (signal.aborted) throw signal.reason || new Error('request aborted');
+      if (done) break;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      if (chunk.byteLength > reservation.remaining) {
+        const fatal = context.abortRun(new WarmError(
+          `Response body exceeded its declared ${declaredBytes} bytes for ${url}`,
+          { fatal: true, responseBytes: bytesRead, chunkBytes: chunk.byteLength }
+        ));
+        await reader.cancel(fatal).catch(() => {});
+        throw fatal;
+      }
+      try {
+        context.budget.consumeBytes(chunk.byteLength, url, reservation, bytesRead);
+      } catch (error) {
+        const fatal = context.abortRun(error);
+        await reader.cancel(fatal).catch(() => {});
+        throw fatal;
+      }
+      chunks.push(chunk);
+      bytesRead += chunk.byteLength;
+    }
+    if (bytesRead !== declaredBytes) {
+      throw context.abortRun(new WarmError(
+        `Response body ended at ${bytesRead} bytes; expected ${declaredBytes} for ${url}`,
+        { fatal: true, responseBytes: bytesRead }
+      ));
+    }
+  } finally {
+    signal.removeEventListener('abort', cancelReader);
+    context.budget.releaseResponseBytes(reservation);
+  }
+
+  const result = new Uint8Array(bytesRead);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+async function sleepUnlessAborted(context, milliseconds) {
+  const signal = context.runAbortController.signal;
+  if (signal.aborted) throw context.abortReason || signal.reason;
+  let abortListener;
+  try {
+    await Promise.race([
+      context.sleep(milliseconds),
+      new Promise((_, reject) => {
+        abortListener = () => reject(context.abortReason || signal.reason);
+        signal.addEventListener('abort', abortListener, { once: true });
+      }),
+    ]);
+  } finally {
+    if (abortListener) signal.removeEventListener('abort', abortListener);
+  }
+  if (signal.aborted) throw context.abortReason || signal.reason;
+}
+
+function makeRecord({
+  phase,
+  kind,
+  slug = null,
+  locale = null,
+  url,
+  attempt,
+  status,
+  cache = null,
+  bytes,
+  response,
+  buildToken = null,
+  error = null,
+}) {
+  const cfRay = response?.headers?.get('cf-ray') || null;
+  return {
+    timestamp: new Date().toISOString(),
+    phase,
+    kind,
+    slug,
+    locale,
+    url,
+    attempt,
+    status,
+    cache,
+    bytes,
+    cfRay,
+    colo: coloFromRay(cfRay),
+    buildToken,
+    ok: !error && status >= 200 && status < 300,
+    error,
+  };
+}
+
+async function fetchRecorded(context, request) {
+  const url = String(request.url);
+  if (context.abortReason) throw context.abortReason;
+  try {
+    context.budget.reserveRequest(url);
+  } catch (error) {
+    throw context.abortRun(error);
+  }
+  const timer = timeoutSignal(
+    request.timeoutMs ?? context.timeoutMs,
+    context.runAbortController.signal
+  );
+  const fetchHeaders = new Headers(request.headers);
+  fetchHeaders.set('Accept-Encoding', 'identity');
+  let response;
+  let body;
+  try {
+    response = await context.fetchImpl(url, {
+      method: 'GET',
+      headers: fetchHeaders,
+      redirect: 'follow',
+      signal: timer.signal,
+    });
+    body = await readResponseBody(response, context, url, timer.signal);
+  } catch (error) {
+    const effectiveError = context.abortReason || error;
+    const message = effectiveError instanceof Error ? effectiveError.message : String(effectiveError);
+    const responseBytes = error instanceof WarmError && Number.isSafeInteger(error.details?.responseBytes)
+      ? error.details.responseBytes
+      : contentBytes(body);
+    const record = makeRecord({
+      ...request,
+      url,
+      status: response?.status || 0,
+      bytes: responseBytes,
+      response,
+      error: message,
+    });
+    await context.report(record);
+    throw effectiveError instanceof WarmError
+      ? effectiveError
+      : new WarmError(`Request failed for ${url}: ${message}`);
+  } finally {
+    timer.clear();
+  }
+
+  const buildToken = response.headers.get(context.buildHeader);
+  const cache = request.cacheHeader
+    ? (response.headers.get(request.cacheHeader) || '').trim().toUpperCase() || null
+    : null;
+  const record = makeRecord({
+    ...request,
+    url,
+    status: response.status,
+    cache,
+    bytes: contentBytes(body),
+    response,
+    buildToken,
+  });
+  await context.report(record);
+  return { response, body, buildToken, cache, record };
+}
+
+async function assertPinnedBuild(context, result, source) {
+  let token;
+  try {
+    token = requireBuildToken(result.buildToken, source);
+  } catch (error) {
+    const failure = new WarmError(error instanceof Error ? error.message : String(error), {
+      fatal: true,
+      source,
+    });
+    throw context.abortRun(failure);
+  }
+  if (token !== context.buildToken) {
+    const failure = new WarmError(`Production deployment changed during warm: expected ${context.buildToken}, received ${token}`, {
+      expected: context.buildToken,
+      actual: token,
+      source,
+      fatal: true,
+    });
+    throw context.abortRun(failure);
+  }
+}
+
+async function probeBuild(context, phase) {
+  try {
+    const url = new URL('/_app/version.json', `${context.siteUrl}/`);
+    const result = await fetchRecorded(context, {
+      phase,
+      kind: 'build',
+      url,
+      attempt: 1,
+      status: 0,
+      bytes: 0,
+      headers: {
+        Accept: 'application/json',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        'User-Agent': context.userAgent,
+        'X-Skillstore-Callback': 'true',
+      },
+    });
+    if (!result.response.ok) {
+      throw new WarmError(`Build probe returned HTTP ${result.response.status}`);
+    }
+
+    const headerToken = requireBuildToken(result.buildToken, 'build probe');
+    let payload;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(result.body));
+    } catch {
+      throw new WarmError('Build probe did not return valid JSON');
+    }
+    if (payload?.version !== headerToken) {
+      throw new WarmError(`Build probe mismatch: version.json=${payload?.version || '<missing>'}, header=${headerToken}`);
+    }
+    return headerToken;
+  } catch (error) {
+    if (context.abortReason) throw context.abortReason;
+    const failure = new WarmError(
+      error instanceof Error ? error.message : String(error),
+      { fatal: true, phase }
+    );
+    throw context.abortRun(failure);
+  }
+}
+
+async function warmEndpoint(context, item) {
+  const baseUrl = new URL(item.url);
+  const endpointStartedAt = context.now();
+  const endpointWindowMs = endpointWindow(
+    String(baseUrl),
+    context.retryWindowMinMs,
+    context.retryWindowMaxMs
+  );
+  const deadlineAt = endpointStartedAt + endpointWindowMs;
+  const headers = {
+    Accept: item.accept,
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+    'User-Agent': context.userAgent,
+    'X-Skillstore-Callback': 'true',
+  };
+
+  const remainingMs = () => Math.max(0, deadlineAt - context.now());
+  const deadlineError = (phase) => new WarmError(
+    `${item.kind} ${baseUrl} exhausted its ${endpointWindowMs}ms endpoint deadline during ${phase}`,
+    {
+      deadlineAt,
+      elapsedMs: context.now() - endpointStartedAt,
+      phase,
+    }
+  );
+  const verificationReserveMs = Math.min(
+    context.timeoutMs,
+    VERIFICATION_RESERVE_PER_REQUEST_MS
+  ) * 2;
+
+  let hitResult = null;
+  for (let attempt = 1; attempt <= context.maxAttempts; attempt++) {
+    if (attempt > 1) {
+      const availableForDelay = remainingMs() - verificationReserveMs - 1;
+      if (availableForDelay <= 0) throw deadlineError('inner-cache backoff');
+      const delayMs = Math.min(retryDelay(String(baseUrl), attempt), availableForDelay);
+      await sleepUnlessAborted(context, delayMs);
+      if (remainingMs() <= verificationReserveMs) throw deadlineError('inner-cache backoff');
+    }
+
+    const innerTimeoutMs = Math.min(
+      context.timeoutMs,
+      remainingMs() - verificationReserveMs
+    );
+    if (innerTimeoutMs <= 0) throw deadlineError('inner-cache request');
+
+    let result;
+    try {
+      result = await fetchRecorded(context, {
+        phase: 'inner-cache',
+        kind: item.kind,
+        slug: item.slug,
+        locale: item.locale,
+        url: baseUrl,
+        attempt,
+        status: 0,
+        bytes: 0,
+        cacheHeader: item.cacheHeader,
+        headers,
+        timeoutMs: innerTimeoutMs,
+      });
+      await assertPinnedBuild(context, result, `${item.kind} ${baseUrl}`);
+    } catch (error) {
+      if (error instanceof WarmError && error.details?.fatal) {
+        throw context.abortRun(error);
+      }
+      if (attempt < context.maxAttempts) continue;
+      throw error;
+    }
+
+    if (result.response.ok && result.cache === 'HIT') {
+      hitResult = result;
+      break;
+    }
+
+    const retryableStatus = RETRYABLE_STATUSES.has(result.response.status);
+    const retryableCache = result.response.ok && RETRYABLE_CACHE_STATES.has(result.cache);
+    if (!retryableStatus && !retryableCache) {
+      throw new WarmError(
+        `${item.kind} ${baseUrl} returned HTTP ${result.response.status} with ${item.cacheHeader}=${result.cache || '<missing>'}`
+      );
+    }
+  }
+
+  if (!hitResult) {
+    throw new WarmError(
+      `${item.kind} ${baseUrl} never reached ${item.cacheHeader}=HIT after ${context.maxAttempts} attempts`
+    );
+  }
+
+  const verificationUrl = withBuildToken(baseUrl, context.buildToken);
+  const verifications = [];
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if (context.abortReason) throw context.abortReason;
+    const requestsRemaining = 3 - attempt;
+    const verificationTimeoutMs = Math.min(
+      context.timeoutMs,
+      Math.floor(remainingMs() / requestsRemaining)
+    );
+    if (verificationTimeoutMs <= 0) throw deadlineError(`ordinary verification ${attempt}`);
+
+    const verification = await fetchRecorded(context, {
+      phase: 'ordinary-verification',
+      kind: item.kind,
+      slug: item.slug,
+      locale: item.locale,
+      url: verificationUrl,
+      attempt,
+      status: 0,
+      bytes: 0,
+      cacheHeader: item.cacheHeader,
+      headers: {
+        Accept: item.accept,
+        'User-Agent': context.userAgent,
+        'X-Skillstore-Callback': 'true',
+      },
+      timeoutMs: verificationTimeoutMs,
+    });
+    await assertPinnedBuild(
+      context,
+      verification,
+      `${item.kind} ordinary verification ${attempt} ${verificationUrl}`
+    );
+    if (!verification.response.ok || verification.cache !== 'HIT') {
+      throw new WarmError(
+        `${item.kind} ordinary verification ${attempt} replayed a non-HIT response: HTTP ${verification.response.status}, ${item.cacheHeader}=${verification.cache || '<missing>'}`
+      );
+    }
+    verifications.push(verification);
+  }
+
+  return {
+    kind: item.kind,
+    slug: item.slug,
+    locale: item.locale,
+    url: String(baseUrl),
+    innerAttempts: hitResult.record.attempt,
+    bytes: hitResult.record.bytes + verifications.reduce(
+      (total, result) => total + result.record.bytes,
+      0
+    ),
+  };
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  let stopped = false;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (!stopped) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      try {
+        results[index] = { ok: true, value: await mapper(items[index], index) };
+      } catch (error) {
+        results[index] = { ok: false, error };
+        stopped = true;
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results.filter(Boolean);
+}
+
+function summarizeFailures(results) {
+  return results
+    .filter((result) => !result.ok)
+    .map((result) => result.error instanceof Error ? result.error.message : String(result.error));
+}
+
+function endpointItems(options, slugs) {
+  const api = slugs.map((slug) => ({
+    kind: 'api',
+    slug,
+    locale: 'en',
+    url: buildSkillApiUrl(options.siteUrl, slug),
+    cacheHeader: options.apiCacheHeader,
+    accept: 'application/json',
+  }));
+  const pages = slugs.flatMap((slug) => options.locales.map((locale) => ({
+    kind: 'page',
+    slug,
+    locale,
+    url: buildSkillPageUrl(options.siteUrl, slug, locale),
+    cacheHeader: options.pageCacheHeader,
+    accept: 'text/html',
+  })));
+  const zips = options.warmZip ? slugs.map((slug) => ({
+    kind: 'zip',
+    slug,
+    locale: null,
+    url: buildSkillZipUrl(options.siteUrl, slug),
+    cacheHeader: options.zipCacheHeader,
+    accept: 'application/zip',
+  })) : [];
+  return { api, pages, zips };
+}
+
+export async function runWarm(rawOptions) {
+  const options = {
+    ...DEFAULTS,
+    ...rawOptions,
+    siteUrl: normalizeSiteUrl(rawOptions.siteUrl || DEFAULTS.siteUrl),
+    locales: rawOptions.locales || DEFAULTS.locales,
+    concurrency: parsePositiveInteger(rawOptions.concurrency ?? DEFAULTS.concurrency, 'concurrency'),
+    maxAttempts: parsePositiveInteger(rawOptions.maxAttempts ?? DEFAULTS.maxAttempts, 'max attempts'),
+    retryWindowMinMs: Number(rawOptions.retryWindowMinMs ?? DEFAULTS.retryWindowMinMs),
+    retryWindowMaxMs: Number(rawOptions.retryWindowMaxMs ?? DEFAULTS.retryWindowMaxMs),
+    timeoutMs: parsePositiveInteger(rawOptions.timeoutMs ?? DEFAULTS.timeoutMs, 'timeout'),
+    requestBudget: parsePositiveInteger(rawOptions.requestBudget, 'request budget'),
+    byteBudget: parsePositiveInteger(rawOptions.byteBudget, 'byte budget'),
+    fetchImpl: rawOptions.fetchImpl || globalThis.fetch,
+    sleep: rawOptions.sleep || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))),
+    now: rawOptions.now || (() => Date.now()),
+    report: rawOptions.report || (() => {}),
+    userAgent: rawOptions.userAgent || 'GitHub-Actions/SkillstoreCacheWarmer',
+    warmZip: rawOptions.warmZip === true,
+  };
+  if (typeof options.fetchImpl !== 'function') throw new WarmError('fetch implementation is required');
+  if (!Array.isArray(options.locales) || options.locales.length === 0) {
+    throw new WarmError('At least one locale is required');
+  }
+  if (!Number.isSafeInteger(options.retryWindowMinMs) || options.retryWindowMinMs <= 0 ||
+      !Number.isSafeInteger(options.retryWindowMaxMs) || options.retryWindowMaxMs < options.retryWindowMinMs ||
+      options.retryWindowMaxMs > 120_000) {
+    throw new WarmError(
+      'Retry window must use integer milliseconds satisfying 0 < minimum <= maximum <= 120000'
+    );
+  }
+
+  const slugs = normalizeSlugs(rawOptions.slugs);
+  const items = endpointItems(options, slugs);
+  const minimumRequests = 2 + (items.api.length + items.pages.length + items.zips.length) * 3;
+  if (options.requestBudget < minimumRequests) {
+    throw new WarmError(
+      `Request budget ${options.requestBudget} is below the minimum ${minimumRequests} required for one inner request plus two ordinary verifications per endpoint`
+    );
+  }
+
+  const budget = new Budget(options.requestBudget, options.byteBudget);
+  const runAbortController = new AbortController();
+  const context = {
+    ...options,
+    budget,
+    buildToken: null,
+    abortReason: null,
+    runAbortController,
+    abortRun(error) {
+      const failure = error instanceof WarmError
+        ? error
+        : new WarmError(error instanceof Error ? error.message : String(error), { fatal: true });
+      if (!context.abortReason) context.abortReason = failure;
+      if (!runAbortController.signal.aborted) runAbortController.abort(context.abortReason);
+      return context.abortReason;
+    },
+  };
+  const startedAt = new Date().toISOString();
+  const failures = [];
+  const completed = [];
+  let failedEndpointCount = 0;
+
+  try {
+    const pinned = await probeBuild(context, 'build-start');
+    if (rawOptions.expectedBuildToken && pinned !== rawOptions.expectedBuildToken) {
+      throw context.abortRun(new WarmError(
+        `Active build ${pinned} does not match expected build ${rawOptions.expectedBuildToken}`,
+        { fatal: true }
+      ));
+    }
+    context.buildToken = pinned;
+
+    const apiResults = await mapWithConcurrency(items.api, options.concurrency, (item) => warmEndpoint(context, item));
+    const apiFailures = summarizeFailures(apiResults);
+    failedEndpointCount += apiFailures.length;
+    failures.push(...apiFailures);
+    completed.push(...apiResults.filter((result) => result.ok).map((result) => result.value));
+
+    if (failures.length === 0) {
+      const pageResults = await mapWithConcurrency(items.pages, options.concurrency, (item) => warmEndpoint(context, item));
+      const pageFailures = summarizeFailures(pageResults);
+      failedEndpointCount += pageFailures.length;
+      failures.push(...pageFailures);
+      completed.push(...pageResults.filter((result) => result.ok).map((result) => result.value));
+    }
+
+    if (failures.length === 0 && items.zips.length > 0) {
+      const zipResults = await mapWithConcurrency(items.zips, Math.min(options.concurrency, 2), (item) => warmEndpoint(context, item));
+      const zipFailures = summarizeFailures(zipResults);
+      failedEndpointCount += zipFailures.length;
+      failures.push(...zipFailures);
+      completed.push(...zipResults.filter((result) => result.ok).map((result) => result.value));
+    }
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  } finally {
+    if (context.buildToken && !runAbortController.signal.aborted) {
+      try {
+        const finalToken = await probeBuild(context, 'build-end');
+        if (finalToken !== context.buildToken) {
+          const failure = context.abortRun(new WarmError(
+            `Production deployment changed before completion: expected ${context.buildToken}, received ${finalToken}`,
+            { fatal: true }
+          ));
+          failures.push(failure.message);
+        }
+      } catch (error) {
+        failures.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+
+  const endpointCounts = completed.reduce((counts, item) => {
+    counts[item.kind] = (counts[item.kind] || 0) + 1;
+    return counts;
+  }, { api: 0, page: 0, zip: 0 });
+  const plannedEndpointTotal = items.api.length + items.pages.length + items.zips.length;
+  const completedEndpointTotal = endpointCounts.api + endpointCounts.page + endpointCounts.zip;
+  return {
+    success: failures.length === 0,
+    mode: rawOptions.mode || 'warm',
+    scope: rawOptions.scope || 'explicit',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    buildToken: context.buildToken,
+    slugs: slugs.length,
+    locales: options.locales.length,
+    plannedEndpoints: {
+      api: items.api.length,
+      page: items.pages.length,
+      zip: items.zips.length,
+    },
+    completedEndpoints: endpointCounts,
+    failedEndpoints: failedEndpointCount,
+    skippedEndpoints: Math.max(0, plannedEndpointTotal - completedEndpointTotal - failedEndpointCount),
+    failureCount: failures.length,
+    failures,
+    budget: budget.snapshot(),
+  };
+}
+
+function parseArguments(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const current = argv[index];
+    if (!current.startsWith('--')) throw new WarmError(`Unexpected argument: ${current}`);
+    const name = current.slice(2);
+    if (name === 'warm-zip') {
+      args.warmZip = true;
+      continue;
+    }
+    const value = argv[++index];
+    if (value === undefined) throw new WarmError(`Missing value for --${name}`);
+    args[name] = value;
+  }
+  return args;
+}
+
+function markdownSummary(summary) {
+  const status = summary.success ? '✅ Passed' : '❌ Failed';
+  const failures = summary.failures.length
+    ? `\n\n### Failures\n\n${summary.failures.map((failure) => `- ${failure}`).join('\n')}`
+    : '';
+  return `## Skill cache warm verification\n\n` +
+    `| Metric | Value |\n|---|---:|\n` +
+    `| Result | ${status} |\n` +
+    `| Mode | \`${summary.mode}\` |\n` +
+    `| Scope | \`${summary.scope}\` |\n` +
+    `| Build | \`${summary.buildToken || 'unavailable'}\` |\n` +
+    `| Skills | ${summary.slugs} |\n` +
+    `| API endpoints | ${summary.completedEndpoints.api}/${summary.plannedEndpoints.api} |\n` +
+    `| Page endpoints | ${summary.completedEndpoints.page}/${summary.plannedEndpoints.page} |\n` +
+    `| ZIP endpoints | ${summary.completedEndpoints.zip}/${summary.plannedEndpoints.zip} |\n` +
+    `| HTTP requests | ${summary.budget.requests}/${summary.budget.requestLimit} |\n` +
+    `| Response bytes | ${summary.budget.bytes}/${summary.budget.byteLimit} |\n` +
+    `| Failed endpoints | ${summary.failedEndpoints} |\n` +
+    `| Skipped endpoints | ${summary.skippedEndpoints} |\n` +
+    `| Failure messages | ${summary.failureCount} |${failures}\n`;
+}
+
+async function cli(argv) {
+  const args = parseArguments(argv);
+  const slugsFile = args['slugs-file'];
+  if (!slugsFile) throw new WarmError('--slugs-file is required');
+  const reportPath = args.report || 'warm-cache-report.jsonl';
+  const summaryPath = args.summary || 'warm-cache-summary.json';
+  const stream = createWriteStream(reportPath, { flags: 'w' });
+  const report = (record) => new Promise((resolve, reject) => {
+    const line = `${JSON.stringify(record)}\n`;
+    const onError = (error) => {
+      stream.off('error', onError);
+      reject(error);
+    };
+    stream.once('error', onError);
+    stream.write(line, () => {
+      stream.off('error', onError);
+      resolve();
+    });
+  });
+
+  let summary;
+  try {
+    const slugs = normalizeSlugs(await readFile(slugsFile, 'utf8'));
+    summary = await runWarm({
+      slugs,
+      siteUrl: args['site-url'] || process.env.SITE_URL || DEFAULTS.siteUrl,
+      locales: String(args.locales || process.env.LOCALES || DEFAULTS.locales.join(' ')).split(/[\s,]+/).filter(Boolean),
+      concurrency: args.concurrency || process.env.CONCURRENCY || DEFAULTS.concurrency,
+      maxAttempts: args['max-attempts'] || process.env.MAX_ATTEMPTS || DEFAULTS.maxAttempts,
+      retryWindowMinMs: args['retry-window-min-ms'] ?? process.env.RETRY_WINDOW_MIN_MS ?? DEFAULTS.retryWindowMinMs,
+      retryWindowMaxMs: args['retry-window-max-ms'] ?? process.env.RETRY_WINDOW_MAX_MS ?? DEFAULTS.retryWindowMaxMs,
+      timeoutMs: args['timeout-ms'] || process.env.REQUEST_TIMEOUT_MS || DEFAULTS.timeoutMs,
+      requestBudget: args['request-budget'] || process.env.REQUEST_BUDGET,
+      byteBudget: args['byte-budget'] || process.env.BYTE_BUDGET,
+      buildHeader: args['build-header'] || process.env.BUILD_HEADER || DEFAULTS.buildHeader,
+      apiCacheHeader: args['api-cache-header'] || process.env.API_CACHE_HEADER || DEFAULTS.apiCacheHeader,
+      pageCacheHeader: args['page-cache-header'] || process.env.PAGE_CACHE_HEADER || DEFAULTS.pageCacheHeader,
+      expectedBuildToken: args['expected-build-token'] || process.env.EXPECTED_BUILD_TOKEN || null,
+      mode: args.mode || process.env.WARM_MODE || 'warm',
+      scope: args.scope || process.env.WARM_SCOPE || 'explicit',
+      warmZip: args.warmZip,
+      report,
+    });
+  } finally {
+    await new Promise((resolve) => stream.end(resolve));
+  }
+
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  const markdown = markdownSummary(summary);
+  process.stdout.write(`${markdown}\n`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await writeFile(process.env.GITHUB_STEP_SUMMARY, markdown, { flag: 'a' });
+  }
+  if (!summary.success) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  cli(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- replace shell/xargs warming with a bounded Node verifier
- pin every request to one exact production build and fail on deployment drift
- require API-first inner KV MISS-to-HIT verification plus two ordinary HIT checks
- enforce per-endpoint deadlines and global request/byte budgets
- hard-fail empty scopes, invalidation failures, missing response sizes, and unsupported full-catalog force invalidation
- limit full-catalog warming to explicit approval and public eligible skills

## Production readiness evidence

Read-only probes on 2026-07-13 confirmed:

- `x-skillstore-build` exactly matches `/_app/version.json.version`
- API responses expose `Content-Length` and `x-api-kv-cache`
- HTML responses expose `x-skillstore-response-bytes` and `x-page-kv-cache`
- the same API and detail page transitioned from inner `MISS` to `HIT`
- two consecutive build-query verification requests remained inner `HIT`

No cache-warming workflow or full-catalog run was triggered.

## Validation

- `node --test scripts/tests/*.test.mjs` (43/43)
- `node --check scripts/warm-skill-cache.mjs`
- YAML parse for changed workflows/action
- `git diff --check origin/main...HEAD`