### PR TITLE
fix: 自动修复 PR 继承提交审批元数据

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -29,14 +29,22 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Extract canonical submission ID from PR body
+      - name: Verify unique submission authorization lease
         id: extract_submission
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          METADATA_JSON=$(node scripts/submission-metadata.mjs --event-path "$GITHUB_EVENT_PATH")
-          SUBMISSION_ID=$(printf '%s' "$METADATA_JSON" | jq -er '.submissionId')
+          AUTHORIZATION_JSON=$(node scripts/submission-authorization.mjs \
+            --mode verify-merge \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --repository "$REPOSITORY")
+          SUBMISSION_ID=$(printf '%s' "$AUTHORIZATION_JSON" | jq -er '.submissionId')
+          AUTHORIZATION_KIND=$(printf '%s' "$AUTHORIZATION_JSON" | jq -er '.authorizationKind')
           echo "submission_id=$SUBMISSION_ID" >> "$GITHUB_OUTPUT"
-          echo "📋 Found canonical submission ID: $SUBMISSION_ID"
+          echo "authorization_kind=$AUTHORIZATION_KIND" >> "$GITHUB_OUTPUT"
+          echo "📋 Verified unique $AUTHORIZATION_KIND authorization for submission: $SUBMISSION_ID"
 
       - name: Find pending skills and commit to skills directory
         env:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -18,24 +18,25 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Checkout the exact merged revision
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '24'
 
-      - name: Extract submission ID from PR body
+      - name: Extract canonical submission ID from PR body
         id: extract_submission
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Extract submission ID from PR body: **Submission ID**: `UUID`
-          SUBMISSION_ID=$(echo "$PR_BODY" | grep -oE 'Submission ID.*`[0-9a-f-]{36}`' | grep -oE '[0-9a-f-]{36}' || echo "")
-          echo "submission_id=$SUBMISSION_ID" >> $GITHUB_OUTPUT
-          if [ -n "$SUBMISSION_ID" ]; then
-            echo "📋 Found submission ID: $SUBMISSION_ID"
-          else
-            echo "⚠️ No submission ID found in PR body"
-          fi
+          set -euo pipefail
+          METADATA_JSON=$(node scripts/submission-metadata.mjs --event-path "$GITHUB_EVENT_PATH")
+          SUBMISSION_ID=$(printf '%s' "$METADATA_JSON" | jq -er '.submissionId')
+          echo "submission_id=$SUBMISSION_ID" >> "$GITHUB_OUTPUT"
+          echo "📋 Found canonical submission ID: $SUBMISSION_ID"
 
       - name: Find pending skills and commit to skills directory
         env:

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/recalculate-scores.sh"
       - "scripts/build-autofix-pr-metadata.mjs"
       - "scripts/submission-metadata.mjs"
+      - "scripts/submission-authorization.mjs"
       - "scripts/autofix-pr-lifecycle.mjs"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
@@ -25,6 +26,7 @@ on:
       - "scripts/recalculate-scores.sh"
       - "scripts/build-autofix-pr-metadata.mjs"
       - "scripts/submission-metadata.mjs"
+      - "scripts/submission-authorization.mjs"
       - "scripts/autofix-pr-lifecycle.mjs"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
@@ -62,6 +64,7 @@ jobs:
           node --check scripts/plan-cache-invalidation.mjs
           node --check scripts/build-autofix-pr-metadata.mjs
           node --check scripts/submission-metadata.mjs
+          node --check scripts/submission-authorization.mjs
           node --check scripts/autofix-pr-lifecycle.mjs
-          node --test scripts/tests/autofix-pr-metadata.test.mjs scripts/tests/autofix-pr-lifecycle.test.mjs
+          node --test scripts/tests/autofix-pr-metadata.test.mjs scripts/tests/autofix-pr-lifecycle.test.mjs scripts/tests/autofix-pr-authorization.test.mjs
           node --test scripts/tests/*.test.mjs

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -8,8 +8,13 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/build-autofix-pr-metadata.mjs"
+      - "scripts/submission-metadata.mjs"
+      - "scripts/autofix-pr-lifecycle.mjs"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
+      - ".github/workflows/validate-marketplace.yml"
+      - ".github/workflows/on-pr-merge.yml"
       - ".github/workflows/test-recalculate-scores.yml"
   push:
     branches: [main]
@@ -18,8 +23,14 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/build-autofix-pr-metadata.mjs"
+      - "scripts/submission-metadata.mjs"
+      - "scripts/autofix-pr-lifecycle.mjs"
       - "scripts/tests/**"
       - ".github/workflows/sync-to-supabase.yml"
+      - ".github/workflows/validate-marketplace.yml"
+      - ".github/workflows/on-pr-merge.yml"
+      - ".github/workflows/test-recalculate-scores.yml"
   workflow_dispatch:
 
 permissions:
@@ -49,4 +60,8 @@ jobs:
           bash -n scripts/recalculate-scores.sh
           bash -n scripts/tests/fake-cli.sh
           node --check scripts/plan-cache-invalidation.mjs
+          node --check scripts/build-autofix-pr-metadata.mjs
+          node --check scripts/submission-metadata.mjs
+          node --check scripts/autofix-pr-lifecycle.mjs
+          node --test scripts/tests/autofix-pr-metadata.test.mjs scripts/tests/autofix-pr-lifecycle.test.mjs
           node --test scripts/tests/*.test.mjs

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -360,6 +360,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
@@ -392,6 +393,17 @@ jobs:
             exit 0
           fi
 
+          # Build replacement-PR metadata from the pull_request event itself.
+          # This survives squash merge because approval never depends on commit history.
+          PR_BODY_FILE="$RUNNER_TEMP/skill-md-autofix-pr-body-${GITHUB_RUN_ID}.md"
+          METADATA_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/build-autofix-pr-metadata.mjs" \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --event-name "$EVENT_NAME" \
+            --body-file "$PR_BODY_FILE" \
+            --modified-count "$MODIFIED_COUNT" \
+            --deleted-count "$DELETED_COUNT")
+          INHERIT_PENDING_REVIEW=$(printf '%s' "$METADATA_JSON" | jq -r '.inheritPendingReview')
+
           # Build commit message
           COMMIT_MSG="fix: auto-fix SKILL.md validation errors
 
@@ -416,33 +428,17 @@ jobs:
           [ "$DELETED_COUNT" -gt 0 ] && [ "$MODIFIED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE ($DELETED_COUNT deleted)"
           [ "$MODIFIED_COUNT" -gt 0 ] && [ "$DELETED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE)"
 
-          # Create PR
-          PR_URL=$(gh pr create \
-            --title "$PR_TITLE" \
-            --body "## Summary
+          PR_ARGS=(
+            --title "$PR_TITLE"
+            --body-file "$PR_BODY_FILE"
+            --base main
+            --head "$BRANCH_NAME"
+          )
+          if [ "$INHERIT_PENDING_REVIEW" = "true" ]; then
+            PR_ARGS+=(--label "pending-review")
+          fi
 
-          AI-powered auto-fix for SKILL.md validation errors.
-
-          | Metric | Value |
-          |--------|-------|
-          | Files Fixed | $MODIFIED_COUNT |
-          | Empty Skills Deleted | $DELETED_COUNT |
-          | Triggered By | ${{ github.event_name }} |
-
-          ### Fixes Applied
-          - Added missing YAML frontmatter
-          - Fixed \`name\` field format (lowercase alphanumeric with hyphens)
-          - Added missing \`description\` field
-          - Truncated overly long descriptions
-          - **Deleted empty skill directories** (unfixable)
-
-          ### After Merge
-          The \`sync-to-supabase.yml\` workflow will automatically update the database.
-
-          ---
-          *Automated fix by validate-marketplace.yml*" \
-            --base main \
-            --head "$BRANCH_NAME")
+          PR_URL=$(gh pr create "${PR_ARGS[@]}")
 
           echo "::notice::Created PR for SKILL.md fixes: $PR_URL"
           echo "🔗 PR Created: $PR_URL"

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -9,6 +9,7 @@ on:
       - "skills/**/skill-report.json"
       - "skills/**/SKILL.md"
   pull_request:
+    types: [opened, synchronize, reopened, edited, labeled]
     branches: [main]
     paths:
       # Validate both pending and skills on PR (CI gate)
@@ -24,9 +25,9 @@ env:
   # Enable auto-fix for push, PRs, and manual triggers (set to 'false' to disable)
   AUTO_FIX_ENABLED: ${{ contains(fromJSON('["pull_request", "push", "workflow_dispatch"]'), github.event_name) }}
 
-# One source PR/head can create or resume only one replacement lifecycle at a time.
+# Every head/body generation of one source PR shares one serialized lifecycle.
 concurrency:
-  group: validate-marketplace-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: validate-marketplace-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -455,28 +456,21 @@ jobs:
           [ "$MODIFIED_COUNT" -gt 0 ] && [ "$DELETED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE)"
 
           if [ "$INHERIT_PENDING_REVIEW" = "true" ]; then
-            # Second live check is immediately before create/reuse; stale events stop here.
-            PREFLIGHT_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
-              --mode preflight \
+            # API response loss is deduped by the exact source lifecycle branch.
+            ENSURE_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
+              --mode ensure-replacement \
               --event-path "$GITHUB_EVENT_PATH" \
-              --repository "$REPOSITORY")
-            EXISTING_PR_NUMBER=$(printf '%s' "$PREFLIGHT_JSON" | jq -r '.existingReplacement.number // empty')
+              --repository "$REPOSITORY" \
+              --title "$PR_TITLE" \
+              --body-file "$PR_BODY_FILE" \
+              --head-ref "$BRANCH_NAME" \
+              --base-ref main \
+              --replacement-head-sha "$REPLACEMENT_HEAD_SHA")
+            PR_NUMBER=$(printf '%s' "$ENSURE_JSON" | jq -er '.number')
+            PR_URL=$(printf '%s' "$ENSURE_JSON" | jq -er '.url')
 
-            if [ -n "$EXISTING_PR_NUMBER" ]; then
-              gh pr edit "$EXISTING_PR_NUMBER" --title "$PR_TITLE" --body-file "$PR_BODY_FILE"
-              PR_NUMBER="$EXISTING_PR_NUMBER"
-              PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
-            else
-              # The replacement starts without approval capability.
-              PR_URL=$(gh pr create \
-                --title "$PR_TITLE" \
-                --body-file "$PR_BODY_FILE" \
-                --base main \
-                --head "$BRANCH_NAME")
-              PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
-            fi
-
-            # Reentrant fail-closed transfer: revoke/close source first, label replacement last.
+            # The lease makes only its exact holder consumer-authorized. Every API
+            # failure is re-read and compensated before this command returns.
             node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
               --mode supersede \
               --event-path "$GITHUB_EVENT_PATH" \

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -24,6 +24,11 @@ env:
   # Enable auto-fix for push, PRs, and manual triggers (set to 'false' to disable)
   AUTO_FIX_ENABLED: ${{ contains(fromJSON('["pull_request", "push", "workflow_dispatch"]'), github.event_name) }}
 
+# One source PR/head can create or resume only one replacement lifecycle at a time.
+concurrency:
+  group: validate-marketplace-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: false
+
 jobs:
   validate:
     runs-on: self-hosted
@@ -45,6 +50,7 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}
@@ -52,34 +58,42 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Determine branch name
           if [ "$EVENT_NAME" == "pull_request" ]; then
             BRANCH="$HEAD_REF"
           else
             BRANCH="$REF_NAME"
           fi
 
-          # Create unique temporary directory for this workflow run
           WORK_DIR="/tmp/marketplace-validate-$RUN_ID"
 
-          echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-          echo "work_dir=$WORK_DIR" >> $GITHUB_OUTPUT
+          echo "WORK_DIR=$WORK_DIR" >> "$GITHUB_ENV"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          echo "work_dir=$WORK_DIR" >> "$GITHUB_OUTPUT"
 
           echo "📁 Creating temporary workspace: $WORK_DIR"
           echo "🌿 Target branch: $BRANCH"
 
-          # Cleanup any existing directory
           rm -rf "$WORK_DIR"
-          mkdir -p "$WORK_DIR"
 
-          # Clone repository to temporary workspace
-          echo "📦 Cloning repository..."
-          git clone --depth 1 --branch "$BRANCH" \
-            "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" \
-            "$WORK_DIR"
-
-          cd "$WORK_DIR"
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            # Repair exactly the commit that produced this event; never a later branch tip.
+            [ -n "$EVENT_HEAD_SHA" ] || { echo "::error::Missing pull_request head SHA"; exit 1; }
+            git clone --no-checkout --filter=blob:none \
+              "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" \
+              "$WORK_DIR"
+            cd "$WORK_DIR"
+            git fetch --depth 1 origin "$EVENT_HEAD_SHA"
+            git checkout -B "$BRANCH" "$EVENT_HEAD_SHA"
+            [ "$(git rev-parse HEAD)" = "$EVENT_HEAD_SHA" ] || {
+              echo "::error::Checked out SHA does not match the pull_request event head"
+              exit 1
+            }
+          else
+            git clone --depth 1 --branch "$BRANCH" \
+              "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" \
+              "$WORK_DIR"
+            cd "$WORK_DIR"
+          fi
 
           # Configure git for potential commits
           git config user.name "github-actions[bot]"
@@ -364,7 +378,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Check if there are any changes (modifications or deletions)
           if git diff --quiet && git status --porcelain | grep -qE '^\s*D|^\?\?'; then
             : # There are deletions or untracked changes
           elif git diff --quiet; then
@@ -372,18 +385,10 @@ jobs:
             exit 0
           fi
 
-          # Configure git remote URL with authentication token
           echo "🔑 Configuring git authentication..."
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
 
-          # Create a new branch for the fixes
-          BRANCH_NAME="fix/skill-md-validation-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b "$BRANCH_NAME"
-
-          # Stage all changes (modifications and deletions)
           git add -A
-
-          # Count changes by type
           MODIFIED_COUNT=$(git diff --cached --diff-filter=M --name-only | wc -l | tr -d ' ')
           DELETED_COUNT=$(git diff --cached --diff-filter=D --name-only | wc -l | tr -d ' ')
           TOTAL_COUNT=$((MODIFIED_COUNT + DELETED_COUNT))
@@ -393,8 +398,6 @@ jobs:
             exit 0
           fi
 
-          # Build replacement-PR metadata from the pull_request event itself.
-          # This survives squash merge because approval never depends on commit history.
           PR_BODY_FILE="$RUNNER_TEMP/skill-md-autofix-pr-body-${GITHUB_RUN_ID}.md"
           METADATA_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/build-autofix-pr-metadata.mjs" \
             --event-path "$GITHUB_EVENT_PATH" \
@@ -404,7 +407,22 @@ jobs:
             --deleted-count "$DELETED_COUNT")
           INHERIT_PENDING_REVIEW=$(printf '%s' "$METADATA_JSON" | jq -r '.inheritPendingReview')
 
-          # Build commit message
+          EXISTING_PR_NUMBER=""
+          EXISTING_HEAD_SHA=""
+          if [ "$INHERIT_PENDING_REVIEW" = "true" ]; then
+            # First live check: source head/body/label must still match the triggering event.
+            PREFLIGHT_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
+              --mode preflight \
+              --event-path "$GITHUB_EVENT_PATH" \
+              --repository "$REPOSITORY")
+            BRANCH_NAME=$(printf '%s' "$PREFLIGHT_JSON" | jq -r '.branchName')
+            EXISTING_PR_NUMBER=$(printf '%s' "$PREFLIGHT_JSON" | jq -r '.existingReplacement.number // empty')
+            EXISTING_HEAD_SHA=$(printf '%s' "$PREFLIGHT_JSON" | jq -r '.existingReplacement.headSha // empty')
+          else
+            BRANCH_NAME="fix/skill-md-validation-$(date +%Y%m%d-%H%M%S)"
+          fi
+          git checkout -b "$BRANCH_NAME"
+
           COMMIT_MSG="fix: auto-fix SKILL.md validation errors
 
           AI-powered fix applied by GitHub Actions workflow."
@@ -415,32 +433,65 @@ jobs:
           COMMIT_MSG="$COMMIT_MSG
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
-
           git commit -m "$COMMIT_MSG"
+          REPLACEMENT_HEAD_SHA=$(git rev-parse HEAD)
 
-          # Push the branch
-          git push origin "$BRANCH_NAME"
+          REMOTE_BRANCH_SHA=$(git ls-remote --heads origin "refs/heads/$BRANCH_NAME" | awk 'NR == 1 { print $1 }')
+          if [ -n "$EXISTING_HEAD_SHA" ] && [ "$REMOTE_BRANCH_SHA" != "$EXISTING_HEAD_SHA" ]; then
+            echo "::error::Replacement branch moved after preflight"
+            exit 1
+          fi
+          if [ -n "$REMOTE_BRANCH_SHA" ]; then
+            git push --force-with-lease="refs/heads/$BRANCH_NAME:$REMOTE_BRANCH_SHA" \
+              origin "HEAD:refs/heads/$BRANCH_NAME"
+          else
+            git push origin "HEAD:refs/heads/$BRANCH_NAME"
+          fi
 
