### PR TITLE
fix(cache): finalize bounded translation cache plans

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 240
     outputs:
       synced_slugs: ${{ steps.sync.outputs.synced_slugs }}
+      synced_skill_count: ${{ steps.synced-plan.outputs.skill_count }}
       skip_sync: ${{ steps.changes.outputs.skip_sync }}
     steps:
       - name: Checkout repository
@@ -596,6 +597,7 @@ jobs:
           echo "::notice::Sync completed - Mode: ${{ steps.changes.outputs.mode }}, Skills: ${{ steps.changes.outputs.changed_skills }}"
 
       - name: Save synced slugs to artifact
+        id: synced-plan
         if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_slugs != ''
         env:
           SYNCED_SLUGS: ${{ steps.sync.outputs.synced_slugs }}
@@ -603,6 +605,7 @@ jobs:
           # Write slugs to file (one per line for easy processing)
           echo "$SYNCED_SLUGS" | tr ',' '\n' > synced-slugs.txt
           SLUG_COUNT=$(wc -l < synced-slugs.txt | tr -d ' ')
+          echo "skill_count=$SLUG_COUNT" >> "$GITHUB_OUTPUT"
           echo "📦 Saved $SLUG_COUNT slugs to artifact"
 
       - name: Resolve published submissions
@@ -883,80 +886,73 @@ jobs:
           echo "✅ Cache invalidated: $RESPONSE"
 
   # ============================================================
-  # CACHE WARMING JOB
-  # Triggers warm-cache.yml workflow for synced skills only
+  # ENGLISH CACHE FINALIZER
+  # Runs exact invalidation + API/page verification before translation is
+  # dispatched. A failure is reported but does not block content translation.
   # ============================================================
-  trigger-cache-warm:
+  finalize-english-cache:
     needs: [sync, calculate-scores, cache-invalidate]
-    if: needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && inputs.skip_cache_warm != true && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
+    if: >-
+      needs.cache-invalidate.result == 'success' &&
+      needs.sync.outputs.skip_sync != 'true' &&
+      inputs.skip_cache_warm != true &&
+      vars.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true' &&
+      fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') >= 1 &&
+      fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') <= 25 &&
+      fromJSON(needs.sync.outputs.synced_skill_count || '0') <= fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') &&
+      !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v3
+      - name: Checkout cache finalizer
+        uses: actions/checkout@v5
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          sparse-checkout: scripts
 
-      - name: Trigger warm-cache workflow for synced skills
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          package-manager-cache: false
+
+      - name: Download synced Skill plan
+        uses: actions/download-artifact@v7
+        with:
+          name: synced-slugs
+          path: ./english-cache-finalizer
+
+      - name: Finalize English cache targets
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SITE_URL: https://skillstore.io
+          CACHE_FINALIZER_MAX_SKILLS: ${{ vars.CACHE_FINALIZER_MAX_SKILLS || '5' }}
         run: |
-          if [ -z "$SYNCED_SLUGS" ]; then
-            echo "No slugs to warm"
-            exit 0
-          fi
+          set -euo pipefail
+          node scripts/finalize-translation-cache.mjs \
+            --slugs-file ./english-cache-finalizer/synced-slugs.txt \
+            --locales en \
+            --site-url "$SITE_URL" \
+            --concurrency 1 \
+            --max-skills "$CACHE_FINALIZER_MAX_SKILLS" \
+            --max-packs 100 \
+            --max-targets 250 \
+            --request-budget 5000 \
+            --byte-budget 536870912 \
+            --plan "$RUNNER_TEMP/english-cache-plan.json" \
+            --report "$RUNNER_TEMP/english-cache-report.jsonl" \
+            --summary "$RUNNER_TEMP/english-cache-summary.json"
 
