### PR TITLE
fix: 分批重试同步后的缓存失效请求

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -207,6 +207,20 @@ jobs:
             echo "skip_sync=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Validate cache matrix capacity
+        if: steps.changes.outputs.skip_sync != 'true'
+        env:
+          CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
+        run: |
+          set -euo pipefail
+          MAX_CACHE_ITEMS=25600 # 256 GitHub matrix jobs × 100 slugs per shard
+          TARGET_COUNT=$(printf '%s\n' "$CHANGED_SKILLS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
+          if [ "$TARGET_COUNT" -gt "$MAX_CACHE_ITEMS" ]; then
+            echo "::error::Sync target count $TARGET_COUNT exceeds cache matrix capacity $MAX_CACHE_ITEMS; refusing before Supabase write"
+            exit 1
+          fi
+          echo "Cache matrix preflight: $TARGET_COUNT target(s) within $MAX_CACHE_ITEMS capacity"
+
       - name: Download skillstore-cli
         if: steps.changes.outputs.skip_sync != 'true'
         uses: ./.github/actions/download-skillstore-cli

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -843,11 +843,14 @@ jobs:
     needs: [sync, calculate-scores]
     if: needs.sync.outputs.skip_sync != 'true'
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 25
+    permissions:
+      contents: read
     steps:
       - name: Checkout cache invalidator
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           sparse-checkout: scripts/invalidate-cache.sh
           sparse-checkout-cone-mode: false
 
@@ -859,6 +862,8 @@ jobs:
           CONTENT_TYPE: skills
           CURL_MAX_TIME: '30'
           MAX_ATTEMPTS: '3'
+          MAX_ITEMS: '100'
+          RETRY_BASE_SECONDS: '5'
           SITE_URL: https://skillstore.io
           SLUGS_STR: ${{ needs.sync.outputs.synced_slugs }}
         run: ./scripts/invalidate-cache.sh

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 240
     outputs:
-      synced_slugs: ${{ steps.sync.outputs.synced_slugs }}
       synced_skill_count: ${{ steps.synced-plan.outputs.skill_count }}
       skip_sync: ${{ steps.changes.outputs.skip_sync }}
     steps:
@@ -421,16 +420,18 @@ jobs:
             exit 1
           fi
 
-          echo "synced_slugs=$SYNCED_SLUGS" >> $GITHUB_OUTPUT
-          echo "::notice::Synced skills: $SYNCED_SLUGS"
+          printf '%s\n' "$SYNCED_SLUGS" | tr ',' '\n' | sed '/^$/d' | sort -u > synced-slugs.txt
+          SYNCED_COUNT=$(wc -l < synced-slugs.txt | tr -d ' ')
+          echo "synced_count=$SYNCED_COUNT" >> "$GITHUB_OUTPUT"
+          echo "::notice::Synced $SYNCED_COUNT skill(s); slug payload saved to artifact input"
 
       - name: Remove generated report evidence from synced audits
-        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_slugs != ''
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          SYNCED_SLUGS: ${{ steps.sync.outputs.synced_slugs }}
         run: |
+          SYNCED_SLUGS=$(paste -sd, synced-slugs.txt)
           SANITIZED_COUNT=0
           SANITIZE_ERRORS=0
 
@@ -598,22 +599,17 @@ jobs:
 
       - name: Save synced slugs to artifact
         id: synced-plan
-        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_slugs != ''
-        env:
-          SYNCED_SLUGS: ${{ steps.sync.outputs.synced_slugs }}
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
         run: |
-          # Write slugs to file (one per line for easy processing)
-          echo "$SYNCED_SLUGS" | tr ',' '\n' > synced-slugs.txt
           SLUG_COUNT=$(wc -l < synced-slugs.txt | tr -d ' ')
           echo "skill_count=$SLUG_COUNT" >> "$GITHUB_OUTPUT"
           echo "📦 Saved $SLUG_COUNT slugs to artifact"
 
       - name: Resolve published submissions
         id: published_submissions
-        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_slugs != ''
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
         env:
           BASE_SHA: ${{ steps.last_sync.outputs.base_sha }}
-          SYNCED_SLUGS: ${{ steps.sync.outputs.synced_slugs }}
         run: |
           node <<'NODE'
           const fs = require('fs');
@@ -621,8 +617,8 @@ jobs:
 
           const baseSha = process.env.BASE_SHA || 'HEAD~1';
           const syncedSlugs = new Set(
-            (process.env.SYNCED_SLUGS || '')
-              .split(',')
+            fs.readFileSync('synced-slugs.txt', 'utf8')
+              .split(/\r?\n/)
               .map((slug) => slug.trim())
               .filter(Boolean),
           );
@@ -757,7 +753,7 @@ jobs:
           done
 
       - name: Upload synced slugs artifact
-        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_slugs != ''
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
         uses: actions/upload-artifact@v6
         with:
           name: synced-slugs
@@ -770,7 +766,7 @@ jobs:
   # ============================================================
   calculate-scores:
     needs: sync
-    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != ''
+    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0'
     runs-on: self-hosted
     timeout-minutes: 120
     steps:
@@ -791,13 +787,19 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
+      - name: Download synced slug plan
+        uses: actions/download-artifact@v7
+        with:
+          name: synced-slugs
+          path: ./score-plan
+
       - name: Calculate quality scores for synced skills
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
         run: |
           echo "🎯 Calculating quality scores (per-slug with retry)"
+          SYNCED_SLUGS=$(paste -sd, ./score-plan/synced-slugs.txt)
 
           # Delegate to the per-slug wrapper so a single breakdown update
           # failure (e.g. transient Supabase TimeoutError) is logged and
@@ -836,25 +838,75 @@ jobs:
           fi
 
   # ============================================================
-  # CACHE INVALIDATION JOB
-  # Invalidates API and page cache for synced skills
+  # CACHE INVALIDATION PLAN
+  # Builds an id-only matrix from the synced-slugs artifact. Slug payloads
+  # stay in the artifact and never enter job outputs or matrix entries.
   # ============================================================
-  cache-invalidate:
-    needs: [sync, calculate-scores]
-    if: needs.sync.outputs.skip_sync != 'true'
+  plan-cache-invalidation:
+    needs: sync
+    if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0'
+    runs-on: self-hosted
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      shard_count: ${{ steps.plan.outputs.shard_count }}
+      slug_count: ${{ steps.plan.outputs.slug_count }}
+    steps:
+      - name: Checkout cache invalidation planner
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/plan-cache-invalidation.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Download synced slug artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: synced-slugs
+          path: ./cache-invalidation-plan
+
+      - name: Plan bounded cache invalidation shards
+        id: plan
+        run: node ./scripts/plan-cache-invalidation.mjs plan --slugs-file ./cache-invalidation-plan/synced-slugs.txt --shard-size 100 --max-shards 256
+
+  # ============================================================
+  # CACHE INVALIDATION SHARDS
+  # Every child has an independent 25-minute budget and reads at most 100
+  # slugs from the artifact. max-parallel protects the production endpoint.
+  # ============================================================
+  cache-invalidate-shard:
+    needs: [sync, calculate-scores, plan-cache-invalidation]
+    if: needs.sync.outputs.skip_sync != 'true' && needs.plan-cache-invalidation.outputs.shard_count != '0'
     runs-on: self-hosted
     timeout-minutes: 25
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan-cache-invalidation.outputs.matrix) }}
     steps:
-      - name: Checkout cache invalidator
+      - name: Checkout cache invalidation scripts
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          sparse-checkout: scripts/invalidate-cache.sh
+          sparse-checkout: |
+            scripts/invalidate-cache.sh
+            scripts/plan-cache-invalidation.mjs
           sparse-checkout-cone-mode: false
 
-      - name: Invalidate cache for synced skills
+      - name: Download synced slug artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: synced-slugs
+          path: ./cache-invalidation-plan
+
+      - name: Extract bounded shard ${{ matrix.shard }}
+        run: node ./scripts/plan-cache-invalidation.mjs extract --slugs-file ./cache-invalidation-plan/synced-slugs.txt --shard-size 100 --shard-id "${{ matrix.shard }}" --output "$RUNNER_TEMP/cache-invalidation-shard.txt"
+
+      - name: Invalidate cache for shard ${{ matrix.shard }}
         id: invalidate
         env:
           BATCH_SIZE: '10'
@@ -865,19 +917,50 @@ jobs:
           MAX_ITEMS: '100'
           RETRY_BASE_SECONDS: '5'
           SITE_URL: https://skillstore.io
-          SLUGS_STR: ${{ needs.sync.outputs.synced_slugs }}
+          SLUGS_FILE: ${{ runner.temp }}/cache-invalidation-shard.txt
         run: ./scripts/invalidate-cache.sh
 
-      - name: Report cache invalidation failure
+      - name: Report shard failure
         if: failure() && steps.invalidate.outcome == 'failure'
+        run: echo "::error::Cache invalidation shard ${{ matrix.shard }} failed"
+
+  # ============================================================
+  # CACHE INVALIDATION AGGREGATE
+  # Always evaluates the matrix result. Any failed/cancelled/skipped child
+  # keeps this job non-success and blocks all downstream cache consumers.
+  # ============================================================
+  cache-invalidate:
+    needs: [sync, calculate-scores, plan-cache-invalidation, cache-invalidate-shard]
+    if: always() && needs.sync.result == 'success' && needs.sync.outputs.skip_sync != 'true'
+    runs-on: self-hosted
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout cache invalidation aggregate guard
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/check-cache-invalidation-aggregate.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Require every cache invalidation shard to succeed
+        env:
+          CACHE_PLAN_RESULT: ${{ needs.plan-cache-invalidation.result }}
+          CACHE_SHARD_RESULT: ${{ needs.cache-invalidate-shard.result }}
+          SCORE_RESULT: ${{ needs.calculate-scores.result }}
+        run: ./scripts/check-cache-invalidation-aggregate.sh
+
+      - name: Report cache invalidation failure
+        if: failure()
         run: |