-          # Build PR title
           PR_TITLE="fix: Auto-fix SKILL.md validation errors"
           [ "$MODIFIED_COUNT" -gt 0 ] && PR_TITLE="$PR_TITLE ($MODIFIED_COUNT fixed"
           [ "$DELETED_COUNT" -gt 0 ] && [ "$MODIFIED_COUNT" -gt 0 ] && PR_TITLE="$PR_TITLE, $DELETED_COUNT deleted)"
           [ "$DELETED_COUNT" -gt 0 ] && [ "$MODIFIED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE ($DELETED_COUNT deleted)"
           [ "$MODIFIED_COUNT" -gt 0 ] && [ "$DELETED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE)"
 
-          PR_ARGS=(
-            --title "$PR_TITLE"
-            --body-file "$PR_BODY_FILE"
-            --base main
-            --head "$BRANCH_NAME"
-          )
           if [ "$INHERIT_PENDING_REVIEW" = "true" ]; then
-            PR_ARGS+=(--label "pending-review")
+            # Second live check is immediately before create/reuse; stale events stop here.
+            PREFLIGHT_JSON=$(node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
+              --mode preflight \
+              --event-path "$GITHUB_EVENT_PATH" \
+              --repository "$REPOSITORY")
+            EXISTING_PR_NUMBER=$(printf '%s' "$PREFLIGHT_JSON" | jq -r '.existingReplacement.number // empty')
+
+            if [ -n "$EXISTING_PR_NUMBER" ]; then
+              gh pr edit "$EXISTING_PR_NUMBER" --title "$PR_TITLE" --body-file "$PR_BODY_FILE"
+              PR_NUMBER="$EXISTING_PR_NUMBER"
+              PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+            else
+              # The replacement starts without approval capability.
+              PR_URL=$(gh pr create \
+                --title "$PR_TITLE" \
+                --body-file "$PR_BODY_FILE" \
+                --base main \
+                --head "$BRANCH_NAME")
+              PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+            fi
+
+            # Reentrant fail-closed transfer: revoke/close source first, label replacement last.
+            node "$GITHUB_WORKSPACE/marketplace-repo/scripts/autofix-pr-lifecycle.mjs" \
+              --mode supersede \
+              --event-path "$GITHUB_EVENT_PATH" \
+              --repository "$REPOSITORY" \
+              --replacement-pr "$PR_NUMBER" \
+              --replacement-head-sha "$REPLACEMENT_HEAD_SHA"
+          else
+            PR_URL=$(gh pr create \
+              --title "$PR_TITLE" \
+              --body-file "$PR_BODY_FILE" \
+              --base main \
+              --head "$BRANCH_NAME")
           fi
 
-          PR_URL=$(gh pr create "${PR_ARGS[@]}")
-
-          echo "::notice::Created PR for SKILL.md fixes: $PR_URL"
+          echo "::notice::Created or resumed PR for SKILL.md fixes: $PR_URL"
           echo "🔗 PR Created: $PR_URL"
 
       - name: Fail if SKILL.md errors remain

--- a/scripts/autofix-pr-lifecycle.mjs
+++ b/scripts/autofix-pr-lifecycle.mjs
@@ -6,12 +6,19 @@ import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 import {
+  authorizationLeaseTagMessage,
+  buildAuthorizationLease,
+  parseAuthorizationLeaseTag,
+} from './submission-authorization.mjs';
+import {
+  authorizationLeaseRef,
   parseCanonicalSubmissionId,
-  parseReplacementSource,
+  parseReplacementAuthorization,
 } from './submission-metadata.mjs';
 
 const PENDING_REVIEW_LABEL = 'pending-review';
 const SHA_RE = /^[0-9a-f]{40}$/;
+const MAX_RECONCILE_ITERATIONS = 30;
 
 function stateOf(pull) {
   return typeof pull?.state === 'string' ? pull.state.toLowerCase() : '';
@@ -32,6 +39,18 @@ function canonicalSha(value, name) {
   const sha = typeof value === 'string' ? value.toLowerCase() : '';
   if (!SHA_RE.test(sha)) throw new Error(`${name} must be a 40-character Git SHA`);
   return sha;
+}
+
+function leasesEqual(left, right) {
+  return left !== null && right !== null
+    && left.version === right.version
+    && left.submissionId === right.submissionId
+    && left.sourcePrNumber === right.sourcePrNumber
+    && left.sourceHeadSha === right.sourceHeadSha
+    && left.holderPrNumber === right.holderPrNumber
+    && left.holderHeadSha === right.holderHeadSha
+    && left.holderKind === right.holderKind
+    && left.ref === right.ref;
 }
 
 export function sourceFromEvent(event) {
@@ -66,18 +85,25 @@ function assertLiveSource(source, liveSource) {
   if (!['open', 'closed'].includes(stateOf(liveSource))) throw new Error(`Unsupported source PR state: ${liveSource?.state}`);
 }
 
-function assertReplacementIdentity(source, replacement, expectedHeadSha = null) {
-  if (stateOf(replacement) !== 'open') throw new Error(`Replacement PR #${replacement?.number} is not OPEN`);
-  if (parseCanonicalSubmissionId(replacement?.body) !== source.submissionId) {
+function assertReplacementIdentity(source, replacement, expectedHeadSha = null, { allowClosed = true } = {}) {
+  const replacementState = stateOf(replacement);
+  if (!['open', ...(allowClosed ? ['closed'] : [])].includes(replacementState) || replacement?.merged_at) {
+    throw new Error(`Replacement PR #${replacement?.number} is not an OPEN or recoverable CLOSED PR`);
+  }
+  const authorization = parseReplacementAuthorization(replacement?.body);
+  if (authorization.submissionId !== source.submissionId) {
     throw new Error('Replacement PR Submission ID does not match the source event');
   }
-  const replacementSource = parseReplacementSource(replacement.body);
-  if (replacementSource.sourcePrNumber !== source.number || replacementSource.sourceHeadSha !== source.headSha) {
+  if (authorization.sourcePrNumber !== source.number || authorization.sourceHeadSha !== source.headSha) {
     throw new Error('Replacement PR metadata is not bound to the exact source PR and head SHA');
+  }
+  if (authorization.leaseRef !== authorizationLeaseRef(source.submissionId)) {
+    throw new Error('Replacement PR Authorization Lease Ref is invalid');
   }
   if (expectedHeadSha && canonicalSha(replacement?.head?.sha, 'Replacement PR head SHA') !== canonicalSha(expectedHeadSha, 'Expected replacement head SHA')) {
     throw new Error('Replacement PR head changed before approval transfer');
   }
+  return authorization;
 }
 
 export function preflightReplacement({ event, liveSource, replacements }) {
@@ -106,9 +132,28 @@ export function preflightReplacement({ event, liveSource, replacements }) {
           number: positiveInteger(existingReplacement.number, 'Replacement PR number'),
           url: existingReplacement.html_url,
           headSha: canonicalSha(existingReplacement?.head?.sha, 'Replacement PR head SHA'),
+          state: stateOf(existingReplacement),
         }
       : null,
   };
+}
+
+function matchingPendingApprovals(pulls, submissionId) {
+  const matches = [];
+  for (const pull of Array.isArray(pulls) ? pulls : []) {
+    if (stateOf(pull) !== 'open' || !hasLabel(pull)) continue;
+    let candidateSubmissionId;
+    try {
+      candidateSubmissionId = parseCanonicalSubmissionId(pull?.body);
+    } catch (error) {
+      if (typeof pull?.body === 'string' && pull.body.toLowerCase().includes(submissionId)) {
+        throw new Error(`Malformed pending-review competitor metadata on PR #${pull.number}`);
+      }
+      continue;
+    }
+    if (candidateSubmissionId === submissionId) matches.push(pull);
+  }
+  return matches;
 }
 
 function activeApprovals(openPulls) {
@@ -122,7 +167,9 @@ export function buildSupersessionPlan({ source, replacement, openPulls, submissi
   if (!['open', 'closed'].includes(sourceState) || source?.merged_at) {
     throw new Error(`Source PR #${source?.number} cannot be superseded from state ${source?.state}`);
   }
-  if (stateOf(replacement) !== 'open') throw new Error(`Replacement PR #${replacement?.number} is not OPEN`);
+  if (!['open', 'closed'].includes(stateOf(replacement)) || replacement?.merged_at) {
+    throw new Error(`Replacement PR #${replacement?.number} is not recoverable`);
+  }
 
   const allowedNumbers = new Set([Number(source.number), Number(replacement.number)]);
   const competitors = activeApprovals(openPulls)
@@ -132,82 +179,332 @@ export function buildSupersessionPlan({ source, replacement, openPulls, submissi
   }
 
   const plan = [];
+  if (stateOf(replacement) === 'closed') plan.push({ action: 'reopen', number: positiveInteger(replacement.number, 'Replacement PR number') });
   const replacementMustBeRevokedFirst = sourceState === 'open' && hasLabel(replacement);
   if (replacementMustBeRevokedFirst) {
     plan.push({ action: 'remove-label', number: positiveInteger(replacement.number, 'Replacement PR number') });
   }
-  if (hasLabel(source)) {
-    plan.push({ action: 'remove-label', number: positiveInteger(source.number, 'Source PR number') });
-  }
-  if (sourceState === 'open') {
-    plan.push({ action: 'close', number: positiveInteger(source.number, 'Source PR number') });
-  }
+  if (hasLabel(source)) plan.push({ action: 'remove-label', number: positiveInteger(source.number, 'Source PR number') });
+  if (sourceState === 'open') plan.push({ action: 'close', number: positiveInteger(source.number, 'Source PR number') });
   if (!hasLabel(replacement) || replacementMustBeRevokedFirst) {
     plan.push({ action: 'add-label', number: positiveInteger(replacement.number, 'Replacement PR number') });
   }
   return plan;
 }
 
+function replacementLease(source, replacementNumber, replacementHeadSha) {
+  return buildAuthorizationLease({
+    submissionId: source.submissionId,
+    sourcePrNumber: source.number,
+    sourceHeadSha: source.headSha,
+    holderPrNumber: replacementNumber,
+    holderHeadSha: replacementHeadSha,
+    holderKind: 'replacement',
+  });
+}
+
+function sourceLease(sourcePull, submissionId) {
+  const headSha = canonicalSha(sourcePull?.head?.sha, 'Compensation source PR head SHA');
+  return buildAuthorizationLease({
+    submissionId,
+    sourcePrNumber: positiveInteger(sourcePull.number, 'Compensation source PR number'),
+    sourceHeadSha: headSha,
+    holderPrNumber: positiveInteger(sourcePull.number, 'Compensation source PR number'),
+    holderHeadSha: headSha,
+    holderKind: 'source',
+  });
+}
+
+async function ensureLease(client, desired, sourcePrNumber) {
+  let current = await client.getAuthorizationLease(desired.submissionId);
+  if (leasesEqual(current, desired)) return current;
+  if (current && current.sourcePrNumber !== sourcePrNumber) {
+    throw new Error(`Authorization lease belongs to competing source PR #${current.sourcePrNumber}`);
+  }
+
+  try {
+    if (current) await client.updateAuthorizationLease(desired);
+    else await client.createAuthorizationLease(desired);
+  } catch (error) {
+    current = await client.getAuthorizationLease(desired.submissionId);
+    if (!leasesEqual(current, desired)) throw error;
+    return current;
+  }
+
+  current = await client.getAuthorizationLease(desired.submissionId);
+  if (!leasesEqual(current, desired)) throw new Error('Authorization lease mutation did not converge to the expected holder');
+  return current;
+}
+
+async function restoreSourceAuthorization({ client, source, replacementNumber }) {
+  const liveSource = await client.getPull(source.number);
+  if (liveSource?.merged_at) throw new Error('Cannot compensate a merged source PR');
+  const liveSubmissionId = parseCanonicalSubmissionId(liveSource?.body);
+  if (liveSubmissionId !== source.submissionId) throw new Error('Cannot compensate after source Submission ID changed');
+  if (!['open', 'closed'].includes(stateOf(liveSource))) throw new Error('Cannot compensate unsupported source PR state');
+
+  const desired = sourceLease(liveSource, source.submissionId);
+  await ensureLease(client, desired, source.number);
+
+  if (stateOf(liveSource) === 'closed') {
+    try {
+      await client.reopenPull(source.number);
+    } catch (error) {
+      const refreshed = await client.getPull(source.number);
+      if (stateOf(refreshed) !== 'open') throw error;
+    }
+  }
+
+  const openPulls = await client.listPulls('open');
+  for (const candidate of matchingPendingApprovals(openPulls, source.submissionId)) {
+    if (Number(candidate.number) === source.number) continue;
+    try {
+      await client.removeLabel(candidate.number, PENDING_REVIEW_LABEL);
+    } catch (error) {
+      const refreshed = await client.getPull(candidate.number);
+      if (hasLabel(refreshed)) throw error;
+    }
+  }
+
+  const refreshedSource = await client.getPull(source.number);
+  if (!hasLabel(refreshedSource)) {
+    try {
+      await client.addLabel(source.number, PENDING_REVIEW_LABEL);
+    } catch (error) {
+      if (!hasLabel(await client.getPull(source.number))) throw error;
+    }
+  }
+
+  if (replacementNumber) {
+    const replacement = await client.getPull(replacementNumber);
+    if (stateOf(replacement) === 'open' && hasLabel(replacement)) {
+      await client.removeLabel(replacementNumber, PENDING_REVIEW_LABEL);
+    }
+  }
+
+  const [terminalSource, terminalPulls, terminalLease] = await Promise.all([
+    client.getPull(source.number),
+    client.listPulls('open'),
+    client.getAuthorizationLease(source.submissionId),
+  ]);
+  const approvals = matchingPendingApprovals(terminalPulls, source.submissionId);
+  if (stateOf(terminalSource) !== 'open' || !hasLabel(terminalSource)
+      || approvals.length !== 1 || Number(approvals[0].number) !== source.number
+      || !leasesEqual(terminalLease, desired)) {
+    throw new Error('Source approval compensation did not converge to exactly one authorized source');
+  }
+  return desired;
+}
+
+async function attemptMutation(operation) {
+  try {
+    await operation();
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
 export async function supersedeReplacement({ client, event, replacementNumber, replacementHeadSha }) {
   const source = sourceFromEvent(event);
   const replacementPrNumber = positiveInteger(replacementNumber, 'Replacement PR number');
+  const expectedReplacementHeadSha = canonicalSha(replacementHeadSha, 'Expected replacement head SHA');
+  const desiredLease = replacementLease(source, replacementPrNumber, expectedReplacementHeadSha);
+  let lastMutationError = null;
+  let terminalConfirmations = 0;
 
-  for (let iteration = 0; iteration < 10; iteration += 1) {
-    const [liveSource, replacement, openPulls] = await Promise.all([
+  for (let iteration = 0; iteration < MAX_RECONCILE_ITERATIONS; iteration += 1) {
+    const [liveSource, replacement] = await Promise.all([
+      client.getPull(source.number),
+      client.getPull(replacementPrNumber),
+    ]);
+
+    try {
+      assertLiveSource(source, liveSource);
+      assertReplacementIdentity(source, replacement, expectedReplacementHeadSha);
+    } catch (error) {
+      try {
+        await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+      } catch (compensationError) {
+        throw new AggregateError([error, compensationError], `Approval transfer failed and compensation failed: ${error.message}`);
+      }
+      throw error;
+    }
+
+    if (stateOf(replacement) === 'closed') {
+      terminalConfirmations = 0;
+      lastMutationError = await attemptMutation(() => client.reopenPull(replacementPrNumber));
+      continue;
+    }
+
+    try {
+      await ensureLease(client, desiredLease, source.number);
+    } catch (error) {
+      try {
+        await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+      } catch (compensationError) {
+        throw new AggregateError([error, compensationError], `Authorization lease failed and compensation failed: ${error.message}`);
+      }
+      throw error;
+    }
+
+    const [checkedSource, checkedReplacement, openPulls] = await Promise.all([
       client.getPull(source.number),
       client.getPull(replacementPrNumber),
       client.listPulls('open'),
     ]);
     try {
-      assertLiveSource(source, liveSource);
-      assertReplacementIdentity(source, replacement, replacementHeadSha);
+      assertLiveSource(source, checkedSource);
+      assertReplacementIdentity(source, checkedReplacement, expectedReplacementHeadSha, { allowClosed: false });
     } catch (error) {
-      // A stale event must never leave the replacement with approval capability.
-      if (stateOf(replacement) === 'open' && hasLabel(replacement)) {
-        await client.removeLabel(replacementPrNumber, PENDING_REVIEW_LABEL);
+      try {
+        await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+      } catch (compensationError) {
+        throw new AggregateError([error, compensationError], `Approval transfer became stale and compensation failed: ${error.message}`);
       }
       throw error;
     }
 
-    let plan;
+    const approvals = matchingPendingApprovals(openPulls, source.submissionId);
+    const unauthorized = approvals.filter((pull) => Number(pull.number) !== replacementPrNumber);
+    if (unauthorized.length > 0) {
+      terminalConfirmations = 0;
+      lastMutationError = await attemptMutation(() => client.removeLabel(unauthorized[0].number, PENDING_REVIEW_LABEL));
+      continue;
+    }
+
+    if (stateOf(checkedSource) === 'open') {
+      terminalConfirmations = 0;
+      lastMutationError = await attemptMutation(() => client.closePull(source.number));
+      continue;
+    }
+
+    if (!hasLabel(checkedReplacement)) {
+      const [grantSource, grantReplacement, grantPulls, grantLease] = await Promise.all([
+        client.getPull(source.number),
+        client.getPull(replacementPrNumber),
+        client.listPulls('open'),
+        client.getAuthorizationLease(source.submissionId),
+      ]);
+      try {
+        assertLiveSource(source, grantSource);
+        assertReplacementIdentity(source, grantReplacement, expectedReplacementHeadSha, { allowClosed: false });
+      } catch (error) {
+        try {
+          await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+        } catch (compensationError) {
+          throw new AggregateError([error, compensationError], `Final grant became stale and compensation failed: ${error.message}`);
+        }
+        throw error;
+      }
+      if (stateOf(grantSource) !== 'closed' || hasLabel(grantSource) || !leasesEqual(grantLease, desiredLease)) {
+        continue;
+      }
+      const grantCompetitors = matchingPendingApprovals(grantPulls, source.submissionId)
+        .filter((pull) => Number(pull.number) !== replacementPrNumber);
+      if (grantCompetitors.length > 0) {
+        terminalConfirmations = 0;
+        lastMutationError = await attemptMutation(() => client.removeLabel(grantCompetitors[0].number, PENDING_REVIEW_LABEL));
+        continue;
+      }
+      terminalConfirmations = 0;
+      lastMutationError = await attemptMutation(() => client.addLabel(replacementPrNumber, PENDING_REVIEW_LABEL));
+      continue;
+    }
+
+    const [terminalSource, terminalReplacement, terminalPulls, terminalLease] = await Promise.all([
+      client.getPull(source.number),
+      client.getPull(replacementPrNumber),
+      client.listPulls('open'),
+      client.getAuthorizationLease(source.submissionId),
+    ]);
+    let terminalApprovals;
     try {
-      plan = buildSupersessionPlan({
-        source: liveSource,
-        replacement,
-        openPulls,
-        submissionId: source.submissionId,
-      });
+      assertLiveSource(source, terminalSource);
+      assertReplacementIdentity(source, terminalReplacement, expectedReplacementHeadSha, { allowClosed: false });
+      terminalApprovals = matchingPendingApprovals(terminalPulls, source.submissionId);
     } catch (error) {
-      if (stateOf(replacement) === 'open' && hasLabel(replacement)) {
-        await client.removeLabel(replacementPrNumber, PENDING_REVIEW_LABEL);
+      try {
+        await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+      } catch (compensationError) {
+        throw new AggregateError([error, compensationError], `Terminal verification failed and compensation failed: ${error.message}`);
       }
       throw error;
     }
-
-    if (plan.length === 0) {
-      if (stateOf(liveSource) !== 'closed' || hasLabel(liveSource) || stateOf(replacement) !== 'open' || !hasLabel(replacement)) {
-        throw new Error('Supersession reached a non-canonical terminal state');
-      }
-      const approvals = activeApprovals(openPulls).filter((entry) => entry.submissionId === source.submissionId);
-      if (approvals.length !== 1 || Number(approvals[0].pull.number) !== replacementPrNumber) {
-        throw new Error('Supersession did not converge to exactly one OPEN pending-review replacement');
-      }
+    if (stateOf(terminalSource) === 'closed' && !hasLabel(terminalSource)
+        && terminalApprovals.length === 1
+        && Number(terminalApprovals[0].number) === replacementPrNumber
+        && leasesEqual(terminalLease, desiredLease)) {
+      terminalConfirmations += 1;
+      if (terminalConfirmations < 2) continue;
       return {
         sourcePrNumber: source.number,
         sourceHeadSha: source.headSha,
         replacementPrNumber,
+        replacementHeadSha: expectedReplacementHeadSha,
         submissionId: source.submissionId,
+        leaseRef: desiredLease.ref,
       };
     }
-
-    const operation = plan[0];
-    if (operation.action === 'remove-label') await client.removeLabel(operation.number, PENDING_REVIEW_LABEL);
-    else if (operation.action === 'close') await client.closePull(operation.number);
-    else if (operation.action === 'add-label') await client.addLabel(operation.number, PENDING_REVIEW_LABEL);
-    else throw new Error(`Unsupported supersession operation: ${operation.action}`);
+    terminalConfirmations = 0;
   }
 
-  throw new Error('Supersession did not converge within the finite operation budget');
+  const convergenceError = new Error(`Supersession did not converge within the finite operation budget${lastMutationError ? `: ${lastMutationError.message}` : ''}`);
+  try {
+    await restoreSourceAuthorization({ client, source, replacementNumber: replacementPrNumber });
+  } catch (compensationError) {
+    throw new AggregateError([convergenceError, compensationError], 'Supersession exhausted retries and compensation failed');
+  }
+  throw convergenceError;
+}
+
+export async function ensureReplacement({
+  client,
+  event,
+  title,
+  body,
+  headRef,
+  headSha,
+  baseRef = 'main',
+}) {
+  const source = sourceFromEvent(event);
+  const expectedBranch = replacementBranchName(source);
+  if (headRef !== expectedBranch) throw new Error('Replacement head ref does not match the source lifecycle');
+  const expectedHeadSha = canonicalSha(headSha, 'Replacement head SHA');
+  const liveSource = await client.getPull(source.number);
+  assertLiveSource(source, liveSource);
+  let replacements = await client.listPulls('all', headRef);
+  if (replacements.length > 1) throw new Error('Multiple replacement PRs exist for one source lifecycle');
+  let replacement = replacements[0] ?? null;
+
+  if (!replacement) {
+    if (stateOf(liveSource) !== 'open' || !hasLabel(liveSource)) {
+      throw new Error('Source PR is not authorized before replacement creation');
+    }
+    try {
+      replacement = await client.createPull({ title, body, head: headRef, base: baseRef });
+    } catch (error) {
+      replacements = await client.listPulls('all', headRef);
+      if (replacements.length !== 1) throw error;
+      replacement = replacements[0];
+    }
+  } else if (replacement.body !== body || replacement.title !== title) {
+    try {
+      replacement = await client.updatePull(replacement.number, { title, body });
+    } catch (error) {
+      replacement = await client.getPull(replacement.number);
+      if (replacement.body !== body || replacement.title !== title) throw error;
+    }
+  }
+
+  assertReplacementIdentity(source, replacement, expectedHeadSha);
+  if (hasLabel(replacement)) throw new Error('Replacement creation must not grant pending-review');
+  return {
+    number: positiveInteger(replacement.number, 'Replacement PR number'),
+    url: replacement.html_url,
+    headSha: expectedHeadSha,
+    state: stateOf(replacement),
+  };
 }
 
 export function createGitHubClient({ repository, token, apiUrl = 'https://api.github.com', fetchImpl = globalThis.fetch }) {
@@ -248,12 +545,59 @@ export function createGitHubClient({ repository, token, apiUrl = 'https://api.gi
     }
   }
 
+  async function getAuthorizationLease(submissionId) {
+    const ref = authorizationLeaseRef(submissionId);
+    const refPath = ref.replace(/^refs\//, '');
+    const refObject = await request(`/git/ref/${refPath}`, { allowNotFound: true });
+    if (!refObject) return null;
+    const tagSha = canonicalSha(refObject?.object?.sha, 'Authorization lease tag SHA');
+    const tag = await request(`/git/tags/${tagSha}`);
+    return parseAuthorizationLeaseTag(tag, ref);
+  }
+
+  async function createLeaseTag(lease) {
+    const tag = await request('/git/tags', {
+      method: 'POST',
+      body: {
+        tag: `autofix-approval-lease-${lease.submissionId}`,
+        message: authorizationLeaseTagMessage(lease),
+        object: lease.holderHeadSha,
+        type: 'commit',
+        tagger: {
+          name: 'ai-skill-store[bot]',
+          email: '2628292+ai-skill-store[bot]@users.noreply.github.com',
+          date: new Date().toISOString(),
+        },
+      },
+    });
+    return canonicalSha(tag?.sha, 'Created authorization lease tag SHA');
+  }
+
+  async function createAuthorizationLease(lease) {
+    const tagSha = await createLeaseTag(lease);
+    await request('/git/refs', { method: 'POST', body: { ref: lease.ref, sha: tagSha } });
+    return getAuthorizationLease(lease.submissionId);
+  }
+
+  async function updateAuthorizationLease(lease) {
+    const tagSha = await createLeaseTag(lease);
+    const refPath = lease.ref.replace(/^refs\//, '');
+    await request(`/git/refs/${refPath}`, { method: 'PATCH', body: { sha: tagSha, force: true } });
+    return getAuthorizationLease(lease.submissionId);
+  }
+
   return {
     getPull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`),
     listPulls,
     removeLabel: (number, label) => request(`/issues/${positiveInteger(number, 'PR number')}/labels/${encodeURIComponent(label)}`, { method: 'DELETE', allowNotFound: true }),
     closePull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`, { method: 'PATCH', body: { state: 'closed' } }),
+    reopenPull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`, { method: 'PATCH', body: { state: 'open' } }),
     addLabel: (number, label) => request(`/issues/${positiveInteger(number, 'PR number')}/labels`, { method: 'POST', body: { labels: [label] } }),
+    createPull: ({ title, body, head, base }) => request('/pulls', { method: 'POST', body: { title, body, head, base } }),
+    updatePull: (number, fields) => request(`/pulls/${positiveInteger(number, 'PR number')}`, { method: 'PATCH', body: fields }),
+    getAuthorizationLease,
+    createAuthorizationLease,
+    updateAuthorizationLease,
   };
 }
 
@@ -265,6 +609,10 @@ async function main() {
       repository: { type: 'string' },
       'replacement-pr': { type: 'string' },
       'replacement-head-sha': { type: 'string' },
+      title: { type: 'string' },
+      'body-file': { type: 'string' },
+      'head-ref': { type: 'string' },
+      'base-ref': { type: 'string' },
     },
     strict: true,
   });
@@ -287,6 +635,24 @@ async function main() {
       client.listPulls('all', branchName),
     ]);
     process.stdout.write(`${JSON.stringify(preflightReplacement({ event, liveSource, replacements }))}\n`);
+    return;
+  }
+
+  if (values.mode === 'ensure-replacement') {
+    for (const name of ['replacement-head-sha', 'title', 'body-file', 'head-ref']) {
+      if (!values[name]) throw new Error(`ensure-replacement mode requires --${name}`);
+    }
+    const body = await readFile(values['body-file'], 'utf8');
+    const result = await ensureReplacement({
+      client,
+      event,
+      title: values.title,
+      body,
+      headRef: values['head-ref'],
+      headSha: values['replacement-head-sha'],
+      baseRef: values['base-ref'] || 'main',
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
     return;
   }
 

--- a/scripts/autofix-pr-lifecycle.mjs
+++ b/scripts/autofix-pr-lifecycle.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseCanonicalSubmissionId,
+  parseReplacementSource,
+} from './submission-metadata.mjs';
+
+const PENDING_REVIEW_LABEL = 'pending-review';
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+function stateOf(pull) {
+  return typeof pull?.state === 'string' ? pull.state.toLowerCase() : '';
+}
+
+function hasLabel(pull, expected = PENDING_REVIEW_LABEL) {
+  return Array.isArray(pull?.labels)
+    && pull.labels.some((label) => (typeof label === 'string' ? label : label?.name) === expected);
+}
+
+function positiveInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) throw new Error(`${name} must be a positive integer`);
+  return number;
+}
+
+function canonicalSha(value, name) {
+  const sha = typeof value === 'string' ? value.toLowerCase() : '';
+  if (!SHA_RE.test(sha)) throw new Error(`${name} must be a 40-character Git SHA`);
+  return sha;
+}
+
+export function sourceFromEvent(event) {
+  const pull = event?.pull_request;
+  if (!pull) throw new Error('pull_request event metadata is required');
+  const number = positiveInteger(pull.number, 'Source PR number');
+  const body = typeof pull.body === 'string' ? pull.body : '';
+  const submissionId = parseCanonicalSubmissionId(body);
+  const headSha = canonicalSha(pull?.head?.sha, 'Source PR head SHA');
+  if (!hasLabel(pull)) throw new Error('Source event does not have pending-review');
+  return { number, body, submissionId, headSha };
+}
+
+export function replacementBranchName(source) {
+  return `fix/skill-md-validation-pr-${source.number}-${source.headSha.slice(0, 12)}`;
+}
+
+function assertLiveSource(source, liveSource) {
+  if (positiveInteger(liveSource?.number, 'Live source PR number') !== source.number) {
+    throw new Error('Live source PR number does not match the event');
+  }
+  if (canonicalSha(liveSource?.head?.sha, 'Live source PR head SHA') !== source.headSha) {
+    throw new Error('Source PR head changed after the workflow event');
+  }
+  if (liveSource?.body !== source.body) {
+    throw new Error('Source PR body changed after the workflow event');
+  }
+  if (parseCanonicalSubmissionId(liveSource.body) !== source.submissionId) {
+    throw new Error('Source PR Submission ID changed after the workflow event');
+  }
+  if (liveSource?.merged_at) throw new Error('Source PR was already merged; replacement approval is forbidden');
+  if (!['open', 'closed'].includes(stateOf(liveSource))) throw new Error(`Unsupported source PR state: ${liveSource?.state}`);
+}
+
+function assertReplacementIdentity(source, replacement, expectedHeadSha = null) {
+  if (stateOf(replacement) !== 'open') throw new Error(`Replacement PR #${replacement?.number} is not OPEN`);
+  if (parseCanonicalSubmissionId(replacement?.body) !== source.submissionId) {
+    throw new Error('Replacement PR Submission ID does not match the source event');
+  }
+  const replacementSource = parseReplacementSource(replacement.body);
+  if (replacementSource.sourcePrNumber !== source.number || replacementSource.sourceHeadSha !== source.headSha) {
+    throw new Error('Replacement PR metadata is not bound to the exact source PR and head SHA');
+  }
+  if (expectedHeadSha && canonicalSha(replacement?.head?.sha, 'Replacement PR head SHA') !== canonicalSha(expectedHeadSha, 'Expected replacement head SHA')) {
+    throw new Error('Replacement PR head changed before approval transfer');
+  }
+}
+
+export function preflightReplacement({ event, liveSource, replacements }) {
+  const source = sourceFromEvent(event);
+  assertLiveSource(source, liveSource);
+  const branchName = replacementBranchName(source);
+  const matchingReplacements = (Array.isArray(replacements) ? replacements : [])
+    .filter((pull) => pull?.head?.ref === branchName);
+
+  if (matchingReplacements.length > 1) {
+    throw new Error(`Found multiple replacement PRs for source PR #${source.number} at ${source.headSha}`);
+  }
+
+  const existingReplacement = matchingReplacements[0] ?? null;
+  if (existingReplacement) {
+    assertReplacementIdentity(source, existingReplacement);
+  } else if (stateOf(liveSource) !== 'open' || !hasLabel(liveSource)) {
+    throw new Error('Source PR is not OPEN or no longer has pending-review before replacement creation');
+  }
+
+  return {
+    source,
+    branchName,
+    existingReplacement: existingReplacement
+      ? {
+          number: positiveInteger(existingReplacement.number, 'Replacement PR number'),
+          url: existingReplacement.html_url,
+          headSha: canonicalSha(existingReplacement?.head?.sha, 'Replacement PR head SHA'),
+        }
+      : null,
+  };
+}
+
+function activeApprovals(openPulls) {
+  return (Array.isArray(openPulls) ? openPulls : [])
+    .filter((pull) => stateOf(pull) === 'open' && hasLabel(pull))
+    .map((pull) => ({ pull, submissionId: parseCanonicalSubmissionId(pull?.body) }));
+}
+
+export function buildSupersessionPlan({ source, replacement, openPulls, submissionId }) {
+  const sourceState = stateOf(source);
+  if (!['open', 'closed'].includes(sourceState) || source?.merged_at) {
+    throw new Error(`Source PR #${source?.number} cannot be superseded from state ${source?.state}`);
+  }
+  if (stateOf(replacement) !== 'open') throw new Error(`Replacement PR #${replacement?.number} is not OPEN`);
+
+  const allowedNumbers = new Set([Number(source.number), Number(replacement.number)]);
+  const competitors = activeApprovals(openPulls)
+    .filter((entry) => entry.submissionId === submissionId && !allowedNumbers.has(Number(entry.pull.number)));
+  if (competitors.length > 0) {
+    throw new Error(`Competing OPEN pending-review PR(s) exist for submission ${submissionId}: ${competitors.map((entry) => `#${entry.pull.number}`).join(', ')}`);
+  }
+
+  const plan = [];
+  const replacementMustBeRevokedFirst = sourceState === 'open' && hasLabel(replacement);
+  if (replacementMustBeRevokedFirst) {
+    plan.push({ action: 'remove-label', number: positiveInteger(replacement.number, 'Replacement PR number') });
+  }
+  if (hasLabel(source)) {
+    plan.push({ action: 'remove-label', number: positiveInteger(source.number, 'Source PR number') });
+  }
+  if (sourceState === 'open') {
+    plan.push({ action: 'close', number: positiveInteger(source.number, 'Source PR number') });
+  }
+  if (!hasLabel(replacement) || replacementMustBeRevokedFirst) {
+    plan.push({ action: 'add-label', number: positiveInteger(replacement.number, 'Replacement PR number') });
+  }
+  return plan;
+}
+
+export async function supersedeReplacement({ client, event, replacementNumber, replacementHeadSha }) {
+  const source = sourceFromEvent(event);
+  const replacementPrNumber = positiveInteger(replacementNumber, 'Replacement PR number');
+
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    const [liveSource, replacement, openPulls] = await Promise.all([
+      client.getPull(source.number),
+      client.getPull(replacementPrNumber),
+      client.listPulls('open'),
+    ]);
+    try {
+      assertLiveSource(source, liveSource);
+      assertReplacementIdentity(source, replacement, replacementHeadSha);
+    } catch (error) {
+      // A stale event must never leave the replacement with approval capability.
+      if (stateOf(replacement) === 'open' && hasLabel(replacement)) {
+        await client.removeLabel(replacementPrNumber, PENDING_REVIEW_LABEL);
+      }
+      throw error;
+    }
+
+    let plan;
+    try {
+      plan = buildSupersessionPlan({
+        source: liveSource,
+        replacement,
+        openPulls,
+        submissionId: source.submissionId,
+      });
+    } catch (error) {
+      if (stateOf(replacement) === 'open' && hasLabel(replacement)) {
+        await client.removeLabel(replacementPrNumber, PENDING_REVIEW_LABEL);
+      }
+      throw error;
+    }
+
+    if (plan.length === 0) {
+      if (stateOf(liveSource) !== 'closed' || hasLabel(liveSource) || stateOf(replacement) !== 'open' || !hasLabel(replacement)) {
+        throw new Error('Supersession reached a non-canonical terminal state');
+      }
+      const approvals = activeApprovals(openPulls).filter((entry) => entry.submissionId === source.submissionId);
+      if (approvals.length !== 1 || Number(approvals[0].pull.number) !== replacementPrNumber) {
+        throw new Error('Supersession did not converge to exactly one OPEN pending-review replacement');
+      }
+      return {
+        sourcePrNumber: source.number,
+        sourceHeadSha: source.headSha,
+        replacementPrNumber,
+        submissionId: source.submissionId,
+      };
+    }
+
+    const operation = plan[0];
+    if (operation.action === 'remove-label') await client.removeLabel(operation.number, PENDING_REVIEW_LABEL);
+    else if (operation.action === 'close') await client.closePull(operation.number);
+    else if (operation.action === 'add-label') await client.addLabel(operation.number, PENDING_REVIEW_LABEL);
+    else throw new Error(`Unsupported supersession operation: ${operation.action}`);
+  }
+
+  throw new Error('Supersession did not converge within the finite operation budget');
+}
+
+export function createGitHubClient({ repository, token, apiUrl = 'https://api.github.com', fetchImpl = globalThis.fetch }) {
+  if (!/^[^/]+\/[^/]+$/.test(repository)) throw new Error('Repository must use owner/name format');
+  if (!token) throw new Error('GH_TOKEN or GITHUB_TOKEN is required');
+  if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+  const [owner] = repository.split('/');
+
+  async function request(path, { method = 'GET', body = null, allowNotFound = false } = {}) {
+    const response = await fetchImpl(`${apiUrl.replace(/\/$/, '')}/repos/${repository}${path}`, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: body === null ? undefined : JSON.stringify(body),
+    });
+    if (allowNotFound && response.status === 404) return null;
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(`GitHub API ${method} ${path} failed (${response.status}): ${message.slice(0, 500)}`);
+    }
+    if (response.status === 204) return null;
+    return response.json();
+  }
+
+  async function listPulls(state, headRef = null) {
+    const pulls = [];
+    for (let page = 1; ; page += 1) {
+      const query = new URLSearchParams({ state, per_page: '100', page: String(page) });
+      if (headRef) query.set('head', `${owner}:${headRef}`);
+      const batch = await request(`/pulls?${query}`);
+      pulls.push(...batch);
+      if (batch.length < 100) return pulls;
+      if (page >= 100) throw new Error('GitHub PR pagination exceeded the finite 100-page budget');
+    }
+  }
+
+  return {
+    getPull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`),
+    listPulls,
+    removeLabel: (number, label) => request(`/issues/${positiveInteger(number, 'PR number')}/labels/${encodeURIComponent(label)}`, { method: 'DELETE', allowNotFound: true }),
+    closePull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`, { method: 'PATCH', body: { state: 'closed' } }),
+    addLabel: (number, label) => request(`/issues/${positiveInteger(number, 'PR number')}/labels`, { method: 'POST', body: { labels: [label] } }),
+  };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      mode: { type: 'string' },
+      'event-path': { type: 'string' },
+      repository: { type: 'string' },
+      'replacement-pr': { type: 'string' },
+      'replacement-head-sha': { type: 'string' },
+    },
+    strict: true,
+  });
+  for (const name of ['mode', 'event-path', 'repository']) {
+    if (!values[name]) throw new Error(`Missing required --${name}`);
+  }
+
+  const event = JSON.parse(await readFile(values['event-path'], 'utf8'));
+  const client = createGitHubClient({
+    repository: values.repository,
+    token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+    apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+  });
+
+  if (values.mode === 'preflight') {
+    const source = sourceFromEvent(event);
+    const branchName = replacementBranchName(source);
+    const [liveSource, replacements] = await Promise.all([
+      client.getPull(source.number),
+      client.listPulls('all', branchName),
+    ]);
+    process.stdout.write(`${JSON.stringify(preflightReplacement({ event, liveSource, replacements }))}\n`);
+    return;
+  }
+
+  if (values.mode === 'supersede') {
+    if (!values['replacement-pr'] || !values['replacement-head-sha']) {
+      throw new Error('supersede mode requires --replacement-pr and --replacement-head-sha');
+    }
+    const result = await supersedeReplacement({
+      client,
+      event,
+      replacementNumber: values['replacement-pr'],
+      replacementHeadSha: values['replacement-head-sha'],
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  throw new Error(`Unsupported --mode: ${values.mode}`);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/build-autofix-pr-metadata.mjs
+++ b/scripts/build-autofix-pr-metadata.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
-import { resolve } from 'node:path';
 
-const SUBMISSION_ID_RE = /Submission ID[^\r\n]*`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`/i;
+import { canonicalizeSubmissionBody } from './submission-metadata.mjs';
 
 function normalizeCount(value, name) {
   const count = Number(value);
@@ -56,11 +56,20 @@ export function buildAutoFixPrMetadata({
   const deletedCount = normalizeCount(rawDeletedCount, 'deletedCount');
   const pullRequest = eventName === 'pull_request' ? event?.pull_request : null;
   const sourceBody = typeof pullRequest?.body === 'string' ? pullRequest.body : '';
-  const submissionId = sourceBody.match(SUBMISSION_ID_RE)?.[1]?.toLowerCase() ?? null;
   const pendingReview = hasLabel(pullRequest, 'pending-review');
+  let canonicalSource = null;
 
+  if (pullRequest) {
+    try {
+      canonicalSource = canonicalizeSubmissionBody(sourceBody);
+    } catch (error) {
+      if (pendingReview) throw error;
+    }
+  }
+
+  const submissionId = canonicalSource?.submissionId ?? null;
   if (pullRequest && pendingReview !== Boolean(submissionId)) {
-    throw new Error('Submission auto-fix metadata is incomplete: pending-review and a valid Submission ID must be present together');
+    throw new Error('Submission auto-fix metadata is incomplete: pending-review and exactly one anchored Submission ID must be present together');
   }
 
   if (!pullRequest || !pendingReview || !submissionId) {
@@ -69,6 +78,7 @@ export function buildAutoFixPrMetadata({
       inheritPendingReview: false,
       submissionId: null,
       sourcePrNumber: null,
+      sourceHeadSha: null,
     };
   }
 
@@ -77,28 +87,36 @@ export function buildAutoFixPrMetadata({
     throw new Error('Submission auto-fix metadata is missing a valid source PR number');
   }
 
+  const sourceHeadSha = typeof pullRequest?.head?.sha === 'string' ? pullRequest.head.sha.toLowerCase() : '';
+  if (!/^[0-9a-f]{40}$/.test(sourceHeadSha)) {
+    throw new Error('Submission auto-fix metadata is missing a valid source PR head SHA');
+  }
+
   const repairSummary = `## Automated SKILL.md Repair
 
 This replacement PR preserves the source submission metadata so its own merge can run the normal approval workflow.
 
+**Source PR**: #${sourcePrNumber}
+**Source PR Head SHA**: \`${sourceHeadSha}\`
+
 | Metric | Value |
 |--------|-------|
-| Source PR | #${sourcePrNumber} |
 | Files Fixed | ${modifiedCount} |
 | Empty Skills Deleted | ${deletedCount} |
 | Triggered By | ${eventName} |
 
-The \`pending-review\` label is inherited explicitly. Approval does not depend on source commits surviving a squash merge.
+The replacement is bound to the exact source head above. The \`pending-review\` label is transferred only after the source PR loses approval capability.
 
 ---
 *Automated fix by validate-marketplace.yml*
 `;
 
   return {
-    body: `${sourceBody.trimEnd()}\n\n---\n\n${repairSummary}`,
+    body: `${canonicalSource.body.trimEnd()}\n\n---\n\n${repairSummary}`,
     inheritPendingReview: true,
     submissionId,
     sourcePrNumber,
+    sourceHeadSha,
   };
 }
 
@@ -131,6 +149,7 @@ async function main() {
     inheritPendingReview: metadata.inheritPendingReview,
     submissionId: metadata.submissionId,
     sourcePrNumber: metadata.sourcePrNumber,
+    sourceHeadSha: metadata.sourceHeadSha,
   })}\n`);
 }
 

--- a/scripts/build-autofix-pr-metadata.mjs
+++ b/scripts/build-autofix-pr-metadata.mjs
@@ -5,7 +5,10 @@ import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
-import { canonicalizeSubmissionBody } from './submission-metadata.mjs';
+import {
+  authorizationLeaseRef,
+  canonicalizeSubmissionBody,
+} from './submission-metadata.mjs';
 
 function normalizeCount(value, name) {
   const count = Number(value);
@@ -92,12 +95,14 @@ export function buildAutoFixPrMetadata({
     throw new Error('Submission auto-fix metadata is missing a valid source PR head SHA');
   }
 
+  const leaseRef = authorizationLeaseRef(submissionId);
   const repairSummary = `## Automated SKILL.md Repair
 
 This replacement PR preserves the source submission metadata so its own merge can run the normal approval workflow.
 
 **Source PR**: #${sourcePrNumber}
 **Source PR Head SHA**: \`${sourceHeadSha}\`
+**Authorization Lease Ref**: \`${leaseRef}\`
 
 | Metric | Value |
 |--------|-------|
@@ -117,6 +122,7 @@ The replacement is bound to the exact source head above. The \`pending-review\` 
     submissionId,
     sourcePrNumber,
     sourceHeadSha,
+    leaseRef,
   };
 }
 
@@ -150,6 +156,7 @@ async function main() {
     submissionId: metadata.submissionId,
     sourcePrNumber: metadata.sourcePrNumber,
     sourceHeadSha: metadata.sourceHeadSha,
+    leaseRef: metadata.leaseRef ?? null,
   })}\n`);
 }
 

--- a/scripts/build-autofix-pr-metadata.mjs
+++ b/scripts/build-autofix-pr-metadata.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const SUBMISSION_ID_RE = /Submission ID[^\r\n]*`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`/i;
+
+function normalizeCount(value, name) {
+  const count = Number(value);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return count;
+}
+
+function hasLabel(pullRequest, expected) {
+  return Array.isArray(pullRequest?.labels)
+    && pullRequest.labels.some((label) => (typeof label === 'string' ? label : label?.name) === expected);
+}
+
+function genericBody({ eventName, modifiedCount, deletedCount }) {
+  return `## Summary
+
+AI-powered auto-fix for SKILL.md validation errors.
+
+| Metric | Value |
+|--------|-------|
+| Files Fixed | ${modifiedCount} |
+| Empty Skills Deleted | ${deletedCount} |
+| Triggered By | ${eventName} |
+
+### Fixes Applied
+- Added missing YAML frontmatter
+- Fixed \`name\` field format (lowercase alphanumeric with hyphens)
+- Added missing \`description\` field
+- Truncated overly long descriptions
+- **Deleted empty skill directories** (unfixable)
+
+### After Merge
+The \`sync-to-supabase.yml\` workflow will automatically update the database.
+
+---
+*Automated fix by validate-marketplace.yml*
+`;
+}
+
+export function buildAutoFixPrMetadata({
+  eventName,
+  event,
+  modifiedCount: rawModifiedCount,
+  deletedCount: rawDeletedCount,
+}) {
+  const modifiedCount = normalizeCount(rawModifiedCount, 'modifiedCount');
+  const deletedCount = normalizeCount(rawDeletedCount, 'deletedCount');
+  const pullRequest = eventName === 'pull_request' ? event?.pull_request : null;
+  const sourceBody = typeof pullRequest?.body === 'string' ? pullRequest.body : '';
+  const submissionId = sourceBody.match(SUBMISSION_ID_RE)?.[1]?.toLowerCase() ?? null;
+  const pendingReview = hasLabel(pullRequest, 'pending-review');
+
+  if (pullRequest && pendingReview !== Boolean(submissionId)) {
+    throw new Error('Submission auto-fix metadata is incomplete: pending-review and a valid Submission ID must be present together');
+  }
+
+  if (!pullRequest || !pendingReview || !submissionId) {
+    return {
+      body: genericBody({ eventName, modifiedCount, deletedCount }),
+      inheritPendingReview: false,
+      submissionId: null,
+      sourcePrNumber: null,
+    };
+  }
+
+  const sourcePrNumber = Number(pullRequest.number);
+  if (!Number.isSafeInteger(sourcePrNumber) || sourcePrNumber <= 0) {
+    throw new Error('Submission auto-fix metadata is missing a valid source PR number');
+  }
+
+  const repairSummary = `## Automated SKILL.md Repair
+
+This replacement PR preserves the source submission metadata so its own merge can run the normal approval workflow.
+
+| Metric | Value |
+|--------|-------|
+| Source PR | #${sourcePrNumber} |
+| Files Fixed | ${modifiedCount} |
+| Empty Skills Deleted | ${deletedCount} |
+| Triggered By | ${eventName} |
+
+The \`pending-review\` label is inherited explicitly. Approval does not depend on source commits surviving a squash merge.
+
+---
+*Automated fix by validate-marketplace.yml*
+`;
+
+  return {
+    body: `${sourceBody.trimEnd()}\n\n---\n\n${repairSummary}`,
+    inheritPendingReview: true,
+    submissionId,
+    sourcePrNumber,
+  };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      'event-path': { type: 'string' },
+      'event-name': { type: 'string' },
+      'body-file': { type: 'string' },
+      'modified-count': { type: 'string' },
+      'deleted-count': { type: 'string' },
+    },
+    strict: true,
+  });
+
+  for (const name of ['event-path', 'event-name', 'body-file', 'modified-count', 'deleted-count']) {
+    if (values[name] === undefined) throw new Error(`Missing required --${name}`);
+  }
+
+  const event = JSON.parse(await readFile(values['event-path'], 'utf8'));
+  const metadata = buildAutoFixPrMetadata({
+    eventName: values['event-name'],
+    event,
+    modifiedCount: values['modified-count'],
+    deletedCount: values['deleted-count'],
+  });
+
+  await writeFile(values['body-file'], metadata.body, 'utf8');
+  process.stdout.write(`${JSON.stringify({
+    inheritPendingReview: metadata.inheritPendingReview,
+    submissionId: metadata.submissionId,
+    sourcePrNumber: metadata.sourcePrNumber,
+  })}\n`);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/submission-authorization.mjs
+++ b/scripts/submission-authorization.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import {
+  authorizationLeaseRef,
+  parseCanonicalSubmissionId,
+  parseReplacementAuthorization,
+} from './submission-metadata.mjs';
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const PENDING_REVIEW_LABEL = 'pending-review';
+
+function positiveInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) throw new Error(`${name} must be a positive integer`);
+  return number;
+}
+
+function canonicalSha(value, name) {
+  const sha = typeof value === 'string' ? value.toLowerCase() : '';
+  if (!SHA_RE.test(sha)) throw new Error(`${name} must be a 40-character Git SHA`);
+  return sha;
+}
+
+function stateOf(pull) {
+  return typeof pull?.state === 'string' ? pull.state.toLowerCase() : '';
+}
+
+function hasLabel(pull, expected = PENDING_REVIEW_LABEL) {
+  return Array.isArray(pull?.labels)
+    && pull.labels.some((label) => (typeof label === 'string' ? label : label?.name) === expected);
+}
+
+function replacementMarkersPresent(body) {
+  return ['**Source PR**:', '**Source PR Head SHA**:', '**Authorization Lease Ref**:']
+    .some((marker) => typeof body === 'string' && body.includes(marker));
+}
+
+export function buildAuthorizationLease({
+  version = 1,
+  submissionId,
+  sourcePrNumber,
+  sourceHeadSha,
+  holderPrNumber,
+  holderHeadSha,
+  holderKind,
+}) {
+  if (version !== 1) throw new Error('Unsupported authorization lease version');
+  if (!['source', 'replacement'].includes(holderKind)) {
+    throw new Error('Authorization lease holderKind must be source or replacement');
+  }
+  const canonicalSubmissionId = parseCanonicalSubmissionId(`**Submission ID**: \`${submissionId}\``);
+  return {
+    version: 1,
+    submissionId: canonicalSubmissionId,
+    sourcePrNumber: positiveInteger(sourcePrNumber, 'Authorization lease source PR number'),
+    sourceHeadSha: canonicalSha(sourceHeadSha, 'Authorization lease source head SHA'),
+    holderPrNumber: positiveInteger(holderPrNumber, 'Authorization lease holder PR number'),
+    holderHeadSha: canonicalSha(holderHeadSha, 'Authorization lease holder head SHA'),
+    holderKind,
+    ref: authorizationLeaseRef(canonicalSubmissionId),
+  };
+}
+
+export function parseAuthorizationLeaseTag(tagObject, expectedRef) {
+  if (!tagObject || tagObject.object?.type !== 'commit') {
+    throw new Error('Authorization lease tag must point to a commit');
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(tagObject.message);
+  } catch {
+    throw new Error('Authorization lease tag message must be canonical JSON');
+  }
+  const lease = buildAuthorizationLease(parsed);
+  if (lease.ref !== expectedRef) throw new Error('Authorization lease ref does not match its submission');
+  if (canonicalSha(tagObject.object.sha, 'Authorization lease tag target SHA') !== lease.holderHeadSha) {
+    throw new Error('Authorization lease tag target does not match holder head SHA');
+  }
+  return lease;
+}
+
+export function authorizationLeaseTagMessage(lease) {
+  const canonical = buildAuthorizationLease(lease);
+  return JSON.stringify({
+    version: canonical.version,
+    submissionId: canonical.submissionId,
+    sourcePrNumber: canonical.sourcePrNumber,
+    sourceHeadSha: canonical.sourceHeadSha,
+    holderPrNumber: canonical.holderPrNumber,
+    holderHeadSha: canonical.holderHeadSha,
+    holderKind: canonical.holderKind,
+  });
+}
+
+export async function verifyMergeAuthorization({
+  event,
+  mergedPull,
+  sourcePull = null,
+  openPulls = [],
+  lease = null,
+}) {
+  const eventPull = event?.pull_request;
+  if (!eventPull || eventPull.merged !== true || !hasLabel(eventPull)) {
+    throw new Error('Merged PR event is not pending-review authorized');
+  }
+
+  const mergedNumber = positiveInteger(mergedPull?.number, 'Merged PR number');
+  if (mergedNumber !== positiveInteger(eventPull.number, 'Event PR number')) {
+    throw new Error('Merged PR number does not match the event');
+  }
+  if (!mergedPull?.merged_at || stateOf(mergedPull) !== 'closed' || !hasLabel(mergedPull)) {
+    throw new Error('Merged PR live state is not CLOSED + merged + pending-review');
+  }
+  if (mergedPull.body !== eventPull.body) throw new Error('Merged PR body changed after the merge event');
+  const mergedHeadSha = canonicalSha(mergedPull?.head?.sha, 'Merged PR head SHA');
+  if (mergedHeadSha !== canonicalSha(eventPull?.head?.sha, 'Event PR head SHA')) {
+    throw new Error('Merged PR head SHA does not match the event');
+  }
+
+  const submissionId = parseCanonicalSubmissionId(mergedPull.body);
+  const competitors = [];
+  for (const candidate of Array.isArray(openPulls) ? openPulls : []) {
+    if (stateOf(candidate) !== 'open' || !hasLabel(candidate)) continue;
+    let candidateSubmissionId;
+    try {
+      candidateSubmissionId = parseCanonicalSubmissionId(candidate.body);
+    } catch (error) {
+      if (typeof candidate.body === 'string' && candidate.body.toLowerCase().includes(submissionId)) {
+        throw new Error(`Malformed competing authorization metadata on PR #${candidate.number}`);
+      }
+      continue;
+    }
+    if (candidateSubmissionId === submissionId) competitors.push(candidate);
+  }
+  if (competitors.length > 0) {
+    throw new Error(`Merged PR is not the unique authorization candidate; OPEN competitor(s): ${competitors.map((pull) => `#${pull.number}`).join(', ')}`);
+  }
+
+  let replacementAuthorization = null;
+  if (replacementMarkersPresent(mergedPull.body)) {
+    replacementAuthorization = parseReplacementAuthorization(mergedPull.body);
+  }
+
+  if (replacementAuthorization) {
+    if (!lease) throw new Error('Replacement authorization lease is missing');
+    const expectedLease = buildAuthorizationLease({
+      submissionId,
+      sourcePrNumber: replacementAuthorization.sourcePrNumber,
+      sourceHeadSha: replacementAuthorization.sourceHeadSha,
+      holderPrNumber: mergedNumber,
+      holderHeadSha: mergedHeadSha,
+      holderKind: 'replacement',
+    });
+    if (JSON.stringify(lease) !== JSON.stringify(expectedLease)) {
+      throw new Error('Replacement authorization lease holder or metadata mismatch');
+    }
+    if (replacementAuthorization.leaseRef !== lease.ref) {
+      throw new Error('Replacement Authorization Lease Ref mismatch');
+    }
+    if (!sourcePull || positiveInteger(sourcePull.number, 'Source PR number') !== replacementAuthorization.sourcePrNumber) {
+      throw new Error('Replacement source PR metadata mismatch');
+    }
+    if (sourcePull.merged_at || stateOf(sourcePull) !== 'closed' || hasLabel(sourcePull)) {
+      throw new Error('Replacement source PR must be CLOSED, unmerged, and deauthorized');
+    }
+    if (canonicalSha(sourcePull?.head?.sha, 'Live source PR head SHA') !== replacementAuthorization.sourceHeadSha) {
+      throw new Error('Replacement source PR head SHA mismatch');
+    }
+    if (parseCanonicalSubmissionId(sourcePull.body) !== submissionId) {
+      throw new Error('Replacement source PR Submission ID mismatch');
+    }
+  } else if (lease) {
+    const expectedLease = buildAuthorizationLease({
+      submissionId,
+      sourcePrNumber: mergedNumber,
+      sourceHeadSha: mergedHeadSha,
+      holderPrNumber: mergedNumber,
+      holderHeadSha: mergedHeadSha,
+      holderKind: 'source',
+    });
+    if (JSON.stringify(lease) !== JSON.stringify(expectedLease)) {
+      throw new Error('Source authorization lease holder mismatch');
+    }
+  }
+
+  return {
+    authorized: true,
+    submissionId,
+    mergedPrNumber: mergedNumber,
+    mergedHeadSha,
+    leaseRef: lease?.ref ?? null,
+    authorizationKind: replacementAuthorization ? 'replacement' : 'source',
+  };
+}
+
+function createGitHubReader({ repository, token, apiUrl = 'https://api.github.com', fetchImpl = globalThis.fetch }) {
+  if (!/^[^/]+\/[^/]+$/.test(repository)) throw new Error('Repository must use owner/name format');
+  if (!token) throw new Error('GH_TOKEN or GITHUB_TOKEN is required');
+
+  async function request(path, { allowNotFound = false } = {}) {
+    const response = await fetchImpl(`${apiUrl.replace(/\/$/, '')}/repos/${repository}${path}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (allowNotFound && response.status === 404) return null;
+    if (!response.ok) throw new Error(`GitHub API GET ${path} failed (${response.status}): ${(await response.text()).slice(0, 500)}`);
+    return response.json();
+  }
+
+  async function listOpenPulls() {
+    const pulls = [];
+    for (let page = 1; page <= 100; page += 1) {
+      const batch = await request(`/pulls?state=open&per_page=100&page=${page}`);
+      pulls.push(...batch);
+      if (batch.length < 100) return pulls;
+    }
+    throw new Error('GitHub PR pagination exceeded the finite 100-page budget');
+  }
+
+  async function getLease(ref) {
+    const refPath = ref.replace(/^refs\//, '');
+    const refObject = await request(`/git/ref/${refPath}`, { allowNotFound: true });
+    if (!refObject) return null;
+    const tagObject = await request(`/git/tags/${canonicalSha(refObject?.object?.sha, 'Authorization lease tag SHA')}`);
+    return parseAuthorizationLeaseTag(tagObject, ref);
+  }
+
+  return {
+    getPull: (number) => request(`/pulls/${positiveInteger(number, 'PR number')}`),
+    listOpenPulls,
+    getLease,
+  };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      mode: { type: 'string' },
+      'event-path': { type: 'string' },
+      repository: { type: 'string' },
+    },
+    strict: true,
+  });
+  for (const name of ['mode', 'event-path', 'repository']) {
+    if (!values[name]) throw new Error(`Missing required --${name}`);
+  }
+  if (values.mode !== 'verify-merge') throw new Error(`Unsupported --mode: ${values.mode}`);
+
+  const event = JSON.parse(await readFile(values['event-path'], 'utf8'));
+  const client = createGitHubReader({
+    repository: values.repository,
+    token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+    apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+  });
+  const mergedNumber = positiveInteger(event?.pull_request?.number, 'Event PR number');
+  const mergedPull = await client.getPull(mergedNumber);
+  const submissionId = parseCanonicalSubmissionId(mergedPull.body);
+  const ref = authorizationLeaseRef(submissionId);
+  const [openPulls, lease] = await Promise.all([client.listOpenPulls(), client.getLease(ref)]);
+  let sourcePull = null;
+  if (replacementMarkersPresent(mergedPull.body)) {
+    const replacement = parseReplacementAuthorization(mergedPull.body);
+    sourcePull = await client.getPull(replacement.sourcePrNumber);
+  }
+  const result = await verifyMergeAuthorization({ event, mergedPull, sourcePull, openPulls, lease });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/submission-metadata.mjs
+++ b/scripts/submission-metadata.mjs
@@ -7,9 +7,11 @@ import { fileURLToPath } from 'node:url';
 
 const UUID_PATTERN = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
 const SOURCE_SHA_PATTERN = '[0-9a-fA-F]{40}';
+const UUID_RE = new RegExp('^' + UUID_PATTERN + '$');
 const SUBMISSION_LINE_RE = new RegExp('^\\*\\*Submission ID\\*\\*: `(' + UUID_PATTERN + ')`\\r?$', 'gm');
 const SOURCE_PR_LINE_RE = /^\*\*Source PR\*\*: #(\d+)\r?$/gm;
 const SOURCE_SHA_LINE_RE = new RegExp('^\\*\\*Source PR Head SHA\\*\\*: `(' + SOURCE_SHA_PATTERN + ')`\\r?$', 'gm');
+const LEASE_REF_LINE_RE = new RegExp('^\\*\\*Authorization Lease Ref\\*\\*: `(refs/tags/autofix-approval-leases/(' + UUID_PATTERN + '))`\\r?$', 'gm');
 
 function uniqueMatch(body, regex, name) {
   if (typeof body !== 'string') throw new Error(`${name} body must be a string`);
@@ -22,6 +24,12 @@ function uniqueMatch(body, regex, name) {
 
 export function parseCanonicalSubmissionId(body) {
   return uniqueMatch(body, SUBMISSION_LINE_RE, 'Submission ID')[1].toLowerCase();
+}
+
+export function authorizationLeaseRef(submissionId) {
+  const canonical = typeof submissionId === 'string' ? submissionId.toLowerCase() : '';
+  if (!UUID_RE.test(canonical)) throw new Error('Authorization lease submission ID must be a UUID');
+  return `refs/tags/autofix-approval-leases/${canonical}`;
 }
 
 export function canonicalizeSubmissionBody(body) {
@@ -44,6 +52,18 @@ export function parseReplacementSource(body) {
     sourcePrNumber,
     sourceHeadSha: sourceShaMatch[1].toLowerCase(),
   };
+}
+
+export function parseReplacementAuthorization(body) {
+  const submissionId = parseCanonicalSubmissionId(body);
+  const source = parseReplacementSource(body);
+  const leaseMatch = uniqueMatch(body, LEASE_REF_LINE_RE, 'Authorization Lease Ref');
+  const leaseRef = leaseMatch[1];
+  const leaseSubmissionId = leaseMatch[2].toLowerCase();
+  if (leaseSubmissionId !== submissionId || leaseRef !== authorizationLeaseRef(submissionId)) {
+    throw new Error('Authorization Lease Ref does not match the canonical Submission ID');
+  }
+  return { submissionId, ...source, leaseRef };
 }
 
 async function main() {

--- a/scripts/submission-metadata.mjs
+++ b/scripts/submission-metadata.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const UUID_PATTERN = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+const SOURCE_SHA_PATTERN = '[0-9a-fA-F]{40}';
+const SUBMISSION_LINE_RE = new RegExp('^\\*\\*Submission ID\\*\\*: `(' + UUID_PATTERN + ')`\\r?$', 'gm');
+const SOURCE_PR_LINE_RE = /^\*\*Source PR\*\*: #(\d+)\r?$/gm;
+const SOURCE_SHA_LINE_RE = new RegExp('^\\*\\*Source PR Head SHA\\*\\*: `(' + SOURCE_SHA_PATTERN + ')`\\r?$', 'gm');
+
+function uniqueMatch(body, regex, name) {
+  if (typeof body !== 'string') throw new Error(`${name} body must be a string`);
+  const matches = [...body.matchAll(regex)];
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one anchored ${name}; found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+export function parseCanonicalSubmissionId(body) {
+  return uniqueMatch(body, SUBMISSION_LINE_RE, 'Submission ID')[1].toLowerCase();
+}
+
+export function canonicalizeSubmissionBody(body) {
+  const match = uniqueMatch(body, SUBMISSION_LINE_RE, 'Submission ID');
+  const submissionId = match[1].toLowerCase();
+  return {
+    submissionId,
+    body: `${body.slice(0, match.index)}**Submission ID**: \`${submissionId}\`${body.slice(match.index + match[0].length)}`,
+  };
+}
+
+export function parseReplacementSource(body) {
+  const sourcePrMatch = uniqueMatch(body, SOURCE_PR_LINE_RE, 'Source PR');
+  const sourceShaMatch = uniqueMatch(body, SOURCE_SHA_LINE_RE, 'Source PR Head SHA');
+  const sourcePrNumber = Number(sourcePrMatch[1]);
+  if (!Number.isSafeInteger(sourcePrNumber) || sourcePrNumber <= 0) {
+    throw new Error('Source PR must be a positive integer');
+  }
+  return {
+    sourcePrNumber,
+    sourceHeadSha: sourceShaMatch[1].toLowerCase(),
+  };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      'event-path': { type: 'string' },
+    },
+    strict: true,
+  });
+  if (!values['event-path']) throw new Error('Missing required --event-path');
+
+  const event = JSON.parse(await readFile(values['event-path'], 'utf8'));
+  const body = event?.pull_request?.body;
+  const submissionId = parseCanonicalSubmissionId(body);
+  process.stdout.write(`${JSON.stringify({ submissionId })}\n`);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/autofix-pr-authorization.test.mjs
+++ b/scripts/tests/autofix-pr-authorization.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const submissionId = 'e950f6aa-4390-426c-b23e-17b2bc4c3670';
+const sourceHeadSha = 'a'.repeat(40);
+const replacementHeadSha = 'b'.repeat(40);
+const leaseRef = `refs/tags/autofix-approval-leases/${submissionId}`;
+const sourceBody = `**Submission ID**: \`${submissionId}\``;
+const replacementBody = `${sourceBody}\n\n**Source PR**: #2443\n**Source PR Head SHA**: \`${sourceHeadSha}\`\n**Authorization Lease Ref**: \`${leaseRef}\``;
+
+function pull({
+  number,
+  state = 'open',
+  body,
+  labels = [],
+  headSha,
+  mergedAt = null,
+} = {}) {
+  return {
+    number,
+    state,
+    body,
+    labels: labels.map((name) => ({ name })),
+    head: { sha: headSha },
+    merged_at: mergedAt,
+  };
+}
+
+function fixture(overrides = {}) {
+  const mergedPull = pull({
+    number: 2468,
+    state: 'closed',
+    body: replacementBody,
+    labels: ['pending-review'],
+    headSha: replacementHeadSha,
+    mergedAt: '2026-07-14T12:00:00Z',
+  });
+  const sourcePull = pull({
+    number: 2443,
+    state: 'closed',
+    body: sourceBody,
+    labels: [],
+    headSha: sourceHeadSha,
+  });
+  const event = {
+    pull_request: structuredClone(mergedPull),
+  };
+  event.pull_request.merged = true;
+
+  return {
+    event,
+    mergedPull,
+    sourcePull,
+    openPulls: [],
+    lease: {
+      version: 1,
+      submissionId,
+      sourcePrNumber: 2443,
+      sourceHeadSha,
+      holderPrNumber: 2468,
+      holderHeadSha: replacementHeadSha,
+      holderKind: 'replacement',
+      ref: leaseRef,
+    },
+    ...overrides,
+  };
+}
+
+async function loadVerifier() {
+  try {
+    const contract = await import('../submission-authorization.mjs');
+    return contract.verifyMergeAuthorization;
+  } catch (error) {
+    if (error?.code !== 'ERR_MODULE_NOT_FOUND') throw error;
+    // This mirrors the old workflow's label-only `if:` gate so each negative
+    // fixture demonstrates the actual fail-open behavior on the old head.
+    return async ({ event }) => {
+      const pullRequest = event?.pull_request;
+      const approved = pullRequest?.merged === true
+        && pullRequest.labels?.some((label) => label.name === 'pending-review');
+      if (!approved) throw new Error('merge is not label-authorized');
+      return { authorized: true };
+    };
+  }
+}
+
+test('consumer accepts the exact unique replacement lease holder', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  const result = await verifyMergeAuthorization(fixture());
+  assert.equal(result.authorized, true);
+});
+
+test('consumer rejects another OPEN pending-review PR for the same submission', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  const competitor = pull({
+    number: 2500,
+    body: sourceBody,
+    labels: ['pending-review'],
+    headSha: 'd'.repeat(40),
+  });
+
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({ openPulls: [competitor] })),
+    /unique|compet|multiple|authorization/i,
+  );
+});
+
+test('consumer rejects a replacement with a missing authorization lease', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({ lease: null })),
+    /lease/i,
+  );
+});
+
+test('consumer rejects a lease held by another PR or head SHA', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({
+      lease: {
+        ...fixture().lease,
+        holderPrNumber: 2500,
+        holderHeadSha: 'd'.repeat(40),
+      },
+    })),
+    /lease|holder|authorization/i,
+  );
+});
+
+test('consumer fails closed when transfer compensation failed after the source head drifted', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  const uncompensatedSource = pull({
+    number: 2443,
+    state: 'open',
+    body: sourceBody,
+    labels: [],
+    headSha: 'c'.repeat(40),
+  });
+
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({ sourcePull: uncompensatedSource })),
+    /source|sha|deauthorized|metadata/i,
+  );
+});
+
+test('consumer rejects source SHA and replacement metadata mismatch', async () => {
+  const verifyMergeAuthorization = await loadVerifier();
+  const mismatchedSource = pull({
+    number: 2443,
+    state: 'closed',
+    body: sourceBody,
+    labels: [],
+    headSha: 'c'.repeat(40),
+  });
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({ sourcePull: mismatchedSource })),
+    /source|sha|metadata/i,
+  );
+
+  const mismatchedBody = replacementBody.replace(sourceHeadSha, 'c'.repeat(40));
+  const mismatchedMerged = pull({
+    number: 2468,
+    state: 'closed',
+    body: mismatchedBody,
+    labels: ['pending-review'],
+    headSha: replacementHeadSha,
+    mergedAt: '2026-07-14T12:00:00Z',
+  });
+  const mismatchedEvent = { pull_request: { ...structuredClone(mismatchedMerged), merged: true } };
+  await assert.rejects(
+    verifyMergeAuthorization(fixture({ event: mismatchedEvent, mergedPull: mismatchedMerged })),
+    /source|sha|metadata/i,
+  );
+});

