### PR TITLE
fix: bound Cloudflare HTML transform bytes

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -68,6 +68,9 @@ env:
   BUILD_HEADER: x-skillstore-build
   API_CACHE_HEADER: x-api-kv-cache
   PAGE_CACHE_HEADER: x-page-kv-cache
+  CACHE_WRITE_HEADER: x-kv-write
+  CACHE_KEY_HEADER: x-kv-key
+  CACHE_VERSION_HEADER: x-kv-version
 
 jobs:
   warm:
@@ -229,6 +232,9 @@ jobs:
             --build-header "$BUILD_HEADER"
             --api-cache-header "$API_CACHE_HEADER"
             --page-cache-header "$PAGE_CACHE_HEADER"
+            --cache-write-header "$CACHE_WRITE_HEADER"
+            --cache-key-header "$CACHE_KEY_HEADER"
+            --cache-version-header "$CACHE_VERSION_HEADER"
             --report "$REPORT"
             --summary "$SUMMARY"
           )

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -13,6 +13,8 @@ import {
 
 const BUILD_A = `${'a'.repeat(40)}.deploy-a`;
 const BUILD_B = `${'b'.repeat(40)}.deploy-b`;
+const CACHE_KEY_A = '00000000aaaa';
+const CACHE_VERSION_A = 'cache-version-a';
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 function response({
@@ -21,6 +23,9 @@ function response({
   apiCache,
   pageCache,
   zipCache,
+  cacheWrite,
+  cacheKey = CACHE_KEY_A,
+  cacheVersion = CACHE_VERSION_A,
   body = 'ok',
   ray = 'abc123-SJC',
   contentLength,
@@ -34,6 +39,14 @@ function response({
   if (apiCache) headers.set('x-api-kv-cache', apiCache);
   if (pageCache) headers.set('x-page-kv-cache', pageCache);
   if (zipCache) headers.set('x-cache', zipCache);
+  const kvCache = apiCache || pageCache;
+  if (kvCache) {
+    if (cacheWrite !== null) {
+      headers.set('x-kv-write', cacheWrite || (kvCache === 'MISS' ? 'STORED' : 'SKIPPED'));
+    }
+    if (cacheKey !== null) headers.set('x-kv-key', cacheKey);
+    if (cacheVersion !== null) headers.set('x-kv-version', cacheVersion);
+  }
   const actualBytes = new TextEncoder().encode(body).byteLength;
   if (!omitLength) headers.set('content-length', String(contentLength ?? actualBytes));
   if (responseBytes !== undefined) {
@@ -50,6 +63,9 @@ function streamingResponse({
   build = BUILD_A,
   apiCache,
   pageCache,
+  cacheWrite,
+  cacheKey = CACHE_KEY_A,
+  cacheVersion = CACHE_VERSION_A,
   chunks = [],
   contentLength,
   responseBytes,
@@ -62,6 +78,14 @@ function streamingResponse({
   });
   if (apiCache) headers.set('x-api-kv-cache', apiCache);
   if (pageCache) headers.set('x-page-kv-cache', pageCache);
+  const kvCache = apiCache || pageCache;
+  if (kvCache) {
+    if (cacheWrite !== null) {
+      headers.set('x-kv-write', cacheWrite || (kvCache === 'MISS' ? 'STORED' : 'SKIPPED'));
+    }
+    if (cacheKey !== null) headers.set('x-kv-key', cacheKey);
+    if (cacheVersion !== null) headers.set('x-kv-version', cacheVersion);
+  }
   if (contentLength !== undefined) headers.set('content-length', String(contentLength));
   if (responseBytes !== undefined) {
     headers.set('x-skillstore-response-bytes', String(responseBytes));
@@ -341,6 +365,93 @@ test('accepts HTML at the exact edge transform ceiling', async () => {
   assert.equal(summary.budget.reservedBytes, 0);
 });
 
+test('accepts transformed HTML when Content-Length is within the origin allowance and exact', async () => {
+  const records = [];
+  const edgeDelta = 1_157;
+  const actual = 1 + edgeDelta;
+  const fetchImpl = async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: `x${'y'.repeat(edgeDelta)}`,
+      contentLength: actual,
+      responseBytes: 1,
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, records));
+
+  assert.equal(summary.success, true);
+  const page = records.find((record) => record.kind === 'page');
+  assert.equal(page?.declared, 1);
+  assert.equal(page?.actual, actual);
+  assert.equal(page?.edgeDelta, edgeDelta);
+});
+
+test('rejects HTML Content-Length below the origin declaration', async () => {
+  const summary = await runWarm(baseOptions(async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: 'x',
+      contentLength: 0,
+      responseBytes: 1,
+    });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /must be between origin declared 1/i);
+});
+
+test('rejects HTML Content-Length above the edge transform allowance', async () => {
+  const contentLength = 1 + MAX_EDGE_TRANSFORM_OVERHEAD + 1;
+  const summary = await runWarm(baseOptions(async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: 'x'.repeat(contentLength),
+      contentLength,
+      responseBytes: 1,
+    });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /must be between origin declared 1/i);
+});
+
+test('requires actual HTML bytes to exactly match an accepted Content-Length', async () => {
+  const records = [];
+  const summary = await runWarm(baseOptions(async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: 'abc',
+      contentLength: 2,
+      responseBytes: 1,
+    });
+  }, records));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /ended at 3 bytes; expected 2/i);
+  const failure = records.find((record) => record.kind === 'page' && record.error);
+  assert.equal(failure?.declared, 1);
+  assert.equal(failure?.actual, 3);
+  assert.equal(failure?.edgeDelta, 2);
+  assert.equal(failure?.cache, 'HIT');
+  assert.equal(failure?.cacheWrite, 'SKIPPED');
+  assert.equal(failure?.cacheKey, CACHE_KEY_A);
+  assert.equal(failure?.cacheVersion, CACHE_VERSION_A);
+  assert.equal(failure?.buildToken, BUILD_A);
+});
+
 test('rejects HTML shorter than declared and records the negative edge delta', async () => {
   const records = [];
   const fetchImpl = async (url) => {
@@ -470,13 +581,12 @@ test('atomically reserves the HTML declaration plus edge allowance', async () =>
   assert.equal(pageCalls, 2);
 });
 
-test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HITs', async () => {
+test('verifies invalidated API and HTML as MISS+STORED then two HIT+SKIPPED responses', async () => {
   const calls = [];
   const records = [];
   const fetchImpl = sequencedFetch([
     { response: versionResponse() },
     { response: response({ apiCache: 'MISS', body: '{"data":{}}' }) },
-    { response: response({ apiCache: 'HIT', body: '{"data":{}}' }) },
     {
       assert: (url, init) => {
         assert.match(url, /__skillstore_build=/);
@@ -492,7 +602,6 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
       response: response({ apiCache: 'HIT', body: '{"data":{}}' }),
     },
     { response: response({ pageCache: 'MISS', body: '<html></html>' }) },
-    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
     {
       assert: (url, init) => {
         assert.match(url, /__skillstore_build=/);
@@ -510,15 +619,18 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
     { response: versionResponse() },
   ], calls);
 
-  const summary = await runWarm(baseOptions(fetchImpl, records));
+  const summary = await runWarm(baseOptions(fetchImpl, records, {
+    mode: 'warm',
+    scope: 'changed',
+  }));
 
   assert.equal(summary.success, true);
   assert.deepEqual(summary.completedEndpoints, { api: 1, page: 1, zip: 0 });
   assert.equal(summary.failedEndpoints, 0);
   assert.equal(summary.skippedEndpoints, 0);
-  assert.equal(summary.budget.requests, 10);
+  assert.equal(summary.budget.requests, 8);
   assert.match(calls[1].url, /\/api\/skills\/alpha/);
-  assert.match(calls[5].url, /\/skills\/alpha/);
+  assert.match(calls[4].url, /\/skills\/alpha/);
   assert.equal(new Headers(calls[1].init.headers).get('cache-control'), 'no-cache');
   const innerRecord = records.find((record) => record.phase === 'inner-cache');
   assert.equal(innerRecord?.colo, 'SJC');
@@ -527,6 +639,9 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
     'attempt',
     'status',
     'cache',
+    'cacheWrite',
+    'cacheKey',
+    'cacheVersion',
     'bytes',
     'declared',
     'actual',
@@ -535,6 +650,24 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
     'colo',
   ]) {
     assert.equal(Object.hasOwn(innerRecord, field), true, `JSONL evidence must include ${field}`);
+  }
+  assert.deepEqual(
+    records
+      .filter((record) => record.kind === 'api')
+      .map((record) => [record.cache, record.cacheWrite]),
+    [['MISS', 'STORED'], ['HIT', 'SKIPPED'], ['HIT', 'SKIPPED']]
+  );
+  assert.deepEqual(
+    records
+      .filter((record) => record.kind === 'page')
+      .map((record) => [record.cache, record.cacheWrite]),
+    [['MISS', 'STORED'], ['HIT', 'SKIPPED'], ['HIT', 'SKIPPED']]
+  );
+  for (const kind of ['api', 'page']) {
+    const chain = records.filter((record) => record.kind === kind);
+    assert.deepEqual([...new Set(chain.map((record) => record.cacheKey))], [CACHE_KEY_A]);
+    assert.deepEqual([...new Set(chain.map((record) => record.cacheVersion))], [CACHE_VERSION_A]);
+    assert.deepEqual([...new Set(chain.map((record) => record.buildToken))], [BUILD_A]);
   }
   assert.deepEqual(
     records
@@ -550,14 +683,74 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
   );
 });
 
+test('rejects an initial HIT for force and changed invalidation scopes', async () => {
+  for (const overrides of [
+    { mode: 'warm', scope: 'changed' },
+    { mode: 'force', scope: 'high-traffic' },
+  ]) {
+    let calls = 0;
+    const summary = await runWarm(baseOptions(async (url) => {
+      calls++;
+      if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+      return response({ apiCache: 'HIT' });
+    }, [], overrides));
+
+    assert.equal(summary.success, false);
+    assert.match(summary.failures.join('\n'), /expected MISS\+STORED/i);
+    assert.equal(calls, 2, 'invalidated cache state must abort before verification traffic');
+  }
+});
+
+test('rejects an invalidated MISS that did not durably store', async () => {
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return response({ apiCache: 'MISS', cacheWrite: 'SKIPPED' });
+  }, [], { mode: 'warm', scope: 'changed' }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /expected MISS\+STORED/i);
+});
+
+test('fails closed when KV key or version evidence is missing', async () => {
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return response({ apiCache: 'MISS', cacheKey: null });
+  }, [], { mode: 'warm', scope: 'changed' }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /did not expose x-kv-key and x-kv-version/i);
+});
+
+test('fails when cache key or version changes across the verification chain', async () => {
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'MISS' }) },
+    {
+      response: response({
+        apiCache: 'HIT',
+        cacheKey: '00000000bbbb',
+        cacheVersion: 'cache-version-b',
+      }),
+    },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    mode: 'warm',
+    scope: 'changed',
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /changed cache identity/i);
+  assert.equal(calls.length, 3);
+});
+
 test('fails a persistent MISS and does not start HTML warming', async () => {
   const calls = [];
   const fetchImpl = sequencedFetch([
     { response: versionResponse() },
     { response: response({ apiCache: 'MISS' }) },
     { response: response({ apiCache: 'MISS' }) },
-    { response: response({ apiCache: 'MISS' }) },
-    { response: versionResponse() },
   ], calls);
 
   const summary = await runWarm(baseOptions(fetchImpl));
@@ -567,7 +760,7 @@ test('fails a persistent MISS and does not start HTML warming', async () => {
   assert.equal(summary.completedEndpoints.page, 0);
   assert.equal(summary.failedEndpoints, 1);
   assert.equal(summary.skippedEndpoints, 1);
-  assert.match(summary.failures.join('\n'), /never reached.*HIT/i);
+  assert.match(summary.failures.join('\n'), /expected HIT\+SKIPPED/i);
   assert.equal(calls.some((call) => new URL(call.url).pathname === '/skills/alpha'), false);
 });
 
@@ -587,12 +780,22 @@ test('retries 429 and 5xx responses before accepting HIT', async () => {
     { response: versionResponse() },
   ], calls);
 
-  const summary = await runWarm(baseOptions(fetchImpl, records, { maxAttempts: 4 }));
+  const summary = await runWarm(baseOptions(fetchImpl, records, {
+    maxAttempts: 4,
+    mode: 'warm',
+    scope: 'high-traffic',
+  }));
 
   assert.equal(summary.success, true);
   assert.deepEqual(
     records.filter((record) => record.kind === 'api').map((record) => record.status),
     [429, 503, 200, 200, 200]
+  );
+  assert.deepEqual(
+    records
+      .filter((record) => record.kind === 'api' && record.status === 200)
+      .map((record) => [record.cache, record.cacheWrite]),
+    [['HIT', 'SKIPPED'], ['HIT', 'SKIPPED'], ['HIT', 'SKIPPED']]
   );
   assert.equal(summary.budget.requests, 10);
 });
