### PR TITLE
fix(cli): preserve dual Skill version identity

### DIFF
--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Local cache directory for self-hosted runners (optional)'
     required: false
     default: ''
+  minimum-version:
+    description: 'Fail if the resolved CLI is older than this version (for example, 1.52.2)'
+    required: false
+    default: ''
 
 outputs:
   cli-path:
@@ -160,6 +164,7 @@ runs:
       shell: bash
       env:
         RELEASE_TAG: ${{ steps.resolve.outputs.release-tag }}
+        MINIMUM_VERSION: ${{ inputs.minimum-version }}
       run: |
         CLI_PATH="$GITHUB_WORKSPACE/skillstore-cli"
 
@@ -178,5 +183,31 @@ runs:
         ACTUAL_VERSION=$(echo "$VERSION_OUTPUT" | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
         echo "cli-version=${ACTUAL_VERSION:-unknown}" >> $GITHUB_OUTPUT
         if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-          echo "::warning::CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}. Continuing so workflows can feature-probe CLI capabilities."
+          if [ -n "$MINIMUM_VERSION" ]; then
+            echo "::error::CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}. Refusing a version-gated writer."
+            exit 1
+          fi
+          echo "::warning::CLI version mismatch: expected $EXPECTED_VERSION from $RELEASE_TAG, got ${ACTUAL_VERSION:-unknown}. Continuing so non-writer workflows can feature-probe CLI capabilities."
+        fi
+
+        if [ -n "$MINIMUM_VERSION" ]; then
+          if ! [[ "$MINIMUM_VERSION" =~ ^[0-9]+([.][0-9]+){2}$ ]]; then
+            echo "::error::Invalid minimum-version '$MINIMUM_VERSION'; expected X.Y.Z."
+            exit 1
+          fi
+          if [ -z "$ACTUAL_VERSION" ]; then
+            echo "::error::Cannot enforce minimum CLI version $MINIMUM_VERSION because the downloaded version is unknown."
+            exit 1
+          fi
+          if [[ "$ACTUAL_VERSION" == *-* ]]; then
+            echo "::error::Prerelease CLI $ACTUAL_VERSION cannot satisfy the stable writer minimum $MINIMUM_VERSION."
+            exit 1
+          fi
+
+          LOWEST_VERSION=$(printf '%s\n%s\n' "$MINIMUM_VERSION" "$ACTUAL_VERSION" | sort -V | head -n1)
+          if [ "$LOWEST_VERSION" != "$MINIMUM_VERSION" ]; then
+            echo "::error::Skill sync requires skillstore-cli >= $MINIMUM_VERSION; downloaded $ACTUAL_VERSION from $RELEASE_TAG."
+            exit 1
+          fi
+          echo "✅ Minimum CLI version satisfied: $ACTUAL_VERSION >= $MINIMUM_VERSION"
         fi

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -227,6 +227,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+          minimum-version: '2.0.0'
 
       - name: Sync skills to Supabase
         id: sync

--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/skillstore/src/cli/index.ts
+++ b/packages/skillstore/src/cli/index.ts
@@ -5,7 +5,7 @@ import { defineCommand, runMain } from 'citty';
 const main = defineCommand({
 	meta: {
 		name: 'skillstore',
-		version: '0.1.8',
+		version: '0.1.9',
 		description: 'Skillstore CLI - Manage AI skills for Claude, Codex, and Claude Code',
 	},
 	subCommands: {

--- a/packages/skillstore/src/commands/add.ts
+++ b/packages/skillstore/src/commands/add.ts
@@ -7,7 +7,14 @@ import {
 	reportSkillInstall,
 	PluginApiError,
 } from '../lib/plugin-api.js';
-import { fetchSkillManifest, downloadSkillZip, getSkillZipHash, SkillApiError } from '../lib/skill-api.js';
+import {
+	fetchSkillManifest,
+	downloadSkillZip,
+	formatSkillVersionIdentity,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+	SkillApiError,
+} from '../lib/skill-api.js';
 import { verifyManifest, verifySkillManifest, verifyZipHash } from '../lib/plugin-verify.js';
 import { downloadAllSkills, printDownloadSummary } from '../lib/plugin-download.js';
 import { logger } from '../lib/plugin-logger.js';
@@ -20,6 +27,7 @@ import {
 	type AgentConfig,
 } from '../lib/agents.js';
 import { addToLock, getLockEntry } from '../lib/skill-lock.js';
+import { lockVerifiedPackMembers } from '../lib/pack-lock.js';
 import { extractSkillZip, installToAgents, getCanonicalSkillPath } from '../lib/installer.js';
 
 /**
@@ -193,6 +201,7 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
 		const manifest = await fetchSkillManifest(config, slug);
 		logger.spinnerSuccess(`Found skill: "${manifest.skill.name}"`);
 		const zipHash = getSkillZipHash(manifest);
+		const lockIdentity = getSkillLockVersionIdentity(manifest.skill);
 
 		// Step 2: Verify manifest signature
 		if (!skipVerify) {
@@ -216,7 +225,7 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
 		// Step 3: Show skill info
 		logger.box(`Skill: ${manifest.skill.name}`, [
 			`Slug: ${manifest.skill.slug}`,
-			`Version: ${manifest.skill.version}`,
+			`Version: ${formatSkillVersionIdentity(manifest.skill)}`,
 			`Author: ${manifest.skill.author || 'Unknown'}`,
 		]);
 
@@ -224,11 +233,25 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
 		const existingLock = await getLockEntry(slug);
 		if (existingLock && !overwrite) {
 			if (existingLock.zipHash === zipHash) {
-				logger.warn(`Skill "${slug}" is already installed (v${existingLock.version})`);
+				const identityChanged = existingLock.version !== lockIdentity.version
+					|| existingLock.authorVersion !== lockIdentity.authorVersion
+					|| (existingLock.skillstoreRevision ?? null) !== lockIdentity.skillstoreRevision
+					|| existingLock.versionStatus !== lockIdentity.versionStatus
+					|| (existingLock.treeHash ?? null) !== lockIdentity.treeHash;
+				if (identityChanged && !dryRun) {
+					await addToLock({
+						...existingLock,
+						...lockIdentity,
+						zipHash,
+					});
+					logger.info(`Refreshed lock metadata: ${formatSkillVersionIdentity(lockIdentity)}`);
+				}
+				const installedIdentity = identityChanged ? lockIdentity : existingLock;
+				logger.warn(`Skill "${slug}" is already installed (${formatSkillVersionIdentity(installedIdentity)})`);
 				logger.info('Use --overwrite to reinstall');
 				return;
 			}
-			logger.info(`Updating "${slug}" from v${existingLock.version} to v${manifest.skill.version}`);
+			logger.info(`Updating "${slug}" from ${formatSkillVersionIdentity(existingLock)} to ${formatSkillVersionIdentity(manifest.skill)}`);
 		}
 
 		if (dryRun) {
@@ -288,7 +311,7 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
 		// Step 9: Update lock file
 		await addToLock({
 			slug,
-			version: manifest.skill.version,
+			...lockIdentity,
 			zipHash,
 			source: 'skillstore',
 			installedAt: new Date().toISOString(),
@@ -405,6 +428,10 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 				logger.spinnerSuccess(
 					`Linked ${successfulSkillSlugs.length} skill${successfulSkillSlugs.length > 1 ? 's' : ''} to ${targetAgents.length} agent${targetAgents.length > 1 ? 's' : ''}`
 				);
+			}
+			const lockResult = await lockVerifiedPackMembers(config, manifest.skills, downloadResult);
+			if (lockResult.skipped > 0) {
+				logger.warn(`${lockResult.skipped} pack member${lockResult.skipped > 1 ? 's were' : ' was'} installed but left unlocked`);
 			}
 		}
 

--- a/packages/skillstore/src/commands/check.ts
+++ b/packages/skillstore/src/commands/check.ts
@@ -1,13 +1,24 @@
 import { defineCommand } from 'citty';
 import { getAllLockedSkills, type SkillLockEntry } from '../lib/skill-lock.js';
-import { fetchSkillManifest, getSkillZipHash, SkillApiError } from '../lib/skill-api.js';
+import {
+	fetchSkillManifest,
+	formatSkillVersionIdentity,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+	SkillApiError,
+} from '../lib/skill-api.js';
 import { getPluginConfig } from '../lib/plugin-config.js';
 import { logger } from '../lib/plugin-logger.js';
+import { verifySkillManifest } from '../lib/plugin-verify.js';
 
 interface UpdateInfo {
 	skill: SkillLockEntry;
-	currentVersion: string;
-	latestVersion: string;
+	currentVersion: string | null;
+	latestVersion: string | null;
+	latestAuthorVersion: string | null;
+	latestVersionStatus: string;
+	currentRevision: number | null;
+	latestRevision: number | null;
 	hasUpdate: boolean;
 }
 
@@ -64,11 +75,21 @@ export default defineCommand({
 						errors.push({ slug: skill.slug, error: 'Manifest is missing ZIP hash' });
 						continue;
 					}
+					const verifyResult = await verifySkillManifest(manifest);
+					if (!verifyResult.valid) {
+						errors.push({ slug: skill.slug, error: 'Manifest verification failed' });
+						continue;
+					}
+					const latestIdentity = getSkillLockVersionIdentity(manifest.skill);
 
 					const info: UpdateInfo = {
 						skill,
 						currentVersion: skill.version,
-						latestVersion: manifest.skill.version,
+						latestVersion: latestIdentity.version,
+						latestAuthorVersion: latestIdentity.authorVersion,
+						latestVersionStatus: latestIdentity.versionStatus,
+						currentRevision: skill.skillstoreRevision ?? null,
+						latestRevision: manifest.skill.skillstoreRevision ?? null,
 						hasUpdate: skill.zipHash !== latestHash,
 					};
 
@@ -97,6 +118,10 @@ export default defineCommand({
 								slug: u.skill.slug,
 								currentVersion: u.currentVersion,
 								latestVersion: u.latestVersion,
+								latestAuthorVersion: u.latestAuthorVersion,
+								latestVersionStatus: u.latestVersionStatus,
+								currentRevision: u.currentRevision,
+								latestRevision: u.latestRevision,
 							})),
 							upToDate: upToDate.map((u) => u.skill.slug),
 							errors,
@@ -116,7 +141,7 @@ export default defineCommand({
 					const isLast = i === updates.length - 1;
 					const prefix = isLast ? '└─' : '├─';
 					console.log(
-						`  ${prefix} ${update.skill.slug}  v${update.currentVersion} → v${update.latestVersion}`
+						`  ${prefix} ${update.skill.slug}  ${formatSkillVersionIdentity(update.skill)} → ${formatSkillVersionIdentity({ version: update.latestVersion, authorVersion: update.latestAuthorVersion, skillstoreRevision: update.latestRevision, versionStatus: update.latestVersionStatus })}`
 					);
 				}
 				console.log('');
@@ -129,7 +154,9 @@ export default defineCommand({
 					const skill = upToDate[i];
 					const isLast = i === upToDate.length - 1;
 					const prefix = isLast ? '└─' : '├─';
-					console.log(`  ${prefix} ${skill.skill.slug}  v${skill.currentVersion} (latest)`);
+					console.log(
+						`  ${prefix} ${skill.skill.slug}  ${formatSkillVersionIdentity(skill.skill)} (latest)`
+					);
 				}
 				console.log('');
 			}

--- a/packages/skillstore/src/commands/generate-lock.ts
+++ b/packages/skillstore/src/commands/generate-lock.ts
@@ -1,10 +1,19 @@
 import { defineCommand } from 'citty';
 import { readdir, access } from 'node:fs/promises';
+import { join } from 'node:path';
 import { writeSkillLock, LOCK_VERSION, type SkillLock, type SkillLockEntry } from '../lib/skill-lock.js';
-import { fetchSkillManifest, getSkillZipHash, SkillApiError } from '../lib/skill-api.js';
+import {
+	fetchSkillManifest,
+	formatSkillVersionIdentity,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+	SkillApiError,
+} from '../lib/skill-api.js';
 import { getPluginConfig } from '../lib/plugin-config.js';
 import { logger } from '../lib/plugin-logger.js';
 import { CANONICAL_SKILLS_DIR } from '../lib/agents.js';
+import { verifySkillManifest } from '../lib/plugin-verify.js';
+import { readInstalledSkillReceipt } from '../lib/skill-receipt.js';
 
 /**
  * Generate lock file from installed skills
@@ -73,22 +82,45 @@ export default defineCommand({
 					// Try to fetch manifest from skillstore.io
 					const manifest = await fetchSkillManifest(config, slug);
 					const zipHash = getSkillZipHash(manifest);
+					const lockIdentity = getSkillLockVersionIdentity(manifest.skill);
 					if (!zipHash) {
 						skipped.push({ slug, reason: 'manifest is missing ZIP hash' });
 						console.log(`  ✗ ${slug} (manifest is missing ZIP hash)`);
 						continue;
 					}
+					const verifyResult = await verifySkillManifest(manifest);
+					if (!verifyResult.valid) {
+						skipped.push({ slug, reason: 'manifest verification failed' });
+						console.log(`  ✗ ${slug} (manifest verification failed)`);
+						continue;
+					}
+					const receipt = await readInstalledSkillReceipt(join(dir, slug));
+					if (!receipt) {
+						skipped.push({ slug, reason: 'verified Skillstore receipt missing' });
+						console.log(`  ✗ ${slug} (verified Skillstore receipt missing)`);
+						continue;
+					}
+					if (
+						lockIdentity.skillstoreRevision == null
+						|| !lockIdentity.treeHash
+						|| receipt.skillstoreRevision !== lockIdentity.skillstoreRevision
+						|| receipt.treeHash !== lockIdentity.treeHash.toLowerCase()
+					) {
+						skipped.push({ slug, reason: 'installed receipt does not match current artifact' });
+						console.log(`  ✗ ${slug} (installed receipt does not match current artifact)`);
+						continue;
+					}
 
 					matched.push({
 						slug,
-						version: manifest.skill.version,
+						...lockIdentity,
 						zipHash,
 						source: 'skillstore',
 						installedAt: new Date().toISOString(),
 						updatedAt: new Date().toISOString(),
 					});
 
-					console.log(`  ✓ ${slug} (v${manifest.skill.version})`);
+					console.log(`  ✓ ${slug} (${formatSkillVersionIdentity(manifest.skill)})`);
 				} catch (err) {
 					if (err instanceof SkillApiError && err.statusCode === 404) {
 						skipped.push({ slug, reason: 'not from skillstore.io' });
@@ -106,9 +138,9 @@ export default defineCommand({
 			console.log('');
 
 			if (matched.length === 0) {
-				logger.warn('No skills matched with skillstore.io');
+				logger.warn('No installed skills could be verified for update tracking');
 				console.log('');
-				console.log('Skills not from skillstore.io cannot be tracked for updates.');
+				console.log('Only skills with a valid Skillstore manifest and matching install receipt can be tracked.');
 				return;
 			}
 
@@ -128,7 +160,7 @@ export default defineCommand({
 				console.log('Would generate lock file with:');
 				console.log(`  - ${matched.length} skill${matched.length > 1 ? 's' : ''} from skillstore.io`);
 				if (skipped.length > 0) {
-					console.log(`  - ${skipped.length} skipped (not from skillstore.io)`);
+					console.log(`  - ${skipped.length} skipped (not verifiable for update tracking)`);
 				}
 				console.log('');
 				console.log(JSON.stringify(lock, null, 2));

--- a/packages/skillstore/src/commands/install.ts
+++ b/packages/skillstore/src/commands/install.ts
@@ -2,12 +2,21 @@ import { defineCommand } from 'citty';
 import { access } from 'node:fs/promises';
 import { getPluginConfig } from '../lib/plugin-config.js';
 import { fetchManifest, reportInstallation, reportSkillInstall, PluginApiError } from '../lib/plugin-api.js';
-import { fetchSkillManifest, downloadSkillZip, getSkillZipHash, SkillApiError } from '../lib/skill-api.js';
+import {
+	fetchSkillManifest,
+	downloadSkillZip,
+	formatSkillVersionIdentity,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+	SkillApiError,
+} from '../lib/skill-api.js';
 import { verifyManifest, verifySkillManifest, verifyZipHash } from '../lib/plugin-verify.js';
 import { downloadAllSkills, printDownloadSummary } from '../lib/plugin-download.js';
 import { logger } from '../lib/plugin-logger.js';
 import { CANONICAL_SKILLS_DIR } from '../lib/agents.js';
 import { extractSkillZip, getCanonicalSkillPath, linkSkillToDirectory } from '../lib/installer.js';
+import { addToLock, getLockEntry } from '../lib/skill-lock.js';
+import { lockVerifiedPackMembers } from '../lib/pack-lock.js';
 
 /**
  * Normalize skill/plugin slug
@@ -103,6 +112,7 @@ async function installSkill(
 		const manifest = await fetchSkillManifest(config, slug);
 		logger.spinnerSuccess(`Found skill: "${manifest.skill.name}"`);
 		const zipHash = getSkillZipHash(manifest);
+		const lockIdentity = getSkillLockVersionIdentity(manifest.skill);
 
 		// Step 2: Verify manifest signature
 		if (!skipVerify) {
@@ -126,7 +136,7 @@ async function installSkill(
 		// Step 3: Show skill info
 		logger.box(`Skill: ${manifest.skill.name}`, [
 			`Slug: ${manifest.skill.slug}`,
-			`Version: ${manifest.skill.version}`,
+			`Version: ${formatSkillVersionIdentity(manifest.skill)}`,
 			`Author: ${manifest.skill.author || 'Unknown'}`,
 		]);
 
@@ -135,6 +145,18 @@ async function installSkill(
 		if (!overwrite) {
 			try {
 				await access(skillDir);
+				const existingLock = await getLockEntry(slug);
+				const identityChanged = existingLock && existingLock.zipHash === zipHash && (
+					existingLock.version !== lockIdentity.version
+					|| existingLock.authorVersion !== lockIdentity.authorVersion
+					|| (existingLock.skillstoreRevision ?? null) !== lockIdentity.skillstoreRevision
+					|| existingLock.versionStatus !== lockIdentity.versionStatus
+					|| (existingLock.treeHash ?? null) !== lockIdentity.treeHash
+				);
+				if (identityChanged && !dryRun) {
+					await addToLock({ ...existingLock, ...lockIdentity, zipHash });
+					logger.info(`Refreshed lock metadata: ${formatSkillVersionIdentity(lockIdentity)}`);
+				}
 				logger.warn(`Skill "${slug}" already exists. Use --overwrite to replace.`);
 				return;
 			} catch {
@@ -183,6 +205,15 @@ async function installSkill(
 		} else {
 			logger.spinnerSuccess('Linked skill');
 		}
+
+		// Keep install and add behavior equivalent for check/update management.
+		await addToLock({
+			slug,
+			...lockIdentity,
+			zipHash,
+			source: 'skillstore',
+			installedAt: new Date().toISOString(),
+		});
 
 		// Step 9: Report installation (non-blocking telemetry)
 		try {
@@ -299,6 +330,10 @@ async function installPlugin(
 				process.exit(1);
 			}
 			logger.spinnerSuccess(`Linked ${linkResults.length} skill${linkResults.length > 1 ? 's' : ''}`);
+			const lockResult = await lockVerifiedPackMembers(config, manifest.skills, downloadResult);
+			if (lockResult.skipped > 0) {
+				logger.warn(`${lockResult.skipped} pack member${lockResult.skipped > 1 ? 's were' : ' was'} installed but left unlocked`);
+			}
 		}
 
 		// Step 6: Report installation (non-blocking)

--- a/packages/skillstore/src/commands/list.ts
+++ b/packages/skillstore/src/commands/list.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 import { getAllLockedSkills } from '../lib/skill-lock.js';
 import { logger } from '../lib/plugin-logger.js';
+import { formatSkillVersionIdentity } from '../lib/skill-api.js';
 
 /**
  * List installed skills
@@ -51,7 +52,9 @@ export default defineCommand({
 				const prefix = isLast ? '└─' : '├─';
 
 				const relativeTime = getRelativeTime(new Date(skill.updatedAt));
-				console.log(`  ${prefix} ${skill.slug}  v${skill.version}  (${relativeTime})`);
+				console.log(
+					`  ${prefix} ${skill.slug}  ${formatSkillVersionIdentity(skill)}  (${relativeTime})`
+				);
 			}
 
 			console.log('');

--- a/packages/skillstore/src/commands/update.ts
+++ b/packages/skillstore/src/commands/update.ts
@@ -1,6 +1,13 @@
 import { defineCommand } from 'citty';
 import { getAllLockedSkills, addToLock, type SkillLockEntry } from '../lib/skill-lock.js';
-import { fetchSkillManifest, downloadSkillZip, getSkillZipHash, SkillApiError } from '../lib/skill-api.js';
+import {
+	fetchSkillManifest,
+	downloadSkillZip,
+	formatSkillVersionIdentity,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+	SkillApiError,
+} from '../lib/skill-api.js';
 import { verifySkillManifest, verifyZipHash } from '../lib/plugin-verify.js';
 import { getPluginConfig } from '../lib/plugin-config.js';
 import { logger } from '../lib/plugin-logger.js';
@@ -78,7 +85,11 @@ export default defineCommand({
 			}
 
 			// Find skills that need updates
-			const updates: { skill: SkillLockEntry; latestVersion: string; latestHash: string }[] = [];
+			const updates: {
+				skill: SkillLockEntry;
+				latestIdentity: ReturnType<typeof getSkillLockVersionIdentity>;
+				latestHash: string;
+			}[] = [];
 
 			for (const skill of skillsToCheck) {
 				try {
@@ -88,12 +99,29 @@ export default defineCommand({
 						logger.warn(`Failed to check "${skill.slug}": manifest is missing ZIP hash`);
 						continue;
 					}
+					if (!skipVerify) {
+						const verifyResult = await verifySkillManifest(manifest);
+						if (!verifyResult.valid) {
+							logger.warn(`Failed to check "${skill.slug}": manifest verification failed`);
+							continue;
+						}
+					}
+					const latestIdentity = getSkillLockVersionIdentity(manifest.skill);
 					if (skill.zipHash !== latestHash) {
 						updates.push({
 							skill,
-							latestVersion: manifest.skill.version,
+							latestIdentity,
 							latestHash,
 						});
+					} else if (!dryRun) {
+						const identityChanged = skill.version !== latestIdentity.version
+							|| skill.authorVersion !== latestIdentity.authorVersion
+							|| (skill.skillstoreRevision ?? null) !== latestIdentity.skillstoreRevision
+							|| skill.versionStatus !== latestIdentity.versionStatus
+							|| (skill.treeHash ?? null) !== latestIdentity.treeHash;
+						if (identityChanged) {
+							await addToLock({ ...skill, ...latestIdentity, zipHash: latestHash });
+						}
 					}
 				} catch (err) {
 					if (err instanceof SkillApiError && err.statusCode === 404) {
@@ -115,7 +143,7 @@ export default defineCommand({
 			console.log(`Updates available (${updates.length}):`);
 			for (const update of updates) {
 				console.log(
-					`  - ${update.skill.slug}  v${update.skill.version} → v${update.latestVersion}`
+					`  - ${update.skill.slug}  ${formatSkillVersionIdentity(update.skill)} → ${formatSkillVersionIdentity(update.latestIdentity)}`
 				);
 			}
 			console.log('');
@@ -136,7 +164,7 @@ export default defineCommand({
 			let failCount = 0;
 
 			for (const update of updates) {
-				const { skill, latestVersion } = update;
+				const { skill } = update;
 
 				try {
 					logger.startSpinner(`Updating ${skill.slug}...`);
@@ -144,6 +172,7 @@ export default defineCommand({
 					// Fetch manifest
 					const manifest = await fetchSkillManifest(config, skill.slug);
 					const zipHash = getSkillZipHash(manifest);
+					const lockIdentity = getSkillLockVersionIdentity(manifest.skill);
 					if (!zipHash) {
 						logger.spinnerError(`${skill.slug}: Manifest is missing ZIP hash`);
 						failCount++;
@@ -182,7 +211,7 @@ export default defineCommand({
 					// Update lock file
 					await addToLock({
 						slug: skill.slug,
-						version: manifest.skill.version,
+						...lockIdentity,
 						zipHash,
 						source: 'skillstore',
 						installedAt: skill.installedAt,
@@ -195,7 +224,9 @@ export default defineCommand({
 						// Ignore telemetry errors
 					}
 
-					logger.spinnerSuccess(`${skill.slug}: v${skill.version} → v${latestVersion}`);
+					logger.spinnerSuccess(
+						`${skill.slug}: ${formatSkillVersionIdentity(skill)} → ${formatSkillVersionIdentity(lockIdentity)}`
+					);
 					successCount++;
 				} catch (err) {
 					logger.spinnerError(

--- a/packages/skillstore/src/lib/pack-lock.ts
+++ b/packages/skillstore/src/lib/pack-lock.ts
@@ -1,0 +1,87 @@
+import type { PluginConfig } from './plugin-config.js';
+import type { ManifestSkill } from './plugin-api.js';
+import type { DownloadSummary } from './plugin-download.js';
+import {
+	fetchSkillManifest,
+	getSkillLockVersionIdentity,
+	getSkillZipHash,
+} from './skill-api.js';
+import { verifySkillManifest } from './plugin-verify.js';
+import { addToLock } from './skill-lock.js';
+import { logger } from './plugin-logger.js';
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function packMemberIdentity(skill: ManifestSkill) {
+	const authorVersion = hasOwn(skill, 'authorVersion')
+		? skill.authorVersion ?? null
+		: skill.version ?? null;
+	return {
+		version: skill.version ?? authorVersion,
+		authorVersion,
+		skillstoreRevision: skill.skillstoreRevision ?? null,
+		versionStatus: skill.versionStatus || (authorVersion ? 'legacy_unknown' : 'missing'),
+		treeHash: skill.treeHash ?? null,
+	};
+}
+
+/**
+ * Lock only pack members installed in this run. The pack's file aggregate hash
+ * is not a single-skill ZIP hash, so each member is rebound to a separately
+ * verified single-skill manifest before it becomes update-managed.
+ */
+export async function lockVerifiedPackMembers(
+	config: PluginConfig,
+	packSkills: ManifestSkill[],
+	download: DownloadSummary
+): Promise<{ locked: number; skipped: number }> {
+	let locked = 0;
+	let skipped = 0;
+	const installed = download.results.filter((result) => result.success && !result.skipped);
+
+	for (const result of installed) {
+		const member = packSkills.find((skill) => skill.slug === result.slug);
+		if (!member) {
+			logger.warn(`Not locking ${result.slug}: missing from verified pack payload`);
+			skipped++;
+			continue;
+		}
+
+		try {
+			const manifest = await fetchSkillManifest(config, result.slug);
+			const verification = await verifySkillManifest(manifest);
+			const zipHash = getSkillZipHash(manifest);
+			const single = getSkillLockVersionIdentity(manifest.skill);
+			const packed = packMemberIdentity(member);
+			const identityMatches = manifest.skill.slug === member.slug
+				&& !!single.treeHash
+				&& single.version === packed.version
+				&& single.authorVersion === packed.authorVersion
+				&& single.skillstoreRevision === packed.skillstoreRevision
+				&& single.versionStatus === packed.versionStatus
+				&& single.treeHash === packed.treeHash;
+
+			if (!verification.valid || !zipHash || !identityMatches) {
+				logger.warn(`Not locking ${result.slug}: single-skill manifest does not match verified pack member`);
+				skipped++;
+				continue;
+			}
+
+			await addToLock({
+				slug: result.slug,
+				...single,
+				zipHash,
+				source: 'skillstore',
+				installedAt: new Date().toISOString(),
+			});
+			locked++;
+		} catch (error) {
+			logger.warn(`Not locking ${result.slug}: ${error instanceof Error ? error.message : 'verification failed'}`);
+			skipped++;
+		}
+	}
+
+	return { locked, skipped };
+}

--- a/packages/skillstore/src/lib/plugin-api.ts
+++ b/packages/skillstore/src/lib/plugin-api.ts
@@ -30,6 +30,12 @@ export interface ManifestSkillArtifact {
 export interface ManifestSkill {
 	slug: string;
 	name: string;
+	/** Compatibility alias for authorVersion. */
+	version?: string | null;
+	authorVersion?: string | null;
+	skillstoreRevision?: number | null;
+	versionStatus?: string;
+	treeHash?: string | null;
 	contentHash: string;
 	downloadUrl: string;
 	artifact?: ManifestSkillArtifact;
@@ -49,7 +55,7 @@ export interface ManifestSignatureInfo {
 
 /** Plugin manifest response */
 export interface PluginManifest {
-	version: '1.0';
+	version: '1.0' | '1.1';
 	kind?: 'pack';
 	plugin: {
 		slug: string;
@@ -155,9 +161,14 @@ function normalizeManifest(rawManifest: unknown): PluginManifest {
 	const pack = isJsonObject(manifest.pack) ? manifest.pack : null;
 	const signed = isJsonObject(manifest.signed) ? manifest.signed : null;
 	const signedPack = signed && isJsonObject(signed.pack) ? signed.pack : null;
-	const sourcePack = pack || signedPack;
+	const signature = isJsonObject(manifest.signature) ? manifest.signature : null;
+	const hasEd25519Envelope = signature?.algorithm === 'Ed25519' && !!signed;
+	const signedVersion = signed?.version === '1.0' || signed?.version === '1.1'
+		? signed.version
+		: null;
+	const sourcePack = hasEd25519Envelope ? signedPack || pack : pack || signedPack;
 
-	if (!manifest.plugin && sourcePack?.slug && sourcePack.name) {
+	if ((hasEd25519Envelope || !manifest.plugin) && sourcePack?.slug && sourcePack.name) {
 		manifest.plugin = {
 			slug: String(sourcePack.slug),
 			name: String(sourcePack.name),
@@ -165,7 +176,7 @@ function normalizeManifest(rawManifest: unknown): PluginManifest {
 		};
 	}
 
-	if (!manifest.pack && sourcePack?.slug && sourcePack.name) {
+	if ((hasEd25519Envelope || !manifest.pack) && sourcePack?.slug && sourcePack.name) {
 		manifest.pack = {
 			slug: String(sourcePack.slug),
 			name: String(sourcePack.name),
@@ -174,15 +185,21 @@ function normalizeManifest(rawManifest: unknown): PluginManifest {
 		};
 	}
 
-	if (!manifest.skills && signed && Array.isArray(signed.skills)) {
+	if (hasEd25519Envelope && signed && Array.isArray(signed.skills)) {
+		manifest.skills = signed.skills;
+	} else if (!manifest.skills && signed && Array.isArray(signed.skills)) {
 		manifest.skills = signed.skills;
 	}
 
-	if (!manifest.version) {
-		manifest.version = signed?.version || '1.0';
+	if (hasEd25519Envelope && signedVersion) {
+		manifest.version = signedVersion;
+	} else if (!manifest.version) {
+		manifest.version = signedVersion || '1.0';
 	}
 
-	if (!manifest.generatedAt && signed?.generatedAt) {
+	if (hasEd25519Envelope && signed?.generatedAt) {
+		manifest.generatedAt = signed.generatedAt;
+	} else if (!manifest.generatedAt && signed?.generatedAt) {
 		manifest.generatedAt = signed.generatedAt;
 	}
 

--- a/packages/skillstore/src/lib/plugin-verify.ts
+++ b/packages/skillstore/src/lib/plugin-verify.ts
@@ -183,7 +183,7 @@ export async function verifyManifest(
 	options: { skipSignature?: boolean } = {}
 ): Promise<VerifyResult> {
 	// Validate manifest structure
-	if (!manifest.version || manifest.version !== '1.0') {
+	if (manifest.version !== '1.0' && manifest.version !== '1.1') {
 		return { valid: false, error: 'Unsupported manifest version' };
 	}
 
@@ -266,7 +266,7 @@ export async function verifySkillManifest(
 	options: { skipSignature?: boolean } = {}
 ): Promise<VerifyResult> {
 	// Validate manifest structure
-	if (!manifest.version || manifest.version !== '1.0') {
+	if (manifest.version !== '1.0' && manifest.version !== '1.1') {
 		return { valid: false, error: 'Unsupported manifest version' };
 	}
 

--- a/packages/skillstore/src/lib/skill-api.ts
+++ b/packages/skillstore/src/lib/skill-api.ts
@@ -29,13 +29,18 @@ export interface SkillZipArtifact {
 }
 
 export interface SkillManifest {
-	version: '1.0';
+	version: '1.0' | '1.1';
 	kind?: 'skill';
 	schemaVersion?: '2.0';
 	skill: {
 		slug: string;
 		name: string;
-		version: string;
+		/** Compatibility alias for authorVersion. */
+		version: string | null;
+		authorVersion?: string | null;
+		skillstoreRevision?: number | null;
+		versionStatus?: string;
+		treeHash?: string | null;
 		author?: string;
 		zipHash?: string;
 	};
@@ -45,10 +50,84 @@ export interface SkillManifest {
 	generatedAt: string;
 	signed?: {
 		kind?: 'skill';
-		version?: '1.0';
+		version?: '1.0' | '1.1';
 		generatedAt?: string;
 		skill?: SkillManifest['skill'];
 		artifact?: SkillZipArtifact;
+	};
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/**
+ * Canonicalize an Ed25519 envelope onto its signed payload. Callers may safely
+ * use the top-level convenience fields after signature verification.
+ */
+export function normalizeSkillManifest(manifest: SkillManifest): SkillManifest {
+	if (typeof manifest.signature === 'object' && manifest.signed?.kind === 'skill') {
+		return {
+			...manifest,
+			version: manifest.signed.version ?? manifest.version,
+			generatedAt: manifest.signed.generatedAt ?? manifest.generatedAt,
+			skill: manifest.signed.skill ?? manifest.skill,
+			artifact: manifest.signed.artifact ?? manifest.artifact,
+		};
+	}
+	return manifest;
+}
+
+export interface SkillVersionIdentity {
+	authorVersion: string | null;
+	skillstoreRevision: number | null;
+	versionStatus: string;
+	treeHash: string | null;
+}
+
+/** Normalize additive dual-version fields while retaining old manifest support. */
+export function getSkillVersionIdentity(skill: SkillManifest['skill']): SkillVersionIdentity {
+	const authorVersion = hasOwn(skill, 'authorVersion')
+		? skill.authorVersion ?? null
+		: skill.version ?? null;
+
+	return {
+		authorVersion,
+		skillstoreRevision: skill.skillstoreRevision ?? null,
+		versionStatus: skill.versionStatus || (authorVersion ? 'legacy_unknown' : 'missing'),
+		treeHash: skill.treeHash ?? null,
+	};
+}
+
+/** Human-readable identity that still distinguishes r1/r2 under one author version. */
+export function formatSkillVersionIdentity(skill: {
+	version?: string | null;
+	authorVersion?: string | null;
+	skillstoreRevision?: number | null;
+	versionStatus?: string;
+}): string {
+	const explicitAuthorVersion = hasOwn(skill, 'authorVersion');
+	const authorVersion = explicitAuthorVersion ? skill.authorVersion ?? null : skill.version ?? null;
+	const legacyAlias = explicitAuthorVersion && authorVersion === null && skill.version
+		? `Legacy v${skill.version.replace(/^v/i, '')} (unverified)`
+		: null;
+	const versionLabel = authorVersion
+		? `v${authorVersion.replace(/^v/i, '')}`
+		: legacyAlias || 'Not declared';
+	return skill.skillstoreRevision == null ? versionLabel : `${versionLabel} (r${skill.skillstoreRevision})`;
+}
+
+/** Keep the old lockfile field as an alias without claiming it is author-owned. */
+export function getSkillVersionAlias(skill: SkillManifest['skill']): string | null {
+	return skill.version ?? getSkillVersionIdentity(skill).authorVersion;
+}
+
+export function getSkillLockVersionIdentity(skill: SkillManifest['skill']): SkillVersionIdentity & {
+	version: string | null;
+} {
+	return {
+		version: getSkillVersionAlias(skill),
+		...getSkillVersionIdentity(skill),
 	};
 }
 
@@ -196,7 +275,7 @@ export async function fetchSkillManifest(
 		);
 	}
 
-	return (await response.json()) as SkillManifest;
+	return normalizeSkillManifest((await response.json()) as SkillManifest);
 }
 
 /**

--- a/packages/skillstore/src/lib/skill-lock.ts
+++ b/packages/skillstore/src/lib/skill-lock.ts
@@ -16,8 +16,16 @@ export const LOCK_VERSION = 1;
 export interface SkillLockEntry {
 	/** Skill slug */
 	slug: string;
-	/** Skill version */
-	version: string;
+	/** Compatibility alias for the author-declared version. */
+	version: string | null;
+	/** Author-declared upstream version. */
+	authorVersion?: string | null;
+	/** Monotonic Skillstore content revision. */
+	skillstoreRevision?: number | null;
+	/** Version provenance/status reported by Skillstore. */
+	versionStatus?: string;
+	/** Immutable installable content identity. */
+	treeHash?: string | null;
 	/** ZIP file SHA256 hash */
 	zipHash: string;
 	/** Source (always 'skillstore' for now) */

--- a/packages/skillstore/src/lib/skill-receipt.ts
+++ b/packages/skillstore/src/lib/skill-receipt.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface InstalledSkillReceipt {
+	skillstoreRevision: number;
+	treeHash: string;
+}
+
+function parseReceipt(content: string): InstalledSkillReceipt | null {
+	if (!content.includes('## Skillstore Install Receipt')) return null;
+
+	const values = new Map<string, string>();
+	for (const line of content.split(/\r?\n/)) {
+		const match = /^\|\s*\*\*([^*]+)\*\*\s*\|\s*(.*?)\s*\|$/.exec(line);
+		if (match) values.set(match[1].trim(), match[2].trim().replace(/^`|`$/g, ''));
+	}
+
+	const revision = /^r([1-9]\d*)$/.exec(values.get('Skillstore revision') || '');
+	const treeHash = values.get('Tree hash') || '';
+	if (!revision || !/^[0-9a-f]{64}$/i.test(treeHash)) return null;
+
+	return {
+		skillstoreRevision: Number(revision[1]),
+		treeHash: treeHash.toLowerCase(),
+	};
+}
+
+export async function readInstalledSkillReceipt(skillDir: string): Promise<InstalledSkillReceipt | null> {
+	for (const filename of ['SKILLSTORE.md', 'README.md']) {
+		try {
+			const receipt = parseReceipt(await readFile(join(skillDir, filename), 'utf8'));
+			if (receipt) return receipt;
+		} catch {
+			// Try the next generated-receipt filename.
+		}
+	}
+	return null;
+}
+
+export { parseReceipt as parseInstalledSkillReceipt };

--- a/packages/skillstore/tests/install-command.test.ts
+++ b/packages/skillstore/tests/install-command.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	access: vi.fn(),
+	fetchSkillManifest: vi.fn(),
+	downloadSkillZip: vi.fn(),
+	verifySkillManifest: vi.fn(),
+	verifyZipHash: vi.fn(),
+	extractSkillZip: vi.fn(),
+	linkSkillToDirectory: vi.fn(),
+	addToLock: vi.fn(),
+	reportSkillInstall: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+	access: mocks.access,
+}));
+
+vi.mock('../src/lib/plugin-config.js', () => ({
+	getPluginConfig: (overrides: Record<string, unknown> = {}) => ({
+		apiBaseUrl: 'https://api.test.com',
+		installDir: '/mock/home/.agents/skills',
+		timeout: 5000,
+		...overrides,
+	}),
+}));
+
+vi.mock('../src/lib/skill-api.js', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../src/lib/skill-api.js')>()),
+	fetchSkillManifest: mocks.fetchSkillManifest,
+	downloadSkillZip: mocks.downloadSkillZip,
+}));
+
+vi.mock('../src/lib/plugin-verify.js', () => ({
+	verifyManifest: vi.fn(),
+	verifySkillManifest: mocks.verifySkillManifest,
+	verifyZipHash: mocks.verifyZipHash,
+}));
+
+vi.mock('../src/lib/plugin-api.js', () => ({
+	fetchManifest: vi.fn(),
+	reportInstallation: vi.fn(),
+	reportSkillInstall: mocks.reportSkillInstall,
+	PluginApiError: class PluginApiError extends Error {},
+}));
+
+vi.mock('../src/lib/plugin-download.js', () => ({
+	downloadAllSkills: vi.fn(),
+	printDownloadSummary: vi.fn(),
+}));
+
+vi.mock('../src/lib/plugin-logger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		success: vi.fn(),
+		box: vi.fn(),
+		startSpinner: vi.fn(),
+		stopSpinner: vi.fn(),
+		spinnerSuccess: vi.fn(),
+		spinnerError: vi.fn(),
+	},
+}));
+
+vi.mock('../src/lib/agents.js', () => ({
+	CANONICAL_SKILLS_DIR: '/mock/home/.agents/skills',
+}));
+
+vi.mock('../src/lib/installer.js', () => ({
+	extractSkillZip: mocks.extractSkillZip,
+	getCanonicalSkillPath: (slug: string) => `/mock/home/.agents/skills/${slug}`,
+	linkSkillToDirectory: mocks.linkSkillToDirectory,
+}));
+
+vi.mock('../src/lib/skill-lock.js', () => ({
+	addToLock: mocks.addToLock,
+}));
+
+import installCommand from '../src/commands/install.js';
+
+describe('install command', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.access.mockRejectedValue(new Error('ENOENT'));
+		mocks.fetchSkillManifest.mockResolvedValue({
+			version: '1.0',
+			schemaVersion: '2.0',
+			kind: 'skill',
+			skill: {
+				slug: 'owner-skill',
+				name: 'Owner Skill',
+				version: '2.0.1',
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				versionStatus: 'valid',
+				treeHash: 'tree-hash-r2',
+				author: 'Owner',
+			},
+			artifact: { sha256: 'zip-hash-r2' },
+			signature: 'signature',
+			generatedAt: '2026-07-14T00:00:00.000Z',
+		});
+		mocks.downloadSkillZip.mockResolvedValue(new ArrayBuffer(8));
+		mocks.verifySkillManifest.mockResolvedValue({ valid: true });
+		mocks.verifyZipHash.mockReturnValue(true);
+		mocks.extractSkillZip.mockResolvedValue(undefined);
+		mocks.linkSkillToDirectory.mockResolvedValue({
+			success: true,
+			path: '/mock/target/owner-skill',
+			symlinkFailed: false,
+		});
+		mocks.addToLock.mockResolvedValue(undefined);
+		mocks.reportSkillInstall.mockResolvedValue(undefined);
+	});
+
+	it('writes the complete dual-version identity to the local lock', async () => {
+		await installCommand.run?.({
+			args: {
+				target: 'owner-skill',
+				dir: '/mock/target',
+				'skip-verify': false,
+				'dry-run': false,
+				overwrite: false,
+			},
+		} as never);
+
+		expect(mocks.addToLock).toHaveBeenCalledOnce();
+		expect(mocks.addToLock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				slug: 'owner-skill',
+				version: '2.0.1',
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				versionStatus: 'valid',
+				treeHash: 'tree-hash-r2',
+				zipHash: 'zip-hash-r2',
+				source: 'skillstore',
+			})
+		);
+	});
+});

--- a/packages/skillstore/tests/list-command.test.ts
+++ b/packages/skillstore/tests/list-command.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getAllLockedSkills: vi.fn(),
+}));
+
+vi.mock('../src/lib/skill-lock.js', () => ({
+	getAllLockedSkills: mocks.getAllLockedSkills,
+}));
+
+vi.mock('../src/lib/plugin-logger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import listCommand from '../src/commands/list.js';
+
+describe('list command', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows revisions and never renders a nullable version as vnull', async () => {
+		mocks.getAllLockedSkills.mockResolvedValue([
+			{
+				slug: 'missing-version',
+				version: null,
+				authorVersion: null,
+				skillstoreRevision: 3,
+				zipHash: 'hash-3',
+				source: 'skillstore',
+				installedAt: '2026-07-14T00:00:00.000Z',
+				updatedAt: '2026-07-14T00:00:00.000Z',
+			},
+			{
+				slug: 'valid-version',
+				version: '2.0.1',
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				zipHash: 'hash-2',
+				source: 'skillstore',
+				installedAt: '2026-07-13T00:00:00.000Z',
+				updatedAt: '2026-07-13T00:00:00.000Z',
+			},
+		]);
+		const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+		await listCommand.run?.({ args: { json: false } } as never);
+
+		const output = log.mock.calls.map(([line]) => String(line)).join('\n');
+		expect(output).toContain('missing-version  Not declared (r3)');
+		expect(output).toContain('valid-version  v2.0.1 (r2)');
+		expect(output).not.toContain('vnull');
+		log.mockRestore();
+	});
+});

--- a/packages/skillstore/tests/pack-lock.test.ts
+++ b/packages/skillstore/tests/pack-lock.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PluginConfig } from '../src/lib/plugin-config.js';
+import type { ManifestSkill } from '../src/lib/plugin-api.js';
+import type { DownloadSummary } from '../src/lib/plugin-download.js';
+
+const mocks = vi.hoisted(() => ({
+	fetchSkillManifest: vi.fn(),
+	getSkillLockVersionIdentity: vi.fn(),
+	getSkillZipHash: vi.fn(),
+	verifySkillManifest: vi.fn(),
+	addToLock: vi.fn(),
+	warn: vi.fn(),
+}));
+
+vi.mock('../src/lib/skill-api.js', () => ({
+	fetchSkillManifest: mocks.fetchSkillManifest,
+	getSkillLockVersionIdentity: mocks.getSkillLockVersionIdentity,
+	getSkillZipHash: mocks.getSkillZipHash,
+}));
+
+vi.mock('../src/lib/plugin-verify.js', () => ({
+	verifySkillManifest: mocks.verifySkillManifest,
+}));
+
+vi.mock('../src/lib/skill-lock.js', () => ({
+	addToLock: mocks.addToLock,
+}));
+
+vi.mock('../src/lib/plugin-logger.js', () => ({
+	logger: { warn: mocks.warn },
+}));
+
+import { lockVerifiedPackMembers } from '../src/lib/pack-lock.js';
+
+const config: PluginConfig = {
+	apiBaseUrl: 'https://skillstore.test/api',
+	installDir: '/tmp/skills',
+	timeout: 1000,
+	maxConcurrent: 1,
+	skipVerify: false,
+	dryRun: false,
+};
+
+const member: ManifestSkill = {
+	slug: 'owner-skill',
+	name: 'Owner Skill',
+	version: '2.0.1',
+	authorVersion: '2.0.1',
+	skillstoreRevision: 7,
+	versionStatus: 'declared',
+	treeHash: 'a'.repeat(64),
+	contentHash: 'pack-content-hash',
+	downloadUrl: 'https://skillstore.test/member',
+};
+
+function download(overrides: Partial<DownloadSummary['results'][number]> = {}): DownloadSummary {
+	return {
+		total: 1,
+		success: 1,
+		failed: 0,
+		skipped: 0,
+		results: [{ slug: member.slug, success: true, ...overrides }],
+	};
+}
+
+describe('pack-lock', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.fetchSkillManifest.mockResolvedValue({ skill: { ...member } });
+		mocks.getSkillLockVersionIdentity.mockReturnValue({
+			version: member.version,
+			authorVersion: member.authorVersion,
+			skillstoreRevision: member.skillstoreRevision,
+			versionStatus: member.versionStatus,
+			treeHash: member.treeHash,
+		});
+		mocks.getSkillZipHash.mockReturnValue('single-skill-zip-hash');
+		mocks.verifySkillManifest.mockResolvedValue({ valid: true });
+	});
+
+	it('locks a verified matching member with the single-skill ZIP hash', async () => {
+		await expect(lockVerifiedPackMembers(config, [member], download()))
+			.resolves.toEqual({ locked: 1, skipped: 0 });
+
+		expect(mocks.addToLock).toHaveBeenCalledWith(expect.objectContaining({
+			slug: member.slug,
+			version: '2.0.1',
+			skillstoreRevision: 7,
+			treeHash: 'a'.repeat(64),
+			zipHash: 'single-skill-zip-hash',
+		}));
+	});
+
+	it('leaves a member unlocked when the signed identities differ', async () => {
+		mocks.getSkillLockVersionIdentity.mockReturnValue({
+			version: member.version,
+			authorVersion: member.authorVersion,
+			skillstoreRevision: 8,
+			versionStatus: member.versionStatus,
+			treeHash: member.treeHash,
+		});
+
+		await expect(lockVerifiedPackMembers(config, [member], download()))
+			.resolves.toEqual({ locked: 0, skipped: 1 });
+		expect(mocks.addToLock).not.toHaveBeenCalled();
+	});
+
+	it('leaves a member unlocked when its single-skill signature is invalid', async () => {
+		mocks.verifySkillManifest.mockResolvedValue({ valid: false, error: 'bad signature' });
+
+		await expect(lockVerifiedPackMembers(config, [member], download()))
+			.resolves.toEqual({ locked: 0, skipped: 1 });
+		expect(mocks.addToLock).not.toHaveBeenCalled();
+	});
+
+	it('does not lock a download skipped because it was already installed', async () => {
+		await expect(lockVerifiedPackMembers(config, [member], download({ skipped: true })))
+			.resolves.toEqual({ locked: 0, skipped: 0 });
+		expect(mocks.fetchSkillManifest).not.toHaveBeenCalled();
+		expect(mocks.addToLock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/skillstore/tests/plugin-api.test.ts
+++ b/packages/skillstore/tests/plugin-api.test.ts
@@ -109,7 +109,9 @@ describe('plugin-api', () => {
 							version: '2026.07.04',
 							visibility: 'public',
 						},
-						skills: [],
+						skills: [
+							{ slug: 'skill-1', name: 'Skill 1', contentHash: 'abc', downloadUrl: 'https://example.com/SKILL.md' },
+						],
 					},
 					signature: {
 						algorithm: 'Ed25519',
@@ -131,6 +133,71 @@ describe('plugin-api', () => {
 			expect(result.pack?.slug).toBe('frontend-ui-builder-pack');
 			expect(result.skills).toHaveLength(1);
 			expect(typeof result.signature).toBe('object');
+		});
+
+		it('should preserve additive dual-version fields on pack members', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						kind: 'pack',
+						version: '1.0',
+						generatedAt: '2026-07-14T00:00:00Z',
+						pack: { slug: 'test-pack', name: 'Test Pack', version: '2026.07.14' },
+						skills: [
+							{
+								slug: 'owner-skill',
+								name: 'Owner Skill',
+								version: null,
+								authorVersion: null,
+								skillstoreRevision: 2,
+								versionStatus: 'missing',
+								treeHash: 'tree-hash-r2',
+								contentHash: 'content-hash',
+								downloadUrl: 'https://example.com/SKILL.md',
+							},
+						],
+						signature: 'signature',
+					}),
+			});
+
+			const result = await fetchManifest(config, 'test-pack');
+
+			expect(result.skills[0]).toMatchObject({
+				version: null,
+				authorVersion: null,
+				skillstoreRevision: 2,
+				versionStatus: 'missing',
+				treeHash: 'tree-hash-r2',
+			});
+		});
+
+		it('should ignore tampered top-level pack aliases and skills for Ed25519 envelopes', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({
+					kind: 'pack', version: '1.0', generatedAt: 'evil',
+					plugin: { slug: 'evil', name: 'Evil', version: '9.9.9' },
+					pack: { slug: 'evil', name: 'Evil', version: '9.9.9' },
+					skills: [{ slug: 'evil', name: 'Evil', contentHash: 'evil', downloadUrl: 'https://evil.test' }],
+					signed: {
+						kind: 'pack', version: '1.0', generatedAt: 'safe',
+						pack: { slug: 'safe', name: 'Safe', version: '1.0.0', visibility: 'public' },
+						skills: [{ slug: 'safe-skill', name: 'Safe', contentHash: 'safe', downloadUrl: 'https://safe.test' }],
+					},
+					signature: {
+						algorithm: 'Ed25519', keyId: 'k',
+						publicKeyJwk: { kty: 'OKP', crv: 'Ed25519', x: 'x' },
+						signedAt: 'safe', value: 'sig',
+					},
+				}),
+			});
+
+			const result = await fetchManifest(config, 'safe');
+			expect(result.plugin.slug).toBe('safe');
+			expect(result.pack?.slug).toBe('safe');
+			expect(result.skills[0].slug).toBe('safe-skill');
+			expect(result.generatedAt).toBe('safe');
 		});
 
 		it('should throw PluginApiError on 404', async () => {

--- a/packages/skillstore/tests/plugin-verify.test.ts
+++ b/packages/skillstore/tests/plugin-verify.test.ts
@@ -317,6 +317,14 @@ describe('plugin-verify', () => {
 			expect(result.valid).toBe(true);
 		});
 
+		it('should accept pack payload schema 1.1 for nullable member versions', async () => {
+			const manifest = createValidManifest({ version: '1.1' });
+			manifest.skills[0].version = null;
+
+			await expect(verifyManifest(manifest, { skipSignature: true }))
+				.resolves.toMatchObject({ valid: true });
+		});
+
 		it('should validate a canonical pack manifest with Ed25519 signature', async () => {
 			const subtle = globalThis.crypto?.subtle || webcrypto.subtle;
 			const keyPair = await subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
@@ -491,6 +499,15 @@ describe('plugin-verify', () => {
 			const result = await verifySkillManifest(manifest);
 
 			expect(result.valid).toBe(true);
+		});
+
+		it('should accept single-skill payload schema 1.1 with a null version', async () => {
+			const manifest = createValidSkillManifest();
+			manifest.version = '1.1';
+			manifest.skill.version = null;
+
+			await expect(verifySkillManifest(manifest, { skipSignature: true }))
+				.resolves.toMatchObject({ valid: true });
 		});
 
 		it('should reject unsupported manifest version', async () => {

--- a/packages/skillstore/tests/skill-api.test.ts
+++ b/packages/skillstore/tests/skill-api.test.ts
@@ -3,8 +3,11 @@ import {
 	fetchSkillInfo,
 	fetchSkillManifest,
 	downloadSkillZip,
+	formatSkillVersionIdentity,
+	getSkillVersionIdentity,
 	getSkillDownloadUrlFromManifest,
 	getSkillZipHash,
+	normalizeSkillManifest,
 	SkillApiError,
 	type SkillInfo,
 	type SkillManifest,
@@ -258,6 +261,30 @@ describe('skill-api', () => {
 			generatedAt: '2024-01-01T00:00:00Z',
 		};
 
+		it('should project Ed25519 convenience fields from the signed payload', () => {
+			const signedSkill = { slug: 'safe', name: 'Safe', version: '2.0.1' };
+			const manifest = normalizeSkillManifest({
+				version: '1.0',
+				skill: { slug: 'evil', name: 'Evil', version: '9.9.9' },
+				artifact: { url: 'https://evil.test/x.zip', sha256: 'evil' },
+				signed: {
+					kind: 'skill',
+					version: '1.0',
+					skill: signedSkill,
+					artifact: { url: 'https://safe.test/x.zip', sha256: 'safe' },
+				},
+				signature: {
+					algorithm: 'Ed25519', keyId: 'k',
+					publicKeyJwk: { kty: 'OKP', crv: 'Ed25519', x: 'x' },
+					signedAt: '2026-07-14T00:00:00Z', value: 'sig',
+				},
+				generatedAt: '2026-07-14T00:00:00Z',
+			});
+
+			expect(manifest.skill.slug).toBe('safe');
+			expect(manifest.artifact?.url).toBe('https://safe.test/x.zip');
+		});
+
 		const modernManifest: SkillManifest = {
 			kind: 'skill',
 			version: '1.0',
@@ -328,6 +355,74 @@ describe('skill-api', () => {
 
 			expect(getSkillDownloadUrlFromManifest(config, manifest, 'test-skill')).toBe(
 				'https://api.test.com/skills/test-skill/download'
+			);
+		});
+
+		it('should preserve the complete dual-version identity', () => {
+			const identity = getSkillVersionIdentity({
+				slug: 'test-skill',
+				name: 'Test Skill',
+				version: '2.0.1',
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				versionStatus: 'valid',
+				treeHash: 'tree-hash-r2',
+			});
+
+			expect(identity).toEqual({
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				versionStatus: 'valid',
+				treeHash: 'tree-hash-r2',
+			});
+		});
+
+		it('should represent an undeclared author version without emitting vnull', () => {
+			const skill = {
+				slug: 'test-skill',
+				name: 'Test Skill',
+				version: null,
+				skillstoreRevision: 1,
+			} satisfies SkillManifest['skill'];
+
+			expect(getSkillVersionIdentity(skill)).toEqual({
+				authorVersion: null,
+				skillstoreRevision: 1,
+				versionStatus: 'missing',
+				treeHash: null,
+			});
+			expect(formatSkillVersionIdentity(skill)).toBe('Not declared (r1)');
+		});
+
+		it('should remain compatible with legacy manifests', () => {
+			expect(getSkillVersionIdentity(legacyManifest.skill)).toEqual({
+				authorVersion: '1.0.0',
+				skillstoreRevision: null,
+				versionStatus: 'legacy_unknown',
+				treeHash: null,
+			});
+			expect(formatSkillVersionIdentity(legacyManifest.skill)).toBe('v1.0.0');
+		});
+
+		it('should not relabel an explicit null authorVersion legacy alias', () => {
+			const skill = {
+				slug: 'legacy-skill',
+				name: 'Legacy Skill',
+				version: '1.0.2',
+				authorVersion: null,
+				versionStatus: 'legacy_unknown',
+			} satisfies SkillManifest['skill'];
+
+			expect(getSkillVersionIdentity(skill).authorVersion).toBeNull();
+			expect(formatSkillVersionIdentity(skill)).toBe('Legacy v1.0.2 (unverified)');
+		});
+
+		it('should visibly distinguish revisions under the same author version', () => {
+			expect(formatSkillVersionIdentity({ version: '2.0.1', skillstoreRevision: 1 })).toBe(
+				'v2.0.1 (r1)'
+			);
+			expect(formatSkillVersionIdentity({ version: '2.0.1', skillstoreRevision: 2 })).toBe(
+				'v2.0.1 (r2)'
 			);
 		});
 	});

--- a/packages/skillstore/tests/skill-lock.test.ts
+++ b/packages/skillstore/tests/skill-lock.test.ts
@@ -99,6 +99,43 @@ describe('skill-lock', () => {
 			expect(lock.version).toBe(LOCK_VERSION);
 			expect(lock.skills['test-skill']).toEqual(mockLockEntry);
 		});
+
+		it('should keep old version-1 lockfiles readable', async () => {
+			vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockLock));
+
+			const lock = await readSkillLock();
+
+			expect(LOCK_VERSION).toBe(1);
+			expect(lock).toEqual(mockLock);
+		});
+
+		it('should preserve nullable and additive dual-version fields', async () => {
+			const dualVersionLock: SkillLock = {
+				version: LOCK_VERSION,
+				skills: {
+					'test-skill': {
+						...mockLockEntry,
+						version: null,
+						authorVersion: null,
+						skillstoreRevision: 3,
+						versionStatus: 'missing',
+						treeHash: 'immutable-tree-hash',
+					},
+				},
+			};
+			vi.mocked(readFile).mockResolvedValue(JSON.stringify(dualVersionLock));
+
+			const lock = await readSkillLock();
+
+			expect(lock).toEqual(dualVersionLock);
+			expect(lock.skills['test-skill']).toMatchObject({
+				version: null,
+				authorVersion: null,
+				skillstoreRevision: 3,
+				versionStatus: 'missing',
+				treeHash: 'immutable-tree-hash',
+			});
+		});
 	});
 
 	describe('writeSkillLock', () => {
@@ -121,6 +158,27 @@ describe('skill-lock', () => {
 
 			expect(parsed).toEqual(mockLock);
 			expect(writtenContent).toContain('\n'); // Pretty formatted
+		});
+
+		it('should round-trip the dual-version identity without changing lock format', async () => {
+			const entry: SkillLockEntry = {
+				...mockLockEntry,
+				version: '2.0.1',
+				authorVersion: '2.0.1',
+				skillstoreRevision: 2,
+				versionStatus: 'valid',
+				treeHash: 'tree-hash-r2',
+			};
+			const lock: SkillLock = {
+				version: LOCK_VERSION,
+				skills: { [entry.slug]: entry },
+			};
+
+			await writeSkillLock(lock);
+			const writtenContent = vi.mocked(writeFile).mock.calls[0][1] as string;
+			vi.mocked(readFile).mockResolvedValue(writtenContent);
+
+			expect(await readSkillLock()).toEqual(lock);
 		});
 	});
 

--- a/packages/skillstore/tests/skill-receipt.test.ts
+++ b/packages/skillstore/tests/skill-receipt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseInstalledSkillReceipt } from '../src/lib/skill-receipt.js';
+
+function receipt(revision = 'r12', treeHash = 'a'.repeat(64)): string {
+	return `# Example
+
+## Skillstore Install Receipt
+
+| Property | Value |
+|----------|-------|
+| **Skillstore revision** | ${revision} |
+| **Tree hash** | \`${treeHash}\` |
+`;
+}
+
+describe('skill-receipt', () => {
+	it('parses a complete install receipt', () => {
+		expect(parseInstalledSkillReceipt(receipt())).toEqual({
+			skillstoreRevision: 12,
+			treeHash: 'a'.repeat(64),
+		});
+	});
+
+	it('rejects receipts without both immutable identity fields', () => {
+		expect(parseInstalledSkillReceipt(receipt().replace(/\| \*\*Tree hash\*\*.*\n/, ''))).toBeNull();
+		expect(parseInstalledSkillReceipt(receipt().replace(/\| \*\*Skillstore revision\*\*.*\n/, ''))).toBeNull();
+	});
+
+	it.each([
+		['revision zero', 'r0', 'a'.repeat(64)],
+		['revision without prefix', '12', 'a'.repeat(64)],
+		['short tree hash', 'r12', 'abc123'],
+		['non-hex tree hash', 'r12', 'z'.repeat(64)],
+	])('rejects malformed %s', (_label, revision, treeHash) => {
+		expect(parseInstalledSkillReceipt(receipt(revision, treeHash))).toBeNull();
+	});
+
+	it('rejects metadata tables that are not an install receipt', () => {
+		expect(parseInstalledSkillReceipt(receipt().replace('## Skillstore Install Receipt', '## Metadata')))
+			.toBeNull();
+	});
+});

--- a/packages/skillstore/tests/update-command.test.ts
+++ b/packages/skillstore/tests/update-command.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getAllLockedSkills: vi.fn(),
+	addToLock: vi.fn(),
+	fetchSkillManifest: vi.fn(),
+	getSkillZipHash: vi.fn(),
+	verifySkillManifest: vi.fn(),
+}));
+
+vi.mock('../src/lib/skill-lock.js', () => ({
+	getAllLockedSkills: mocks.getAllLockedSkills,
+	addToLock: mocks.addToLock,
+}));
+
+vi.mock('../src/lib/skill-api.js', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../src/lib/skill-api.js')>()),
+	fetchSkillManifest: mocks.fetchSkillManifest,
+	downloadSkillZip: vi.fn(),
+	getSkillZipHash: mocks.getSkillZipHash,
+}));
+
+vi.mock('../src/lib/plugin-verify.js', () => ({
+	verifySkillManifest: mocks.verifySkillManifest,
+	verifyZipHash: vi.fn(),
+}));
+
+vi.mock('../src/lib/plugin-config.js', () => ({
+	getPluginConfig: (options: Record<string, unknown>) => options,
+}));
+
+vi.mock('../src/lib/plugin-logger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		success: vi.fn(),
+		spinnerSuccess: vi.fn(),
+		spinnerError: vi.fn(),
+		startSpinner: vi.fn(),
+		stopSpinner: vi.fn(),
+	},
+}));
+
+vi.mock('../src/lib/agents.js', () => ({
+	CANONICAL_SKILLS_DIR: '/mock/home/.agents/skills',
+	agents: { 'claude-code': { id: 'claude-code', name: 'Claude Code' } },
+	detectInstalledAgents: vi.fn(() => []),
+}));
+
+vi.mock('../src/lib/installer.js', () => ({
+	extractSkillZip: vi.fn(),
+	installToAgents: vi.fn(),
+	getCanonicalSkillPath: (slug: string) => `/mock/home/.agents/skills/${slug}`,
+}));
+
+vi.mock('../src/lib/plugin-api.js', () => ({
+	reportSkillInstall: vi.fn(),
+}));
+
+import updateCommand from '../src/commands/update.js';
+
+describe('update command', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getAllLockedSkills.mockResolvedValue([
+			{
+				slug: 'legacy-skill',
+				version: '1.0.1',
+				zipHash: 'old-zip-hash',
+				source: 'skillstore',
+				installedAt: '2026-07-13T00:00:00.000Z',
+				updatedAt: '2026-07-13T00:00:00.000Z',
+			},
+		]);
+		mocks.fetchSkillManifest.mockResolvedValue({
+			version: '1.0',
+			skill: {
+				slug: 'legacy-skill',
+				name: 'Legacy Skill',
+				version: '1.0.2',
+				authorVersion: null,
+				skillstoreRevision: 2,
+				versionStatus: 'legacy_unknown',
+				treeHash: 'a'.repeat(64),
+			},
+			signature: 'signature',
+			generatedAt: '2026-07-14T00:00:00.000Z',
+		});
+		mocks.getSkillZipHash.mockReturnValue('new-zip-hash');
+		mocks.verifySkillManifest.mockResolvedValue({ valid: true });
+	});
+
+	it('does not present an explicit legacy alias as an author-owned version', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+		await updateCommand.run?.({
+			args: { slug: undefined, 'skip-verify': false, 'dry-run': true },
+		} as never);
+
+		const output = log.mock.calls.map(([line]) => String(line)).join('\n');
+		expect(output).toContain('Legacy v1.0.2 (unverified) (r2)');
+		expect(output).not.toContain('→ v1.0.2 (r2)');
+		log.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary

- Upgrade the public `skillstore` NPX package from `0.1.8` to `0.1.9`.
- Preserve the author-owned version and Skillstore-owned artifact revision as separate additive fields in manifests and the existing version-1 local lockfile.
- Display same-author-version changes as `v2.0.1 (r1) -> v2.0.1 (r2)` and render explicit legacy aliases as unverified instead of author-owned versions.
- Support signed manifest payload schema `1.1` when an author version is not declared.
- Consume Ed25519-signed `skill`, `skills`, `pack`, and artifact fields instead of unsigned top-level convenience fields.
- Make single `add`/`install`, `list`, `check`, `update`, `generate-lock`, and Pack installation revision-aware.
- Require verified install receipts before reconstructing a lock and independently verify Pack members against their single-Skill manifests before locking them.
- Gate the Supabase artifact writer on stable Skillstore admin CLI `>=2.0.0`; older, unknown, mismatched, and prerelease CLIs fail closed.

## Why two versions

`authorVersion` reflects exactly what the Skill author declared. `skillstoreRevision` (`rN`) identifies an immutable installable artifact observed by Skillstore. If content changes without an author version bump, the author version stays unchanged while the Skillstore revision advances.

## Compatibility

- Existing manifest and lockfile `version` fields remain compatibility aliases.
- `.skill-lock.json` stays at schema version `1`; new identity fields are additive.
- Old version-1 lockfiles remain readable and are enriched safely when the ZIP hash still matches.
- Explicit `authorVersion: null` is preserved and never reinterpreted from a legacy alias.

## Validation

- `corepack pnpm --filter skillstore check`
- `corepack pnpm --filter skillstore test` - 266/266 passed
- `corepack pnpm --filter skillstore build`
- YAML parse for the shared downloader action and sync workflow
- Writer version gate cases: `1.52.2` rejected, `2.0.0-beta.1` rejected, `2.0.0+` accepted
- Real PR-preview single-Skill add/list/check/lock verification
- Real PR-preview Pack install/list/check/member-lock verification
- `git diff --check`

## Release order

1. Merge the paired Skillstore PR: https://github.com/aiskillstore/skillstore/pull/199
2. Pause artifact-writing sync jobs.
3. Publish Skillstore admin CLI `2.0.0` and apply the guarded v2 database migration in the same maintenance window.
4. Merge this PR so the writer workflow enforces CLI `>=2.0.0`.
5. Publish npm `skillstore@0.1.9`.
6. Re-run the existing one-Skill canary before any bounded historical initialization.

No production workflow, npm release, database migration, or backfill is performed by this PR.