--- a/scripts/tests/autofix-pr-lifecycle.test.mjs
+++ b/scripts/tests/autofix-pr-lifecycle.test.mjs
@@ -3,20 +3,30 @@ import test from 'node:test';
 
 import {
   buildSupersessionPlan,
+  ensureReplacement,
   preflightReplacement,
   supersedeReplacement,
 } from '../autofix-pr-lifecycle.mjs';
 
 const submissionId = 'e950f6aa-4390-426c-b23e-17b2bc4c3670';
 const sourceHeadSha = 'a'.repeat(40);
+const nextSourceHeadSha = 'c'.repeat(40);
 const replacementHeadSha = 'b'.repeat(40);
+const nextReplacementHeadSha = 'e'.repeat(40);
+const leaseRef = `refs/tags/autofix-approval-leases/${submissionId}`;
 const sourceBody = `**Submission ID**: \`${submissionId}\``;
-const replacementBody = `${sourceBody}\n\n**Source PR**: #2443\n**Source PR Head SHA**: \`${sourceHeadSha}\``;
 
-function pull({ number, state = 'open', body, labels = [], headSha, headRef, mergedAt = null }) {
+function replacementBodyFor(headSha = sourceHeadSha) {
+  return `${sourceBody}\n\n**Source PR**: #2443\n**Source PR Head SHA**: \`${headSha}\`\n**Authorization Lease Ref**: \`${leaseRef}\``;
+}
+
+const replacementBody = replacementBodyFor();
+
+function pull({ number, state = 'open', title = '', body, labels = [], headSha, headRef, mergedAt = null }) {
   return {
     number,
     state,
+    title,
     body,
     labels: labels.map((name) => ({ name })),
     head: { sha: headSha, ref: headRef },
@@ -25,13 +35,13 @@ function pull({ number, state = 'open', body, labels = [], headSha, headRef, mer
   };
 }
 
-function event() {
+function event({ headSha = sourceHeadSha, body = sourceBody } = {}) {
   return {
     pull_request: pull({
       number: 2443,
-      body: sourceBody,
+      body,
       labels: ['pending-review'],
-      headSha: sourceHeadSha,
+      headSha,
       headRef: 'submission/source',
     }),
   };
@@ -59,6 +69,53 @@ function replacement(overrides = {}) {
   });
 }
 
+function nextReplacement(overrides = {}) {
+  return pull({
+    number: 2469,
+    body: replacementBodyFor(nextSourceHeadSha),
+    labels: [],
+    headSha: nextReplacementHeadSha,
+    headRef: `fix/skill-md-validation-pr-2443-${nextSourceHeadSha.slice(0, 12)}`,
+    ...overrides,
+  });
+}
+
+function activePendingReview(pulls) {
+  return [...pulls.values()].filter((pr) => pr.state === 'open' && pr.labels.some((label) => label.name === 'pending-review'));
+}
+
+test('create response loss is deduped to the one exact unlabeled replacement', async () => {
+  const sourcePr = source();
+  const created = replacement({ title: 'fix: replacement' });
+  const pulls = new Map([[sourcePr.number, structuredClone(sourcePr)]]);
+  let createAttempts = 0;
+  const client = {
+    getPull: async (number) => structuredClone(pulls.get(number)),
+    listPulls: async (_state, headRef) => [...pulls.values()]
+      .filter((candidate) => candidate.head.ref === headRef)
+      .map((candidate) => structuredClone(candidate)),
+    createPull: async () => {
+      createAttempts += 1;
+      pulls.set(created.number, structuredClone(created));
+      throw new Error('injected create response loss after apply');
+    },
+  };
+
+  const result = await ensureReplacement({
+    client,
+    event: event(),
+    title: created.title,
+    body: created.body,
+    headRef: created.head.ref,
+    headSha: replacementHeadSha,
+  });
+
+  assert.equal(createAttempts, 1);
+  assert.equal(result.number, created.number);
+  assert.equal(result.headSha, replacementHeadSha);
+  assert.deepEqual(pulls.get(created.number).labels, []);
+});
+
 test('preflight rejects stale source head, body, or label before replacement creation', () => {
   const replacements = [];
 
@@ -74,6 +131,17 @@ test('preflight rejects stale source head, body, or label before replacement cre
     () => preflightReplacement({ event: event(), liveSource: source({ labels: [] }), replacements }),
     /no longer has pending-review/i,
   );
+});
+
+test('preflight resumes one exact CLOSED unmerged replacement after source deauthorization', () => {
+  const result = preflightReplacement({
+    event: event(),
+    liveSource: source({ state: 'closed', labels: [] }),
+    replacements: [replacement({ state: 'closed' })],
+  });
+
+  assert.equal(result.existingReplacement.number, 2468);
+  assert.equal(result.existingReplacement.state, 'closed');
 });
 
 test('preflight deduplicates one exact source PR and head SHA replacement', () => {
@@ -171,36 +239,104 @@ test('supersession rejects a competing OPEN pending-review PR for the same submi
 });
 
 class FakeClient {
-  constructor(sourcePr, replacementPr) {
+  constructor(sourcePr, replacementPr, { hooks = {}, failures = [] } = {}) {
     this.pulls = new Map([[sourcePr.number, structuredClone(sourcePr)], [replacementPr.number, structuredClone(replacementPr)]]);
     this.operations = [];
+    this.hooks = hooks;
+    this.failures = failures.map((failure) => ({ remaining: 1, timing: 'after', ...failure }));
+    this.lease = null;
+    this.consumerAcceptedDualAuthorization = false;
+  }
+
+  #recordAuthorizationWindow() {
+    const candidates = activePendingReview(this.pulls);
+    const authorized = this.lease
+      ? candidates.filter((pr) => pr.number === this.lease.holderPrNumber && pr.head.sha === this.lease.holderHeadSha)
+      : candidates;
+    if (authorized.length > 1) this.consumerAcceptedDualAuthorization = true;
+  }
+
+  async #mutate(action, number, apply) {
+    const key = `${action}:${number}`;
+    await this.hooks[`before:${key}`]?.(this);
+    const failure = this.failures.find((entry) => entry.remaining > 0 && entry.action === action && (entry.number === undefined || entry.number === number));
+    if (failure?.timing === 'before') {
+      failure.remaining -= 1;
+      throw new Error(`injected ${key} failure before apply`);
+    }
+    this.operations.push(key);
+    apply();
+    await this.hooks[`after:${key}`]?.(this);
+    this.#recordAuthorizationWindow();
+    if (failure) {
+      failure.remaining -= 1;
+      throw new Error(`injected ${key} failure after apply`);
+    }
   }
 
   async getPull(number) {
-    return structuredClone(this.pulls.get(number));
+    await this.hooks[`before:get:${number}`]?.(this);
+    const result = structuredClone(this.pulls.get(number));
+    await this.hooks[`after:get:${number}`]?.(this);
+    return result;
   }
 
   async listPulls(state) {
-    return [...this.pulls.values()]
+    await this.hooks[`before:list:${state}`]?.(this);
+    const result = [...this.pulls.values()]
       .filter((pr) => state === 'all' || pr.state === state)
       .map((pr) => structuredClone(pr));
+    await this.hooks[`after:list:${state}`]?.(this);
+    return result;
   }
 
   async removeLabel(number) {
-    this.operations.push(`remove:${number}`);
-    const pr = this.pulls.get(number);
-    pr.labels = pr.labels.filter((label) => label.name !== 'pending-review');
+    return this.#mutate('remove', number, () => {
+      const pr = this.pulls.get(number);
+      pr.labels = pr.labels.filter((label) => label.name !== 'pending-review');
+    });
   }
 
   async closePull(number) {
-    this.operations.push(`close:${number}`);
-    this.pulls.get(number).state = 'closed';
+    return this.#mutate('close', number, () => {
+      this.pulls.get(number).state = 'closed';
+    });
+  }
+
+  async reopenPull(number) {
+    return this.#mutate('reopen', number, () => {
+      const pr = this.pulls.get(number);
+      if (pr.merged_at) throw new Error(`cannot reopen merged PR #${number}`);
+      pr.state = 'open';
+    });
   }
 
   async addLabel(number) {
-    this.operations.push(`add:${number}`);
-    const pr = this.pulls.get(number);
-    if (!pr.labels.some((label) => label.name === 'pending-review')) pr.labels.push({ name: 'pending-review' });
+    return this.#mutate('add', number, () => {
+      const pr = this.pulls.get(number);
+      if (!pr.labels.some((label) => label.name === 'pending-review')) pr.labels.push({ name: 'pending-review' });
+    });
+  }
+
+  async getAuthorizationLease() {
+    return structuredClone(this.lease);
+  }
+
+  async createAuthorizationLease(manifest) {
+    if (this.lease) throw new Error('authorization lease already exists');
+    this.operations.push(`lease-create:${manifest.holderPrNumber}`);
+    this.lease = structuredClone(manifest);
+    this.#recordAuthorizationWindow();
+    return structuredClone(this.lease);
+  }
+
+  async updateAuthorizationLease(manifest) {
+    if (!this.lease) throw new Error('authorization lease is missing');
+    if (this.lease.sourcePrNumber !== manifest.sourcePrNumber) throw new Error('authorization lease source owner mismatch');
+    this.operations.push(`lease-update:${manifest.holderPrNumber}`);
+    this.lease = structuredClone(manifest);
+    this.#recordAuthorizationWindow();
+    return structuredClone(this.lease);
   }
 }
 