-          echo "::error::Cache invalidation failed; cache warming is blocked"
+          echo "::error::Cache invalidation failed; cache warming is blocked; translation is blocked"
           cat << EOF >> "$GITHUB_STEP_SUMMARY"
           ## ❌ Cache invalidation failed
 
-          Skill data was synced, but the long-lived production detail cache was not invalidated. Detail API entries can live for **365 days**, so cache warming must not continue with stale data.
+          Skill data was synced, but at least one bounded cache invalidation shard did not succeed. Detail API entries can live for **365 days**, so downstream cache finalization and translation remain blocked.
 
-          **Action required**: fix the invalidation error, rerun cache invalidation for the synced slugs, then rerun the scoped warm workflow.
+          **Action required**: fix the failed shard, rerun cache invalidation for the synced artifact, then rerun the scoped warm workflow.
           EOF
 
   # ============================================================
@@ -957,10 +1040,16 @@ jobs:
   # ============================================================
   trigger-translate:
     needs: [sync, cache-invalidate, finalize-english-cache]
-    if: always() && needs.sync.result == 'success' && needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_slugs != '' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
+    if: always() && needs.sync.result == 'success' && needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      - name: Download synced slug plan
+        uses: actions/download-artifact@v7
+        with:
+          name: synced-slugs
+          path: ./translation-plan
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -971,16 +1060,17 @@ jobs:
       - name: Trigger translation workflow
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
+          SYNCED_SKILL_COUNT: ${{ needs.sync.outputs.synced_skill_count }}
           ENGLISH_CACHE_FINALIZER_RESULT: ${{ needs.finalize-english-cache.result }}
         run: |