@@ -601,7 +804,7 @@ test('never exceeds the hard 120 second deadline for one endpoint', async () => 
   let clock = 0;
   const fetchImpl = async (url) => {
     if (new URL(url).pathname === '/_app/version.json') return versionResponse();
-    return response({ apiCache: 'MISS' });
+    return response({ apiCache: 'STALE' });
   };
 
   const summary = await runWarm(baseOptions(fetchImpl, [], {
@@ -740,6 +943,9 @@ test('workflow checks out scripts, requires bounded skill scope, and has no reti
   assert.match(workflow, /approve_full_catalog/);
   assert.match(workflow, /request_budget/);
   assert.match(workflow, /byte_budget/);
+  assert.match(workflow, /CACHE_WRITE_HEADER: x-kv-write/);
+  assert.match(workflow, /CACHE_KEY_HEADER: x-kv-key/);
+  assert.match(workflow, /CACHE_VERSION_HEADER: x-kv-version/);
   assert.match(workflow, /Warm scope is empty/);
   assert.match(workflow, /node scripts\/warm-skill-cache\.mjs/);
   assert.match(workflow, /status=eq\.approved&public_eligible=eq\.true/);

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -4,7 +4,12 @@ import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { normalizeSlugs, runWarm, WarmError } from '../warm-skill-cache.mjs';
+import {
+  MAX_EDGE_TRANSFORM_OVERHEAD,
+  normalizeSlugs,
+  runWarm,
+  WarmError,
+} from '../warm-skill-cache.mjs';
 
 const BUILD_A = `${'a'.repeat(40)}.deploy-a`;
 const BUILD_B = `${'b'.repeat(40)}.deploy-b`;
@@ -280,6 +285,191 @@ test('accepts the trusted Skillstore response-size header for dynamic pages', as
   assert.equal(new Headers(calls[4].init.headers).get('accept-encoding'), 'identity');
 });
 
+test('accepts bounded HTML edge transforms and records declared, actual, and edgeDelta', async () => {
+  const records = [];
+  const originHtml = '<html>cached</html>';
+  const edgeDelta = 1_157;
+  const transformedHtml = `${originHtml}${'x'.repeat(edgeDelta)}`;
+  const declared = new TextEncoder().encode(originHtml).byteLength;
+  const fetchImpl = async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: transformedHtml,
+      omitLength: true,
+      responseBytes: declared,
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, records));
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.budget.reservedBytes, 0);
+  const pageRecords = records.filter((record) => record.kind === 'page');
+  assert.equal(pageRecords.length, 3);
+  for (const record of pageRecords) {
+    assert.equal(record.declared, declared);
+    assert.equal(record.actual, declared + edgeDelta);
+    assert.equal(record.edgeDelta, edgeDelta);
+    assert.equal(record.bytes, record.actual);
+  }
+  assert.equal(
+    summary.budget.bytes,
+    records.reduce((total, record) => total + record.actual, 0),
+    'unused edge reservations must be released instead of counted as downloaded bytes'
+  );
+});
+
+test('accepts HTML at the exact edge transform ceiling', async () => {
+  const fetchImpl = async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: `x${'y'.repeat(MAX_EDGE_TRANSFORM_OVERHEAD)}`,
+      omitLength: true,
+      responseBytes: 1,
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl));
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.budget.reservedBytes, 0);
+});
+
+test('rejects HTML shorter than declared and records the negative edge delta', async () => {
+  const records = [];
+  const fetchImpl = async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: '',
+      omitLength: true,
+      responseBytes: 1,
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, records));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /expected at least its declared 1 bytes/i);
+  const failure = records.find((record) => record.kind === 'page' && record.error);
+  assert.equal(failure?.declared, 1);
+  assert.equal(failure?.actual, 0);
+  assert.equal(failure?.edgeDelta, -1);
+});
+
+test('rejects HTML that exceeds the fixed edge transform allowance', async () => {
+  const records = [];
+  const actual = MAX_EDGE_TRANSFORM_OVERHEAD + 2;
+  const fetchImpl = async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({
+      pageCache: 'HIT',
+      body: 'x'.repeat(actual),
+      omitLength: true,
+      responseBytes: 1,
+    });
+  };
+
+  const summary = await runWarm(baseOptions(fetchImpl, records));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /edge transform allowance/i);
+  const failure = records.find((record) => record.kind === 'page' && record.error);
+  assert.equal(failure?.declared, 1);
+  assert.equal(failure?.actual, actual);
+  assert.equal(failure?.edgeDelta, MAX_EDGE_TRANSFORM_OVERHEAD + 1);
+});
+
+test('continues to require exact byte equality for API responses', async () => {
+  const records = [];
+  const summary = await runWarm(baseOptions(async (url) => {
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    return response({ apiCache: 'HIT', body: 'abc', contentLength: 2 });
+  }, records));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /exceeded its declared 2 bytes/i);
+  const failure = records.find((record) => record.kind === 'api' && record.error);
+  assert.equal(failure?.declared, 2);
+  assert.equal(failure?.actual, 3);
+  assert.equal(failure?.edgeDelta, 1);
+});
+
+test('continues to require exact byte equality for build probes', async () => {
+  const records = [];
+  const body = JSON.stringify({ version: BUILD_A });
+  const summary = await runWarm(baseOptions(async () => response({
+    build: BUILD_A,
+    body,
+    contentLength: new TextEncoder().encode(body).byteLength - 1,
+  }), records));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /exceeded its declared/i);
+  const failure = records.find((record) => record.kind === 'build' && record.error);
+  assert.equal(failure?.actual, failure.declared + 1);
+  assert.equal(failure?.edgeDelta, 1);
+});
+
+test('continues to require exact byte equality for ZIP responses', async () => {
+  const records = [];
+  const summary = await runWarm(baseOptions(async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.endsWith('/download')) {
+      return response({ zipCache: 'HIT', body: 'abc', contentLength: 2 });
+    }
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    return response({ pageCache: 'HIT', body: '<html></html>' });
+  }, records, { warmZip: true }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /exceeded its declared 2 bytes/i);
+  const failure = records.find((record) => record.kind === 'zip' && record.error);
+  assert.equal(failure?.declared, 2);
+  assert.equal(failure?.actual, 3);
+  assert.equal(failure?.edgeDelta, 1);
+});
+
+test('atomically reserves the HTML declaration plus edge allowance', async () => {
+  const cancelled = [];
+  let pageCalls = 0;
+  const versionBytes = versionBodyBytes();
+  const apiBytes = 2 * 2 * 3;
+  const summary = await runWarm(baseOptions(async (url) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/skills/')) return response({ apiCache: 'HIT' });
+    const index = pageCalls++;
+    return streamingResponse({
+      pageCache: 'HIT',
+      responseBytes: 60,
+      pending: true,
+      onCancel: () => { cancelled[index] = true; },
+    });
+  }, [], {
+    slugs: ['alpha', 'beta'],
+    concurrency: 2,
+    byteBudget: versionBytes + apiBytes + 60 + MAX_EDGE_TRANSFORM_OVERHEAD + 50,
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /byte budget/i);
+  assert.equal(summary.budget.reservedBytes, 0);
+  assert.deepEqual(cancelled, [true, true]);
+  assert.equal(pageCalls, 2);
+});
+
 test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HITs', async () => {
   const calls = [];
   const records = [];
@@ -332,7 +522,18 @@ test('warms API before HTML, accepts MISS then HIT, and verifies two ordinary HI
   assert.equal(new Headers(calls[1].init.headers).get('cache-control'), 'no-cache');
   const innerRecord = records.find((record) => record.phase === 'inner-cache');
   assert.equal(innerRecord?.colo, 'SJC');
-  for (const field of ['url', 'attempt', 'status', 'cache', 'bytes', 'cfRay', 'colo']) {
+  for (const field of [
+    'url',
+    'attempt',
+    'status',
+    'cache',
+    'bytes',
+    'declared',
+    'actual',
+    'edgeDelta',
+    'cfRay',
+    'colo',
+  ]) {
     assert.equal(Object.hasOwn(innerRecord, field), true, `JSONL evidence must include ${field}`);
   }
   assert.deepEqual(

--- a/scripts/warm-skill-cache.mjs
+++ b/scripts/warm-skill-cache.mjs
@@ -24,6 +24,7 @@ const RETRYABLE_CACHE_STATES = new Set(['MISS', 'STALE']);
 const RETRY_BASE_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 15_000;
 const VERIFICATION_RESERVE_PER_REQUEST_MS = 10_000;
+export const MAX_EDGE_TRANSFORM_OVERHEAD = 16 * 1024;
 
 export class WarmError extends Error {
   constructor(message, details = {}) {
@@ -250,27 +251,60 @@ async function cancelBody(body, reason) {
   }
 }
 
-async function readResponseBody(response, context, url, signal) {
+async function readResponseBody(response, context, url, signal, allowEdgeTransform) {
   const body = response.body;
   let reservation = null;
   let declaredBytes;
+  // Cloudflare may rewrite canonical HTML (for example Rocket Loader and JSD)
+  // after the Pages function has emitted its origin byte count. Only page
+  // responses get this bounded allowance; every other response stays exact.
+  const edgeAllowance = allowEdgeTransform ? MAX_EDGE_TRANSFORM_OVERHEAD : 0;
   try {
     declaredBytes = declaredResponseBytes(response);
+    const reservationBytes = declaredBytes + edgeAllowance;
+    if (!Number.isSafeInteger(reservationBytes)) {
+      throw new WarmError(`Response reservation exceeds the safe integer range for ${url}`, {
+        fatal: true,
+        responseBytes: 0,
+      });
+    }
     // This synchronous reservation occurs before getReader()/reader.read(), so
     // concurrent responses cannot collectively cross the hard run budget.
-    reservation = context.budget.reserveResponseBytes(declaredBytes, url);
+    reservation = context.budget.reserveResponseBytes(reservationBytes, url);
   } catch (error) {
-    const fatal = context.abortRun(error);
+    const failure = error instanceof WarmError
+      ? error
+      : new WarmError(error instanceof Error ? error.message : String(error), { fatal: true });
+    failure.details = {
+      ...failure.details,
+      declared: Number.isSafeInteger(declaredBytes) ? declaredBytes : null,
+      actual: 0,
+      edgeDelta: Number.isSafeInteger(declaredBytes) ? -declaredBytes : null,
+    };
+    const fatal = context.abortRun(failure);
     await cancelBody(body, fatal);
     throw fatal;
   }
 
   if (!body) {
     context.budget.releaseResponseBytes(reservation);
-    if (declaredBytes === 0) return new Uint8Array();
+    if (declaredBytes === 0) {
+      return {
+        body: new Uint8Array(),
+        declared: 0,
+        actual: 0,
+        edgeDelta: 0,
+      };
+    }
     const fatal = context.abortRun(new WarmError(
       `Response body ended before its declared ${declaredBytes} bytes for ${url}`,
-      { fatal: true, responseBytes: 0 }
+      {
+        fatal: true,
+        responseBytes: 0,
+        declared: declaredBytes,
+        actual: 0,
+        edgeDelta: -declaredBytes,
+      }
     ));
     throw fatal;
   }
@@ -291,9 +325,19 @@ async function readResponseBody(response, context, url, signal) {
       if (done) break;
       const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
       if (chunk.byteLength > reservation.remaining) {
+        const actual = bytesRead + chunk.byteLength;
         const fatal = context.abortRun(new WarmError(
-          `Response body exceeded its declared ${declaredBytes} bytes for ${url}`,
-          { fatal: true, responseBytes: bytesRead, chunkBytes: chunk.byteLength }
+          allowEdgeTransform
+            ? `HTML response body exceeded declared bytes plus the ${MAX_EDGE_TRANSFORM_OVERHEAD}-byte edge transform allowance for ${url}`
+            : `Response body exceeded its declared ${declaredBytes} bytes for ${url}`,
+          {
+            fatal: true,
+            responseBytes: actual,
+            chunkBytes: chunk.byteLength,
+            declared: declaredBytes,
+            actual,
+            edgeDelta: actual - declaredBytes,
+          }
         ));
         await reader.cancel(fatal).catch(() => {});
         throw fatal;
@@ -301,17 +345,46 @@ async function readResponseBody(response, context, url, signal) {
       try {
         context.budget.consumeBytes(chunk.byteLength, url, reservation, bytesRead);
       } catch (error) {
-        const fatal = context.abortRun(error);
+        const actual = bytesRead + chunk.byteLength;
+        const failure = error instanceof WarmError
+          ? error
+          : new WarmError(error instanceof Error ? error.message : String(error), { fatal: true });
+        failure.details = {
+          ...failure.details,
+          declared: declaredBytes,
+          actual,
+          edgeDelta: actual - declaredBytes,
+        };
+        const fatal = context.abortRun(failure);
         await reader.cancel(fatal).catch(() => {});
         throw fatal;
       }
       chunks.push(chunk);
       bytesRead += chunk.byteLength;
     }
-    if (bytesRead !== declaredBytes) {
+    const edgeDelta = bytesRead - declaredBytes;
+    if (allowEdgeTransform && edgeDelta < 0) {
+      throw context.abortRun(new WarmError(
+        `HTML response body ended at ${bytesRead} bytes; expected at least its declared ${declaredBytes} bytes for ${url}`,
+        {
+          fatal: true,
+          responseBytes: bytesRead,
+          declared: declaredBytes,
+          actual: bytesRead,
+          edgeDelta,
+        }
+      ));
+    }
+    if (!allowEdgeTransform && edgeDelta !== 0) {
       throw context.abortRun(new WarmError(
         `Response body ended at ${bytesRead} bytes; expected ${declaredBytes} for ${url}`,
-        { fatal: true, responseBytes: bytesRead }
+        {
+          fatal: true,
+          responseBytes: bytesRead,
+          declared: declaredBytes,
+          actual: bytesRead,
+          edgeDelta,
+        }
       ));
     }
   } finally {
@@ -325,7 +398,12 @@ async function readResponseBody(response, context, url, signal) {
     result.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return result;
+  return {
+    body: result,
+    declared: declaredBytes,
+    actual: bytesRead,
+    edgeDelta: bytesRead - declaredBytes,
+  };
 }
 
 async function sleepUnlessAborted(context, milliseconds) {
@@ -358,6 +436,9 @@ function makeRecord({
   bytes,
   response,
   buildToken = null,
+  declared = null,
+  actual = null,
+  edgeDelta = null,
   error = null,
 }) {
   const cfRay = response?.headers?.get('cf-ray') || null;
@@ -372,6 +453,9 @@ function makeRecord({
     status,
     cache,
     bytes,
+    declared,
+    actual,
+    edgeDelta,
     cfRay,
     colo: coloFromRay(cfRay),
     buildToken,
@@ -396,6 +480,7 @@ async function fetchRecorded(context, request) {
   fetchHeaders.set('Accept-Encoding', 'identity');
   let response;
   let body;
+  let bodyMetadata;
   try {
     response = await context.fetchImpl(url, {
       method: 'GET',
@@ -403,7 +488,14 @@ async function fetchRecorded(context, request) {
       redirect: 'follow',
       signal: timer.signal,
     });
-    body = await readResponseBody(response, context, url, timer.signal);
+    bodyMetadata = await readResponseBody(
+      response,
+      context,
+      url,
+      timer.signal,
+      request.kind === 'page'
+    );
+    body = bodyMetadata.body;
   } catch (error) {
     const effectiveError = context.abortReason || error;
     const message = effectiveError instanceof Error ? effectiveError.message : String(effectiveError);
@@ -416,6 +508,9 @@ async function fetchRecorded(context, request) {
       status: response?.status || 0,
       bytes: responseBytes,
       response,
+      declared: error instanceof WarmError ? error.details?.declared ?? null : null,
+      actual: error instanceof WarmError ? error.details?.actual ?? responseBytes : responseBytes,
+      edgeDelta: error instanceof WarmError ? error.details?.edgeDelta ?? null : null,
       error: message,
     });
     await context.report(record);
@@ -438,6 +533,9 @@ async function fetchRecorded(context, request) {
     bytes: contentBytes(body),
     response,
     buildToken,
+    declared: bodyMetadata.declared,
+    actual: bodyMetadata.actual,
+    edgeDelta: bodyMetadata.edgeDelta,
   });
   await context.report(record);
   return { response, body, buildToken, cache, record };

--- a/scripts/warm-skill-cache.mjs
+++ b/scripts/warm-skill-cache.mjs
@@ -16,6 +16,9 @@ const DEFAULTS = {
   apiCacheHeader: 'x-api-kv-cache',
   pageCacheHeader: 'x-page-kv-cache',
   zipCacheHeader: 'x-cache',
+  cacheWriteHeader: 'x-kv-write',
+  cacheKeyHeader: 'x-kv-key',
+  cacheVersionHeader: 'x-kv-version',
 };
 
 const BUILD_TOKEN_RE = /^[0-9a-f]{40}\.[a-z0-9-]+$/i;
@@ -218,7 +221,7 @@ function parseDeclaredBytes(value, headerName) {
   return parsed;
 }
 
-function declaredResponseBytes(response) {
+function responseByteContract(response, allowEdgeTransform) {
   const contentLength = parseDeclaredBytes(
     response.headers.get('content-length'),
     'Content-Length'
@@ -233,13 +236,51 @@ function declaredResponseBytes(response) {
       { fatal: true, responseBytes: 0 }
     );
   }
-  if (contentLength !== null && skillstoreLength !== null && contentLength !== skillstoreLength) {
-    throw new WarmError(
-      `Conflicting response sizes: Content-Length=${contentLength}, x-skillstore-response-bytes=${skillstoreLength}`,
-      { fatal: true, responseBytes: 0 }
-    );
+  if (contentLength !== null && skillstoreLength !== null) {
+    if (!allowEdgeTransform && contentLength !== skillstoreLength) {
+      throw new WarmError(
+        `Conflicting response sizes: Content-Length=${contentLength}, x-skillstore-response-bytes=${skillstoreLength}`,
+        {
+          fatal: true,
+          responseBytes: 0,
+          declared: skillstoreLength,
+          actual: 0,
+          edgeDelta: -skillstoreLength,
+          contentLength,
+        }
+      );
+    }
+    if (allowEdgeTransform &&
+        (contentLength < skillstoreLength ||
+          contentLength > skillstoreLength + MAX_EDGE_TRANSFORM_OVERHEAD)) {
+      throw new WarmError(
+        `HTML Content-Length ${contentLength} must be between origin declared ${skillstoreLength} and ${skillstoreLength + MAX_EDGE_TRANSFORM_OVERHEAD}`,
+        {
+          fatal: true,
+          responseBytes: 0,
+          declared: skillstoreLength,
+          actual: 0,
+          edgeDelta: -skillstoreLength,
+          contentLength,
+        }
+      );
+    }
+    return {
+      declared: allowEdgeTransform ? skillstoreLength : contentLength,
+      expectedActual: contentLength,
+      edgeAllowance: allowEdgeTransform ? MAX_EDGE_TRANSFORM_OVERHEAD : 0,
+    };
   }
-  return contentLength ?? skillstoreLength;
+
+  const declared = contentLength ?? skillstoreLength;
+  const hasOriginDeclaration = skillstoreLength !== null;
+  return {
+    declared,
+    expectedActual: allowEdgeTransform && hasOriginDeclaration ? null : declared,
+    edgeAllowance: allowEdgeTransform && hasOriginDeclaration
+      ? MAX_EDGE_TRANSFORM_OVERHEAD
+      : 0,
+  };
 }
 
 async function cancelBody(body, reason) {
@@ -255,12 +296,16 @@ async function readResponseBody(response, context, url, signal, allowEdgeTransfo
   const body = response.body;
   let reservation = null;
   let declaredBytes;
+  let expectedActualBytes;
   // Cloudflare may rewrite canonical HTML (for example Rocket Loader and JSD)
   // after the Pages function has emitted its origin byte count. Only page
   // responses get this bounded allowance; every other response stays exact.
-  const edgeAllowance = allowEdgeTransform ? MAX_EDGE_TRANSFORM_OVERHEAD : 0;
+  let edgeAllowance = 0;
   try {
-    declaredBytes = declaredResponseBytes(response);
+    const contract = responseByteContract(response, allowEdgeTransform);
+    declaredBytes = contract.declared;
+    expectedActualBytes = contract.expectedActual;
+    edgeAllowance = contract.edgeAllowance;
     const reservationBytes = declaredBytes + edgeAllowance;
     if (!Number.isSafeInteger(reservationBytes)) {
       throw new WarmError(`Response reservation exceeds the safe integer range for ${url}`, {
@@ -275,11 +320,16 @@ async function readResponseBody(response, context, url, signal, allowEdgeTransfo
     const failure = error instanceof WarmError
       ? error
       : new WarmError(error instanceof Error ? error.message : String(error), { fatal: true });
+    const evidenceDeclared = Number.isSafeInteger(declaredBytes)
+      ? declaredBytes
+      : failure.details?.declared ?? null;
+    const evidenceActual = failure.details?.actual ?? 0;
     failure.details = {
       ...failure.details,
-      declared: Number.isSafeInteger(declaredBytes) ? declaredBytes : null,
-      actual: 0,
-      edgeDelta: Number.isSafeInteger(declaredBytes) ? -declaredBytes : null,
+      declared: evidenceDeclared,
+      actual: evidenceActual,
+      edgeDelta: failure.details?.edgeDelta ??
+        (Number.isSafeInteger(evidenceDeclared) ? evidenceActual - evidenceDeclared : null),
     };
     const fatal = context.abortRun(failure);
     await cancelBody(body, fatal);
@@ -327,7 +377,7 @@ async function readResponseBody(response, context, url, signal, allowEdgeTransfo
       if (chunk.byteLength > reservation.remaining) {
         const actual = bytesRead + chunk.byteLength;
         const fatal = context.abortRun(new WarmError(
-          allowEdgeTransform
+          edgeAllowance > 0
             ? `HTML response body exceeded declared bytes plus the ${MAX_EDGE_TRANSFORM_OVERHEAD}-byte edge transform allowance for ${url}`
             : `Response body exceeded its declared ${declaredBytes} bytes for ${url}`,
           {
@@ -363,9 +413,9 @@ async function readResponseBody(response, context, url, signal, allowEdgeTransfo
       bytesRead += chunk.byteLength;
     }
     const edgeDelta = bytesRead - declaredBytes;
-    if (allowEdgeTransform && edgeDelta < 0) {
+    if (expectedActualBytes !== null && bytesRead !== expectedActualBytes) {
       throw context.abortRun(new WarmError(
-        `HTML response body ended at ${bytesRead} bytes; expected at least its declared ${declaredBytes} bytes for ${url}`,
+        `Response body ended at ${bytesRead} bytes; expected ${expectedActualBytes} for ${url}`,
         {
           fatal: true,
           responseBytes: bytesRead,
@@ -375,9 +425,9 @@ async function readResponseBody(response, context, url, signal, allowEdgeTransfo
         }
       ));
     }
-    if (!allowEdgeTransform && edgeDelta !== 0) {
+    if (expectedActualBytes === null && edgeDelta < 0) {
       throw context.abortRun(new WarmError(
-        `Response body ended at ${bytesRead} bytes; expected ${declaredBytes} for ${url}`,
+        `HTML response body ended at ${bytesRead} bytes; expected at least its declared ${declaredBytes} bytes for ${url}`,
         {
           fatal: true,
           responseBytes: bytesRead,
@@ -433,6 +483,9 @@ function makeRecord({
   attempt,
   status,
   cache = null,
+  cacheWrite = null,
+  cacheKey = null,
+  cacheVersion = null,
   bytes,
   response,
   buildToken = null,
@@ -452,6 +505,9 @@ function makeRecord({
     attempt,
     status,
     cache,
+    cacheWrite,
+    cacheKey,
+    cacheVersion,
     bytes,
     declared,
     actual,
@@ -502,12 +558,29 @@ async function fetchRecorded(context, request) {
     const responseBytes = error instanceof WarmError && Number.isSafeInteger(error.details?.responseBytes)
       ? error.details.responseBytes
       : contentBytes(body);
+    const failedCache = request.cacheHeader && response
+      ? (response.headers.get(request.cacheHeader) || '').trim().toUpperCase() || null
+      : null;
+    const failedCacheWrite = request.cacheHeader && response
+      ? (response.headers.get(context.cacheWriteHeader) || '').trim().toUpperCase() || null
+      : null;
+    const failedCacheKey = request.cacheHeader && response
+      ? (response.headers.get(context.cacheKeyHeader) || '').trim() || null
+      : null;
+    const failedCacheVersion = request.cacheHeader && response
+      ? (response.headers.get(context.cacheVersionHeader) || '').trim() || null
+      : null;
     const record = makeRecord({
       ...request,
       url,
       status: response?.status || 0,
+      cache: failedCache,
+      cacheWrite: failedCacheWrite,
+      cacheKey: failedCacheKey,
+      cacheVersion: failedCacheVersion,
       bytes: responseBytes,
       response,
+      buildToken: response?.headers?.get(context.buildHeader) || null,
       declared: error instanceof WarmError ? error.details?.declared ?? null : null,
       actual: error instanceof WarmError ? error.details?.actual ?? responseBytes : responseBytes,
       edgeDelta: error instanceof WarmError ? error.details?.edgeDelta ?? null : null,
@@ -525,11 +598,23 @@ async function fetchRecorded(context, request) {
   const cache = request.cacheHeader
     ? (response.headers.get(request.cacheHeader) || '').trim().toUpperCase() || null
     : null;
+  const cacheWrite = request.cacheHeader
+    ? (response.headers.get(context.cacheWriteHeader) || '').trim().toUpperCase() || null
+    : null;
+  const cacheKey = request.cacheHeader
+    ? (response.headers.get(context.cacheKeyHeader) || '').trim() || null
+    : null;
+  const cacheVersion = request.cacheHeader
+    ? (response.headers.get(context.cacheVersionHeader) || '').trim() || null
+    : null;
   const record = makeRecord({
     ...request,
     url,
     status: response.status,
     cache,
+    cacheWrite,
+    cacheKey,
+    cacheVersion,
     bytes: contentBytes(body),
     response,
     buildToken,
@@ -538,7 +623,16 @@ async function fetchRecorded(context, request) {
     edgeDelta: bodyMetadata.edgeDelta,
   });
   await context.report(record);
-  return { response, body, buildToken, cache, record };
+  return {
+    response,
+    body,
+    buildToken,
+    cache,
+    cacheWrite,
+    cacheKey,
+    cacheVersion,
+    record,
+  };
 }
 
 async function assertPinnedBuild(context, result, source) {
@@ -561,6 +655,37 @@ async function assertPinnedBuild(context, result, source) {
     });
     throw context.abortRun(failure);
   }
+}
+
+function assertCacheIdentity(context, result, source, expected = null) {
+  if (!result.cacheKey || !result.cacheVersion) {
+    throw context.abortRun(new WarmError(
+      `${source} did not expose ${context.cacheKeyHeader} and ${context.cacheVersionHeader}`,
+      { fatal: true, source }
+    ));
+  }
+  const identity = {
+    key: result.cacheKey,
+    version: result.cacheVersion,
+    build: result.buildToken,
+  };
+  if (expected &&
+      (identity.key !== expected.key ||
+        identity.version !== expected.version ||
+        identity.build !== expected.build)) {
+    throw context.abortRun(new WarmError(
+      `${source} changed cache identity: expected key=${expected.key}, version=${expected.version}, build=${expected.build}; received key=${identity.key}, version=${identity.version}, build=${identity.build}`,
+      { fatal: true, source, expected, actual: identity }
+    ));
+  }
+  return identity;
+}
+
+function cacheStateFailure(context, item, result, source, expected) {
+  return context.abortRun(new WarmError(
+    `${source} expected ${expected}; received HTTP ${result.response.status}, ${item.cacheHeader}=${result.cache || '<missing>'}, ${context.cacheWriteHeader}=${result.cacheWrite || '<missing>'}`,
+    { fatal: true, source }
+  ));
 }
 
 async function probeBuild(context, phase) {
@@ -637,7 +762,11 @@ async function warmEndpoint(context, item) {
     VERIFICATION_RESERVE_PER_REQUEST_MS
   ) * 2;
 
-  let hitResult = null;
+  const usesKvStateMachine = item.kind === 'api' || item.kind === 'page';
+  const requiresInvalidatedMiss = usesKvStateMachine &&
+    (context.mode === 'force' || context.scope === 'changed');
+  let acceptedResult = null;
+  let cacheIdentity = null;
   for (let attempt = 1; attempt <= context.maxAttempts; attempt++) {
     if (attempt > 1) {
       const availableForDelay = remainingMs() - verificationReserveMs - 1;
@@ -677,23 +806,66 @@ async function warmEndpoint(context, item) {
       throw error;
     }
 
-    if (result.response.ok && result.cache === 'HIT') {
-      hitResult = result;
-      break;
-    }
-
     const retryableStatus = RETRYABLE_STATUSES.has(result.response.status);
-    const retryableCache = result.response.ok && RETRYABLE_CACHE_STATES.has(result.cache);
-    if (!retryableStatus && !retryableCache) {
+    if (!result.response.ok) {
+      if (retryableStatus && attempt < context.maxAttempts) continue;
       throw new WarmError(
         `${item.kind} ${baseUrl} returned HTTP ${result.response.status} with ${item.cacheHeader}=${result.cache || '<missing>'}`
       );
     }
+
+    if (!usesKvStateMachine) {
+      if (result.cache === 'HIT') {
+        acceptedResult = result;
+        break;
+      }
+      if (RETRYABLE_CACHE_STATES.has(result.cache) && attempt < context.maxAttempts) continue;
+      throw new WarmError(
+        `${item.kind} ${baseUrl} returned HTTP ${result.response.status} with ${item.cacheHeader}=${result.cache || '<missing>'}`
+      );
+    }
+
+    cacheIdentity = assertCacheIdentity(
+      context,
+      result,
+      `${item.kind} inner-cache attempt ${attempt} ${baseUrl}`,
+      cacheIdentity
+    );
+    if (requiresInvalidatedMiss) {
+      if (result.cache !== 'MISS' || result.cacheWrite !== 'STORED') {
+        throw cacheStateFailure(
+          context,
+          item,
+          result,
+          `${item.kind} invalidated cache ${baseUrl}`,
+          'MISS+STORED'
+        );
+      }
+      acceptedResult = result;
+      break;
+    }
+
+    if ((result.cache === 'MISS' && result.cacheWrite === 'STORED') ||
+        (result.cache === 'HIT' && result.cacheWrite === 'SKIPPED')) {
+      acceptedResult = result;
+      break;
+    }
+    if (result.cache === 'STALE' && result.cacheWrite === 'SKIPPED' &&
+        attempt < context.maxAttempts) {
+      continue;
+    }
+    throw cacheStateFailure(
+      context,
+      item,
+      result,
+      `${item.kind} cache ${baseUrl}`,
+      'MISS+STORED or HIT+SKIPPED'
+    );
   }
 
-  if (!hitResult) {
+  if (!acceptedResult) {
     throw new WarmError(
-      `${item.kind} ${baseUrl} never reached ${item.cacheHeader}=HIT after ${context.maxAttempts} attempts`
+      `${item.kind} ${baseUrl} never reached an acceptable cache state after ${context.maxAttempts} attempts`
     );
   }
 
@@ -730,7 +902,24 @@ async function warmEndpoint(context, item) {
       verification,
       `${item.kind} ordinary verification ${attempt} ${verificationUrl}`
     );
-    if (!verification.response.ok || verification.cache !== 'HIT') {
+    if (usesKvStateMachine) {
+      assertCacheIdentity(
+        context,
+        verification,
+        `${item.kind} ordinary verification ${attempt} ${verificationUrl}`,
+        cacheIdentity
+      );
+      if (!verification.response.ok || verification.cache !== 'HIT' ||
+          verification.cacheWrite !== 'SKIPPED') {
+        throw cacheStateFailure(
+          context,
+          item,
+          verification,
+          `${item.kind} ordinary verification ${attempt} ${verificationUrl}`,
+          'HIT+SKIPPED'
+        );
+      }
+    } else if (!verification.response.ok || verification.cache !== 'HIT') {
       throw new WarmError(
         `${item.kind} ordinary verification ${attempt} replayed a non-HIT response: HTTP ${verification.response.status}, ${item.cacheHeader}=${verification.cache || '<missing>'}`
       );
@@ -743,8 +932,8 @@ async function warmEndpoint(context, item) {
     slug: item.slug,
     locale: item.locale,
     url: String(baseUrl),
-    innerAttempts: hitResult.record.attempt,
-    bytes: hitResult.record.bytes + verifications.reduce(
+    innerAttempts: acceptedResult.record.attempt,
+    bytes: acceptedResult.record.bytes + verifications.reduce(
       (total, result) => total + result.record.bytes,
       0
     ),
@@ -1023,6 +1212,9 @@ async function cli(argv) {
       buildHeader: args['build-header'] || process.env.BUILD_HEADER || DEFAULTS.buildHeader,
       apiCacheHeader: args['api-cache-header'] || process.env.API_CACHE_HEADER || DEFAULTS.apiCacheHeader,
       pageCacheHeader: args['page-cache-header'] || process.env.PAGE_CACHE_HEADER || DEFAULTS.pageCacheHeader,
+      cacheWriteHeader: args['cache-write-header'] || process.env.CACHE_WRITE_HEADER || DEFAULTS.cacheWriteHeader,
+      cacheKeyHeader: args['cache-key-header'] || process.env.CACHE_KEY_HEADER || DEFAULTS.cacheKeyHeader,
+      cacheVersionHeader: args['cache-version-header'] || process.env.CACHE_VERSION_HEADER || DEFAULTS.cacheVersionHeader,
       expectedBuildToken: args['expected-build-token'] || process.env.EXPECTED_BUILD_TOKEN || null,
       mode: args.mode || process.env.WARM_MODE || 'warm',
       scope: args.scope || process.env.WARM_SCOPE || 'explicit',


### PR DESCRIPTION
## Summary

- keep cache warming on canonical `skillstore.io` so the production page cache can reach HIT
- reserve each HTML response origin declaration plus a fixed 16 KiB Cloudflare edge-transform allowance before reading body bytes
- when HTML also has `Content-Length`, require it within the origin allowance and require final actual bytes to equal it exactly
- keep API, build, and ZIP responses on exact declared-versus-actual byte equality
- require invalidated `changed`/`force` API and page caches to prove `MISS+STORED -> HIT+SKIPPED -> HIT+SKIPPED`
- allow non-invalidated/high-traffic endpoints to begin at `HIT+SKIPPED`
- require one stable KV key, KV version, and exact build through the complete chain
- record `declared`, `actual`, `edgeDelta`, `cacheWrite`, `cacheKey`, and `cacheVersion` in JSONL evidence
- release unused HTML reservations while preserving the hard global byte budget

## Incident evidence

Production identity responses consistently showed origin `x-skillstore-response-bytes=401545` and actual `402702` bytes (`edgeDelta=1157`) because Cloudflare rewrites script tags and injects Rocket Loader/JSD. The deployment Pages hostname cannot replace canonical warming because its page cache reports `BYPASS`.

## Validation

- `node --test scripts/tests/*.test.mjs` (59/59)
- `node --check scripts/warm-skill-cache.mjs`
- YAML parse for the changed workflow
- `git diff --check`

No cache-warming workflow or full-catalog run was triggered.