-          SLUG_COUNT=$(echo "$SYNCED_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
-          THRESHOLD=500
-          REQUEST_BUDGET=$((SLUG_COUNT * 80 + 20))
-          BYTE_BUDGET=$((SLUG_COUNT * 10485760 + 10485760))
-
-          echo "🔥 Triggering warm-cache workflow for $SLUG_COUNT synced skills"
-          echo "   Request budget: $REQUEST_BUDGET"
-          echo "   Byte budget: $BYTE_BUDGET"
-
-          if [ "$SLUG_COUNT" -le "$THRESHOLD" ]; then
-            # Small batch: pass slugs directly via input
-            echo "   Mode: direct (≤$THRESHOLD slugs)"
-            gh workflow run warm-cache.yml \
-              --repo "${{ github.repository }}" \
-              -f mode=warm \
-              -f scope=changed \
-              -f slugs="$SYNCED_SLUGS" \
-              -f request_budget="$REQUEST_BUDGET" \
-              -f byte_budget="$BYTE_BUDGET" \
-              -f warm_zip=false
-            MODE="direct"
-          else
-            # Large batch: use artifact to avoid input size limits
-            echo "   Mode: artifact (>$THRESHOLD slugs)"
-            gh workflow run warm-cache.yml \
-              --repo "${{ github.repository }}" \
-              -f mode=warm \
-              -f scope=changed \
-              -f source_run_id=${{ github.run_id }} \
-              -f request_budget="$REQUEST_BUDGET" \
-              -f byte_budget="$BYTE_BUDGET" \
-              -f warm_zip=false
-            MODE="artifact (source: ${{ github.run_id }})"
-          fi
-
-          echo "✅ Cache warming workflow triggered"
-          echo "   Monitor at: https://github.com/${{ github.repository }}/actions/workflows/warm-cache.yml"
-
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          ## 🔥 Cache Warming Triggered
-
-          Triggered \`warm-cache.yml\` workflow for **$SLUG_COUNT synced skills** (mode: $MODE).
-
-          - Request budget: \`$REQUEST_BUDGET\`
-          - Byte budget: \`$BYTE_BUDGET\`
-
-          [View workflow runs →](https://github.com/${{ github.repository }}/actions/workflows/warm-cache.yml)
-          EOF
+      - name: Upload English cache evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: english-cache-finalizer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/english-cache-plan.json
+            ${{ runner.temp }}/english-cache-report.jsonl
+            ${{ runner.temp }}/english-cache-summary.json
+          if-no-files-found: warn
+          retention-days: 14
 
   # ============================================================
   # TRIGGER TRANSLATION (Async - Fire and Forget)
@@ -965,8 +961,8 @@ jobs:
   # Translation only needs synced content, doesn't require scores
   # ============================================================
   trigger-translate:
-    needs: [sync]
-    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != '' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
+    needs: [sync, cache-invalidate, finalize-english-cache]
+    if: always() && needs.sync.result == 'success' && needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != '' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
@@ -981,6 +977,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
+          ENGLISH_CACHE_FINALIZER_RESULT: ${{ needs.finalize-english-cache.result }}
         run: |
           SLUG_COUNT=$(echo "$SYNCED_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
           THRESHOLD=500
@@ -994,7 +991,8 @@ jobs:
               --method POST \
               -f event_type=translate-skills \
               -f "client_payload[skill_slugs]=$SYNCED_SLUGS" \
-              -f "client_payload[triggered_by]=sync-to-supabase"
+              -f "client_payload[triggered_by]=sync-to-supabase" \
+              -f "client_payload[english_cache_finalizer_failed]=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)"
             MODE="direct"
           else
             # Large batch: use artifact to avoid payload size limits
@@ -1003,7 +1001,8 @@ jobs:
               --method POST \
               -f event_type=translate-skills \
               -f "client_payload[source_run_id]=${{ github.run_id }}" \
-              -f "client_payload[triggered_by]=sync-to-supabase"
+              -f "client_payload[triggered_by]=sync-to-supabase" \
+              -f "client_payload[english_cache_finalizer_failed]=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)"
             MODE="artifact (source: ${{ github.run_id }})"
           fi
 

--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -4,10 +4,9 @@
 # IMPORTANT: This workflow is triggered BY sync-to-supabase.yml after data sync completes.
 # This ensures translation reads fresh data from the database, avoiding race conditions.
 #
-# Concurrency Strategy:
-# - Full translation (no skill_slugs): Only ONE allowed at a time, queued via 'translate-skills-full'
-# - Partial translation (with skill_slugs): Unlimited concurrency, each run gets unique group
-# This allows partial translations to run alongside a long-running full translation without conflicts.
+# Concurrency strategy: all translation runs are serialized because each run owns
+# a write -> exact invalidation -> verified warm transaction. Interleaving partial
+# runs could otherwise invalidate between another run's MISS and HIT evidence.
 
 name: Auto-Translate Skill Content
 
@@ -29,6 +28,10 @@ on:
         description: "Force re-translation of existing translations"
         type: boolean
         default: false
+      locale:
+        description: "Optional single locale for a bounded canary (for example zh-hans); empty translates all target locales"
+        type: string
+        default: ""
       concurrency:
         description: "Parallel skills per language (1-10, language-first parallelism)"
         type: string
@@ -51,11 +54,11 @@ env:
   CLI_VERSION: ${{ inputs.cli_version || 'latest' }}
   SHARD_THRESHOLD: 10
 
-# Dynamic concurrency groups:
-# - Full translation: 'translate-skills-full' (only 1 allowed, others queue)
-# - Partial translation: 'translate-skills-partial-{run_id}' (unlimited, no blocking)
+# Translation writes and cache finalization share one global owner. Serializing
+# the complete workflow prevents an older run from invalidating between a newer
+# run's exact invalidation and warm verification.
 concurrency:
-  group: ${{ (github.event.inputs.skill_slugs == '' && github.event_name == 'workflow_dispatch') && 'translate-skills-full' || format('translate-skills-partial-{0}', github.run_id) }}
+  group: translate-skills-cache-owner
   cancel-in-progress: false
 
 jobs:
@@ -350,7 +353,19 @@ jobs:
 
   translate:
     needs: detect-and-plan
-    if: needs.detect-and-plan.outputs.has_changes == 'true' && needs.detect-and-plan.outputs.shard_count != '0'
+    # This is the mutation boundary. If cache finalization is disabled or the
+    # bounded rollout cap is invalid/exceeded, translation must not write first
+    # and leave the existing 365-day detail cache stale.
+    if: >-
+      needs.detect-and-plan.outputs.has_changes == 'true' &&
+      needs.detect-and-plan.outputs.shard_count != '0' &&
+      fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') >= 1 &&
+      fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') <= 25 &&
+      fromJSON(needs.detect-and-plan.outputs.skill_count || '0') <= fromJSON(vars.CACHE_FINALIZER_MAX_SKILLS || '5') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        vars.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true'
+      )
     runs-on: self-hosted
     timeout-minutes: 1440
     continue-on-error: true
@@ -392,6 +407,10 @@ jobs:
           OFFSET: ${{ matrix.offset }}
           LIMIT: ${{ matrix.limit }}
           CONCURRENCY: ${{ inputs.concurrency || '8' }}
+          TARGET_LOCALE: ${{ inputs.locale }}
+          # Cache invalidation is owned by the exact post-translation finalizer.
+          # Never let a runner-level environment secret reactivate CLI best-effort invalidation.
+          CACHE_INVALIDATE_SECRET: ''
         run: |
           echo "=== Shard ${{ matrix.shard }} ==="
           
@@ -418,6 +437,18 @@ jobs:
           FORCE_FLAG=""
           if [ "${{ inputs.force }}" = "true" ]; then
             FORCE_FLAG="--force"
+          fi
+
+          LANG_FLAG=""
+          if [ -n "$TARGET_LOCALE" ]; then
+            case "$TARGET_LOCALE" in
+              zh-hans|zh-hant|ja|ko|de|fr|es|pt|ru|ar) ;;
+              *)
+                echo "::error::Unsupported translation locale: $TARGET_LOCALE"
+                exit 1
+                ;;
+            esac
+            LANG_FLAG="--lang $TARGET_LOCALE"
           fi
 
           configure_tls() {
@@ -476,7 +507,8 @@ jobs:
               --concurrency "$CURRENT_CONCURRENCY" \
               --output json \
               $MODEL_FLAG \
-              $FORCE_FLAG 2>"$ERR_FILE")
+              $FORCE_FLAG \
+              $LANG_FLAG 2>"$ERR_FILE")
             EXIT_CODE=$?
             set -e
             ERR_OUTPUT=$(cat "$ERR_FILE")
@@ -539,13 +571,16 @@ jobs:
           fi
 
       - name: Translate queued security audits
-        if: always()
+        if: always() && matrix.shard == 0 && inputs.locale == ''
         continue-on-error: true
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
           CONCURRENCY: ${{ inputs.concurrency || '8' }}
+          # Audit translation cache ownership will move to its own exact
+          # mutation manifest; never allow runner ambient secrets to invalidate here.
+          CACHE_INVALIDATE_SECRET: ''
         run: |
           MODEL_FLAG=""
           if [ -n "${{ inputs.model }}" ]; then
@@ -587,7 +622,11 @@ jobs:
 
   merge-results:
     needs: [detect-and-plan, translate]
-    if: always() && needs.detect-and-plan.outputs.has_changes == 'true' && needs.detect-and-plan.outputs.shard_count != '0'
+    if: >-
+      always() &&
+      needs.translate.result == 'success' &&
+      needs.detect-and-plan.outputs.has_changes == 'true' &&
+      needs.detect-and-plan.outputs.shard_count != '0'
     runs-on: self-hosted
     timeout-minutes: 30
     outputs:
@@ -661,8 +700,9 @@ jobs:
           TRANSLATED_SLUGS=""
           for result in ./results/shard-*-result.json; do
             if [ -f "$result" ]; then
-              # Extract slugs where at least one language was translated (not skipped)
-              SHARD_SLUGS=$(jq -r '[.languages[].skills[] | select(.status != "skipped") | .slug] | unique | .[]' "$result" 2>/dev/null || echo "")
+              # Only successful writes may enter cache finalization. Errors are
+              # not mutations and must never be treated as invalidation targets.
+              SHARD_SLUGS=$(jq -r '[.languages[].skills[] | select(.status == "translated" or .status == "stale_retranslated") | .slug] | unique | .[]' "$result" 2>/dev/null || echo "")
               if [ -n "$SHARD_SLUGS" ]; then
                 if [ -n "$TRANSLATED_SLUGS" ]; then
                   TRANSLATED_SLUGS="$TRANSLATED_SLUGS"$'\n'"$SHARD_SLUGS"
@@ -705,33 +745,64 @@ jobs:
           
           echo "result_json=$RESULT_JSON" >> $GITHUB_OUTPUT
 
-  invalidate-cache:
+  finalize-cache:
     needs: [detect-and-plan, translate, merge-results]
-    if: always() && needs.translate.result == 'success'
+    if: always() && needs.merge-results.result == 'success' && needs.merge-results.outputs.total_translated != '0' && (github.event_name == 'workflow_dispatch' || vars.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true')
     runs-on: self-hosted
-    timeout-minutes: 15
-    outputs:
-      total_count: ${{ steps.invalidate.outputs.total_count }}
-      success_count: ${{ steps.invalidate.outputs.success_count }}
-      failed_count: ${{ steps.invalidate.outputs.failed_count }}
+    timeout-minutes: 60
     steps:
-      - name: Checkout repository
+      - name: Checkout cache finalizer
         uses: actions/checkout@v5
         with:
-          sparse-checkout: .github/actions
+          sparse-checkout: scripts
 
-      - name: Invalidate cache for translated skills
-        id: invalidate
-        uses: ./.github/actions/invalidate-cache
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
         with:
-          type: skills
-          # Use slugs_csv if provided (partial mode), otherwise use translated_slugs from merge-results (translate-all mode)
-          slugs: ${{ needs.detect-and-plan.outputs.slugs_csv || needs.merge-results.outputs.translated_slugs }}
-          secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
-          fail-on-error: false
+          node-version: 20
+          package-manager-cache: false
+
+      - name: Download exact translation results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: translate-shard-*
+          merge-multiple: true
+          path: ./cache-finalizer-results
+
+      - name: Finalize translated cache targets
+        env:
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SITE_URL: https://skillstore.io
+          CACHE_FINALIZER_MAX_SKILLS: ${{ vars.CACHE_FINALIZER_MAX_SKILLS || '5' }}
+        run: |
+          set -euo pipefail
+          node scripts/finalize-translation-cache.mjs \
+            --results-dir ./cache-finalizer-results \
+            --site-url "$SITE_URL" \
+            --concurrency 1 \
+            --max-skills "$CACHE_FINALIZER_MAX_SKILLS" \
+            --max-packs 100 \
+            --max-targets 250 \
+            --request-budget 5000 \
+            --byte-budget 536870912 \
+            --plan "$RUNNER_TEMP/cache-finalizer-plan.json" \
+            --report "$RUNNER_TEMP/cache-finalizer-report.jsonl" \
+            --summary "$RUNNER_TEMP/cache-finalizer-summary.json"
+
+      - name: Upload cache finalizer evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-finalizer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/cache-finalizer-plan.json
+            ${{ runner.temp }}/cache-finalizer-report.jsonl
+            ${{ runner.temp }}/cache-finalizer-summary.json
+          if-no-files-found: warn
+          retention-days: 14
 
   notify:
-    needs: [detect-and-plan, translate, merge-results, invalidate-cache]
+    needs: [detect-and-plan, translate, merge-results, finalize-cache]
     if: always() && needs.detect-and-plan.outputs.has_changes == 'true'
     runs-on: self-hosted
     timeout-minutes: 10
@@ -743,9 +814,6 @@ jobs:
           TRANSLATE_ALL: ${{ needs.detect-and-plan.outputs.translate_all }}
           IS_SHARDED: ${{ needs.detect-and-plan.outputs.is_sharded }}
           SHARD_COUNT: ${{ needs.detect-and-plan.outputs.shard_count }}
-          CACHE_INVALIDATE_TOTAL: ${{ needs.invalidate-cache.outputs.total_count || '0' }}
-          CACHE_INVALIDATE_SUCCESS: ${{ needs.invalidate-cache.outputs.success_count || '0' }}
-          CACHE_INVALIDATE_FAILED: ${{ needs.invalidate-cache.outputs.failed_count || '0' }}
         run: |
           echo "# Translation Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -796,13 +864,11 @@ jobs:
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.invalidate-cache.result }}" = "success" ] && [ "$CACHE_INVALIDATE_FAILED" -gt 0 ]; then
-            echo "⚠️ Cache invalidation failed for $CACHE_INVALIDATE_FAILED/$CACHE_INVALIDATE_TOTAL item(s)" >> $GITHUB_STEP_SUMMARY
-            echo "Translations were written, but affected pages may stay stale until cache is fixed or refreshed." >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.invalidate-cache.result }}" = "success" ]; then
-            echo "✅ Cache invalidated" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.invalidate-cache.result }}" = "skipped" ]; then
-            echo "⏭️ Cache invalidation skipped" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.finalize-cache.result }}" = "success" ]; then
+            echo "✅ Exact cache invalidation and warm verification passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.finalize-cache.result }}" = "skipped" ]; then
+            echo "⏭️ Cache finalization skipped (no successful translation mutations)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "⚠️ Cache invalidation: ${{ needs.invalidate-cache.result }}" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Cache finalization: ${{ needs.finalize-cache.result }}" >> $GITHUB_STEP_SUMMARY
+            echo "Translations were written, but automatic rollout remains blocked until the immutable plan is rerun." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: ''
+      locales:
+        description: 'Allowlisted locales to warm (comma/space separated); automatic callers should pass only the affected locales'
+        required: false
+        type: string
+        default: 'en'
       source_run_id:
         description: 'Source workflow run containing the synced-slugs artifact (changed scope only)'
         required: false
@@ -62,7 +67,7 @@ concurrency:
 
 env:
   SITE_URL: https://skillstore.io
-  LOCALES: 'en zh-hans zh-hant ja ko de fr es pt ru ar'
+  SUPPORTED_LOCALES: 'en zh-hans zh-hant ja ko de fr es pt ru ar'
   CONCURRENCY: 10
   INVALIDATE_BATCH_SIZE: 10
   BUILD_HEADER: x-skillstore-build
@@ -104,6 +109,7 @@ jobs:
           SCOPE: ${{ inputs.scope }}
           MODE: ${{ inputs.mode }}
           INPUT_SLUGS: ${{ inputs.slugs }}
+          INPUT_LOCALES: ${{ inputs.locales }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
           APPROVE_FULL_CATALOG: ${{ inputs.approve_full_catalog }}
           REQUEST_BUDGET: ${{ inputs.request_budget }}
@@ -121,6 +127,23 @@ jobs:
             echo "::error::byte_budget must be a positive integer"
             exit 1
           fi
+
+          LOCALES_FILE="$RUNNER_TEMP/warm-cache-locales.txt"
+          printf '%s\n' "$INPUT_LOCALES" | tr ',[:space:]' '\n' | sed '/^$/d' | sort -u > "$LOCALES_FILE"
+          if [ ! -s "$LOCALES_FILE" ]; then
+            echo "::error::locales must contain at least one supported locale"
+            exit 1
+          fi
+          while IFS= read -r locale; do
+            case " $SUPPORTED_LOCALES " in
+              *" $locale "*) ;;
+              *)
+                echo "::error::Unsupported locale: $locale"
+                exit 1
+                ;;
+            esac
+          done < "$LOCALES_FILE"
+          RESOLVED_LOCALES=$(tr '\n' ' ' < "$LOCALES_FILE" | sed 's/ $//')
 
           WORK_DIR="$RUNNER_TEMP/warm-cache"
           mkdir -p "$WORK_DIR"
@@ -195,6 +218,7 @@ jobs:
           echo "Resolved $SLUG_COUNT skill(s) for scope $SCOPE"
           echo "slugs_file=$SLUGS_FILE" >> "$GITHUB_OUTPUT"
           echo "slug_count=$SLUG_COUNT" >> "$GITHUB_OUTPUT"
+          echo "locales=$RESOLVED_LOCALES" >> "$GITHUB_OUTPUT"
 
       - name: Invalidate selected skill caches
         if: inputs.mode == 'force'
@@ -215,6 +239,7 @@ jobs:
           WARM_ZIP: ${{ inputs.warm_zip }}
           WARM_MODE: ${{ inputs.mode }}
           WARM_SCOPE: ${{ inputs.scope }}
+          LOCALES: ${{ steps.scope.outputs.locales }}
         run: |
           set -euo pipefail
 

--- a/scripts/finalize-translation-cache.mjs
+++ b/scripts/finalize-translation-cache.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  calculateWorstCaseRequests,
+  normalizeSlugs,
+  normalizeWarmTargets,
+  runWarm,
+  WarmError,
+} from './warm-skill-cache.mjs';
+
+const MUTATED_STATUSES = new Set(['translated', 'stale_retranslated']);
+const SUPPORTED_LOCALES = new Set([
+  'en', 'zh-hans', 'zh-hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'ru', 'ar',
+]);
+const PLAN_SCHEMA_VERSION = 1;
+const DEFAULT_CAPS = Object.freeze({
+  skills: 25,
+  packs: 100,
+  targets: 250,
+  requestBudget: 5_000,
+  byteBudget: 512 * 1024 * 1024,
+  bytesPerTarget: 10 * 1024 * 1024,
+  fixedByteReserve: 10 * 1024 * 1024,
+});
+
+export class FinalizerError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'FinalizerError';
+    this.details = details;
+  }
+}
+
+function canonicalStrings(values) {
+  return [...new Set((values || []).map((value) => String(value).trim()).filter(Boolean))].sort();
+}
+
+function stablePlanPayload(plan) {
+  const { checksum: _checksum, ...payload } = plan;
+  return JSON.stringify(payload);
+}
+
+export function planChecksum(plan) {
+  return createHash('sha256').update(stablePlanPayload(plan)).digest('hex');
+}
+
+export function verifyFinalizationPlan(plan) {
+  if (!plan || plan.schemaVersion !== PLAN_SCHEMA_VERSION) {
+    throw new FinalizerError(`Unsupported cache finalization plan schema: ${plan?.schemaVersion ?? '<missing>'}`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(plan.checksum || '') || planChecksum(plan) !== plan.checksum) {
+    throw new FinalizerError('Cache finalization plan checksum mismatch');
+  }
+  normalizeWarmTargets(plan.targets);
+  return plan;
+}
+
+export function groupsFromTranslationResults(documents) {
+  const groups = new Map();
+  for (const document of documents) {
+    for (const language of document?.languages || []) {
+      const locale = String(language?.language || '').trim();
+      if (!locale) continue;
+      if (!SUPPORTED_LOCALES.has(locale)) {
+        throw new FinalizerError(`Unsupported translation result locale: ${locale}`);
+      }
+      if (locale === 'en') continue;
+      for (const skill of language?.skills || []) {
+        if (!MUTATED_STATUSES.has(skill?.status)) continue;
+        const slug = String(skill?.slug || '').trim();
+        if (!slug) throw new FinalizerError(`Translated result for ${locale} is missing a slug`);
+        const slugs = groups.get(locale) || new Set();
+        slugs.add(slug);
+        groups.set(locale, slugs);
+      }
+    }
+  }
+  return [...groups.entries()]
+    .map(([locale, slugs]) => ({ locale, slugs: [...slugs].sort() }))
+    .sort((left, right) => left.locale.localeCompare(right.locale));
+}
+
+async function loadTranslationDocuments(resultsDir) {
+  const files = (await readdir(resultsDir))
+    .filter((name) => /^shard-.*-result\.json$/.test(name))
+    .sort();
+  const documents = [];
+  for (const file of files) {
+    documents.push(JSON.parse(await readFile(join(resultsDir, file), 'utf8')));
+  }
+  return documents;
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new FinalizerError(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+async function responseJson(response, source) {
+  const text = await response.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new FinalizerError(`${source} returned invalid JSON (HTTP ${response.status})`);
+  }
+  if (!response.ok) {
+    throw new FinalizerError(`${source} returned HTTP ${response.status}: ${payload?.message || payload?.error || text.slice(0, 500)}`);
+  }
+  return payload;
+}
+
+async function callInvalidation(options, body, source) {
+  const response = await options.fetchImpl(`${options.siteUrl}/api/cache/invalidate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${options.cacheSecret}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'GitHub-Actions/SkillstoreCacheFinalizer',
+      'X-Skillstore-Callback': 'true',
+    },
+    body: JSON.stringify(body),
+  });
+  return responseJson(response, source);
+}
+
+function invalidationBody(group, overrides = {}) {
+  return {
+    type: 'skills',
+    slugs: group.slugs,
+    locales: [group.locale],
+    invalidateApi: true,
+    invalidateLists: false,
+    invalidateArtifacts: false,
+    invalidateDependentPacks: true,
+    ...overrides,
+  };
+}
+
+function readClosure(payload, source) {
+  const closure = payload?.closure?.dependentPacks;
+  if (!closure || closure.overflow !== false) {
+    throw new FinalizerError(`${source} did not return a complete dependent-Pack closure`);
+  }
+  const all = canonicalStrings(closure.all);
+  const warmable = canonicalStrings(closure.warmable);
+  if (warmable.some((slug) => !all.includes(slug))) {
+    throw new FinalizerError(`${source} returned a warmable Pack outside the invalidation closure`);
+  }
+  return { all, warmable, cap: closure.cap };
+}
+
+export async function buildFinalizationPlan(rawOptions) {
+  const caps = { ...DEFAULT_CAPS, ...(rawOptions.caps || {}) };
+  const groups = rawOptions.groups
+    .map((group) => ({ locale: group.locale, slugs: canonicalStrings(group.slugs) }))
+    .filter((group) => group.slugs.length > 0)
+    .sort((left, right) => left.locale.localeCompare(right.locale));
+  const uniqueSkills = canonicalStrings(groups.flatMap((group) => group.slugs));
+  if (uniqueSkills.length === 0) return null;
+  if (uniqueSkills.length > caps.skills) {
+    throw new FinalizerError(`Automatic cache finalization has ${uniqueSkills.length} Skills; cap is ${caps.skills}`);
+  }
+
+  const invalidations = [];
+  for (const group of groups) {
+    if (!SUPPORTED_LOCALES.has(group.locale)) {
+      throw new FinalizerError(`Unsupported finalization locale: ${group.locale}`);
+    }
+    const payload = await callInvalidation(
+      rawOptions,
+      invalidationBody(group, { preflight: true }),
+      `Cache invalidation preflight for ${group.locale}`
+    );
+    if (payload.preflight !== true) {
+      throw new FinalizerError(`Cache invalidation preflight for ${group.locale} performed an unexpected execution`);
+    }
+    const closure = readClosure(payload, `Cache invalidation preflight for ${group.locale}`);
+    invalidations.push({ ...group, dependentPacks: closure });
+  }
+
+  const uniquePacks = canonicalStrings(invalidations.flatMap((item) => item.dependentPacks.all));
+  if (uniquePacks.length > caps.packs) {
+    throw new FinalizerError(`Dependent-Pack closure has ${uniquePacks.length} Packs; cap is ${caps.packs}`);
+  }
+  const targets = normalizeWarmTargets(invalidations.flatMap((item) => [
+    ...item.slugs.map((slug) => ({ resource: 'skills', slug, locale: item.locale })),
+    ...item.dependentPacks.warmable.map((slug) => ({ resource: 'packs', slug, locale: item.locale })),
+  ]));
+  if (targets.length > caps.targets) {
+    throw new FinalizerError(`Exact cache warm plan has ${targets.length} resource-locale targets; cap is ${caps.targets}`);
+  }
+
+  const computedRequests = calculateWorstCaseRequests(targets);
+  const computedBytes = caps.fixedByteReserve + (targets.length * caps.bytesPerTarget);
+  if (computedRequests > caps.requestBudget) {
+    throw new FinalizerError(`Worst-case warm requests ${computedRequests} exceed aggregate cap ${caps.requestBudget}`);
+  }
+  if (computedBytes > caps.byteBudget) {
+    throw new FinalizerError(`Computed warm byte budget ${computedBytes} exceeds aggregate cap ${caps.byteBudget}`);
+  }
+
+  const invalidateOnly = invalidations.flatMap((item) =>
+    item.dependentPacks.all
+      .filter((slug) => !item.dependentPacks.warmable.includes(slug))
+      .map((slug) => ({ resource: 'packs', slug, locale: item.locale, reason: 'not_anonymous_warmable' }))
+  );
+  const plan = {
+    schemaVersion: PLAN_SCHEMA_VERSION,
+    createdAt: new Date().toISOString(),
+    source: rawOptions.source || 'translation',
+    invalidations,
+    targets,
+    invalidateOnly,
+    counts: {
+      skills: uniqueSkills.length,
+      packs: uniquePacks.length,
+      targets: targets.length,
+    },
+    budgets: {
+      requests: computedRequests,
+      bytes: computedBytes,
+    },
+    caps,
+  };
+  return { ...plan, checksum: planChecksum(plan) };
+}
+
+async function executeInvalidations(options, plan) {
+  for (const item of plan.invalidations) {
+    const payload = await callInvalidation(
+      options,
+      invalidationBody(item, {
+        preflight: false,
+        expectedDependentPacks: item.dependentPacks.all,
+        expectedWarmableDependentPacks: item.dependentPacks.warmable,
+      }),
+      `Cache invalidation execution for ${item.locale}`
+    );
+    if (payload.preflight !== false) {
+      throw new FinalizerError(`Cache invalidation execution for ${item.locale} returned preflight state`);
+    }
+    const closure = readClosure(payload, `Cache invalidation execution for ${item.locale}`);
+    if (JSON.stringify(closure.all) !== JSON.stringify(item.dependentPacks.all)) {
+      throw new FinalizerError(`Dependent-Pack closure drifted during execution for ${item.locale}`);
+    }
+    if (JSON.stringify(closure.warmable) !== JSON.stringify(item.dependentPacks.warmable)) {
+      throw new FinalizerError(`Dependent-Pack warmability drifted during execution for ${item.locale}`);
+    }
+    if (payload?.invalidated?.listVersionBumped !== false || payload?.invalidated?.artifacts !== 0) {
+      throw new FinalizerError(`Translation finalization unexpectedly invalidated lists or artifacts for ${item.locale}`);
+    }
+  }
+}
+
+export async function executeFinalization(rawOptions) {
+  const options = {
+    ...rawOptions,
+    siteUrl: String(rawOptions.siteUrl || 'https://skillstore.io').replace(/\/$/, ''),
+    fetchImpl: rawOptions.fetchImpl || globalThis.fetch,
+  };
+  if (!options.cacheSecret) throw new FinalizerError('Cache invalidation secret is required');
+  if (typeof options.fetchImpl !== 'function') throw new FinalizerError('fetch implementation is required');
+
+  const plan = await buildFinalizationPlan(options);
+  if (!plan) return { success: true, skipped: true, reason: 'no_mutated_targets' };
+  if (options.planPath) await writeFile(options.planPath, `${JSON.stringify(plan, null, 2)}\n`);
+  verifyFinalizationPlan(plan);
+  await executeInvalidations(options, plan);
+
+  const stream = options.reportPath ? createWriteStream(options.reportPath, { flags: 'w' }) : null;
+  try {
+    const warm = await runWarm({
+      targets: plan.targets,
+      siteUrl: options.siteUrl,
+      mode: 'warm',
+      scope: 'changed',
+      concurrency: options.concurrency || 1,
+      requestBudget: plan.budgets.requests,
+      byteBudget: plan.budgets.bytes,
+      expectedBuildToken: options.expectedBuildToken || undefined,
+      report: stream ? (record) => stream.write(`${JSON.stringify(record)}\n`) : undefined,
+      fetchImpl: options.warmFetchImpl || globalThis.fetch,
+    });
+    const result = { success: warm.success, skipped: false, plan, warm };
+    if (!warm.success) throw new FinalizerError('Exact cache warm verification failed', { result });
+    return result;
+  } finally {
+    if (stream) await new Promise((resolveStream) => stream.end(resolveStream));
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const current = argv[index];
+    if (!current.startsWith('--')) throw new FinalizerError(`Unexpected argument: ${current}`);
+    const value = argv[++index];
+    if (value === undefined) throw new FinalizerError(`Missing value for ${current}`);
+    args[current.slice(2)] = value;
+  }
+  return args;
+}
+
+async function cli(argv) {
+  const args = parseArgs(argv);
+  const hasResults = !!args['results-dir'];
+  const hasSlugs = !!args['slugs-file'];
+  if (hasResults === hasSlugs) {
+    throw new FinalizerError('Exactly one of --results-dir or --slugs-file is required');
+  }
+  let groups;
+  let source;
+  if (hasResults) {
+    groups = groupsFromTranslationResults(await loadTranslationDocuments(resolve(args['results-dir'])));
+    source = 'translation';
+  } else {
+    const locales = canonicalStrings(String(args.locales || 'en').split(/[\s,]+/));
+    const slugs = normalizeSlugs(await readFile(resolve(args['slugs-file']), 'utf8'));
+    groups = locales.map((locale) => ({ locale, slugs }));
+    source = 'sync';
+  }
+  const caps = {
+    skills: parsePositiveInteger(args['max-skills'] || DEFAULT_CAPS.skills, 'max skills'),
+    packs: parsePositiveInteger(args['max-packs'] || DEFAULT_CAPS.packs, 'max packs'),
+    targets: parsePositiveInteger(args['max-targets'] || DEFAULT_CAPS.targets, 'max targets'),
+    requestBudget: parsePositiveInteger(args['request-budget'] || DEFAULT_CAPS.requestBudget, 'request budget'),
+    byteBudget: parsePositiveInteger(args['byte-budget'] || DEFAULT_CAPS.byteBudget, 'byte budget'),
+    bytesPerTarget: DEFAULT_CAPS.bytesPerTarget,
+    fixedByteReserve: DEFAULT_CAPS.fixedByteReserve,
+  };
+  try {
+    const result = await executeFinalization({
+      groups,
+      source,
+      siteUrl: args['site-url'] || process.env.SITE_URL || 'https://skillstore.io',
+      cacheSecret: args['cache-secret'] || process.env.CACHE_INVALIDATE_SECRET,
+      expectedBuildToken: args['expected-build-token'] || process.env.EXPECTED_BUILD_TOKEN,
+      concurrency: parsePositiveInteger(args.concurrency || 1, 'concurrency'),
+      caps,
+      planPath: args.plan,
+      reportPath: args.report,
+    });
+    if (args.summary) await writeFile(args.summary, `${JSON.stringify(result, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    const failure = {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      details: error instanceof FinalizerError ? error.details : undefined,
+    };
+    if (args.summary) await writeFile(args.summary, `${JSON.stringify(failure, null, 2)}\n`);
+    throw error;
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  cli(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/finalize-translation-cache.test.mjs
+++ b/scripts/tests/finalize-translation-cache.test.mjs
@@ -1,0 +1,335 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildFinalizationPlan,
+  executeFinalization,
+  FinalizerError,
+  groupsFromTranslationResults,
+  planChecksum,
+  verifyFinalizationPlan,
+} from '../finalize-translation-cache.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function closureResponse({ locale = 'fr', all = [], warmable = all, preflight = true } = {}) {
+  return {
+    preflight,
+    type: 'skills',
+    slugs: ['alpha'],
+    locales: [locale],
+    closure: {
+      dependentPacks: { all, warmable, overflow: false, cap: 100 },
+    },
+    invalidated: {
+      total: 0,
+      page: 0,
+      api: 0,
+      artifacts: 0,
+      listVersionBumped: false,
+      listMaxStaleSeconds: 86400,
+    },
+  };
+}
+
+test('extracts only successful mutated locale pairs and deduplicates slugs', () => {
+  const groups = groupsFromTranslationResults([{ languages: [
+    {
+      language: 'fr',
+      skills: [
+        { slug: 'alpha', status: 'translated' },
+        { slug: 'alpha', status: 'stale_retranslated' },
+        { slug: 'beta', status: 'error' },
+        { slug: 'gamma', status: 'skipped' },
+      ],
+    },
+    { language: 'ja', skills: [{ slug: 'delta', status: 'stale_retranslated' }] },
+  ] }]);
+  assert.deepEqual(groups, [
+    { locale: 'fr', slugs: ['alpha'] },
+    { locale: 'ja', slugs: ['delta'] },
+  ]);
+});
+
+test('all skipped translation results produce an empty no-op plan', async () => {
+  const groups = groupsFromTranslationResults([{ languages: [
+    { language: 'fr', skills: [{ slug: 'alpha', status: 'skipped' }] },
+  ] }]);
+  let calls = 0;
+  const plan = await buildFinalizationPlan({
+    groups,
+    siteUrl: 'https://skillstore.test',
+    cacheSecret: 'secret',
+    fetchImpl: async () => { calls++; return jsonResponse({}); },
+  });
+  assert.equal(plan, null);
+  assert.equal(calls, 0);
+});
+
+test('materializes exact Skill and anonymous-warmable Pack targets', async () => {
+  const requests = [];
+  const plan = await buildFinalizationPlan({
+    groups: [{ locale: 'fr', slugs: ['alpha'] }],
+    siteUrl: 'https://skillstore.test',
+    cacheSecret: 'secret',
+    fetchImpl: async (_url, init) => {
+      requests.push(JSON.parse(init.body));
+      return jsonResponse(closureResponse({
+        all: ['private-pack', 'public-pack'],
+        warmable: ['public-pack'],
+      }));
+    },
+  });
+
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0], {
+    type: 'skills',
+    slugs: ['alpha'],
+    locales: ['fr'],
+    invalidateApi: true,
+    invalidateLists: false,
+    invalidateArtifacts: false,
+    invalidateDependentPacks: true,
+    preflight: true,
+  });
+  assert.deepEqual(plan.targets, [
+    { resource: 'packs', slug: 'public-pack', locale: 'fr' },
+    { resource: 'skills', slug: 'alpha', locale: 'fr' },
+  ]);
+  assert.deepEqual(plan.invalidateOnly, [
+    { resource: 'packs', slug: 'private-pack', locale: 'fr', reason: 'not_anonymous_warmable' },
+  ]);
+  assert.equal(plan.counts.skills, 1);
+  assert.equal(plan.counts.packs, 2);
+  assert.equal(plan.counts.targets, 2);
+  assert.equal(plan.budgets.requests, 66);
+  assert.equal(verifyFinalizationPlan(plan), plan);
+});
+
+test('rejects 26 Skills before making a preflight request', async () => {
+  let calls = 0;
+  await assert.rejects(
+    buildFinalizationPlan({
+      groups: [{ locale: 'fr', slugs: Array.from({ length: 26 }, (_, index) => `skill-${index}`) }],
+      siteUrl: 'https://skillstore.test',
+      cacheSecret: 'secret',
+      fetchImpl: async () => { calls++; return jsonResponse(closureResponse()); },
+    }),
+    /26 Skills; cap is 25/
+  );
+  assert.equal(calls, 0);
+});
+
+test('rejects Pack and target amplification after preflight without truncation', async () => {
+  const packs = Array.from({ length: 101 }, (_, index) => `pack-${index}`);
+  await assert.rejects(
+    buildFinalizationPlan({
+      groups: [{ locale: 'fr', slugs: ['alpha'] }],
+      siteUrl: 'https://skillstore.test',
+      cacheSecret: 'secret',
+      fetchImpl: async () => jsonResponse(closureResponse({ all: packs, warmable: packs })),
+    }),
+    /101 Packs; cap is 100/
+  );
+
+  const targets = Array.from({ length: 250 }, (_, index) => `pack-${index}`);
+  await assert.rejects(
+    buildFinalizationPlan({
+      groups: [{ locale: 'fr', slugs: ['alpha'] }],
+      siteUrl: 'https://skillstore.test',
+      cacheSecret: 'secret',
+      caps: { packs: 300, targets: 250, requestBudget: 100_000, byteBudget: 10_000_000_000 },
+      fetchImpl: async () => jsonResponse(closureResponse({ all: targets, warmable: targets })),
+    }),
+    /251 resource-locale targets; cap is 250/
+  );
+});
+
+test('detects immutable plan tampering', async () => {
+  const plan = await buildFinalizationPlan({
+    groups: [{ locale: 'fr', slugs: ['alpha'] }],
+    siteUrl: 'https://skillstore.test',
+    cacheSecret: 'secret',
+    fetchImpl: async () => jsonResponse(closureResponse()),
+  });
+  const tampered = { ...plan, targets: [{ resource: 'skills', slug: 'other', locale: 'fr' }] };
+  assert.notEqual(planChecksum(tampered), plan.checksum);
+  assert.throws(() => verifyFinalizationPlan(tampered), /checksum mismatch/);
+});
+
+test('closure drift stops execution before warming', async () => {
+  const bodies = [];
+  await assert.rejects(
+    executeFinalization({
+      groups: [{ locale: 'fr', slugs: ['alpha'] }],
+      siteUrl: 'https://skillstore.test',
+      cacheSecret: 'secret',
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(init.body);
+        bodies.push(body);
+        if (body.preflight) {
+          return jsonResponse(closureResponse({ all: [], warmable: [], preflight: true }));
+        }
+        return jsonResponse(closureResponse({ all: ['new-pack'], warmable: ['new-pack'], preflight: false }));
+      },
+      warmFetchImpl: async () => {
+        throw new Error('warming must not start after closure drift');
+      },
+    }),
+    (error) => error instanceof FinalizerError && /HTTP 409|closure drift|closure.*execution/i.test(error.message)
+  );
+  assert.equal(bodies.length, 2);
+  assert.deepEqual(bodies[1].expectedDependentPacks, []);
+  assert.deepEqual(bodies[1].expectedWarmableDependentPacks, []);
+});
+
+test('warmability drift stops execution before the frozen target plan can warm', async () => {
+  const bodies = [];
+  await assert.rejects(
+    executeFinalization({
+      groups: [{ locale: 'fr', slugs: ['alpha'] }],
+      siteUrl: 'https://skillstore.test',
+      cacheSecret: 'secret',
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(init.body);
+        bodies.push(body);
+        if (body.preflight) {
+          return jsonResponse(closureResponse({
+            all: ['visibility-changed-pack'],
+            warmable: [],
+            preflight: true,
+          }));
+        }
+        return jsonResponse(closureResponse({
+          all: ['visibility-changed-pack'],
+          warmable: ['visibility-changed-pack'],
+          preflight: false,
+        }));
+      },
+      warmFetchImpl: async () => {
+        throw new Error('warming must not start after warmability drift');
+      },
+    }),
+    (error) => error instanceof FinalizerError && /warmability drifted/i.test(error.message)
+  );
+  assert.equal(bodies.length, 2);
+  assert.deepEqual(bodies[1].expectedDependentPacks, ['visibility-changed-pack']);
+  assert.deepEqual(bodies[1].expectedWarmableDependentPacks, []);
+});
+
+test('workflow DAG has one serialized finalizer and no fire-and-forget warm', () => {
+  const translation = readFileSync(
+    resolve(REPO_ROOT, '.github/workflows/translate-skills.yml'),
+    'utf8'
+  );
+  const sync = readFileSync(
+    resolve(REPO_ROOT, '.github/workflows/sync-to-supabase.yml'),
+    'utf8'
+  );
+  const warm = readFileSync(
+    resolve(REPO_ROOT, '.github/workflows/warm-cache.yml'),
+    'utf8'
+  );
+
+  assert.match(translation, /group:\s*translate-skills-cache-owner/);
+  assert.match(translation, /cancel-in-progress:\s*false/);
+  assert.match(translation, /^  finalize-cache:/m);
+  assert.match(translation, /finalize-translation-cache\.mjs/);
+  assert.match(translation, /CACHE_FINALIZER_AUTOMATION_ENABLED/);
+  assert.match(translation, /CACHE_FINALIZER_MAX_SKILLS/);
+  assert.match(translation, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(
+    translation,
+    /fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\) >= 1/
+  );
+  assert.match(
+    translation,
+    /fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\) <= 25/
+  );
+  assert.match(
+    translation,
+    /fromJSON\(needs\.detect-and-plan\.outputs\.skill_count \|\| '0'\) <= fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\)/
+  );
+  assert.match(
+    translation,
+    /github\.event_name == 'workflow_dispatch' \|\|\s*vars\.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true'/
+  );
+  assert.match(
+    translation,
+    /^  merge-results:[\s\S]*?needs\.translate\.result == 'success'[\s\S]*?^  finalize-cache:/m
+  );
+  assert.match(translation, /status == "translated" or \.status == "stale_retranslated"/);
+  assert.doesNotMatch(translation, /^  invalidate-cache:/m);
+
+  assert.match(sync, /^  finalize-english-cache:/m);
+  assert.match(sync, /vars\.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true'/);
+  assert.match(sync, /synced_skill_count: \$\{\{ steps\.synced-plan\.outputs\.skill_count \}\}/);
+  assert.match(sync, /echo "skill_count=\$SLUG_COUNT" >> "\$GITHUB_OUTPUT"/);
+  assert.match(
+    sync,
+    /fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\) >= 1/
+  );
+  assert.match(
+    sync,
+    /fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\) <= 25/
+  );
+  assert.match(
+    sync,
+    /fromJSON\(needs\.sync\.outputs\.synced_skill_count \|\| '0'\) <= fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\)/
+  );
+  assert.match(sync, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
+  assert.match(sync, /english_cache_finalizer_failed/);
+  assert.doesNotMatch(sync, /gh workflow run warm-cache\.yml/);
+
+  assert.match(warm, /^      locales:/m);
+  assert.match(warm, /default: 'en'/);
+  assert.match(warm, /Unsupported locale/);
+});
+
+test('translation mutation gate is fail-closed for automation and rollout caps', () => {
+  const mayTranslate = ({ eventName, automationEnabled, skillCount, configuredMax }) => (
+    Number.isSafeInteger(configuredMax) &&
+    configuredMax >= 1 &&
+    configuredMax <= 25 &&
+    skillCount <= configuredMax &&
+    (eventName === 'workflow_dispatch' || automationEnabled === true)
+  );
+
+  assert.equal(mayTranslate({
+    eventName: 'repository_dispatch',
+    automationEnabled: false,
+    skillCount: 1,
+    configuredMax: 5,
+  }), false, 'disabled automation must prevent translation writes');
+
+  assert.equal(mayTranslate({
+    eventName: 'repository_dispatch',
+    automationEnabled: true,
+    skillCount: 6,
+    configuredMax: 5,
+  }), false, 'over-cap automation must be blocked before translation');
+
+  assert.equal(mayTranslate({
+    eventName: 'repository_dispatch',
+    automationEnabled: true,
+    skillCount: 1,
+    configuredMax: 26,
+  }), false, 'the automatic finalizer ceiling must never exceed 25 Skills');
+
+  assert.equal(mayTranslate({
+    eventName: 'workflow_dispatch',
+    automationEnabled: false,
+    skillCount: 1,
+    configuredMax: 5,
+  }), true, 'a bounded manual one-Skill canary may proceed while automation is disabled');
+});

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -5,8 +5,13 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  calculateWorstCaseRequests,
+  MAX_ENDPOINT_ATTEMPTS,
+  MAX_ERROR_RESPONSE_BYTES,
   MAX_EDGE_TRANSFORM_OVERHEAD,
   normalizeSlugs,
+  normalizeWarmTargets,
+  parseWarmTargets,
   runWarm,
   WarmError,
 } from '../warm-skill-cache.mjs';
@@ -60,6 +65,7 @@ function versionResponse(build = BUILD_A) {
 }
 
 function streamingResponse({
+  status = 200,
   build = BUILD_A,
   apiCache,
   pageCache,
@@ -100,7 +106,7 @@ function streamingResponse({
     },
     cancel: onCancel,
   }, { highWaterMark: 0 });
-  return new Response(body, { headers });
+  return new Response(body, { status, headers });
 }
 
 function versionBodyBytes(build = BUILD_A) {
@@ -142,6 +148,34 @@ test('normalizes and rejects empty warm scopes', async () => {
   await assert.rejects(
     runWarm(baseOptions(async () => versionResponse(), [], { slugs: [] })),
     (error) => error instanceof WarmError && /scope is empty/i.test(error.message)
+  );
+});
+
+test('normalizes exact Skill and Pack locale targets and calculates a deterministic aggregate cap', () => {
+  const raw = [
+    { resource: 'packs', slug: 'beta-pack', locale: 'ja' },
+    { resource: 'skills', slug: 'alpha-skill', locale: 'fr' },
+    { resource: 'skills', slug: 'alpha-skill', locale: 'fr' },
+  ];
+  const targets = normalizeWarmTargets(raw);
+  assert.deepEqual(targets, [
+    { resource: 'packs', slug: 'beta-pack', locale: 'ja' },
+    { resource: 'skills', slug: 'alpha-skill', locale: 'fr' },
+  ]);
+  assert.deepEqual(
+    parseWarmTargets(targets.map((target) => JSON.stringify(target)).join('\n')),
+    targets
+  );
+  assert.equal(MAX_ENDPOINT_ATTEMPTS, 16);
+  assert.equal(calculateWorstCaseRequests(targets, { maxAttempts: 3 }), 14);
+  assert.equal(calculateWorstCaseRequests(targets, { maxAttempts: 3, warmZip: true }), 19);
+  assert.throws(
+    () => normalizeWarmTargets([{ resource: 'workflows', slug: 'bad', locale: 'en' }]),
+    /unsupported resource/i
+  );
+  assert.throws(
+    () => normalizeWarmTargets([{ resource: 'skills', slug: 'bad', locale: 'xx' }]),
+    /unsupported locale/i
   );
 });
 
@@ -683,22 +717,41 @@ test('verifies invalidated API and HTML as MISS+STORED then two HIT+SKIPPED resp
   );
 });
 
-test('rejects an initial HIT for force and changed invalidation scopes', async () => {
-  for (const overrides of [
-    { mode: 'warm', scope: 'changed' },
-    { mode: 'force', scope: 'high-traffic' },
-  ]) {
-    let calls = 0;
-    const summary = await runWarm(baseOptions(async (url) => {
-      calls++;
-      if (new URL(url).pathname === '/_app/version.json') return versionResponse();
-      return response({ apiCache: 'HIT' });
-    }, [], overrides));
+test('changed cache retries old HIT/STALE without pinning identity before fresh MISS', async () => {
+  const calls = [];
+  const records = [];
+  const oldKey = '00000000old0';
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'HIT', cacheKey: oldKey }) },
+    { response: response({ apiCache: 'STALE', cacheKey: oldKey }) },
+    { response: response({ apiCache: 'MISS', cacheKey: CACHE_KEY_A }) },
+    { response: response({ apiCache: 'HIT', cacheKey: CACHE_KEY_A }) },
+    { response: response({ apiCache: 'HIT', cacheKey: CACHE_KEY_A }) },
+    { response: response({ pageCache: 'MISS', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse() },
+  ], calls);
 
-    assert.equal(summary.success, false);
-    assert.match(summary.failures.join('\n'), /expected MISS\+STORED/i);
-    assert.equal(calls, 2, 'invalidated cache state must abort before verification traffic');
-  }
+  const summary = await runWarm(baseOptions(fetchImpl, records, {
+    mode: 'warm',
+    scope: 'changed',
+    maxAttempts: 5,
+  }));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(
+    records.filter((record) => record.kind === 'api').map((record) => [record.cache, record.cacheWrite]),
+    [
+      ['HIT', 'SKIPPED'],
+      ['STALE', 'SKIPPED'],
+      ['MISS', 'STORED'],
+      ['HIT', 'SKIPPED'],
+      ['HIT', 'SKIPPED'],
+    ]
+  );
+  assert.equal(calls.length, 10);
 });
 
 test('rejects an invalidated MISS that did not durably store', async () => {
@@ -708,7 +761,7 @@ test('rejects an invalidated MISS that did not durably store', async () => {
   }, [], { mode: 'warm', scope: 'changed' }));
 
   assert.equal(summary.success, false);
-  assert.match(summary.failures.join('\n'), /expected MISS\+STORED/i);
+  assert.match(summary.failures.join('\n'), /fresh MISS\+STORED/i);
 });
 
 test('fails closed when KV key or version evidence is missing', async () => {
@@ -751,6 +804,7 @@ test('fails a persistent MISS and does not start HTML warming', async () => {
     { response: versionResponse() },
     { response: response({ apiCache: 'MISS' }) },
     { response: response({ apiCache: 'MISS' }) },
+    { response: response({ apiCache: 'MISS' }) },
   ], calls);
 
   const summary = await runWarm(baseOptions(fetchImpl));
@@ -760,8 +814,114 @@ test('fails a persistent MISS and does not start HTML warming', async () => {
   assert.equal(summary.completedEndpoints.page, 0);
   assert.equal(summary.failedEndpoints, 1);
   assert.equal(summary.skippedEndpoints, 1);
-  assert.match(summary.failures.join('\n'), /expected HIT\+SKIPPED/i);
+  assert.match(summary.failures.join('\n'), /attempt deterministic cap/i);
   assert.equal(calls.some((call) => new URL(call.url).pathname === '/skills/alpha'), false);
+});
+
+test('requires two consecutive HITs after the newest fresh MISS', async () => {
+  const calls = [];
+  const records = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: response({ apiCache: 'MISS' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'MISS' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ pageCache: 'MISS', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, records, {
+    mode: 'warm',
+    scope: 'changed',
+    maxAttempts: 5,
+  }));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(
+    records.filter((record) => record.kind === 'api').map((record) => record.cache),
+    ['MISS', 'HIT', 'MISS', 'HIT', 'HIT']
+  );
+});
+
+test('retries headerless edge errors before strict application header validation', async () => {
+  const calls = [];
+  const records = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    { response: new Response('busy', { status: 429 }) },
+    { response: new Response('unavailable', { status: 503 }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, records, {
+    maxAttempts: 5,
+    mode: 'warm',
+    scope: 'high-traffic',
+  }));
+
+  assert.equal(summary.success, true);
+  assert.deepEqual(records.filter((record) => record.kind === 'api').map((record) => record.status), [429, 503, 200, 200, 200]);
+  assert.equal(summary.budget.bytes >= versionBodyBytes() + 15, true);
+});
+
+test('cancels oversized error responses without applying the strict app byte contract', async () => {
+  let cancelled = false;
+  const calls = [];
+  const fetchImpl = sequencedFetch([
+    { response: versionResponse() },
+    {
+      response: streamingResponse({
+        status: 503,
+        contentLength: MAX_ERROR_RESPONSE_BYTES + 1,
+        pending: true,
+        onCancel: () => { cancelled = true; },
+      }),
+    },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ apiCache: 'HIT' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: response({ pageCache: 'HIT', body: '<html></html>' }) },
+    { response: versionResponse() },
+  ], calls);
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    maxAttempts: 4,
+    mode: 'warm',
+    scope: 'high-traffic',
+  }));
+
+  assert.equal(summary.success, true);
+  assert.equal(cancelled, true);
+  assert.equal(summary.budget.reservedBytes, 0);
+});
+
+test('reports a headerless non-retryable response by HTTP status without retrying it', async () => {
+  let calls = 0;
+  let endpointCalls = 0;
+  const summary = await runWarm(baseOptions(async (url) => {
+    calls++;
+    if (new URL(url).pathname === '/_app/version.json') return versionResponse();
+    endpointCalls++;
+    return new Response('not found', { status: 404 });
+  }));
+
+  assert.equal(summary.success, false);
+  assert.match(summary.failures.join('\n'), /HTTP 404/i);
+  assert.doesNotMatch(summary.failures.join('\n'), /Content-Length|build token/i);
+  assert.equal(endpointCalls, 1, 'non-retryable endpoint must be requested exactly once');
+  assert.equal(calls, 3, 'start and end build probes still bracket the failed run');
 });
 
 test('retries 429 and 5xx responses before accepting HIT', async () => {
@@ -781,7 +941,7 @@ test('retries 429 and 5xx responses before accepting HIT', async () => {
   ], calls);
 
   const summary = await runWarm(baseOptions(fetchImpl, records, {
-    maxAttempts: 4,
+    maxAttempts: 5,
     mode: 'warm',
     scope: 'high-traffic',
   }));
@@ -927,12 +1087,45 @@ test('reports exact counts for multiple slugs and locales', async () => {
   }));
 
   assert.equal(summary.success, true);
-  assert.deepEqual(summary.plannedEndpoints, { api: 2, page: 4, zip: 0 });
-  assert.deepEqual(summary.completedEndpoints, { api: 2, page: 4, zip: 0 });
-  assert.equal(summary.budget.requests, 20);
+  assert.deepEqual(summary.plannedEndpoints, { api: 4, page: 4, zip: 0 });
+  assert.deepEqual(summary.completedEndpoints, { api: 4, page: 4, zip: 0 });
+  assert.equal(summary.budget.requests, 26);
   assert.equal(summary.failedEndpoints, 0);
   assert.equal(summary.skippedEndpoints, 0);
-  assert.equal(calls.length, 20);
+  assert.equal(calls.length, 26);
+});
+
+test('warms exact Skill and Pack targets with locale-specific API and page URLs in one budget', async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    const pathname = new URL(url).pathname;
+    if (pathname === '/_app/version.json') return versionResponse();
+    if (pathname.startsWith('/api/')) return response({ apiCache: 'HIT' });
+    return response({ pageCache: 'HIT', body: '<html></html>' });
+  };
+  const targets = [
+    { resource: 'skills', slug: 'alpha', locale: 'fr' },
+    { resource: 'packs', slug: 'beta-pack', locale: 'ja' },
+  ];
+
+  const summary = await runWarm(baseOptions(fetchImpl, [], {
+    slugs: undefined,
+    targets,
+    locales: undefined,
+    requestBudget: calculateWorstCaseRequests(targets, { maxAttempts: 3 }),
+  }));
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.targets, 2);
+  assert.deepEqual(summary.resources, { skills: 1, packs: 1 });
+  assert.deepEqual(summary.plannedEndpoints, { api: 2, page: 2, zip: 0 });
+  assert.equal(summary.budget.requests, 14);
+  const requested = calls.map((call) => call.url);
+  assert.equal(requested.some((url) => url.includes('/api/skills/alpha') && url.includes('lang=fr')), true);
+  assert.equal(requested.some((url) => url.includes('/fr/skills/alpha')), true);
+  assert.equal(requested.some((url) => url.includes('/api/packs/beta-pack') && url.includes('lang=ja')), true);
+  assert.equal(requested.some((url) => url.includes('/ja/packs/beta-pack')), true);
 });
 
 test('workflow checks out scripts, requires bounded skill scope, and has no retired content branches', () => {
@@ -965,7 +1158,9 @@ test('sync propagates invalidation failures and cannot warm stale 365-day detail
   assert.match(invalidationSection, /cache warming is blocked/);
   assert.match(invalidationSection, /365 days/);
   assert.match(invalidationSection, /needs\.cache-invalidate\.result == 'success'/);
-  assert.match(invalidationSection, /-f scope=changed/);
-  assert.match(invalidationSection, /-f request_budget=/);
-  assert.match(invalidationSection, /-f byte_budget=/);
+  assert.match(invalidationSection, /finalize-english-cache:/);
+  assert.match(invalidationSection, /finalize-translation-cache\.mjs/);
+  assert.match(invalidationSection, /--request-budget 5000/);
+  assert.match(invalidationSection, /--byte-budget 536870912/);
+  assert.doesNotMatch(invalidationSection, /gh workflow run warm-cache\.yml/);
 });

--- a/scripts/warm-skill-cache.mjs
+++ b/scripts/warm-skill-cache.mjs
@@ -8,7 +8,7 @@ const DEFAULTS = {
   siteUrl: 'https://skillstore.io',
   locales: ['en', 'zh-hans', 'zh-hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'ru', 'ar'],
   concurrency: 10,
-  maxAttempts: 5,
+  maxAttempts: 16,
   retryWindowMinMs: 90_000,
   retryWindowMaxMs: 120_000,
   timeoutMs: 60_000,
@@ -21,12 +21,16 @@ const DEFAULTS = {
   cacheVersionHeader: 'x-kv-version',
 };
 
+const SUPPORTED_RESOURCES = new Set(['skills', 'packs']);
+const SUPPORTED_LOCALES = new Set(DEFAULTS.locales);
 const BUILD_TOKEN_RE = /^[0-9a-f]{40}\.[a-z0-9-]+$/i;
 const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 const RETRYABLE_CACHE_STATES = new Set(['MISS', 'STALE']);
 const RETRY_BASE_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 15_000;
-const VERIFICATION_RESERVE_PER_REQUEST_MS = 10_000;
+export const MAX_ENDPOINT_ATTEMPTS = DEFAULTS.maxAttempts;
+export const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
+export const ERROR_RESPONSE_TIMEOUT_MS = 5_000;
 export const MAX_EDGE_TRANSFORM_OVERHEAD = 16 * 1024;
 
 export class WarmError extends Error {
@@ -62,19 +66,95 @@ export function normalizeSlugs(input) {
   return slugs;
 }
 
-function buildSkillApiUrl(siteUrl, slug) {
-  const url = new URL(`/api/skills/${encodeURIComponent(slug)}`, `${siteUrl}/`);
-  url.searchParams.set('lang', 'en');
+export function normalizeWarmTargets(input) {
+  if (!Array.isArray(input)) {
+    throw new WarmError('Exact warm targets must be a JSON array');
+  }
+  const normalized = input.map((rawTarget, index) => {
+    if (!rawTarget || typeof rawTarget !== 'object' || Array.isArray(rawTarget)) {
+      throw new WarmError(`Warm target ${index + 1} must be an object`);
+    }
+    const resource = String(rawTarget.resource || '').trim();
+    const slug = String(rawTarget.slug || '').trim();
+    const locale = String(rawTarget.locale || '').trim();
+    if (!SUPPORTED_RESOURCES.has(resource)) {
+      throw new WarmError(`Warm target ${index + 1} has unsupported resource ${resource || '<missing>'}`);
+    }
+    if (!slug) throw new WarmError(`Warm target ${index + 1} is missing slug`);
+    if (!SUPPORTED_LOCALES.has(locale)) {
+      throw new WarmError(`Warm target ${index + 1} has unsupported locale ${locale || '<missing>'}`);
+    }
+    return { resource, slug, locale };
+  });
+  const deduped = new Map();
+  for (const target of normalized) {
+    deduped.set(`${target.resource}\0${target.slug}\0${target.locale}`, target);
+  }
+  const targets = [...deduped.values()].sort((left, right) =>
+    left.resource.localeCompare(right.resource) ||
+    left.slug.localeCompare(right.slug) ||
+    left.locale.localeCompare(right.locale)
+  );
+  if (targets.length === 0) {
+    throw new WarmError('Warm scope is empty; provide at least one exact target');
+  }
+  return targets;
+}
+
+export function parseWarmTargets(value, source = 'targets') {
+  const text = String(value || '').trim();
+  if (!text) throw new WarmError(`${source} is empty`);
+  try {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return normalizeWarmTargets(parsed);
+    if (parsed && typeof parsed === 'object') return normalizeWarmTargets([parsed]);
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+  }
+
+  const rows = text.split(/\r?\n/).map((row) => row.trim()).filter(Boolean);
+  try {
+    return normalizeWarmTargets(rows.map((row) => JSON.parse(row)));
+  } catch (error) {
+    if (error instanceof WarmError) throw error;
+    throw new WarmError(`${source} must contain a JSON array, object, or JSONL records`);
+  }
+}
+
+function targetsFromSlugs(slugs, locales) {
+  return normalizeWarmTargets(slugs.flatMap((slug) =>
+    locales.map((locale) => ({ resource: 'skills', slug, locale }))
+  ));
+}
+
+function buildDetailApiUrl(siteUrl, target) {
+  const url = new URL(`/api/${target.resource}/${encodeURIComponent(target.slug)}`, `${siteUrl}/`);
+  url.searchParams.set('lang', target.locale);
   return url;
 }
 
-function buildSkillPageUrl(siteUrl, slug, locale) {
-  const prefix = locale === 'en' ? '' : `/${locale}`;
-  return new URL(`${prefix}/skills/${encodeURIComponent(slug)}`, `${siteUrl}/`);
+function buildDetailPageUrl(siteUrl, target) {
+  const prefix = target.locale === 'en' ? '' : `/${target.locale}`;
+  return new URL(`${prefix}/${target.resource}/${encodeURIComponent(target.slug)}`, `${siteUrl}/`);
 }
 
 function buildSkillZipUrl(siteUrl, slug) {
   return new URL(`/api/skills/${encodeURIComponent(slug)}/download`, `${siteUrl}/`);
+}
+
+export function calculateWorstCaseRequests(
+  rawTargets,
+  { maxAttempts = MAX_ENDPOINT_ATTEMPTS, warmZip = false } = {}
+) {
+  const targets = normalizeWarmTargets(rawTargets);
+  const attempts = parsePositiveInteger(maxAttempts, 'max attempts');
+  const skillZipCount = warmZip
+    ? new Set(targets.filter((target) => target.resource === 'skills').map((target) => target.slug)).size
+    : 0;
+  // Two deployment probes surround the run. API/page state machines consume at
+  // most maxAttempts total requests. ZIP keeps maxAttempts fill attempts plus
+  // two ordinary HIT verifications for backward compatibility.
+  return 2 + (targets.length * 2 * attempts) + (skillZipCount * (attempts + 2));
 }
 
 function withBuildToken(url, token) {
@@ -292,6 +372,94 @@ async function cancelBody(body, reason) {
   }
 }
 
+async function readBoundedErrorBody(response, context, url, runSignal) {
+  const body = response.body;
+  if (!body) {
+    return { body: new Uint8Array(), declared: 0, actual: 0, edgeDelta: null, truncated: false };
+  }
+
+  const rawLength = response.headers.get('content-length');
+  const parsedLength = rawLength !== null && /^\d+$/.test(rawLength) ? Number(rawLength) : null;
+  if (parsedLength !== null && (!Number.isSafeInteger(parsedLength) || parsedLength > MAX_ERROR_RESPONSE_BYTES)) {
+    await cancelBody(body, new Error('error response body exceeds bounded drain limit'));
+    return {
+      body: new Uint8Array(),
+      declared: Number.isSafeInteger(parsedLength) ? parsedLength : null,
+      actual: 0,
+      edgeDelta: null,
+      truncated: true,
+    };
+  }
+
+  const reservationBytes = parsedLength ?? MAX_ERROR_RESPONSE_BYTES;
+  let reservation;
+  try {
+    reservation = context.budget.reserveResponseBytes(reservationBytes, url);
+  } catch (error) {
+    const fatal = context.abortRun(error);
+    await cancelBody(body, fatal);
+    throw fatal;
+  }
+
+  const timer = timeoutSignal(ERROR_RESPONSE_TIMEOUT_MS, runSignal);
+  const reader = body.getReader();
+  const chunks = [];
+  let bytesRead = 0;
+  let truncated = false;
+  const cancelReader = () => reader.cancel(timer.signal.reason || new Error('error body drain aborted')).catch(() => {});
+  timer.signal.addEventListener('abort', cancelReader, { once: true });
+  try {
+    while (true) {
+      if (timer.signal.aborted) {
+        if (context.abortReason) throw context.abortReason;
+        truncated = true;
+        break;
+      }
+      let next;
+      try {
+        next = await reader.read();
+      } catch (error) {
+        if (context.abortReason) throw context.abortReason;
+        truncated = true;
+        break;
+      }
+      if (next.done) break;
+      const chunk = next.value instanceof Uint8Array ? next.value : new Uint8Array(next.value);
+      const remaining = MAX_ERROR_RESPONSE_BYTES - bytesRead;
+      const acceptedBytes = Math.min(chunk.byteLength, remaining);
+      if (acceptedBytes > 0) {
+        const accepted = acceptedBytes === chunk.byteLength ? chunk : chunk.subarray(0, acceptedBytes);
+        context.budget.consumeBytes(accepted.byteLength, url, reservation, bytesRead);
+        chunks.push(accepted);
+        bytesRead += accepted.byteLength;
+      }
+      if (chunk.byteLength > acceptedBytes || bytesRead >= MAX_ERROR_RESPONSE_BYTES) {
+        truncated = true;
+        await reader.cancel(new Error('error response body reached bounded drain limit')).catch(() => {});
+        break;
+      }
+    }
+  } finally {
+    timer.signal.removeEventListener('abort', cancelReader);
+    timer.clear();
+    context.budget.releaseResponseBytes(reservation);
+  }
+
+  const result = new Uint8Array(bytesRead);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return {
+    body: result,
+    declared: parsedLength,
+    actual: bytesRead,
+    edgeDelta: null,
+    truncated,
+  };
+}
+
 async function readResponseBody(response, context, url, signal, allowEdgeTransform) {
   const body = response.body;
   let reservation = null;
@@ -477,6 +645,7 @@ async function sleepUnlessAborted(context, milliseconds) {
 function makeRecord({
   phase,
   kind,
+  resource = null,
   slug = null,
   locale = null,
   url,
@@ -492,6 +661,7 @@ function makeRecord({
   declared = null,
   actual = null,
   edgeDelta = null,
+  truncated = false,
   error = null,
 }) {
   const cfRay = response?.headers?.get('cf-ray') || null;
@@ -499,6 +669,7 @@ function makeRecord({
     timestamp: new Date().toISOString(),
     phase,
     kind,
+    resource,
     slug,
     locale,
     url,
@@ -512,6 +683,7 @@ function makeRecord({
     declared,
     actual,
     edgeDelta,
+    truncated,
     cfRay,
     colo: coloFromRay(cfRay),
     buildToken,
@@ -544,13 +716,24 @@ async function fetchRecorded(context, request) {
       redirect: 'follow',
       signal: timer.signal,
     });
-    bodyMetadata = await readResponseBody(
-      response,
-      context,
-      url,
-      timer.signal,
-      request.kind === 'page'
-    );
+    // Edge-generated errors are not application responses: they commonly omit
+    // build/cache/size headers. Classify them first and drain only a small,
+    // globally-budgeted diagnostic body. Strict application contracts apply to
+    // successful responses only.
+    bodyMetadata = response.ok
+      ? await readResponseBody(
+        response,
+        context,
+        url,
+        timer.signal,
+        request.kind === 'page'
+      )
+      : await readBoundedErrorBody(
+        response,
+        context,
+        url,
+        timer.signal
+      );
     body = bodyMetadata.body;
   } catch (error) {
     const effectiveError = context.abortReason || error;
@@ -621,6 +804,7 @@ async function fetchRecorded(context, request) {
     declared: bodyMetadata.declared,
     actual: bodyMetadata.actual,
     edgeDelta: bodyMetadata.edgeDelta,
+    truncated: bodyMetadata.truncated || false,
   });
   await context.report(record);
   return {
@@ -731,158 +915,262 @@ async function probeBuild(context, phase) {
   }
 }
 
-async function warmEndpoint(context, item) {
+function endpointDeadline(context, item) {
   const baseUrl = new URL(item.url);
-  const endpointStartedAt = context.now();
-  const endpointWindowMs = endpointWindow(
+  const startedAt = context.now();
+  const windowMs = endpointWindow(
     String(baseUrl),
     context.retryWindowMinMs,
     context.retryWindowMaxMs
   );
-  const deadlineAt = endpointStartedAt + endpointWindowMs;
-  const headers = {
+  const deadlineAt = startedAt + windowMs;
+  const remainingMs = () => Math.max(0, deadlineAt - context.now());
+  const error = (phase) => new WarmError(
+    `${item.kind} ${baseUrl} exhausted its ${windowMs}ms endpoint deadline during ${phase}`,
+    { deadlineAt, elapsedMs: context.now() - startedAt, phase }
+  );
+  return { baseUrl, windowMs, deadlineAt, remainingMs, error };
+}
+
+function endpointResult(item, baseUrl, records, innerAttempts) {
+  return {
+    kind: item.kind,
+    resource: item.resource,
+    slug: item.slug,
+    locale: item.locale,
+    url: String(baseUrl),
+    innerAttempts,
+    bytes: records.reduce((total, result) => total + result.record.bytes, 0),
+  };
+}
+
+async function warmKvEndpoint(context, item) {
+  const deadline = endpointDeadline(context, item);
+  const requiresInvalidatedMiss = context.mode === 'force' || context.scope === 'changed';
+  const noCacheHeaders = {
     Accept: item.accept,
     'Cache-Control': 'no-cache',
     Pragma: 'no-cache',
     'User-Agent': context.userAgent,
     'X-Skillstore-Callback': 'true',
   };
-
-  const remainingMs = () => Math.max(0, deadlineAt - context.now());
-  const deadlineError = (phase) => new WarmError(
-    `${item.kind} ${baseUrl} exhausted its ${endpointWindowMs}ms endpoint deadline during ${phase}`,
-    {
-      deadlineAt,
-      elapsedMs: context.now() - endpointStartedAt,
-      phase,
-    }
-  );
-  const verificationReserveMs = Math.min(
-    context.timeoutMs,
-    VERIFICATION_RESERVE_PER_REQUEST_MS
-  ) * 2;
-
-  const usesKvStateMachine = item.kind === 'api' || item.kind === 'page';
-  const requiresInvalidatedMiss = usesKvStateMachine &&
-    (context.mode === 'force' || context.scope === 'changed');
-  let acceptedResult = null;
+  const ordinaryHeaders = {
+    Accept: item.accept,
+    'User-Agent': context.userAgent,
+    'X-Skillstore-Callback': 'true',
+  };
+  const records = [];
   let cacheIdentity = null;
+  let consecutiveHits = 0;
+  let freshMissAttempt = 0;
+  let innerAttempt = 0;
+  let verificationAttempt = 0;
+  let shouldDelay = false;
+
   for (let attempt = 1; attempt <= context.maxAttempts; attempt++) {
-    if (attempt > 1) {
-      const availableForDelay = remainingMs() - verificationReserveMs - 1;
-      if (availableForDelay <= 0) throw deadlineError('inner-cache backoff');
-      const delayMs = Math.min(retryDelay(String(baseUrl), attempt), availableForDelay);
-      await sleepUnlessAborted(context, delayMs);
-      if (remainingMs() <= verificationReserveMs) throw deadlineError('inner-cache backoff');
+    if (context.abortReason) throw context.abortReason;
+    if (shouldDelay) {
+      const available = deadline.remainingMs() - 1;
+      if (available <= 0) throw deadline.error('cache propagation backoff');
+      await sleepUnlessAborted(
+        context,
+        Math.min(retryDelay(String(deadline.baseUrl), attempt), available)
+      );
     }
+    const remaining = deadline.remainingMs();
+    if (remaining <= 0) throw deadline.error('cache state request');
 
-    const innerTimeoutMs = Math.min(
-      context.timeoutMs,
-      remainingMs() - verificationReserveMs
-    );
-    if (innerTimeoutMs <= 0) throw deadlineError('inner-cache request');
-
+    const stabilizing = cacheIdentity !== null;
+    const phase = stabilizing ? 'ordinary-verification' : 'inner-cache';
+    const phaseAttempt = stabilizing ? ++verificationAttempt : ++innerAttempt;
+    const requestUrl = stabilizing
+      ? withBuildToken(deadline.baseUrl, context.buildToken)
+      : deadline.baseUrl;
     let result;
     try {
       result = await fetchRecorded(context, {
-        phase: 'inner-cache',
+        phase,
         kind: item.kind,
+        resource: item.resource,
         slug: item.slug,
         locale: item.locale,
-        url: baseUrl,
-        attempt,
+        url: requestUrl,
+        attempt: phaseAttempt,
         status: 0,
         bytes: 0,
         cacheHeader: item.cacheHeader,
-        headers,
-        timeoutMs: innerTimeoutMs,
+        headers: stabilizing ? ordinaryHeaders : noCacheHeaders,
+        timeoutMs: Math.min(context.timeoutMs, remaining),
       });
-      await assertPinnedBuild(context, result, `${item.kind} ${baseUrl}`);
     } catch (error) {
-      if (error instanceof WarmError && error.details?.fatal) {
-        throw context.abortRun(error);
-      }
-      if (attempt < context.maxAttempts) continue;
-      throw error;
+      if (error instanceof WarmError && error.details?.fatal) throw context.abortRun(error);
+      if (attempt >= context.maxAttempts) throw error;
+      shouldDelay = true;
+      continue;
     }
+    records.push(result);
 
-    const retryableStatus = RETRYABLE_STATUSES.has(result.response.status);
     if (!result.response.ok) {
-      if (retryableStatus && attempt < context.maxAttempts) continue;
-      throw new WarmError(
-        `${item.kind} ${baseUrl} returned HTTP ${result.response.status} with ${item.cacheHeader}=${result.cache || '<missing>'}`
-      );
-    }
-
-    if (!usesKvStateMachine) {
-      if (result.cache === 'HIT') {
-        acceptedResult = result;
-        break;
+      if (RETRYABLE_STATUSES.has(result.response.status) && attempt < context.maxAttempts) {
+        shouldDelay = true;
+        continue;
       }
-      if (RETRYABLE_CACHE_STATES.has(result.cache) && attempt < context.maxAttempts) continue;
       throw new WarmError(
-        `${item.kind} ${baseUrl} returned HTTP ${result.response.status} with ${item.cacheHeader}=${result.cache || '<missing>'}`
+        `${item.kind} ${deadline.baseUrl} returned HTTP ${result.response.status}`
       );
     }
+    await assertPinnedBuild(context, result, `${item.kind} ${requestUrl}`);
 
-    cacheIdentity = assertCacheIdentity(
-      context,
-      result,
-      `${item.kind} inner-cache attempt ${attempt} ${baseUrl}`,
-      cacheIdentity
-    );
-    if (requiresInvalidatedMiss) {
-      if (result.cache !== 'MISS' || result.cacheWrite !== 'STORED') {
+    if (!cacheIdentity) {
+      const observedIdentity = assertCacheIdentity(
+        context,
+        result,
+        `${item.kind} pre-stabilization attempt ${phaseAttempt} ${deadline.baseUrl}`
+      );
+      if (requiresInvalidatedMiss) {
+        if ((result.cache === 'HIT' || result.cache === 'STALE') && result.cacheWrite === 'SKIPPED') {
+          shouldDelay = true;
+          continue;
+        }
+        if (result.cache !== 'MISS' || result.cacheWrite !== 'STORED') {
+          throw cacheStateFailure(
+            context,
+            item,
+            result,
+            `${item.kind} invalidated cache ${deadline.baseUrl}`,
+            'pre-MISS HIT/STALE+SKIPPED or fresh MISS+STORED'
+          );
+        }
+      } else if (!(
+        (result.cache === 'MISS' && result.cacheWrite === 'STORED') ||
+        (result.cache === 'HIT' && result.cacheWrite === 'SKIPPED')
+      )) {
+        if (result.cache === 'STALE' && result.cacheWrite === 'SKIPPED') {
+          shouldDelay = true;
+          continue;
+        }
         throw cacheStateFailure(
           context,
           item,
           result,
-          `${item.kind} invalidated cache ${baseUrl}`,
-          'MISS+STORED'
+          `${item.kind} cache ${deadline.baseUrl}`,
+          'MISS+STORED or HIT+SKIPPED'
         );
       }
-      acceptedResult = result;
-      break;
+      cacheIdentity = observedIdentity;
+      freshMissAttempt = phaseAttempt;
+      consecutiveHits = 0;
+      shouldDelay = false;
+      continue;
     }
 
-    if ((result.cache === 'MISS' && result.cacheWrite === 'STORED') ||
-        (result.cache === 'HIT' && result.cacheWrite === 'SKIPPED')) {
-      acceptedResult = result;
-      break;
+    assertCacheIdentity(
+      context,
+      result,
+      `${item.kind} stabilization attempt ${phaseAttempt} ${requestUrl}`,
+      cacheIdentity
+    );
+    if (result.cache === 'HIT' && result.cacheWrite === 'SKIPPED') {
+      consecutiveHits += 1;
+      if (consecutiveHits === 2) {
+        return endpointResult(item, deadline.baseUrl, records, freshMissAttempt);
+      }
+      shouldDelay = false;
+      continue;
     }
-    if (result.cache === 'STALE' && result.cacheWrite === 'SKIPPED' &&
-        attempt < context.maxAttempts) {
+    if (result.cache === 'MISS' && result.cacheWrite === 'STORED') {
+      consecutiveHits = 0;
+      freshMissAttempt = phaseAttempt;
+      shouldDelay = false;
+      continue;
+    }
+    if (result.cache === 'STALE' && result.cacheWrite === 'SKIPPED') {
+      consecutiveHits = 0;
+      shouldDelay = true;
       continue;
     }
     throw cacheStateFailure(
       context,
       item,
       result,
-      `${item.kind} cache ${baseUrl}`,
-      'MISS+STORED or HIT+SKIPPED'
+      `${item.kind} stabilization ${requestUrl}`,
+      'MISS+STORED or two consecutive HIT+SKIPPED'
     );
   }
 
-  if (!acceptedResult) {
+  if (deadline.remainingMs() <= 0) throw deadline.error('cache state verification');
+  throw new WarmError(
+    `${item.kind} ${deadline.baseUrl} exhausted its ${context.maxAttempts}-attempt deterministic cap before reaching two consecutive HITs`,
+    { attempts: context.maxAttempts, deadlineAt: deadline.deadlineAt }
+  );
+}
+
+async function warmSimpleEndpoint(context, item) {
+  const deadline = endpointDeadline(context, item);
+  const records = [];
+  let acceptedResult = null;
+  let shouldDelay = false;
+  for (let attempt = 1; attempt <= context.maxAttempts; attempt++) {
+    if (shouldDelay) {
+      const available = deadline.remainingMs() - 1;
+      if (available <= 0) throw deadline.error('simple-cache backoff');
+      await sleepUnlessAborted(context, Math.min(retryDelay(String(deadline.baseUrl), attempt), available));
+    }
+    const remaining = deadline.remainingMs();
+    if (remaining <= 0) throw deadline.error('simple-cache request');
+    const result = await fetchRecorded(context, {
+      phase: 'inner-cache',
+      kind: item.kind,
+      resource: item.resource,
+      slug: item.slug,
+      locale: item.locale,
+      url: deadline.baseUrl,
+      attempt,
+      status: 0,
+      bytes: 0,
+      cacheHeader: item.cacheHeader,
+      headers: {
+        Accept: item.accept,
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        'User-Agent': context.userAgent,
+        'X-Skillstore-Callback': 'true',
+      },
+      timeoutMs: Math.min(context.timeoutMs, remaining),
+    });
+    records.push(result);
+    if (!result.response.ok) {
+      if (RETRYABLE_STATUSES.has(result.response.status) && attempt < context.maxAttempts) {
+        shouldDelay = true;
+        continue;
+      }
+      throw new WarmError(`${item.kind} ${deadline.baseUrl} returned HTTP ${result.response.status}`);
+    }
+    await assertPinnedBuild(context, result, `${item.kind} ${deadline.baseUrl}`);
+    if (result.cache === 'HIT') {
+      acceptedResult = result;
+      break;
+    }
+    if (RETRYABLE_CACHE_STATES.has(result.cache) && attempt < context.maxAttempts) {
+      shouldDelay = true;
+      continue;
+    }
     throw new WarmError(
-      `${item.kind} ${baseUrl} never reached an acceptable cache state after ${context.maxAttempts} attempts`
+      `${item.kind} ${deadline.baseUrl} returned ${item.cacheHeader}=${result.cache || '<missing>'}`
     );
   }
+  if (!acceptedResult) {
+    throw new WarmError(`${item.kind} ${deadline.baseUrl} did not reach HIT within its attempt cap`);
+  }
 
-  const verificationUrl = withBuildToken(baseUrl, context.buildToken);
-  const verifications = [];
+  const verificationUrl = withBuildToken(deadline.baseUrl, context.buildToken);
   for (let attempt = 1; attempt <= 2; attempt++) {
-    if (context.abortReason) throw context.abortReason;
-    const requestsRemaining = 3 - attempt;
-    const verificationTimeoutMs = Math.min(
-      context.timeoutMs,
-      Math.floor(remainingMs() / requestsRemaining)
-    );
-    if (verificationTimeoutMs <= 0) throw deadlineError(`ordinary verification ${attempt}`);
-
-    const verification = await fetchRecorded(context, {
+    const remaining = deadline.remainingMs();
+    if (remaining <= 0) throw deadline.error(`ordinary verification ${attempt}`);
+    const result = await fetchRecorded(context, {
       phase: 'ordinary-verification',
       kind: item.kind,
+      resource: item.resource,
       slug: item.slug,
       locale: item.locale,
       url: verificationUrl,
@@ -895,49 +1183,26 @@ async function warmEndpoint(context, item) {
         'User-Agent': context.userAgent,
         'X-Skillstore-Callback': 'true',
       },
-      timeoutMs: verificationTimeoutMs,
+      timeoutMs: Math.min(context.timeoutMs, remaining),
     });
-    await assertPinnedBuild(
-      context,
-      verification,
-      `${item.kind} ordinary verification ${attempt} ${verificationUrl}`
-    );
-    if (usesKvStateMachine) {
-      assertCacheIdentity(
-        context,
-        verification,
-        `${item.kind} ordinary verification ${attempt} ${verificationUrl}`,
-        cacheIdentity
-      );
-      if (!verification.response.ok || verification.cache !== 'HIT' ||
-          verification.cacheWrite !== 'SKIPPED') {
-        throw cacheStateFailure(
-          context,
-          item,
-          verification,
-          `${item.kind} ordinary verification ${attempt} ${verificationUrl}`,
-          'HIT+SKIPPED'
-        );
-      }
-    } else if (!verification.response.ok || verification.cache !== 'HIT') {
+    records.push(result);
+    if (!result.response.ok) {
+      throw new WarmError(`${item.kind} verification returned HTTP ${result.response.status}`);
+    }
+    await assertPinnedBuild(context, result, `${item.kind} ordinary verification ${verificationUrl}`);
+    if (result.cache !== 'HIT') {
       throw new WarmError(
-        `${item.kind} ordinary verification ${attempt} replayed a non-HIT response: HTTP ${verification.response.status}, ${item.cacheHeader}=${verification.cache || '<missing>'}`
+        `${item.kind} ordinary verification replayed ${item.cacheHeader}=${result.cache || '<missing>'}`
       );
     }
-    verifications.push(verification);
   }
+  return endpointResult(item, deadline.baseUrl, records, acceptedResult.record.attempt);
+}
 
-  return {
-    kind: item.kind,
-    slug: item.slug,
-    locale: item.locale,
-    url: String(baseUrl),
-    innerAttempts: acceptedResult.record.attempt,
-    bytes: acceptedResult.record.bytes + verifications.reduce(
-      (total, result) => total + result.record.bytes,
-      0
-    ),
-  };
+async function warmEndpoint(context, item) {
+  return item.kind === 'api' || item.kind === 'page'
+    ? warmKvEndpoint(context, item)
+    : warmSimpleEndpoint(context, item);
 }
 
 async function mapWithConcurrency(items, concurrency, mapper) {
@@ -966,25 +1231,27 @@ function summarizeFailures(results) {
     .map((result) => result.error instanceof Error ? result.error.message : String(result.error));
 }
 
-function endpointItems(options, slugs) {
-  const api = slugs.map((slug) => ({
+function endpointItems(options, targets) {
+  const api = targets.map((target) => ({
     kind: 'api',
-    slug,
-    locale: 'en',
-    url: buildSkillApiUrl(options.siteUrl, slug),
+    ...target,
+    url: buildDetailApiUrl(options.siteUrl, target),
     cacheHeader: options.apiCacheHeader,
     accept: 'application/json',
   }));
-  const pages = slugs.flatMap((slug) => options.locales.map((locale) => ({
+  const pages = targets.map((target) => ({
     kind: 'page',
-    slug,
-    locale,
-    url: buildSkillPageUrl(options.siteUrl, slug, locale),
+    ...target,
+    url: buildDetailPageUrl(options.siteUrl, target),
     cacheHeader: options.pageCacheHeader,
     accept: 'text/html',
-  })));
-  const zips = options.warmZip ? slugs.map((slug) => ({
+  }));
+  const skillSlugs = [
+    ...new Set(targets.filter((target) => target.resource === 'skills').map((target) => target.slug)),
+  ];
+  const zips = options.warmZip ? skillSlugs.map((slug) => ({
     kind: 'zip',
+    resource: 'skills',
     slug,
     locale: null,
     url: buildSkillZipUrl(options.siteUrl, slug),
@@ -1018,6 +1285,10 @@ export async function runWarm(rawOptions) {
   if (!Array.isArray(options.locales) || options.locales.length === 0) {
     throw new WarmError('At least one locale is required');
   }
+  options.locales = [...new Set(options.locales.map((locale) => String(locale).trim()))];
+  for (const locale of options.locales) {
+    if (!SUPPORTED_LOCALES.has(locale)) throw new WarmError(`Unsupported locale: ${locale}`);
+  }
   if (!Number.isSafeInteger(options.retryWindowMinMs) || options.retryWindowMinMs <= 0 ||
       !Number.isSafeInteger(options.retryWindowMaxMs) || options.retryWindowMaxMs < options.retryWindowMinMs ||
       options.retryWindowMaxMs > 120_000) {
@@ -1026,8 +1297,10 @@ export async function runWarm(rawOptions) {
     );
   }
 
-  const slugs = normalizeSlugs(rawOptions.slugs);
-  const items = endpointItems(options, slugs);
+  const targets = rawOptions.targets
+    ? normalizeWarmTargets(rawOptions.targets)
+    : targetsFromSlugs(normalizeSlugs(rawOptions.slugs), options.locales);
+  const items = endpointItems(options, targets);
   const minimumRequests = 2 + (items.api.length + items.pages.length + items.zips.length) * 3;
   if (options.requestBudget < minimumRequests) {
     throw new WarmError(
@@ -1113,6 +1386,12 @@ export async function runWarm(rawOptions) {
   }, { api: 0, page: 0, zip: 0 });
   const plannedEndpointTotal = items.api.length + items.pages.length + items.zips.length;
   const completedEndpointTotal = endpointCounts.api + endpointCounts.page + endpointCounts.zip;
+  const uniqueSlugs = new Set(targets.map((target) => `${target.resource}\0${target.slug}`));
+  const uniqueLocales = new Set(targets.map((target) => target.locale));
+  const resourceCounts = targets.reduce((counts, target) => {
+    counts[target.resource] = (counts[target.resource] || 0) + 1;
+    return counts;
+  }, { skills: 0, packs: 0 });
   return {
     success: failures.length === 0,
     mode: rawOptions.mode || 'warm',
@@ -1120,8 +1399,10 @@ export async function runWarm(rawOptions) {
     startedAt,
     finishedAt: new Date().toISOString(),
     buildToken: context.buildToken,
-    slugs: slugs.length,
-    locales: options.locales.length,
+    targets: targets.length,
+    slugs: uniqueSlugs.size,
+    locales: uniqueLocales.size,
+    resources: resourceCounts,
     plannedEndpoints: {
       api: items.api.length,
       page: items.pages.length,
@@ -1158,13 +1439,16 @@ function markdownSummary(summary) {
   const failures = summary.failures.length
     ? `\n\n### Failures\n\n${summary.failures.map((failure) => `- ${failure}`).join('\n')}`
     : '';
-  return `## Skill cache warm verification\n\n` +
+  return `## Catalog cache warm verification\n\n` +
     `| Metric | Value |\n|---|---:|\n` +
     `| Result | ${status} |\n` +
     `| Mode | \`${summary.mode}\` |\n` +
     `| Scope | \`${summary.scope}\` |\n` +
     `| Build | \`${summary.buildToken || 'unavailable'}\` |\n` +
-    `| Skills | ${summary.slugs} |\n` +
+    `| Exact targets | ${summary.targets} |\n` +
+    `| Skill targets | ${summary.resources.skills} |\n` +
+    `| Pack targets | ${summary.resources.packs} |\n` +
+    `| Resource slugs | ${summary.slugs} |\n` +
     `| API endpoints | ${summary.completedEndpoints.api}/${summary.plannedEndpoints.api} |\n` +
     `| Page endpoints | ${summary.completedEndpoints.page}/${summary.plannedEndpoints.page} |\n` +
     `| ZIP endpoints | ${summary.completedEndpoints.zip}/${summary.plannedEndpoints.zip} |\n` +
@@ -1178,7 +1462,14 @@ function markdownSummary(summary) {
 async function cli(argv) {
   const args = parseArguments(argv);
   const slugsFile = args['slugs-file'];
-  if (!slugsFile) throw new WarmError('--slugs-file is required');
+  const targetsFile = args['targets-file'] || process.env.TARGETS_FILE || null;
+  const inlineTargets = args.targets || process.env.TARGETS || null;
+  if (!slugsFile && !targetsFile && !inlineTargets) {
+    throw new WarmError('--slugs-file, --targets, or --targets-file is required');
+  }
+  if (slugsFile && (targetsFile || inlineTargets)) {
+    throw new WarmError('--slugs-file cannot be combined with exact targets');
+  }
   const reportPath = args.report || 'warm-cache-report.jsonl';
   const summaryPath = args.summary || 'warm-cache-summary.json';
   const stream = createWriteStream(reportPath, { flags: 'w' });
@@ -1197,9 +1488,15 @@ async function cli(argv) {
 
   let summary;
   try {
-    const slugs = normalizeSlugs(await readFile(slugsFile, 'utf8'));
+    const exactTargets = [];
+    if (inlineTargets) exactTargets.push(...parseWarmTargets(inlineTargets, '--targets'));
+    if (targetsFile) {
+      exactTargets.push(...parseWarmTargets(await readFile(targetsFile, 'utf8'), '--targets-file'));
+    }
+    const targets = exactTargets.length > 0 ? normalizeWarmTargets(exactTargets) : null;
+    const slugs = slugsFile ? normalizeSlugs(await readFile(slugsFile, 'utf8')) : null;
     summary = await runWarm({
-      slugs,
+      ...(targets ? { targets } : { slugs }),
       siteUrl: args['site-url'] || process.env.SITE_URL || DEFAULTS.siteUrl,
       locales: String(args.locales || process.env.LOCALES || DEFAULTS.locales.join(' ')).split(/[\s,]+/).filter(Boolean),
       concurrency: args.concurrency || process.env.CONCURRENCY || DEFAULTS.concurrency,


### PR DESCRIPTION
## Summary
- replace fire-and-forget warming with immutable exact Skill/Pack/locale finalization plans
- require fresh MISS+STORED followed by two matching HIT+SKIPPED responses
- gate translation before database mutation when automation is disabled or bounds are exceeded
- hard-lock automatic Skill plans to 1..25 and keep automation disabled by default

## Safety
- zero-write preflight and closure checksum before invalidation
- aggregate request/byte budgets, bounded retries, pinned deployment/key/version
- one global translation owner and API-before-page verification

## Verification
- `node --test scripts/tests/*.test.mjs` (75 passed)
- workflow YAML parsed
- all embedded Bash blocks parsed with `bash -n`
- `git diff --check`