-          SLUG_COUNT=$(echo "$SYNCED_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
+          SLUG_COUNT="$SYNCED_SKILL_COUNT"
           THRESHOLD=500
 
           echo "🌍 Triggering translation for $SLUG_COUNT synced skills"
 
           if [ "$SLUG_COUNT" -le "$THRESHOLD" ]; then
             # Small batch: pass slugs directly in payload
+            SYNCED_SLUGS=$(paste -sd, ./translation-plan/synced-slugs.txt)
             echo "   Mode: direct (≤$THRESHOLD slugs)"
             gh api repos/${{ github.repository }}/dispatches \
               --method POST \

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -845,45 +845,35 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      - name: Checkout cache invalidator
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/invalidate-cache.sh
+          sparse-checkout-cone-mode: false
+
       - name: Invalidate cache for synced skills
         id: invalidate
         env:
-          SYNCED_SLUGS: ${{ needs.sync.outputs.synced_slugs }}
+          BATCH_SIZE: '10'
+          CACHE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          CONTENT_TYPE: skills
+          CURL_MAX_TIME: '30'
+          MAX_ATTEMPTS: '3'
           SITE_URL: https://skillstore.io
-          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SLUGS_STR: ${{ needs.sync.outputs.synced_slugs }}
+        run: ./scripts/invalidate-cache.sh
+
+      - name: Report cache invalidation failure
+        if: failure() && steps.invalidate.outcome == 'failure'
         run: |
-          if [ -z "$SYNCED_SLUGS" ]; then
-            echo "No slugs to invalidate"
-            exit 0
-          fi
-
-          SLUGS_JSON=$(echo "$SYNCED_SLUGS" | tr ',' '\n' | jq -R . | jq -s .)
-
-          echo "Invalidating cache for: $SYNCED_SLUGS"
-
-          set +e
-          RESPONSE=$(curl -sf -X POST "$SITE_URL/api/cache/invalidate" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $CACHE_INVALIDATE_SECRET" \
-            -d "{\"type\": \"skills\", \"slugs\": $SLUGS_JSON, \"invalidateApi\": true}" \
-            --max-time 30 2>&1)
-          EXIT_CODE=$?
-          set -e
-
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "::error::Cache invalidation failed; cache warming is blocked"
-            echo "Response: $RESPONSE"
-            cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Cache invalidation failed; cache warming is blocked"
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
           ## ❌ Cache invalidation failed
 
           Skill data was synced, but the long-lived production detail cache was not invalidated. Detail API entries can live for **365 days**, so cache warming must not continue with stale data.
 
           **Action required**: fix the invalidation error, rerun cache invalidation for the synced slugs, then rerun the scoped warm workflow.
           EOF
-            exit "$EXIT_CODE"
-          fi
-
-          echo "✅ Cache invalidated: $RESPONSE"
 
   # ============================================================
   # ENGLISH CACHE FINALIZER

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "scripts/invalidate-cache.sh"
       - "scripts/recalculate-scores.sh"
       - "scripts/tests/**"
+      - ".github/workflows/sync-to-supabase.yml"
       - ".github/workflows/test-recalculate-scores.yml"
   push:
     branches: [main]
     paths:
+      - "scripts/invalidate-cache.sh"
       - "scripts/recalculate-scores.sh"
       - "scripts/tests/**"
+      - ".github/workflows/sync-to-supabase.yml"
   workflow_dispatch:
 
 permissions:
@@ -24,16 +28,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
 
-      - name: Run wrapper unit tests
+      - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/invalidate-cache.sh scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
           bash -n scripts/tests/fake-cli.sh
-          node --test scripts/tests/recalculate-scores.test.mjs
+          node --test scripts/tests/*.test.mjs

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/invalidate-cache.sh"
+      - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
@@ -12,7 +14,9 @@ on:
   push:
     branches: [main]
     paths:
+      - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/invalidate-cache.sh"
+      - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
@@ -39,8 +43,10 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/invalidate-cache.sh scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
           bash -n scripts/tests/fake-cli.sh
+          node --check scripts/plan-cache-invalidation.mjs
           node --test scripts/tests/*.test.mjs

--- a/scripts/check-cache-invalidation-aggregate.sh
+++ b/scripts/check-cache-invalidation-aggregate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CACHE_PLAN_RESULT="${CACHE_PLAN_RESULT:-}"
+CACHE_SHARD_RESULT="${CACHE_SHARD_RESULT:-}"
+SCORE_RESULT="${SCORE_RESULT:-}"
+
+if [ "$CACHE_PLAN_RESULT" = "success" ] &&
+  [ "$CACHE_SHARD_RESULT" = "success" ] &&
+  [ "$SCORE_RESULT" = "success" ]; then
+  echo "Cache invalidation aggregate succeeded"
+  exit 0
+fi
+
+echo "::error::Cache invalidation did not complete successfully (plan=$CACHE_PLAN_RESULT, shards=$CACHE_SHARD_RESULT, scores=$SCORE_RESULT)" >&2
+exit 1

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_BATCH_SIZE=30
+BATCH_SIZE="${BATCH_SIZE:-10}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+RETRY_BASE_SECONDS="${RETRY_BASE_SECONDS:-5}"
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
+CONTENT_TYPE="${CONTENT_TYPE:-}"
+SLUGS_STR="${SLUGS_STR:-}"
+SLUGS_FILE="${SLUGS_FILE:-}"
+SITE_URL="${SITE_URL:-}"
+CACHE_SECRET="${CACHE_SECRET:-}"
+
+if ! WORK_DIR="$(mktemp -d)"; then
+  echo "::error::Failed to create temporary workspace" >&2
+  exit 1
+fi
+ITEMS_FILE="$WORK_DIR/items"
+trap 'rm -rf "$WORK_DIR"' EXIT
+: > "$ITEMS_FILE"
+
+write_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+write_counts() {
+  write_output total_count "$1"
+  write_output success_count "$2"
+  write_output failed_count "$3"
+}
+
+normalize_items() {
+  tr ',[:space:]' '\n' | sed '/^$/d'
+}
+
+if [ -n "$SLUGS_FILE" ]; then
+  if [ ! -f "$SLUGS_FILE" ]; then
+    echo "::error::slugs-file does not exist: $SLUGS_FILE" >&2
+    exit 1
+  fi
+  normalize_items < "$SLUGS_FILE" >> "$ITEMS_FILE"
+fi
+
+if [ -n "$SLUGS_STR" ]; then
+  printf '%s\n' "$SLUGS_STR" | normalize_items >> "$ITEMS_FILE"
+fi
+
+SLUGS=()
+while IFS= read -r slug; do
+  SLUGS+=("$slug")
+done < "$ITEMS_FILE"
+
+TOTAL=${#SLUGS[@]}
+if [ "$TOTAL" -eq 0 ]; then
+  write_counts 0 0 0
+  echo "No items to invalidate"
+  exit 0
+fi
+
+case "$CONTENT_TYPE" in
+  skills|packs|plugins|releases) ;;
+  *)
+    echo "::error::Unsupported cache content type: $CONTENT_TYPE" >&2
+    exit 1
+    ;;
+esac
+
+if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] ||
+  [ "$BATCH_SIZE" -lt 1 ] ||
+  [ "$BATCH_SIZE" -gt "$MAX_BATCH_SIZE" ]; then
+  echo "::error::batch-size must be between 1 and $MAX_BATCH_SIZE" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
+  [ "$MAX_ATTEMPTS" -lt 1 ] ||
+  [ "$MAX_ATTEMPTS" -gt 10 ]; then
+  echo "::error::MAX_ATTEMPTS must be between 1 and 10" >&2
+  exit 1
+fi
+
+if ! [[ "$RETRY_BASE_SECONDS" =~ ^[0-9]+$ ]] ||
+  [ "$RETRY_BASE_SECONDS" -gt 300 ]; then
+  echo "::error::RETRY_BASE_SECONDS must be between 0 and 300" >&2
+  exit 1
+fi
+
+if ! [[ "$CURL_CONNECT_TIMEOUT" =~ ^[0-9]+$ ]] ||
+  [ "$CURL_CONNECT_TIMEOUT" -lt 1 ] ||
+  ! [[ "$CURL_MAX_TIME" =~ ^[0-9]+$ ]] ||
+  [ "$CURL_MAX_TIME" -lt 1 ]; then
+  echo "::error::curl timeouts must be positive integers" >&2
+  exit 1
+fi
+
+if [ -z "$SITE_URL" ]; then
+  echo "::error::Site URL is empty" >&2
+  exit 1
+fi
+
+if [ -z "$CACHE_SECRET" ]; then
+  echo "::error::Cache invalidation secret is empty" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required for cache invalidation" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "::error::curl is required for cache invalidation" >&2
+  exit 1
+fi
+
+request_batch_once() {
+  local body_file="$1"
+  local response_file="$2"
+  local status
+  local curl_exit
+
+  if status=$(curl -sS -o "$response_file" -w "%{http_code}" \
+      --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+      --max-time "$CURL_MAX_TIME" \
+      -X POST "$SITE_URL/api/cache/invalidate" \
+      -H "Authorization: Bearer $CACHE_SECRET" \
+      -H "Content-Type: application/json" \
+      -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+      -H "X-Skillstore-Callback: true" \
+      --data-binary @"$body_file"); then
+    curl_exit=0
+  else
+    curl_exit=$?
+  fi
+
+  if [ "$curl_exit" -ne 0 ]; then
+    case "$curl_exit" in
+      5|6|7|16|18|28|35|52|55|56|92)
+        echo "    Transient curl transport failure (exit $curl_exit)" >&2
+        return 75
+        ;;
+      *)
+        echo "    Non-transient curl failure (exit $curl_exit)" >&2
+        return 1
+        ;;
+    esac
+  fi
+
+  case "$status" in
+    2[0-9][0-9])
+      return 0
+      ;;
+    408|429|5[0-9][0-9])
+      echo "    Transient HTTP $status" >&2
+      return 75
+      ;;
+    [0-9][0-9][0-9])
+      echo "    Non-transient HTTP $status" >&2
+      return 1
+      ;;
+    *)
+      echo "    Invalid HTTP status '$status'" >&2
+      return 1
+      ;;
+  esac
+}
+
+invalidate_batch() {
+  local body_file="$1"
+  local batch_number="$2"
+  local attempt
+  local delay
+  local request_status
+  local response_file="$WORK_DIR/response-$batch_number"
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    : > "$response_file"
+    if request_batch_once "$body_file" "$response_file"; then
+      request_status=0
+    else
+      request_status=$?
+    fi
+
+    if [ "$request_status" -eq 0 ]; then
+      return 0
+    fi
+
+    if [ "$request_status" -ne 75 ]; then
+      return 1
+    fi
+
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+      delay=$((attempt * RETRY_BASE_SECONDS))
+      echo "    Attempt $attempt/$MAX_ATTEMPTS failed; retrying in ${delay}s" >&2
+      sleep "$delay"
+    fi
+  done
+
+  echo "    Retry budget exhausted after $MAX_ATTEMPTS attempts" >&2
+  return 1
+}
+
+write_output total_count "$TOTAL"
+BATCHES=$(((TOTAL + BATCH_SIZE - 1) / BATCH_SIZE))
+SUCCESS=0
+
+echo "Invalidating $TOTAL $CONTENT_TYPE item(s) in $BATCHES batch(es)"
+
+for ((offset = 0; offset < TOTAL; offset += BATCH_SIZE)); do
+  BATCH=("${SLUGS[@]:offset:BATCH_SIZE}")
+  BATCH_NUMBER=$((offset / BATCH_SIZE + 1))
+  BODY_FILE="$WORK_DIR/body-$BATCH_NUMBER.json"
+
+  if ! printf '%s\n' "${BATCH[@]}" |
+    jq -Rsc --arg type "$CONTENT_TYPE" \
+      '{type: $type, slugs: (split("\n") | map(select(length > 0))), invalidateApi: true}' \
+      > "$BODY_FILE"; then
+    echo "::error::Failed to construct cache invalidation JSON" >&2
+    write_counts "$TOTAL" "$SUCCESS" "$((TOTAL - SUCCESS))"
+    exit 1
+  fi
+
+  echo "  Batch $BATCH_NUMBER/$BATCHES (${#BATCH[@]} items)"
+  if ! invalidate_batch "$BODY_FILE" "$BATCH_NUMBER"; then
+    write_counts "$TOTAL" "$SUCCESS" "$((TOTAL - SUCCESS))"
+    echo "::error::Cache invalidation batch $BATCH_NUMBER/$BATCHES failed" >&2
+    exit 1
+  fi
+
+  SUCCESS=$((SUCCESS + ${#BATCH[@]}))
+done
+
+write_counts "$TOTAL" "$SUCCESS" 0
+echo "Cache invalidation complete: $SUCCESS item(s)"

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 MAX_BATCH_SIZE=30
 BATCH_SIZE="${BATCH_SIZE:-10}"
+MAX_ITEMS="${MAX_ITEMS:-100}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 RETRY_BASE_SECONDS="${RETRY_BASE_SECONDS:-5}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
@@ -56,6 +57,17 @@ while IFS= read -r slug; do
 done < "$ITEMS_FILE"
 
 TOTAL=${#SLUGS[@]}
+if ! [[ "$MAX_ITEMS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::MAX_ITEMS must be a positive integer" >&2
+  exit 1
+fi
+
+if [ "${#TOTAL}" -gt "${#MAX_ITEMS}" ] ||
+  { [ "${#TOTAL}" -eq "${#MAX_ITEMS}" ] && [[ "$TOTAL" > "$MAX_ITEMS" ]]; }; then
+  echo "::error::item count $TOTAL exceeds MAX_ITEMS $MAX_ITEMS" >&2
+  exit 1
+fi
+
 if [ "$TOTAL" -eq 0 ]; then
   write_counts 0 0 0
   echo "No items to invalidate"
@@ -138,19 +150,6 @@ request_batch_once() {
     curl_exit=$?
   fi
 
-  if [ "$curl_exit" -ne 0 ]; then
-    case "$curl_exit" in
-      5|6|7|16|18|28|35|52|55|56|92)
-        echo "    Transient curl transport failure (exit $curl_exit)" >&2
-        return 75
-        ;;
-      *)
-        echo "    Non-transient curl failure (exit $curl_exit)" >&2
-        return 1
-        ;;
-    esac
-  fi
-
   case "$status" in
     2[0-9][0-9])
       return 0
@@ -158,6 +157,23 @@ request_batch_once() {
     408|429|5[0-9][0-9])
       echo "    Transient HTTP $status" >&2
       return 75
+      ;;
+    ''|000)
+      if [ "$curl_exit" -ne 0 ]; then
+        case "$curl_exit" in
+          5|6|7|16|18|28|35|52|55|56|92)
+            echo "    Transient curl transport failure (exit $curl_exit)" >&2
+            return 75
+            ;;
+          *)
+            echo "    Non-transient curl failure (exit $curl_exit)" >&2
+            return 1
+            ;;
+        esac
+      fi
+
+      echo "    Invalid HTTP status '$status'" >&2
+      return 1
       ;;
     [0-9][0-9][0-9])
       echo "    Non-transient HTTP $status" >&2

--- a/scripts/plan-cache-invalidation.mjs
+++ b/scripts/plan-cache-invalidation.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+function parsePositiveInteger(value, name, maximum) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  if (maximum !== undefined && parsed > maximum) {
+    throw new Error(`${name} must be between 1 and ${maximum}`);
+  }
+  return parsed;
+}
+
+export function normalizeSlugs(input) {
+  const values = Array.isArray(input)
+    ? input
+    : String(input ?? '').split(/[\s,]+/);
+
+  return [...new Set(values.map((slug) => String(slug).trim()).filter(Boolean))].sort();
+}
+
+export function extractShard(input, shardId, shardSize) {
+  const normalized = normalizeSlugs(input);
+  const parsedShardId = Number(shardId);
+  const parsedShardSize = parsePositiveInteger(shardSize, 'shard-size', 100);
+
+  if (!Number.isSafeInteger(parsedShardId) || parsedShardId < 0) {
+    throw new Error('shard-id must be a non-negative integer');
+  }
+
+  const start = parsedShardId * parsedShardSize;
+  const shard = normalized.slice(start, start + parsedShardSize);
+  if (shard.length === 0) {
+    throw new Error(`shard ${parsedShardId} is outside the artifact plan`);
+  }
+  return shard;
+}
+
+export function buildShardPlan(input, { shardSize = 100, maxShards = 256 } = {}) {
+  const parsedShardSize = parsePositiveInteger(shardSize, 'shard-size', 100);
+  const parsedMaxShards = parsePositiveInteger(maxShards, 'max-shards', 256);
+  const slugs = normalizeSlugs(input);
+  const shardCount = Math.ceil(slugs.length / parsedShardSize);
+
+  if (shardCount > parsedMaxShards) {
+    throw new Error(
+      `cache invalidation requires ${shardCount} shards, exceeding matrix limit ${parsedMaxShards}`,
+    );
+  }
+
+  const shards = Array.from({ length: shardCount }, (_, shard) =>
+    extractShard(slugs, shard, parsedShardSize));
+  const matrix = {
+    include: Array.from({ length: shardCount }, (_, shard) => ({ shard })),
+  };
+
+  return {
+    matrix,
+    shardCount,
+    shardSize: parsedShardSize,
+    shards,
+    slugCount: slugs.length,
+    slugs,
+  };
+}
+
+function readOption(args, name, { required = false, fallback } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) throw new Error(`missing required option ${name}`);
+    return fallback;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) {
+    throw new Error(`missing value for ${name}`);
+  }
+  return args[index + 1];
+}
+
+function readArtifact(path) {
+  return normalizeSlugs(readFileSync(path, 'utf8'));
+}
+
+function appendOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    throw new Error('GITHUB_OUTPUT is required for plan mode');
+  }
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+function runPlan(args) {
+  const slugsFile = readOption(args, '--slugs-file', { required: true });
+  const shardSize = parsePositiveInteger(
+    readOption(args, '--shard-size', { fallback: '100' }),
+    'shard-size',
+    100,
+  );
+  const maxShards = parsePositiveInteger(
+    readOption(args, '--max-shards', { fallback: '256' }),
+    'max-shards',
+    256,
+  );
+  const plan = buildShardPlan(readArtifact(slugsFile), { shardSize, maxShards });
+
+  appendOutput('matrix', JSON.stringify(plan.matrix));
+  appendOutput('shard_count', plan.shardCount);
+  appendOutput('slug_count', plan.slugCount);
+  console.log(
+    `Cache invalidation plan: ${plan.slugCount} slug(s), ${plan.shardCount} bounded shard(s)`,
+  );
+}
+
+function runExtract(args) {
+  const slugsFile = readOption(args, '--slugs-file', { required: true });
+  const output = readOption(args, '--output', { required: true });
+  const shardSize = parsePositiveInteger(
+    readOption(args, '--shard-size', { fallback: '100' }),
+    'shard-size',
+    100,
+  );
+  const shardId = readOption(args, '--shard-id', { required: true });
+  const shard = extractShard(readArtifact(slugsFile), shardId, shardSize);
+
+  writeFileSync(output, `${shard.join('\n')}\n`, { mode: 0o600 });
+  console.log(`Materialized cache invalidation shard ${shardId} (${shard.length} slug(s))`);
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  switch (command) {
+    case 'plan':
+      runPlan(args);
+      break;
+    case 'extract':
+      runExtract(args);
+      break;
+    default:
+      throw new Error('usage: plan-cache-invalidation.mjs <plan|extract> [options]');
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/cache-invalidation-plan.test.mjs
+++ b/scripts/tests/cache-invalidation-plan.test.mjs
@@ -1,0 +1,175 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildShardPlan,
+  extractShard,
+} from '../plan-cache-invalidation.mjs';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const PLANNER = join(REPO_ROOT, 'scripts', 'plan-cache-invalidation.mjs');
+
+function makeSlugs(count) {
+  return Array.from(
+    { length: count },
+    (_, index) => `skill-${String(index).padStart(5, '0')}`,
+  );
+}
+
+function parseOutputs(path) {
+  const outputs = {};
+  for (const line of readFileSync(path, 'utf8').trim().split('\n').filter(Boolean)) {
+    const separator = line.indexOf('=');
+    assert.notEqual(separator, -1, `Invalid GITHUB_OUTPUT line: ${line}`);
+    outputs[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return outputs;
+}
+
+test('planner maps 1, 100, 101, and 5263 slugs to bounded shards', () => {
+  for (const [slugCount, expectedShardCount] of [
+    [1, 1],
+    [100, 1],
+    [101, 2],
+    [5263, 53],
+  ]) {
+    const plan = buildShardPlan(makeSlugs(slugCount), {
+      shardSize: 100,
+      maxShards: 256,
+    });
+
+    assert.equal(plan.slugCount, slugCount);
+    assert.equal(plan.shardCount, expectedShardCount);
+    assert.equal(plan.matrix.include.length, expectedShardCount);
+    assert.ok(plan.shards.every((shard) => shard.length >= 1 && shard.length <= 100));
+    assert.ok(
+      plan.matrix.include.every(
+        (entry, shard) => Object.keys(entry).length === 1 && entry.shard === shard,
+      ),
+      'matrix entries must contain only the shard id',
+    );
+  }
+});
+
+test('planner and extractor are deterministic and exactly-once across the artifact', () => {
+  const expected = makeSlugs(5263);
+  const artifactOrder = [...expected].reverse();
+  artifactOrder.splice(200, 0, expected[100], expected[300]);
+
+  const first = buildShardPlan(artifactOrder, { shardSize: 100, maxShards: 256 });
+  const second = buildShardPlan([...artifactOrder].reverse(), {
+    shardSize: 100,
+    maxShards: 256,
+  });
+
+  assert.deepEqual(first.matrix, second.matrix);
+  assert.deepEqual(first.slugs, expected);
+  assert.deepEqual(second.slugs, expected);
+
+  const extracted = first.matrix.include.flatMap(({ shard }) =>
+    extractShard(first.slugs, shard, 100));
+  assert.deepEqual(extracted, expected);
+  assert.equal(new Set(extracted).size, expected.length);
+  assert.ok(first.shards.every((shard) => shard.length >= 1 && shard.length <= 100));
+});
+
+test('empty artifact is a successful no-op', () => {
+  const plan = buildShardPlan([], { shardSize: 100, maxShards: 256 });
+
+  assert.equal(plan.slugCount, 0);
+  assert.equal(plan.shardCount, 0);
+  assert.deepEqual(plan.slugs, []);
+  assert.deepEqual(plan.shards, []);
+  assert.deepEqual(plan.matrix, { include: [] });
+});
+
+test('planner enforces 100 slugs per shard and the GitHub 256-job matrix limit', () => {
+  const boundary = buildShardPlan(makeSlugs(25_600), {
+    shardSize: 100,
+    maxShards: 256,
+  });
+  assert.equal(boundary.shardCount, 256);
+
+  assert.throws(
+    () => buildShardPlan(makeSlugs(25_601), { shardSize: 100, maxShards: 256 }),
+    /requires 257 shards, exceeding matrix limit 256/,
+  );
+  assert.throws(
+    () => buildShardPlan(makeSlugs(101), { shardSize: 101, maxShards: 256 }),
+    /shard-size must be between 1 and 100/,
+  );
+  assert.throws(
+    () => buildShardPlan(makeSlugs(1), { shardSize: 100, maxShards: 257 }),
+    /max-shards must be between 1 and 256/,
+  );
+});
+
+test('plan CLI writes only shard ids and counts to GITHUB_OUTPUT', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'cache-plan-test-'));
+  const slugsFile = join(tmp, 'synced-slugs.txt');
+  const githubOutput = join(tmp, 'github-output');
+  const secretSlug = 'private-slug-must-stay-in-artifact';
+  writeFileSync(slugsFile, `${secretSlug}\n${makeSlugs(100).join('\n')}\n`);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      PLANNER,
+      'plan',
+      '--slugs-file',
+      slugsFile,
+      '--shard-size',
+      '100',
+      '--max-shards',
+      '256',
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_OUTPUT: githubOutput },
+    },
+  );
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  const outputs = parseOutputs(githubOutput);
+  assert.equal(outputs.slug_count, '101');
+  assert.equal(outputs.shard_count, '2');
+  assert.deepEqual(JSON.parse(outputs.matrix), {
+    include: [{ shard: 0 }, { shard: 1 }],
+  });
+  assert.doesNotMatch(readFileSync(githubOutput, 'utf8'), new RegExp(secretSlug));
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(secretSlug));
+});
+
+test('extract CLI materializes only the selected bounded shard from the artifact', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'cache-extract-test-'));
+  const slugsFile = join(tmp, 'synced-slugs.txt');
+  const outputFile = join(tmp, 'shard.txt');
+  const slugs = makeSlugs(101).reverse();
+  writeFileSync(slugsFile, `${slugs.join('\n')}\n`);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      PLANNER,
+      'extract',
+      '--slugs-file',
+      slugsFile,
+      '--shard-size',
+      '100',
+      '--shard-id',
+      '1',
+      '--output',
+      outputFile,
+    ],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.deepEqual(readFileSync(outputFile, 'utf8').trim().split('\n'), ['skill-00100']);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /skill-00100/);
+});

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -1,0 +1,129 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildShardPlan } from '../plan-cache-invalidation.mjs';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
+const TEST_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'test-recalculate-scores.yml');
+const AGGREGATE = join(REPO_ROOT, 'scripts', 'check-cache-invalidation-aggregate.sh');
+
+function section(workflow, start, end) {
+  const startIndex = workflow.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing section: ${start}`);
+  const endIndex = end ? workflow.indexOf(end, startIndex + start.length) : workflow.length;
+  assert.notEqual(endIndex, -1, `missing section boundary: ${end}`);
+  return workflow.slice(startIndex, endIndex);
+}
+
+function runAggregate({ plan = 'success', shards = 'success', scores = 'success' } = {}) {
+  return spawnSync('/bin/bash', [AGGREGATE], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CACHE_PLAN_RESULT: plan,
+      CACHE_SHARD_RESULT: shards,
+      SCORE_RESULT: scores,
+    },
+  });
+}
+
+test('workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const planJob = section(workflow, '  plan-cache-invalidation:', '  cache-invalidate-shard:');
+  const shardJob = section(workflow, '  cache-invalidate-shard:', '  cache-invalidate:');
+
+  assert.match(planJob, /name: synced-slugs/);
+  assert.match(planJob, /run: node \.\/scripts\/plan-cache-invalidation\.mjs plan/);
+  assert.match(planJob, /matrix: \$\{\{ steps\.plan\.outputs\.matrix \}\}/);
+  assert.doesNotMatch(planJob, /synced_slugs.*GITHUB_OUTPUT|slugs.*GITHUB_OUTPUT/i);
+
+  assert.match(shardJob, /matrix: \$\{\{ fromJSON\(needs\.plan-cache-invalidation\.outputs\.matrix\) \}\}/);
+  assert.match(shardJob, /max-parallel: 3/);
+  assert.match(shardJob, /fail-fast: false/);
+  assert.doesNotMatch(shardJob, /continue-on-error:/);
+  assert.match(shardJob, /timeout-minutes: 25/);
+  assert.match(shardJob, /name: synced-slugs/);
+  assert.match(shardJob, /--shard-id "\$\{\{ matrix\.shard \}\}"/);
+  assert.match(shardJob, /SLUGS_FILE: .*cache-invalidation-shard\.txt/);
+  assert.match(shardJob, /MAX_ITEMS: ['"]100['"]/);
+  assert.doesNotMatch(shardJob, /needs\.sync\.outputs\.synced_slugs/);
+});
+
+test('workflow full_sync inputs above 100 use the configured bounded matrix', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const detectJob = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+  const planJob = section(workflow, '  plan-cache-invalidation:', '  cache-invalidate-shard:');
+  const shardJob = section(workflow, '  cache-invalidate-shard:', '  cache-invalidate:');
+  const shardSize = Number(planJob.match(/--shard-size (\d+)/)?.[1]);
+  const maxShards = Number(planJob.match(/--max-shards (\d+)/)?.[1]);
+
+  assert.match(detectJob, /inputs\.full_sync.*true[\s\S]*CHANGED=\$\(find_all_skills/s);
+  assert.equal(shardSize, 100);
+  assert.equal(maxShards, 256);
+  assert.match(shardJob, /max-parallel: 3/);
+
+  for (const [slugCount, expectedShards] of [[101, 2], [5263, 53]]) {
+    const plan = buildShardPlan(
+      Array.from({ length: slugCount }, (_, index) => `full-sync-${index}`),
+      { shardSize, maxShards },
+    );
+    assert.equal(plan.shardCount, expectedShards);
+    assert.ok(plan.shards.every((shard) => shard.length >= 1 && shard.length <= 100));
+  }
+});
+
+test('workflow treats an empty sync as a no-op before planning or invalidation', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const planJob = section(workflow, '  plan-cache-invalidation:', '  cache-invalidate-shard:');
+  const aggregateJob = section(workflow, '  cache-invalidate:', '  # ENGLISH CACHE FINALIZER');
+
+  assert.match(planJob, /if: needs\.sync\.outputs\.skip_sync != 'true'/);
+  assert.match(aggregateJob, /needs\.sync\.outputs\.skip_sync != 'true'/);
+  assert.match(workflow, /No skills to sync[\s\S]*skip_sync=true/);
+});
+
+test('one permanently failed shard makes the aggregate fail closed', () => {
+  const success = runAggregate();
+  assert.equal(success.status, 0, success.stderr);
+
+  for (const failedResult of ['failure', 'cancelled', 'skipped']) {
+    const failed = runAggregate({ shards: failedResult });
+    assert.notEqual(failed.status, 0, `matrix result ${failedResult} must fail closed`);
+    assert.match(failed.stderr, /Cache invalidation did not complete successfully/);
+  }
+});
+
+test('CI tracks and executes the planner, aggregate guard, and full script suite', () => {
+  const workflow = readFileSync(TEST_WORKFLOW, 'utf8');
+
+  assert.match(workflow, /scripts\/plan-cache-invalidation\.mjs/);
+  assert.match(workflow, /scripts\/check-cache-invalidation-aggregate\.sh/);
+  assert.match(workflow, /node --check scripts\/plan-cache-invalidation\.mjs/);
+  assert.match(workflow, /bash -n scripts\/check-cache-invalidation-aggregate\.sh/);
+  assert.match(workflow, /node --test scripts\/tests\/\*\.test\.mjs/);
+});
+
+test('downstream finalizer and translation require aggregate success', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const aggregateJob = section(workflow, '  cache-invalidate:', '  # ENGLISH CACHE FINALIZER');
+  const finalizerJob = section(workflow, '  finalize-english-cache:', '  # TRIGGER TRANSLATION');
+  const triggerJob = section(workflow, '  trigger-translate:');
+
+  assert.match(aggregateJob, /if: always\(\)/);
+  assert.match(aggregateJob, /CACHE_SHARD_RESULT: \$\{\{ needs\.cache-invalidate-shard\.result \}\}/);
+  assert.match(aggregateJob, /run: \.\/scripts\/check-cache-invalidation-aggregate\.sh/);
+  assert.doesNotMatch(aggregateJob, /continue-on-error:/);
+
+  assert.match(finalizerJob, /needs: \[sync, calculate-scores, cache-invalidate\]/);
+  assert.match(finalizerJob, /needs\.cache-invalidate\.result == 'success'/);
+  assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
+  assert.match(
+    triggerJob,
+    /needs\.sync\.result == 'success' && needs\.cache-invalidate\.result == 'success'/,
+  );
+});

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -57,6 +57,7 @@ test('workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3',
 test('workflow full_sync inputs above 100 use the configured bounded matrix', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const detectJob = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+  const capacityGuard = section(workflow, '      - name: Validate cache matrix capacity', '      - name: Download skillstore-cli');
   const planJob = section(workflow, '  plan-cache-invalidation:', '  cache-invalidate-shard:');
   const shardJob = section(workflow, '  cache-invalidate-shard:', '  cache-invalidate:');
   const shardSize = Number(planJob.match(/--shard-size (\d+)/)?.[1]);
@@ -65,6 +66,13 @@ test('workflow full_sync inputs above 100 use the configured bounded matrix', ()
   assert.match(detectJob, /inputs\.full_sync.*true[\s\S]*CHANGED=\$\(find_all_skills/s);
   assert.equal(shardSize, 100);
   assert.equal(maxShards, 256);
+  assert.match(capacityGuard, /MAX_CACHE_ITEMS=25600/);
+  assert.match(capacityGuard, /exceeds cache matrix capacity/);
+  assert.ok(
+    workflow.indexOf('      - name: Validate cache matrix capacity')
+      < workflow.indexOf('      - name: Sync skills to Supabase'),
+    'matrix capacity must be checked before any Supabase write',
+  );
   assert.match(shardJob, /max-parallel: 3/);
 
   for (const [slugCount, expectedShards] of [[101, 2], [5263, 53]]) {

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -67,9 +67,15 @@ case "$result" in
     exit "\${result#transport:}"
     ;;
   http:*)
-    status="\${result#http:}"
+    response="\${result#http:}"
+    status="\${response%%:*}"
+    curl_exit=0
+    if [ "$response" != "$status" ]; then
+      curl_exit="\${response#*:}"
+    fi
     printf '{"ok":true}' > "$response_file"
     printf '%s' "$status"
+    exit "$curl_exit"
     ;;
   *)
     echo "unknown fake curl result: $result" >&2
@@ -88,6 +94,7 @@ function runInvalidator({
   secret = SECRET,
   batchSize = 2,
   maxAttempts = 3,
+  maxItems = 100,
   retryBaseSeconds = 1,
   results = 'http:200',
   contentType = 'skills',
@@ -119,6 +126,7 @@ function runInvalidator({
       SLUGS_FILE: slugsFile,
       BATCH_SIZE: String(batchSize),
       MAX_ATTEMPTS: String(maxAttempts),
+      MAX_ITEMS: String(maxItems),
       RETRY_BASE_SECONDS: String(retryBaseSeconds),
       CURL_CONNECT_TIMEOUT: '1',
       CURL_MAX_TIME: '2',
@@ -195,6 +203,20 @@ test('single and 96-item inputs use deterministic bounded JSON batches', () => {
   assert.deepEqual(unbounded.payloads, []);
 });
 
+test('inputs above the explicit 100-item budget fail before making an HTTP request', () => {
+  const slugs = Array.from({ length: 101 }, (_, index) => `skill-${index}`);
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: slugs.join(','),
+    batchSize: 10,
+    maxItems: 100,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(payloads, []);
+  assert.deepEqual(sleeps, []);
+  assert.match(result.stderr, /item count 101 exceeds MAX_ITEMS 100/);
+});
+
 test('temporary workspace failure fails closed before making an HTTP request', () => {
   const { result, payloads, outputs } = runInvalidator({
     slugs: 'alpha',
@@ -241,6 +263,59 @@ test('HTTP 408, 429, and 5xx responses are transient and use finite retries', ()
     assert.equal(sleeps.length, 1);
     assert.deepEqual(payloads[0], payloads[1]);
   }
+});
+
+test('HTTP 401 takes precedence over curl exit 18 and fails after one request', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha',
+    results: 'http:401:18,http:200',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(sleeps, []);
+  assert.match(result.stderr, /Non-transient HTTP 401/);
+});
+
+test('HTTP 403 takes precedence over curl exit 28 and fails after one request', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha',
+    results: 'http:403:28,http:200',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(sleeps, []);
+  assert.match(result.stderr, /Non-transient HTTP 403/);
+});
+
+test('HTTP 503 takes precedence over curl exit 18 and retries within the finite budget', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha',
+    maxAttempts: 3,
+    results: 'http:503:18,http:503:18,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.equal(payloads.length, 3);
+  assert.ok(payloads.every((payload) => JSON.stringify(payload) === JSON.stringify(payloads[0])));
+  assert.deepEqual(sleeps, ['1', '2']);
+  assert.match(result.stderr, /Transient HTTP 503/);
+  assert.doesNotMatch(result.stderr, /curl transport failure/);
+});
+
+test('status 000 with curl exit 28 uses transport retries within the finite budget', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha',
+    maxAttempts: 3,
+    results: 'http:000:28,http:000:28,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.equal(payloads.length, 3);
+  assert.ok(payloads.every((payload) => JSON.stringify(payload) === JSON.stringify(payloads[0])));
+  assert.deepEqual(sleeps, ['1', '2']);
+  assert.match(result.stderr, /Transient curl transport failure \(exit 28\)/);
 });
 
 test('non-transient curl failures fail closed without retrying', () => {
@@ -328,4 +403,61 @@ test('sync workflow uses the local bounded invalidator and preserves downstream 
     triggerJob,
     /if: always\(\) && needs\.sync\.result == 'success' && needs\.cache-invalidate\.result == 'success'/,
   );
+});
+
+test('sync cache invalidation has a fixed 10-batch budget below its job timeout', () => {
+  const workflow = readFileSync(SYNC_WORKFLOW, 'utf8');
+  const invalidationJob = workflow.slice(
+    workflow.indexOf('  cache-invalidate:'),
+    workflow.indexOf('  # ENGLISH CACHE FINALIZER'),
+  );
+  const readInteger = (name) => {
+    const match = invalidationJob.match(
+      new RegExp(`^\\s+${name}:\\s*['"]?(\\d+)['"]?\\s*$`, 'm'),
+    );
+    return match ? Number(match[1]) : undefined;
+  };
+
+  const timeoutMinutes = readInteger('timeout-minutes');
+  const settings = {
+    BATCH_SIZE: readInteger('BATCH_SIZE'),
+    MAX_ATTEMPTS: readInteger('MAX_ATTEMPTS'),
+    CURL_MAX_TIME: readInteger('CURL_MAX_TIME'),
+    RETRY_BASE_SECONDS: readInteger('RETRY_BASE_SECONDS'),
+    MAX_ITEMS: readInteger('MAX_ITEMS'),
+  };
+  const expectedSettings = {
+    BATCH_SIZE: 10,
+    MAX_ATTEMPTS: 3,
+    CURL_MAX_TIME: 30,
+    RETRY_BASE_SECONDS: 5,
+    MAX_ITEMS: 100,
+  };
+  const violations = [];
+
+  if (timeoutMinutes === undefined || timeoutMinutes < 25) {
+    violations.push(
+      `cache-invalidate timeout-minutes must be at least 25 (found ${timeoutMinutes ?? 'missing'})`,
+    );
+  }
+  for (const [name, expected] of Object.entries(expectedSettings)) {
+    if (settings[name] !== expected) {
+      violations.push(
+        `cache-invalidate must fix ${name}=${expected} (found ${settings[name] ?? 'missing'})`,
+      );
+    }
+  }
+  assert.deepEqual(violations, []);
+
+  const maxBatches = Math.ceil(settings.MAX_ITEMS / settings.BATCH_SIZE);
+  const retrySleepSeconds = settings.RETRY_BASE_SECONDS
+    * ((settings.MAX_ATTEMPTS - 1) * settings.MAX_ATTEMPTS / 2);
+  const worstSecondsPerBatch = settings.MAX_ATTEMPTS * settings.CURL_MAX_TIME
+    + retrySleepSeconds;
+  const worstCaseSeconds = maxBatches * worstSecondsPerBatch;
+
+  assert.equal(maxBatches, 10);
+  assert.equal(worstSecondsPerBatch, 105);
+  assert.equal(worstCaseSeconds, 1050);
+  assert.ok(worstCaseSeconds < timeoutMinutes * 60);
 });

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -304,6 +304,18 @@ test('HTTP 503 takes precedence over curl exit 18 and retries within the finite 
   assert.doesNotMatch(result.stderr, /curl transport failure/);
 });
 
+test('HTTP 200 takes precedence over curl exit 18 and succeeds without retrying', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha',
+    results: 'http:200:18,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(sleeps, []);
+  assert.doesNotMatch(result.stderr, /curl transport failure|retrying/);
+});
+
 test('status 000 with curl exit 28 uses transport retries within the finite budget', () => {
   const { result, payloads, sleeps } = runInvalidator({
     slugs: 'alpha',
@@ -366,11 +378,11 @@ test('an exhausted batch fails immediately without sending later batches', () =>
   assert.equal(outputs.total_count, outputs.success_count + outputs.failed_count);
 });
 
-test('sync workflow uses the local bounded invalidator and preserves downstream success gates', () => {
+test('sync workflow uses an artifact-backed bounded invalidator and preserves downstream success gates', () => {
   const workflow = readFileSync(SYNC_WORKFLOW, 'utf8');
   const invalidationJob = workflow.slice(
+    workflow.indexOf('  cache-invalidate-shard:'),
     workflow.indexOf('  cache-invalidate:'),
-    workflow.indexOf('  # ENGLISH CACHE FINALIZER'),
   );
   const finalizerJob = workflow.slice(
     workflow.indexOf('  finalize-english-cache:'),
@@ -383,19 +395,17 @@ test('sync workflow uses the local bounded invalidator and preserves downstream 
     0,
     'workflow invokes the invalidator directly, so it must be committed executable',
   );
-  assert.match(invalidationJob, /sparse-checkout: scripts\/invalidate-cache\.sh/);
-  assert.match(invalidationJob, /sparse-checkout-cone-mode: false/);
+  assert.match(invalidationJob, /scripts\/invalidate-cache\.sh/);
+  assert.match(invalidationJob, /name: synced-slugs/);
   assert.match(invalidationJob, /BATCH_SIZE: ['"]10['"]/);
   assert.match(invalidationJob, /CONTENT_TYPE: skills/);
   assert.match(invalidationJob, /CURL_MAX_TIME: ['"]30['"]/);
   assert.match(invalidationJob, /MAX_ATTEMPTS: ['"]3['"]/);
+  assert.match(invalidationJob, /MAX_ITEMS: ['"]100['"]/);
   assert.match(invalidationJob, /run: \.\/scripts\/invalidate-cache\.sh/);
   assert.doesNotMatch(invalidationJob, /uses: \.\/\.github\/actions\/invalidate-cache/);
   assert.doesNotMatch(invalidationJob, /curl .*api\/cache\/invalidate/);
-  assert.match(
-    invalidationJob,
-    /Report cache invalidation failure[\s\S]*if: failure\(\) && steps\.invalidate\.outcome == 'failure'/,
-  );
+  assert.doesNotMatch(invalidationJob, /needs\.sync\.outputs\.synced_slugs/);
   assert.match(finalizerJob, /needs: \[sync, calculate-scores, cache-invalidate\]/);
   assert.match(finalizerJob, /needs\.cache-invalidate\.result == 'success'/);
   assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
@@ -405,11 +415,11 @@ test('sync workflow uses the local bounded invalidator and preserves downstream 
   );
 });
 
-test('sync cache invalidation has a fixed 10-batch budget below its job timeout', () => {
+test('each cache invalidation shard has a fixed 10-batch budget below its own timeout', () => {
   const workflow = readFileSync(SYNC_WORKFLOW, 'utf8');
   const invalidationJob = workflow.slice(
+    workflow.indexOf('  cache-invalidate-shard:'),
     workflow.indexOf('  cache-invalidate:'),
-    workflow.indexOf('  # ENGLISH CACHE FINALIZER'),
   );
   const readInteger = (name) => {
     const match = invalidationJob.match(
@@ -437,13 +447,13 @@ test('sync cache invalidation has a fixed 10-batch budget below its job timeout'
 
   if (timeoutMinutes === undefined || timeoutMinutes < 25) {
     violations.push(
-      `cache-invalidate timeout-minutes must be at least 25 (found ${timeoutMinutes ?? 'missing'})`,
+      `cache-invalidate-shard timeout-minutes must be at least 25 (found ${timeoutMinutes ?? 'missing'})`,
     );
   }
   for (const [name, expected] of Object.entries(expectedSettings)) {
     if (settings[name] !== expected) {
       violations.push(
-        `cache-invalidate must fix ${name}=${expected} (found ${settings[name] ?? 'missing'})`,
+        `cache-invalidate-shard must fix ${name}=${expected} (found ${settings[name] ?? 'missing'})`,
       );
     }
   }

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -1,0 +1,331 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const INVALIDATOR = join(REPO_ROOT, 'scripts', 'invalidate-cache.sh');
+const SYNC_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
+const SECRET = 'never-print-this-bearer-secret';
+
+const FAKE_CURL = `#!/usr/bin/env bash
+set -u
+
+count_file="$FAKE_CURL_LOG_DIR/count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+
+response_file=""
+payload_arg=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      response_file="$2"
+      shift 2
+      ;;
+    --data-binary|-d)
+      payload_arg="$2"
+      shift 2
+      ;;
+    -H|-X|-w|--connect-timeout|--max-time)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+payload_file="\${payload_arg#@}"
+cp "$payload_file" "$FAKE_CURL_LOG_DIR/payload-$count.json"
+
+IFS=',' read -r -a results <<< "$FAKE_CURL_RESULTS"
+result_index=$((count - 1))
+if [ "$result_index" -ge "\${#results[@]}" ]; then
+  result_index=$(("\${#results[@]}" - 1))
+fi
+result="\${results[$result_index]}"
+
+case "$result" in
+  transport:*)
+    printf '000'
+    exit "\${result#transport:}"
+    ;;
+  http:*)
+    status="\${result#http:}"
+    printf '{"ok":true}' > "$response_file"
+    printf '%s' "$status"
+    ;;
+  *)
+    echo "unknown fake curl result: $result" >&2
+    exit 99
+    ;;
+esac
+`;
+
+const FAKE_SLEEP = `#!/usr/bin/env bash
+printf '%s\n' "$1" >> "$FAKE_SLEEP_LOG"
+`;
+
+function runInvalidator({
+  slugs = '',
+  slugsFile = '',
+  secret = SECRET,
+  batchSize = 2,
+  maxAttempts = 3,
+  retryBaseSeconds = 1,
+  results = 'http:200',
+  contentType = 'skills',
+  mktempFails = false,
+} = {}) {
+  const tmp = mkdtempSync(join(tmpdir(), 'invalidate-cache-test-'));
+  const bin = join(tmp, 'bin');
+  const curlLogDir = join(tmp, 'curl-log');
+  const sleepLog = join(tmp, 'sleep.log');
+  const githubOutput = join(tmp, 'github-output');
+  mkdirSync(bin);
+  mkdirSync(curlLogDir);
+  writeFileSync(join(bin, 'curl'), FAKE_CURL, { mode: 0o755 });
+  writeFileSync(join(bin, 'sleep'), FAKE_SLEEP, { mode: 0o755 });
+  if (mktempFails) {
+    writeFileSync(join(bin, 'mktemp'), '#!/usr/bin/env bash\nexit 1\n', { mode: 0o755 });
+  }
+
+  const result = spawnSync('/bin/bash', [INVALIDATOR], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      CACHE_SECRET: secret,
+      SITE_URL: 'https://offline.invalid',
+      CONTENT_TYPE: contentType,
+      SLUGS_STR: slugs,
+      SLUGS_FILE: slugsFile,
+      BATCH_SIZE: String(batchSize),
+      MAX_ATTEMPTS: String(maxAttempts),
+      RETRY_BASE_SECONDS: String(retryBaseSeconds),
+      CURL_CONNECT_TIMEOUT: '1',
+      CURL_MAX_TIME: '2',
+      GITHUB_OUTPUT: githubOutput,
+      FAKE_CURL_LOG_DIR: curlLogDir,
+      FAKE_CURL_RESULTS: results,
+      FAKE_SLEEP_LOG: sleepLog,
+    },
+  });
+
+  const payloads = readdirSync(curlLogDir)
+    .filter((name) => /^payload-\d+\.json$/.test(name))
+    .sort((a, b) => Number(a.match(/\d+/)[0]) - Number(b.match(/\d+/)[0]))
+    .map((name) => JSON.parse(readFileSync(join(curlLogDir, name), 'utf8')));
+  const sleeps = readdirSync(tmp).includes('sleep.log')
+    ? readFileSync(sleepLog, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+  const outputs = {};
+  if (readdirSync(tmp).includes('github-output')) {
+    for (const line of readFileSync(githubOutput, 'utf8').trim().split('\n').filter(Boolean)) {
+      const separator = line.indexOf('=');
+      assert.notEqual(separator, -1, `Invalid GITHUB_OUTPUT line: ${line}`);
+      outputs[line.slice(0, separator)] = Number(line.slice(separator + 1));
+    }
+  }
+
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(SECRET));
+  return { result, payloads, sleeps, outputs };
+}
+
+test('empty input succeeds without validating a secret or making an HTTP request', () => {
+  const { result, payloads, outputs } = runInvalidator({ slugs: '', secret: '' });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.deepEqual(payloads, []);
+  assert.deepEqual(outputs, { total_count: 0, success_count: 0, failed_count: 0 });
+});
+
+test('single and 96-item inputs use deterministic bounded JSON batches', () => {
+  const single = runInvalidator({ slugs: 'only-one', batchSize: 30 });
+  assert.equal(single.result.status, 0);
+  assert.deepEqual(single.payloads, [
+    { type: 'skills', slugs: ['only-one'], invalidateApi: true },
+  ]);
+
+  const slugs = [
+    'alpha',
+    'quote"slug',
+    String.raw`slash\slug`,
+    ...Array.from({ length: 93 }, (_, index) => `skill-${String(index).padStart(2, '0')}`),
+  ];
+  const larger = runInvalidator({ slugs: slugs.join(','), batchSize: 10 });
+
+  assert.equal(
+    larger.result.status,
+    0,
+    `STDOUT:\n${larger.result.stdout}\nSTDERR:\n${larger.result.stderr}`,
+  );
+  assert.deepEqual(
+    larger.payloads.map((payload) => payload.slugs.length),
+    [10, 10, 10, 10, 10, 10, 10, 10, 10, 6],
+  );
+  assert.ok(larger.payloads.every((payload) => payload.type === 'skills'));
+  assert.ok(larger.payloads.every((payload) => payload.invalidateApi === true));
+  assert.deepEqual(larger.payloads.flatMap((payload) => payload.slugs), slugs);
+  assert.deepEqual(larger.outputs, {
+    total_count: 96,
+    success_count: 96,
+    failed_count: 0,
+  });
+
+  const unbounded = runInvalidator({ slugs: 'alpha,beta', batchSize: 31 });
+  assert.notEqual(unbounded.result.status, 0);
+  assert.deepEqual(unbounded.payloads, []);
+});
+
+test('temporary workspace failure fails closed before making an HTTP request', () => {
+  const { result, payloads, outputs } = runInvalidator({
+    slugs: 'alpha',
+    mktempFails: true,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(payloads, []);
+  assert.deepEqual(outputs, {});
+  assert.match(result.stderr, /Failed to create temporary workspace/);
+});
+
+test('retryable curl transport failures retry the same idempotent batch', () => {
+  for (const exitCode of [5, 6, 7, 16, 18, 28, 35, 52, 55, 56, 92]) {
+    const { result, payloads, sleeps } = runInvalidator({
+      slugs: 'alpha,beta',
+      results: `transport:${exitCode},http:200`,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `curl exit ${exitCode}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+    assert.equal(payloads.length, 2);
+    assert.deepEqual(payloads[0], payloads[1]);
+    assert.equal(sleeps.length, 1);
+  }
+});
+
+test('HTTP 408, 429, and 5xx responses are transient and use finite retries', () => {
+  for (const status of [408, 429, 503]) {
+    const { result, payloads, sleeps } = runInvalidator({
+      slugs: 'alpha',
+      results: `http:${status},http:200`,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `HTTP ${status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+    assert.equal(payloads.length, 2);
+    assert.equal(sleeps.length, 1);
+    assert.deepEqual(payloads[0], payloads[1]);
+  }
+});
+
+test('non-transient curl failures fail closed without retrying', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha,beta,gamma',
+    results: 'transport:3,http:200',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.deepEqual(sleeps, []);
+});
+
+test('non-transient HTTP failures fail closed without retrying', () => {
+  const { result, payloads, sleeps } = runInvalidator({
+    slugs: 'alpha,beta,gamma',
+    results: 'http:400,http:200',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.deepEqual(sleeps, []);
+});
+
+test('an exhausted batch fails immediately without sending later batches', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
+    slugs: 'alpha,beta,gamma,delta,epsilon',
+    maxAttempts: 3,
+    results: 'http:200,http:503',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 4);
+  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.ok(
+    payloads.slice(1).every(
+      (payload) => JSON.stringify(payload.slugs) === '["gamma","delta"]',
+    ),
+  );
+  assert.equal(sleeps.length, 2);
+  assert.deepEqual(outputs, {
+    total_count: 5,
+    success_count: 2,
+    failed_count: 3,
+  });
+  assert.equal(outputs.total_count, outputs.success_count + outputs.failed_count);
+});
+
+test('sync workflow uses the local bounded invalidator and preserves downstream success gates', () => {
+  const workflow = readFileSync(SYNC_WORKFLOW, 'utf8');
+  const invalidationJob = workflow.slice(
+    workflow.indexOf('  cache-invalidate:'),
+    workflow.indexOf('  # ENGLISH CACHE FINALIZER'),
+  );
+  const finalizerJob = workflow.slice(
+    workflow.indexOf('  finalize-english-cache:'),
+    workflow.indexOf('  # TRIGGER TRANSLATION'),
+  );
+  const triggerJob = workflow.slice(workflow.indexOf('  trigger-translate:'));
+
+  assert.notEqual(
+    statSync(INVALIDATOR).mode & 0o111,
+    0,
+    'workflow invokes the invalidator directly, so it must be committed executable',
+  );
+  assert.match(invalidationJob, /sparse-checkout: scripts\/invalidate-cache\.sh/);
+  assert.match(invalidationJob, /sparse-checkout-cone-mode: false/);
+  assert.match(invalidationJob, /BATCH_SIZE: ['"]10['"]/);
+  assert.match(invalidationJob, /CONTENT_TYPE: skills/);
+  assert.match(invalidationJob, /CURL_MAX_TIME: ['"]30['"]/);
+  assert.match(invalidationJob, /MAX_ATTEMPTS: ['"]3['"]/);
+  assert.match(invalidationJob, /run: \.\/scripts\/invalidate-cache\.sh/);
+  assert.doesNotMatch(invalidationJob, /uses: \.\/\.github\/actions\/invalidate-cache/);
+  assert.doesNotMatch(invalidationJob, /curl .*api\/cache\/invalidate/);
+  assert.match(
+    invalidationJob,
+    /Report cache invalidation failure[\s\S]*if: failure\(\) && steps\.invalidate\.outcome == 'failure'/,
+  );
+  assert.match(finalizerJob, /needs: \[sync, calculate-scores, cache-invalidate\]/);
+  assert.match(finalizerJob, /needs\.cache-invalidate\.result == 'success'/);
+  assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
+  assert.match(
+    triggerJob,
+    /if: always\(\) && needs\.sync\.result == 'success' && needs\.cache-invalidate\.result == 'success'/,
+  );
+});


### PR DESCRIPTION
## 背景 / 问题描述

[Sync to Supabase Run 29293569719](https://github.com/aiskillstore/marketplace/actions/runs/29293569719) 在 Supabase 同步完成后，用单 job 失效全部缓存并超时。Retry #1 已关闭 HTTP status-first、CI 真实性和 `<=100` 项单 job 预算，但 Trent 在 head `e6c4fd10645cb615d09f9cdd2fbb10fad3adaa32` 发现唯一剩余 blocker：workflow 合法 `full_sync` 可产生 5263 个 slug，原实现却在 Supabase 写入完成后才执行全局 `MAX_ITEMS=100` 拒绝，形成“DB 新、365 天缓存旧”。

## Retry #2：上次 FAIL 与本次修复

**上次 FAIL 原因**：`MAX_ITEMS=100` 位于生产写之后；`full_sync=true` 没有 100 项业务上限。直接移除上限也不可行，5263 项在一个 25 分钟 job 内最坏约 15.4 小时。

**本次修复**：保留 full sync，复用 `synced-slugs` artifact，新增 id-only planner + bounded matrix：

- `sync` 将 slug 只保存到 `synced-slugs.txt` artifact，不再把整份 synced slug 列表写入 step/job output；score 与 translation 的既有消费者也改为从 artifact 读取，翻译 direct/artifact 分支语义不变。
- `plan-cache-invalidation` 只向 `GITHUB_OUTPUT` 写 `slug_count`、`shard_count` 和仅含 `{shard}` 的 matrix；不写 slug payload。
- `cache-invalidate-shard` 每个 child 从 artifact 按确定性排序后的 shard id 提取 `1..100` 个 slug，独立 `timeout-minutes: 25`，`strategy.max-parallel: 3`、`fail-fast: false`，无 `continue-on-error`。
- `cache-invalidate` aggregate 使用 `always()` 检查 planner、score、整个 matrix 的结果；任一 child 为 failure/cancelled/skipped 时 aggregate 非 success，`finalize-english-cache` / `trigger-translate` 继续只接受 aggregate success。
- GitHub matrix 最大 256 jobs，因此在 Supabase 写入前增加 `256 × 100 = 25600` 容量 preflight；超过时零生产写失败。当前 5263 个已发布报告生成 53 个 shard，完整支持 full sync。
- 保持 Retry #1 的缓存失效语义：`type=skills`、`invalidateApi=true`、全部 locale / API+page cache / dependent packs / artifact prefixes 仍由同一 endpoint 处理；401/403 永久失败，408/429/5xx 与 `000` transport 有限重试，任一 shard 失败非零。

## Trent Retry #2 五条硬约束对应证据

1. **`max-parallel=3`；matrix 只含 shard id；slug 只走 artifact**  
   验收：`scripts/tests/cache-invalidation-workflow.test.mjs::workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3`、`scripts/tests/cache-invalidation-plan.test.mjs::plan CLI writes only shard ids and counts to GITHUB_OUTPUT` + CI：[Run 29300182450](https://github.com/aiskillstore/marketplace/actions/runs/29300182450)
2. **exactly-once：确定性排序、无遗漏、无重复、每 shard 1..100；空输入 no-op**  
   验收：`scripts/tests/cache-invalidation-plan.test.mjs::planner and extractor are deterministic and exactly-once across the artifact`、`scripts/tests/cache-invalidation-plan.test.mjs::empty artifact is a successful no-op`、`scripts/tests/cache-invalidation-workflow.test.mjs::workflow treats an empty sync as a no-op before planning or invalidation` + 同一 CI
3. **任一 shard 非成功 → aggregate 非 success；下游只接受 aggregate success**  
   验收：`scripts/tests/cache-invalidation-workflow.test.mjs::one permanently failed shard makes the aggregate fail closed`、`scripts/tests/cache-invalidation-workflow.test.mjs::downstream finalizer and translation require aggregate success` + 同一 CI
4. **固定 planner/workflow 边界：1→1、100→1、101→2、5263→53；256 上限**  
   验收：`scripts/tests/cache-invalidation-plan.test.mjs::planner maps 1, 100, 101, and 5263 slugs to bounded shards`、`scripts/tests/cache-invalidation-workflow.test.mjs::workflow full_sync inputs above 100 use the configured bounded matrix`、`scripts/tests/cache-invalidation-plan.test.mjs::planner enforces 100 slugs per shard and the GitHub 256-job matrix limit` + 同一 CI
5. **HTTP 200 + curl exit 18 定义为成功，不重试**  
   验收：`scripts/tests/invalidate-cache.test.mjs::HTTP 200 takes precedence over curl exit 18 and succeeds without retrying` + 同一 CI。契约：2xx status 表示服务端已接受并完成 mutation；invalidator 不消费响应体，因此响应体截断不应重复 mutation。

## Acceptance Criteria

- [x] full sync 不再被写后全局 100 项 guard 拒绝；5263 项生成 53 个 `<=100` shard，matrix 只含 shard id。— 验收：上述 planner + workflow full_sync tests + [CI Run 29300182450](https://github.com/aiskillstore/marketplace/actions/runs/29300182450)
- [x] 每个 matrix child 有独立 25 分钟预算，单 child 最坏 10 batches / 1050s < 1500s，且最多 3 个并发。— 验收：`scripts/tests/invalidate-cache.test.mjs::each cache invalidation shard has a fixed 10-batch budget below its own timeout`、`scripts/tests/cache-invalidation-workflow.test.mjs::workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3` + 同一 CI
- [x] 任一 shard 永久失败时 aggregate fail closed，finalizer/translation 均不放行。— 验收：上述 aggregate/downstream tests + 同一 CI
- [x] artifact 的 unique slug 集合不丢失、不重复，顺序确定；空输入正常 no-op。— 验收：上述 exactly-once/empty tests + 同一 CI
- [x] 1/100/101/5263 与 256-job 边界固化；超过 25600 target 在 Supabase 写之前失败。— 验收：上述 planner limit/workflow full_sync tests + 同一 CI
- [x] HTTP status-first 契约完整：`200+18` 成功一次；`401+18`/`403+28` 永久失败；`503+18` 与 `000+28` 有限重试。— 验收：`scripts/tests/invalidate-cache.test.mjs::HTTP 200 takes precedence over curl exit 18 and succeeds without retrying`、`HTTP 401 takes precedence over curl exit 18 and fails after one request`、`HTTP 403 takes precedence over curl exit 28 and fails after one request`、`HTTP 503 takes precedence over curl exit 18 and retries within the finite budget`、`status 000 with curl exit 28 uses transport retries within the finite budget` + 同一 CI
- [x] 新 planner / aggregate / workflow tests 已接现有 script CI。— 验收：`scripts/tests/cache-invalidation-workflow.test.mjs::CI tracks and executes the planner, aggregate guard, and full script suite` + 同一 CI

## 验证证据

- Retry #2 TDD RED：首次新增 planner/workflow tests 后，focused suite `14 pass / 6 fail`，失败原因分别为 planner/aggregate 脚本与 matrix jobs 尚不存在；随后新增 25600 pre-write guard test 也先因 guard 缺失而 RED。
- Focused GREEN：`node --test scripts/tests/cache-invalidation-plan.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/invalidate-cache.test.mjs` → 28/28 PASS。
- 本地全量：`node --test scripts/tests/*.test.mjs` → 103/103 PASS。
- CI：[Run 29300182450](https://github.com/aiskillstore/marketplace/actions/runs/29300182450) → SUCCESS，head `c9ce617881827ac9567834518fbe138f592c7957`；真实日志包含 planner、full_sync、aggregate fail-closed、`200+18` 测试以及 `bash -n` / `node --check`，103/103 PASS。
- 当前仓库实数：5263 个 unique published report slug → 53 shards，最大 shard id 52，matrix entry keys 仅 `shard`。
- 静态检查：Bash syntax、Node syntax、两份 YAML、`git diff --check` 全 PASS；二进制 evidence 0。
- 安全边界：未访问 skillstore.io 生产 endpoint、未触发 `workflow_dispatch`、未部署、未合并、未做生产写。

## 风险点

- **并发 / 时长**：并发固定为 3；5263 项在每个 batch 都走第三次成功的理论最坏路径下，整个 matrix 仍可能运行约 5.25 小时，但每个 child 都有可证明的 25 分钟独立预算，不会因单 job 15.4 小时而必失败。
- **容量边界**：GitHub 单 matrix 上限 256，故最多 25600 unique targets；更大输入会在 Supabase 写前 fail closed，不形成 DB/cache 不一致。
- **HTTP 2xx 契约**：2xx 优先视为 mutation 已完成，即使 curl 因响应体截断返回 18 也不重试；这避免重复失效请求。
- **退避**：429 仍使用固定 5s/10s，不读取 `Retry-After`，保持为非阻塞后续优化。
- **回滚**：revert Retry #2 两个 commit，恢复单 job slug output 路径。

## 人类 review 关注点

请 reviewer 重点判断：
1. `synced-slugs` 是否已成为 cache matrix 唯一 slug payload 通道，matrix/job output 是否仅含 id/count。
2. `max-parallel: 3`、`<=100`、独立 25 分钟与 25600 pre-write guard 是否共同关闭所有 full_sync 容量路径。
3. aggregate 对 failure/cancelled/skipped 是否均 fail closed，finalizer/translation 是否没有旁路。
4. `200+curl 18` 的 status-first 成功契约是否与 handler“2xx 前完成 mutation”一致。
5. 翻译/finalizer 除 slug transport 改走 artifact 外，既有业务分支是否保持不变。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：修改已上线主分支同步 workflow 的生产缓存失效行为。当前仅请求 Trent Retry #2 复审；不自动合并、不触发生产任务。

Wiki delta: none