@@ -214,7 +350,7 @@ test('supersedeReplacement executes the fail-closed order and converges to exact
     replacementHeadSha,
   });
 
-  assert.deepEqual(client.operations, ['remove:2443', 'close:2443', 'add:2468']);
+  assert.deepEqual(client.operations, ['lease-create:2468', 'remove:2443', 'close:2443', 'add:2468']);
   assert.equal((await client.getPull(2443)).state, 'closed');
   assert.deepEqual((await client.getPull(2443)).labels, []);
   assert.deepEqual((await client.getPull(2468)).labels, [{ name: 'pending-review' }]);
@@ -236,11 +372,12 @@ test('stale source metadata revokes an already-labeled replacement before failin
     /source PR body changed/i,
   );
 
-  assert.deepEqual(client.operations, ['remove:2468']);
+  assert.deepEqual(client.operations, ['lease-create:2443', 'remove:2468']);
   assert.deepEqual((await client.getPull(2468)).labels, []);
+  assert.equal(client.lease?.holderPrNumber, 2443);
 });
 
-test('a competing approval revokes the replacement before failing', async () => {
+test('a competing approval is revoked while the leased replacement remains uniquely authorized', async () => {
   const client = new FakeClient(
     source({ state: 'closed', labels: [] }),
     replacement({ labels: ['pending-review'] }),
@@ -254,6 +391,31 @@ test('a competing approval revokes the replacement before failing', async () => 
   });
   client.pulls.set(competitor.number, competitor);
 
+  await supersedeReplacement({
+    client,
+    event: event(),
+    replacementNumber: 2468,
+    replacementHeadSha,
+  });
+
+  assert.deepEqual((await client.getPull(competitor.number)).labels, []);
+  assert.deepEqual((await client.getPull(2468)).labels, [{ name: 'pending-review' }]);
+  assert.equal(client.lease?.holderPrNumber, 2468);
+  assert.equal(client.consumerAcceptedDualAuthorization, false);
+});
+
+test('cross-head stale run compensates to one authorized source and the serialized new head can continue', async () => {
+  let drifted = false;
+  const client = new FakeClient(source(), replacement(), {
+    hooks: {
+      'after:remove:2443': (fake) => {
+        if (drifted) return;
+        drifted = true;
+        fake.pulls.get(2443).head.sha = nextSourceHeadSha;
+      },
+    },
+  });
+
   await assert.rejects(
     supersedeReplacement({
       client,
@@ -261,9 +423,179 @@ test('a competing approval revokes the replacement before failing', async () => 
       replacementNumber: 2468,
       replacementHeadSha,
     }),
-    /competing OPEN pending-review/i,
+    /source PR head changed/i,
   );
 
-  assert.deepEqual(client.operations, ['remove:2468']);
+  assert.equal((await client.getPull(2443)).state, 'open');
+  assert.deepEqual((await client.getPull(2443)).labels, [{ name: 'pending-review' }]);
   assert.deepEqual((await client.getPull(2468)).labels, []);
+  assert.equal(activePendingReview(client.pulls).length, 1);
+
+  const next = nextReplacement();
+  client.pulls.set(next.number, next);
+  await supersedeReplacement({
+    client,
+    event: event({ headSha: nextSourceHeadSha }),
+    replacementNumber: next.number,
+    replacementHeadSha: nextReplacementHeadSha,
+  });
+
+  assert.equal(activePendingReview(client.pulls).length, 1);
+  assert.deepEqual((await client.getPull(next.number)).labels, [{ name: 'pending-review' }]);
+});
+
+test('body drift after source close reopens and reauthorizes the source before aborting', async () => {
+  let drifted = false;
+  const client = new FakeClient(source(), replacement(), {
+    hooks: {
+      'after:close:2443': (fake) => {
+        if (drifted) return;
+        drifted = true;
+        fake.pulls.get(2443).body = `${sourceBody}\n\nEdited description`;
+      },
+    },
+  });
+
+  await assert.rejects(
+    supersedeReplacement({
+      client,
+      event: event(),
+      replacementNumber: 2468,
+      replacementHeadSha,
+    }),
+    /source PR body changed/i,
+  );
+
+  assert.equal((await client.getPull(2443)).state, 'open');
+  assert.deepEqual((await client.getPull(2443)).labels, [{ name: 'pending-review' }]);
+  assert.deepEqual((await client.getPull(2468)).labels, []);
+  assert.equal(client.lease?.holderPrNumber, 2443);
+});
+
+test('drift immediately after the first terminal snapshot is caught by stable confirmation and compensated', async () => {
+  let terminalReads = 0;
+  let drifted = false;
+  const client = new FakeClient(source(), replacement(), {
+    hooks: {
+      'after:get:2443': (fake) => {
+        const sourcePr = fake.pulls.get(2443);
+        const replacementPr = fake.pulls.get(2468);
+        if (drifted || sourcePr.state !== 'closed' || !replacementPr.labels.some((label) => label.name === 'pending-review')) return;
+        terminalReads += 1;
+        if (terminalReads === 3) {
+          drifted = true;
+          sourcePr.head.sha = nextSourceHeadSha;
+        }
+      },
+    },
+  });
+
+  await assert.rejects(
+    supersedeReplacement({
+      client,
+      event: event(),
+      replacementNumber: 2468,
+      replacementHeadSha,
+    }),
+    /source PR head changed/i,
+  );
+
+  assert.equal((await client.getPull(2443)).state, 'open');
+  assert.deepEqual((await client.getPull(2443)).labels, [{ name: 'pending-review' }]);
+  assert.deepEqual((await client.getPull(2468)).labels, []);
+  assert.equal(client.lease?.holderPrNumber, 2443);
+});
+
+test('competitor injected immediately before grant never becomes consumer-authorized and is revoked', async () => {
+  const competitor = pull({
+    number: 2500,
+    body: sourceBody,
+    labels: ['pending-review'],
+    headSha: 'd'.repeat(40),
+    headRef: 'competing-submission',
+  });
+  const client = new FakeClient(source(), replacement(), {
+    hooks: {
+      'before:add:2468': (fake) => fake.pulls.set(competitor.number, structuredClone(competitor)),
+    },
+  });
+
+  await supersedeReplacement({
+    client,
+    event: event(),
+    replacementNumber: 2468,
+    replacementHeadSha,
+  });
+
+  assert.equal(client.consumerAcceptedDualAuthorization, false);
+  assert.deepEqual((await client.getPull(2500)).labels, []);
+  assert.deepEqual(activePendingReview(client.pulls).map((pr) => pr.number), [2468]);
+  assert.equal(client.lease?.holderPrNumber, 2468);
+  assert.equal(client.lease?.holderHeadSha, replacementHeadSha);
+});
+
+test('rerun reopens an exact unmerged replacement closed after source deauthorization', async () => {
+  let closedReplacement = false;
+  const client = new FakeClient(source(), replacement(), {
+    hooks: {
+      'after:close:2443': (fake) => {
+        if (closedReplacement) return;
+        closedReplacement = true;
+        fake.pulls.get(2468).state = 'closed';
+      },
+    },
+  });
+
+  await supersedeReplacement({
+    client,
+    event: event(),
+    replacementNumber: 2468,
+    replacementHeadSha,
+  });
+
+  assert.equal((await client.getPull(2443)).state, 'closed');
+  assert.deepEqual((await client.getPull(2443)).labels, []);
+  assert.equal((await client.getPull(2468)).state, 'open');
+  assert.deepEqual((await client.getPull(2468)).labels, [{ name: 'pending-review' }]);
+  assert.equal(activePendingReview(client.pulls).length, 1);
+  assert.ok(client.operations.includes('reopen:2468'));
+});
+
+for (const failure of [
+  { action: 'remove', number: 2443 },
+  { action: 'close', number: 2443 },
+  { action: 'add', number: 2468 },
+]) {
+  test(`response loss after ${failure.action} is reconciled to exactly one authorized candidate`, async () => {
+    const client = new FakeClient(source(), replacement(), { failures: [failure] });
+
+    await supersedeReplacement({
+      client,
+      event: event(),
+      replacementNumber: 2468,
+      replacementHeadSha,
+    });
+
+    assert.deepEqual(activePendingReview(client.pulls).map((pr) => pr.number), [2468]);
+    assert.equal(client.consumerAcceptedDualAuthorization, false);
+    assert.equal(client.lease?.holderPrNumber, 2468);
+  });
+}
+
+test('response loss after replacement reopen is reconciled and still grants only the replacement', async () => {
+  const client = new FakeClient(
+    source({ state: 'closed', labels: [] }),
+    replacement({ state: 'closed' }),
+    { failures: [{ action: 'reopen', number: 2468 }] },
+  );
+
+  await supersedeReplacement({
+    client,
+    event: event(),
+    replacementNumber: 2468,
+    replacementHeadSha,
+  });
+
+  assert.deepEqual(activePendingReview(client.pulls).map((pr) => pr.number), [2468]);
+  assert.equal(client.lease?.holderPrNumber, 2468);
 });

--- a/scripts/tests/autofix-pr-lifecycle.test.mjs
+++ b/scripts/tests/autofix-pr-lifecycle.test.mjs
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildSupersessionPlan,
+  preflightReplacement,
+  supersedeReplacement,
+} from '../autofix-pr-lifecycle.mjs';
+
+const submissionId = 'e950f6aa-4390-426c-b23e-17b2bc4c3670';
+const sourceHeadSha = 'a'.repeat(40);
+const replacementHeadSha = 'b'.repeat(40);
+const sourceBody = `**Submission ID**: \`${submissionId}\``;
+const replacementBody = `${sourceBody}\n\n**Source PR**: #2443\n**Source PR Head SHA**: \`${sourceHeadSha}\``;
+
+function pull({ number, state = 'open', body, labels = [], headSha, headRef, mergedAt = null }) {
+  return {
+    number,
+    state,
+    body,
+    labels: labels.map((name) => ({ name })),
+    head: { sha: headSha, ref: headRef },
+    merged_at: mergedAt,
+    html_url: `https://github.com/aiskillstore/marketplace/pull/${number}`,
+  };
+}
+
+function event() {
+  return {
+    pull_request: pull({
+      number: 2443,
+      body: sourceBody,
+      labels: ['pending-review'],
+      headSha: sourceHeadSha,
+      headRef: 'submission/source',
+    }),
+  };
+}
+
+function source(overrides = {}) {
+  return pull({
+    number: 2443,
+    body: sourceBody,
+    labels: ['pending-review'],
+    headSha: sourceHeadSha,
+    headRef: 'submission/source',
+    ...overrides,
+  });
+}
+
+function replacement(overrides = {}) {
+  return pull({
+    number: 2468,
+    body: replacementBody,
+    labels: [],
+    headSha: replacementHeadSha,
+    headRef: `fix/skill-md-validation-pr-2443-${sourceHeadSha.slice(0, 12)}`,
+    ...overrides,
+  });
+}
+
+test('preflight rejects stale source head, body, or label before replacement creation', () => {
+  const replacements = [];
+
+  assert.throws(
+    () => preflightReplacement({ event: event(), liveSource: source({ headSha: 'c'.repeat(40) }), replacements }),
+    /source PR head changed/i,
+  );
+  assert.throws(
+    () => preflightReplacement({ event: event(), liveSource: source({ body: `${sourceBody}\nchanged` }), replacements }),
+    /source PR body changed/i,
+  );
+  assert.throws(
+    () => preflightReplacement({ event: event(), liveSource: source({ labels: [] }), replacements }),
+    /no longer has pending-review/i,
+  );
+});
+
+test('preflight deduplicates one exact source PR and head SHA replacement', () => {
+  const result = preflightReplacement({
+    event: event(),
+    liveSource: source(),
+    replacements: [replacement()],
+  });
+
+  assert.equal(result.source.number, 2443);
+  assert.equal(result.source.headSha, sourceHeadSha);
+  assert.equal(result.existingReplacement.number, 2468);
+  assert.equal(result.branchName, `fix/skill-md-validation-pr-2443-${sourceHeadSha.slice(0, 12)}`);
+
+  assert.throws(
+    () => preflightReplacement({
+      event: event(),
+      liveSource: source(),
+      replacements: [replacement(), replacement({ number: 2469 })],
+    }),
+    /multiple replacement PRs/i,
+  );
+});
+
+test('supersession plan revokes source approval before closing and labels replacement last', () => {
+  const sourcePr = source();
+  const replacementPr = replacement();
+
+  assert.deepEqual(
+    buildSupersessionPlan({
+      source: sourcePr,
+      replacement: replacementPr,
+      openPulls: [sourcePr, replacementPr],
+      submissionId,
+    }),
+    [
+      { action: 'remove-label', number: 2443 },
+      { action: 'close', number: 2443 },
+      { action: 'add-label', number: 2468 },
+    ],
+  );
+});
+
+test('supersession plan is reentrant and repairs a previous dual-active state fail closed', () => {
+  const sourcePr = source();
+  const replacementPr = replacement({ labels: ['pending-review'] });
+
+  assert.deepEqual(
+    buildSupersessionPlan({
+      source: sourcePr,
+      replacement: replacementPr,
+      openPulls: [sourcePr, replacementPr],
+      submissionId,
+    }),
+    [
+      { action: 'remove-label', number: 2468 },
+      { action: 'remove-label', number: 2443 },
+      { action: 'close', number: 2443 },
+      { action: 'add-label', number: 2468 },
+    ],
+  );
+
+  const closedSource = source({ state: 'closed', labels: [] });
+  assert.deepEqual(
+    buildSupersessionPlan({
+      source: closedSource,
+      replacement: replacementPr,
+      openPulls: [replacementPr],
+      submissionId,
+    }),
+    [],
+  );
+});
+
+test('supersession rejects a competing OPEN pending-review PR for the same submission', () => {
+  const sourcePr = source({ state: 'closed', labels: [] });
+  const replacementPr = replacement();
+  const competitor = pull({
+    number: 2500,
+    body: sourceBody,
+    labels: ['pending-review'],
+    headSha: 'd'.repeat(40),
+    headRef: 'other-replacement',
+  });
+
+  assert.throws(
+    () => buildSupersessionPlan({
+      source: sourcePr,
+      replacement: replacementPr,
+      openPulls: [replacementPr, competitor],
+      submissionId,
+    }),
+    /competing OPEN pending-review/i,
+  );
+});
+
+class FakeClient {
+  constructor(sourcePr, replacementPr) {
+    this.pulls = new Map([[sourcePr.number, structuredClone(sourcePr)], [replacementPr.number, structuredClone(replacementPr)]]);
+    this.operations = [];
+  }
+
+  async getPull(number) {
+    return structuredClone(this.pulls.get(number));
+  }
+
+  async listPulls(state) {
+    return [...this.pulls.values()]
+      .filter((pr) => state === 'all' || pr.state === state)
+      .map((pr) => structuredClone(pr));
+  }
+
+  async removeLabel(number) {
+    this.operations.push(`remove:${number}`);
+    const pr = this.pulls.get(number);
+    pr.labels = pr.labels.filter((label) => label.name !== 'pending-review');
+  }
+
+  async closePull(number) {
+    this.operations.push(`close:${number}`);
+    this.pulls.get(number).state = 'closed';
+  }
+
+  async addLabel(number) {
+    this.operations.push(`add:${number}`);
+    const pr = this.pulls.get(number);
+    if (!pr.labels.some((label) => label.name === 'pending-review')) pr.labels.push({ name: 'pending-review' });
+  }
+}
+
+test('supersedeReplacement executes the fail-closed order and converges to exactly one active approval', async () => {
+  const client = new FakeClient(source(), replacement());
+
+  await supersedeReplacement({
+    client,
+    event: event(),
+    replacementNumber: 2468,
+    replacementHeadSha,
+  });
+
+  assert.deepEqual(client.operations, ['remove:2443', 'close:2443', 'add:2468']);
+  assert.equal((await client.getPull(2443)).state, 'closed');
+  assert.deepEqual((await client.getPull(2443)).labels, []);
+  assert.deepEqual((await client.getPull(2468)).labels, [{ name: 'pending-review' }]);
+});
+
+test('stale source metadata revokes an already-labeled replacement before failing', async () => {
+  const client = new FakeClient(
+    source({ body: `${sourceBody}\nchanged` }),
+    replacement({ labels: ['pending-review'] }),
+  );
+
+  await assert.rejects(
+    supersedeReplacement({
+      client,
+      event: event(),
+      replacementNumber: 2468,
+      replacementHeadSha,
+    }),
+    /source PR body changed/i,
+  );
+
+  assert.deepEqual(client.operations, ['remove:2468']);
+  assert.deepEqual((await client.getPull(2468)).labels, []);
+});
+
+test('a competing approval revokes the replacement before failing', async () => {
+  const client = new FakeClient(
+    source({ state: 'closed', labels: [] }),
+    replacement({ labels: ['pending-review'] }),
+  );
+  const competitor = pull({
+    number: 2500,
+    body: sourceBody,
+    labels: ['pending-review'],
+    headSha: 'd'.repeat(40),
+    headRef: 'other-replacement',
+  });
+  client.pulls.set(competitor.number, competitor);
+
+  await assert.rejects(
+    supersedeReplacement({
+      client,
+      event: event(),
+      replacementNumber: 2468,
+      replacementHeadSha,
+    }),
+    /competing OPEN pending-review/i,
+  );
+
+  assert.deepEqual(client.operations, ['remove:2468']);
+  assert.deepEqual((await client.getPull(2468)).labels, []);
+});

--- a/scripts/tests/autofix-pr-metadata.test.mjs
+++ b/scripts/tests/autofix-pr-metadata.test.mjs
@@ -3,21 +3,25 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import { buildAutoFixPrMetadata } from '../build-autofix-pr-metadata.mjs';
+import { parseCanonicalSubmissionId } from '../submission-metadata.mjs';
 
 const submissionId = 'e950f6aa-4390-426c-b23e-17b2bc4c3670';
+const sourceHeadSha = 'a'.repeat(40);
 
-function pullRequestEvent({ body, labels = [], number = 2443 } = {}) {
+function pullRequestEvent({ body, labels = [], number = 2443, headSha = sourceHeadSha } = {}) {
   return {
     pull_request: {
       number,
       body: body ?? '',
       labels: labels.map((name) => ({ name })),
+      head: { sha: headSha },
     },
   };
 }
 
-test('pending-review auto-fix preserves submission metadata for its own merge event', () => {
-  const sourceBody = `## Skill Submission\n\n**Submission ID**: \`${submissionId}\`\n**Source**: https://github.com/example/skills`;
+test('pending-review auto-fix canonicalizes one anchored Submission ID for its own merge event', () => {
+  const uppercaseId = submissionId.toUpperCase();
+  const sourceBody = `## Skill Submission\n\n**Submission ID**: \`${uppercaseId}\`\n**Source**: https://github.com/example/skills`;
   const result = buildAutoFixPrMetadata({
     eventName: 'pull_request',
     event: pullRequestEvent({ body: sourceBody, labels: ['pending-review'] }),
@@ -27,28 +31,43 @@ test('pending-review auto-fix preserves submission metadata for its own merge ev
 
   assert.equal(result.inheritPendingReview, true);
   assert.equal(result.submissionId, submissionId);
-  assert.ok(result.body.includes('**Submission ID**: `' + submissionId + '`'));
-  assert.match(result.body, /\| Source PR \| #2443 \|/);
+  assert.equal(result.sourceHeadSha, sourceHeadSha);
+  assert.match(result.body, new RegExp('^\\*\\*Submission ID\\*\\*: `' + submissionId + '`$', 'm'));
+  assert.doesNotMatch(result.body, new RegExp(uppercaseId));
+  assert.equal(parseCanonicalSubmissionId(result.body), submissionId, 'on-pr-merge consumes the replacement body through the same canonical parser');
+  assert.match(result.body, new RegExp('^\\*\\*Source PR Head SHA\\*\\*: `' + sourceHeadSha + '`$', 'm'));
   assert.match(result.body, /Files Fixed \| 1/);
 });
 
-test('metadata inheritance does not depend on source commits surviving a squash merge', () => {
-  const result = buildAutoFixPrMetadata({
-    eventName: 'pull_request',
-    event: pullRequestEvent({
-      body: `**Submission ID**: \`${submissionId}\``,
-      labels: ['pending-review'],
-    }),
-    modifiedCount: 2,
-    deletedCount: 1,
-  });
+test('duplicate anchored Submission IDs fail closed instead of selecting one', () => {
+  const sourceBody = `**Submission ID**: \`${submissionId}\`\n\n**Submission ID**: \`${submissionId}\``;
 
-  assert.equal(result.inheritPendingReview, true);
-  assert.equal(result.submissionId, submissionId);
-  assert.equal(result.sourcePrNumber, 2443);
+  assert.throws(
+    () => buildAutoFixPrMetadata({
+      eventName: 'pull_request',
+      event: pullRequestEvent({ body: sourceBody, labels: ['pending-review'] }),
+      modifiedCount: 1,
+      deletedCount: 0,
+    }),
+    /exactly one anchored Submission ID/i,
+  );
 });
 
-test('pending-review without a valid submission ID fails closed', () => {
+test('quoted Submission ID text fails closed instead of becoming approval metadata', () => {
+  const sourceBody = `> **Submission ID**: \`${submissionId}\``;
+
+  assert.throws(
+    () => buildAutoFixPrMetadata({
+      eventName: 'pull_request',
+      event: pullRequestEvent({ body: sourceBody, labels: ['pending-review'] }),
+      modifiedCount: 1,
+      deletedCount: 0,
+    }),
+    /exactly one anchored Submission ID/i,
+  );
+});
+
+test('pending-review without a unique canonical Submission ID fails closed', () => {
   assert.throws(
     () => buildAutoFixPrMetadata({
       eventName: 'pull_request',
@@ -56,7 +75,7 @@ test('pending-review without a valid submission ID fails closed', () => {
       modifiedCount: 1,
       deletedCount: 0,
     }),
-    /pending-review.*Submission ID/i,
+    /exactly one anchored Submission ID/i,
   );
 });
 
@@ -70,17 +89,32 @@ test('non-submission auto-fix remains unlabeled and uses the generic body', () =
 
   assert.equal(result.inheritPendingReview, false);
   assert.equal(result.submissionId, null);
+  assert.equal(result.sourceHeadSha, null);
   assert.match(result.body, /AI-powered auto-fix/);
   assert.doesNotMatch(result.body, /Submission ID/);
 });
 
-test('validate workflow uses event metadata and body-file instead of commit history', async () => {
-  const workflow = await readFile(new URL('../../.github/workflows/validate-marketplace.yml', import.meta.url), 'utf8');
-  const createStep = workflow.match(/- name: Create PR for SKILL\.md fixes[\s\S]*?(?=\n\s{6}- name:)/)?.[0] ?? '';
+test('workflows use the shared canonical parser and event-head lifecycle guard', async () => {
+  const [validateWorkflow, mergeWorkflow, testWorkflow] = await Promise.all([
+    readFile(new URL('../../.github/workflows/validate-marketplace.yml', import.meta.url), 'utf8'),
+    readFile(new URL('../../.github/workflows/on-pr-merge.yml', import.meta.url), 'utf8'),
+    readFile(new URL('../../.github/workflows/test-recalculate-scores.yml', import.meta.url), 'utf8'),
+  ]);
+  const createStep = validateWorkflow.match(/- name: Create PR for SKILL\.md fixes[\s\S]*?(?=\n\s{6}- name:)/)?.[0] ?? '';
 
-  assert.match(createStep, /build-autofix-pr-metadata\.mjs/);
-  assert.match(createStep, /GITHUB_EVENT_PATH/);
+  assert.match(validateWorkflow, /github\.event\.pull_request\.head\.sha/);
+  assert.match(validateWorkflow, /git fetch --depth 1 origin "\$EVENT_HEAD_SHA"/);
+  assert.match(validateWorkflow, /autofix-pr-lifecycle\.mjs[\s\S]*--mode preflight/);
+  assert.match(createStep, /autofix-pr-lifecycle\.mjs[\s\S]*--mode supersede/);
   assert.match(createStep, /--body-file/);
-  assert.match(createStep, /--label["']?\s+["']?pending-review/);
-  assert.doesNotMatch(createStep, /git log|github\.event\.head_commit|git show/);
+  assert.doesNotMatch(createStep, /PR_ARGS\+=\(--label/);
+  assert.match(mergeWorkflow, /actions\/checkout@v5/);
+  assert.match(mergeWorkflow, /scripts\/submission-metadata\.mjs/);
+  assert.doesNotMatch(mergeWorkflow, /grep -oE 'Submission ID/);
+  assert.match(testWorkflow, /scripts\/build-autofix-pr-metadata\.mjs/);
+  assert.match(testWorkflow, /scripts\/submission-metadata\.mjs/);
+  assert.match(testWorkflow, /scripts\/autofix-pr-lifecycle\.mjs/);
+  assert.match(testWorkflow, /\.github\/workflows\/validate-marketplace\.yml/);
+  assert.match(testWorkflow, /\.github\/workflows\/on-pr-merge\.yml/);
+  assert.match(testWorkflow, /node --test scripts\/tests\/autofix-pr-metadata\.test\.mjs/);
 });

--- a/scripts/tests/autofix-pr-metadata.test.mjs
+++ b/scripts/tests/autofix-pr-metadata.test.mjs
@@ -36,6 +36,10 @@ test('pending-review auto-fix canonicalizes one anchored Submission ID for its o
   assert.doesNotMatch(result.body, new RegExp(uppercaseId));
   assert.equal(parseCanonicalSubmissionId(result.body), submissionId, 'on-pr-merge consumes the replacement body through the same canonical parser');
   assert.match(result.body, new RegExp('^\\*\\*Source PR Head SHA\\*\\*: `' + sourceHeadSha + '`$', 'm'));
+  assert.match(
+    result.body,
+    new RegExp('^\\*\\*Authorization Lease Ref\\*\\*: `refs/tags/autofix-approval-leases/' + submissionId + '`$', 'm'),
+  );
   assert.match(result.body, /Files Fixed \| 1/);
 });
 
@@ -102,17 +106,24 @@ test('workflows use the shared canonical parser and event-head lifecycle guard',
   ]);
   const createStep = validateWorkflow.match(/- name: Create PR for SKILL\.md fixes[\s\S]*?(?=\n\s{6}- name:)/)?.[0] ?? '';
 
+  assert.match(validateWorkflow, /pull_request:\s*\n\s+types:\s*\[[^\]]*edited[^\]]*\]/);
+  const concurrencyGroup = validateWorkflow.match(/concurrency:\s*\n\s+group:\s*([^\n]+)/)?.[1] ?? '';
+  assert.match(concurrencyGroup, /pull_request\.number/);
+  assert.doesNotMatch(concurrencyGroup, /head\.sha|github\.sha/);
   assert.match(validateWorkflow, /github\.event\.pull_request\.head\.sha/);
   assert.match(validateWorkflow, /git fetch --depth 1 origin "\$EVENT_HEAD_SHA"/);
   assert.match(validateWorkflow, /autofix-pr-lifecycle\.mjs[\s\S]*--mode preflight/);
+  assert.match(createStep, /autofix-pr-lifecycle\.mjs[\s\S]*--mode ensure-replacement/);
   assert.match(createStep, /autofix-pr-lifecycle\.mjs[\s\S]*--mode supersede/);
   assert.match(createStep, /--body-file/);
   assert.doesNotMatch(createStep, /PR_ARGS\+=\(--label/);
   assert.match(mergeWorkflow, /actions\/checkout@v5/);
-  assert.match(mergeWorkflow, /scripts\/submission-metadata\.mjs/);
+  assert.match(mergeWorkflow, /scripts\/submission-authorization\.mjs[\s\S]*--mode verify-merge/);
+  assert.match(mergeWorkflow, /authorization[\s\S]*Find pending skills and commit to skills directory/i);
   assert.doesNotMatch(mergeWorkflow, /grep -oE 'Submission ID/);
   assert.match(testWorkflow, /scripts\/build-autofix-pr-metadata\.mjs/);
   assert.match(testWorkflow, /scripts\/submission-metadata\.mjs/);
+  assert.match(testWorkflow, /scripts\/submission-authorization\.mjs/);
   assert.match(testWorkflow, /scripts\/autofix-pr-lifecycle\.mjs/);
   assert.match(testWorkflow, /\.github\/workflows\/validate-marketplace\.yml/);
   assert.match(testWorkflow, /\.github\/workflows\/on-pr-merge\.yml/);

--- a/scripts/tests/autofix-pr-metadata.test.mjs
+++ b/scripts/tests/autofix-pr-metadata.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { buildAutoFixPrMetadata } from '../build-autofix-pr-metadata.mjs';
+
+const submissionId = 'e950f6aa-4390-426c-b23e-17b2bc4c3670';
+
+function pullRequestEvent({ body, labels = [], number = 2443 } = {}) {
+  return {
+    pull_request: {
+      number,
+      body: body ?? '',
+      labels: labels.map((name) => ({ name })),
+    },
+  };
+}
+
+test('pending-review auto-fix preserves submission metadata for its own merge event', () => {
+  const sourceBody = `## Skill Submission\n\n**Submission ID**: \`${submissionId}\`\n**Source**: https://github.com/example/skills`;
+  const result = buildAutoFixPrMetadata({
+    eventName: 'pull_request',
+    event: pullRequestEvent({ body: sourceBody, labels: ['pending-review'] }),
+    modifiedCount: 1,
+    deletedCount: 0,
+  });
+
+  assert.equal(result.inheritPendingReview, true);
+  assert.equal(result.submissionId, submissionId);
+  assert.ok(result.body.includes('**Submission ID**: `' + submissionId + '`'));
+  assert.match(result.body, /\| Source PR \| #2443 \|/);
+  assert.match(result.body, /Files Fixed \| 1/);
+});
+
+test('metadata inheritance does not depend on source commits surviving a squash merge', () => {
+  const result = buildAutoFixPrMetadata({
+    eventName: 'pull_request',
+    event: pullRequestEvent({
+      body: `**Submission ID**: \`${submissionId}\``,
+      labels: ['pending-review'],
+    }),
+    modifiedCount: 2,
+    deletedCount: 1,
+  });
+
+  assert.equal(result.inheritPendingReview, true);
+  assert.equal(result.submissionId, submissionId);
+  assert.equal(result.sourcePrNumber, 2443);
+});
+
+test('pending-review without a valid submission ID fails closed', () => {
+  assert.throws(
+    () => buildAutoFixPrMetadata({
+      eventName: 'pull_request',
+      event: pullRequestEvent({ body: 'missing metadata', labels: ['pending-review'] }),
+      modifiedCount: 1,
+      deletedCount: 0,
+    }),
+    /pending-review.*Submission ID/i,
+  );
+});
+
+test('non-submission auto-fix remains unlabeled and uses the generic body', () => {
+  const result = buildAutoFixPrMetadata({
+    eventName: 'push',
+    event: {},
+    modifiedCount: 1,
+    deletedCount: 0,
+  });
+
+  assert.equal(result.inheritPendingReview, false);
+  assert.equal(result.submissionId, null);
+  assert.match(result.body, /AI-powered auto-fix/);
+  assert.doesNotMatch(result.body, /Submission ID/);
+});
+
+test('validate workflow uses event metadata and body-file instead of commit history', async () => {
+  const workflow = await readFile(new URL('../../.github/workflows/validate-marketplace.yml', import.meta.url), 'utf8');
+  const createStep = workflow.match(/- name: Create PR for SKILL\.md fixes[\s\S]*?(?=\n\s{6}- name:)/)?.[0] ?? '';
+
+  assert.match(createStep, /build-autofix-pr-metadata\.mjs/);
+  assert.match(createStep, /GITHUB_EVENT_PATH/);
+  assert.match(createStep, /--body-file/);
+  assert.match(createStep, /--label["']?\s+["']?pending-review/);
+  assert.doesNotMatch(createStep, /git log|github\.event\.head_commit|git show/);
+});


### PR DESCRIPTION
## 背景 / 问题描述

[PR #2444](https://github.com/aiskillstore/marketplace/pull/2444) 是 submission PR 的自动修复替代 PR。#2467 Retry #1 已统一 metadata parser 与 exact event SHA，但 Trent 在新 head 上继续复现出 3 个审批转移 blocker：跨 head stale 后永久零审批、competitor 在检查与 grant 之间插入导致可利用双授权、replacement 被关闭后无法恢复。

## Retry #2：上次 FAIL 的 3 个 blocker

1. **跨 head stale 会永久零审批**：workflow concurrency 含 head SHA；旧 run 撤 source label 后才发现 head/body drift，catch 不恢复 source，新 head 随后也因 source 无 label 被拒绝。
2. **competitor 检查与 grant 非原子**：`listPulls()` 与 replacement `add-label` 之间可插入同 submission competitor；Retry #1 只能事后撤回，窗口内 consumer 仍可接受两条 PR。
3. **replacement CLOSED 后无恢复**：source 已撤权/关闭后，exact replacement 若被外部关闭，rerun 只会报 `not OPEN`，source/replacement 永久都无审批能力。

Review source：[Trent Retry #1 review 4694578431](https://github.com/aiskillstore/marketplace/pull/2467#pullrequestreview-4694578431)。

## 本次修复

### 1. source 生命周期串行 + stale 补偿

- `validate-marketplace.yml` concurrency 改为按 event + source PR number 串行，移除 head SHA；同一 source 的不同 head/body generation 不再并行。
- `pull_request` 显式覆盖 `edited` / `labeled`，补偿重新加 label 后可用新 body/head 重新进入链路。
- lifecycle 在 source head/body drift、mutation response loss、终态复核失败时，统一执行补偿：把权威 lease 切回 live source head，必要时 reopen source、撤其他审批 label、恢复 source `pending-review`。
- 终态要求连续两次稳定 live snapshot；旧 run 在任一 live read 后 stale 都不能误报成功。

### 2. submission-scoped 权威 lease

- 新增共享合同 `scripts/submission-authorization.mjs`；每个 Submission ID 使用唯一持久 ref：`refs/tags/autofix-approval-leases/<submission-id>`。
- ref 指向 annotated tag；tag JSON 同时绑定 submission、source PR/SHA、holder PR/SHA、holder kind，tag target 必须等于 holder commit SHA。
- lease ref 创建是 GitHub 原子 create；后续只允许同一个 source PR 生命周期更新。不同 source PR 的同 submission competitor 无权抢 lease。
- source label 撤销前 lease 先指向 exact replacement；即使 competitor 在 `add-label` 前一瞬插入，consumer 也只接受 lease holder。grant 后再次清理 competitor 并做双重稳定终态复核。
- lease 持久保留，不在 promotion 后删除，避免迟到 competitor 重新退化成 label-only 授权。

### 3. consumer required authorization gate

- `on-pr-merge.yml` 在任何 pending 文件搬运和 callback **之前**执行共享 `verify-merge`。
- replacement merge 必须同时满足：event/live body 与 head SHA 一致、唯一 canonical Submission ID、lease ref/manifest/target 与 merged PR 精确一致、source PR/SHA/Submission ID 一致、source 为 `CLOSED + unmerged + no pending-review`、同 submission 无其他 OPEN pending-review。
- 双 label、lease 缺失/错 holder/错 SHA、source metadata/SHA drift、补偿失败残态全部 fail closed；不搬 pending、不 callback。
- builder、lifecycle、consumer 共用 `submission-metadata.mjs` + `submission-authorization.mjs`，不再维护两套 parser。

### 4. replacement create/reopen 与部分失败恢复

- 新增 `ensure-replacement`：create API 响应丢失后按 exact lifecycle branch 重查并 dedupe，replacement 初始始终无审批 label。
- exact、unmerged、CLOSED replacement 可 reopen 后继续；reopen 失败则恢复 source。
- remove-label / close / reopen / create / add-label 任一步出现“服务端已生效但响应丢失”时，都重新读 live state 后继续收敛。
- 若补偿本身失败，lease + consumer gate 保证残态不可被消费。

## Acceptance Criteria

- [x] 同一 source 两个不同 head 串行；旧 run 撤权后 stale 会恢复唯一 source，新 head 可继续并最终唯一 replacement。— 验收：`scripts/tests/autofix-pr-lifecycle.test.mjs::cross-head stale run compensates to one authorized source and the serialized new head can continue`、`body drift after source close reopens and reauthorizes the source before aborting`、`drift immediately after the first terminal snapshot is caught by stable confirmation and compensated`；CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155)
- [x] competitor 在 grant 前插入时，consumer 从未接受双授权，最终只保留 exact lease holder。— 验收：`scripts/tests/autofix-pr-lifecycle.test.mjs::competitor injected immediately before grant never becomes consumer-authorized and is revoked`、`a competing approval is revoked while the leased replacement remains uniquely authorized`；CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155)
- [x] source 已关闭且 replacement 被外部关闭时，rerun 可 reopen exact replacement 并恢复唯一审批。— 验收：`scripts/tests/autofix-pr-lifecycle.test.mjs::preflight resumes one exact CLOSED unmerged replacement after source deauthorization`、`rerun reopens an exact unmerged replacement closed after source deauthorization`；CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155)
- [x] remove-label / close / reopen / create / add-label 部分失败均可重读收敛；补偿失败时 consumer fail closed。— 验收：`create response loss is deduped to the one exact unlabeled replacement`、`response loss after remove|close|add is reconciled to exactly one authorized candidate`、`response loss after replacement reopen is reconciled and still grants only the replacement`、`scripts/tests/autofix-pr-authorization.test.mjs::consumer fails closed when transfer compensation failed after the source head drifted`；CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155)
- [x] merge consumer 对双 label、lease 缺失/失配、source/replacement SHA/metadata 失配全部拒绝。— 验收：`scripts/tests/autofix-pr-authorization.test.mjs::consumer rejects another OPEN pending-review PR for the same submission`、`consumer rejects a replacement with a missing authorization lease`、`consumer rejects a lease held by another PR or head SHA`、`consumer rejects source SHA and replacement metadata mismatch`；CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155)

## 验证证据

- TDD RED（旧 head `97bd367e0c570995ada42bc317585f9c79243ea9`）：focused 26 项中 13 PASS / 13 FAIL；明确复现 consumer 双 label/缺 lease/错 lease/SHA drift、跨 head 零审批、grant competitor、replacement CLOSED、remove/close/add response loss、缺 lease metadata/workflow gate。
- GREEN（新 head `790dc3a63257ae3c1d6a07bf056c525fc35d7a6d`）：focused 31/31 PASS；全量 scripts 134/134 PASS。
- CI：[Run 29341089155](https://github.com/aiskillstore/marketplace/actions/runs/29341089155) SUCCESS，head 与 PR 一致。
- 静态检查：4 个生产 `.mjs` `node --check`；相关 Bash `bash -n`；3 个 workflow `yq` parse；JSON parse；`git diff --check` 全部 PASS（本机未安装 `actionlint`，未把它计为证据）。
- 二进制 evidence：0。
- 未触发生产 auto-fix / workflow_dispatch，未搬运 pending，未写 Supabase，未部署、未合并。

## 当前 pending 恢复边界

本 PR **不**处理 #2470/#2474，不迁 `skills/pending/pending`，不倒灌或审批当前 flat `pending/`；只修未来 auto-fix replacement 的 metadata / lifecycle / consumer authorization。

## 风险点

- 数据写入：本 PR 不写 Supabase；consumer gate 不满足时会在搬 pending 前失败。
- 权限 / 安全：沿用现有 GitHub App `contents: write` / `pull-requests: write`；新增写操作为同仓库 authorization tag/ref 与 PR reopen/label。lease tag 不含 secret。
- 并发 / 事务：GitHub PR/label API 仍非事务；原子 lease ref + required consumer gate 把 label 窗口降为不可消费状态，并以补偿恢复唯一候选。
- 用户体验：异常时可能暂时零 label，但 lease 阻止错误消费；补偿成功后 source 会自动 reopen/relabel，新事件继续。
- 回滚方式：revert 本 PR 恢复旧 workflow；已创建的 lease refs 可保留为惰性安全记录，不需要生产数据回滚。

## 人类 review 关注点

请 reviewer 重点判断：
1. annotated-tag lease 是否把 source/submission/holder/head 绑定完整，且不同 source 无法抢 lease。
2. 每个 mutation / stale / CLOSED replacement 分支是否都收敛到唯一候选，或在补偿失败时被 consumer 拒绝。
3. `on-pr-merge` gate 是否严格位于 pending 搬运/callback 前，且没有 label-only 旁路。
4. flat pending P0 是否继续保持独立范围。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：改动已上线 submission 审批 workflow 的 PR close/reopen/label 与 Git ref 行为。不得自动合并。

Wiki delta: none
