### PR TITLE
fix: 对源监控证书错误做有限重试

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -140,6 +140,9 @@ jobs:
           DELETE_ARCHIVED: ${{ inputs.delete_archived || false }}
           MIN_MISSING_AGE_HOURS: ${{ inputs.min_missing_age_hours || 24 }}
           MODEL: ${{ inputs.model || '' }}
+          MONITOR_OUTPUT_FILE: source-monitor-results/stdout-${{ github.run_id }}.log
+          MONITOR_MAX_ATTEMPTS: '2'
+          MONITOR_RETRY_DELAY_SECONDS: '15'
         run: |
           set -euo pipefail
 
@@ -223,7 +226,7 @@ jobs:
           echo "Archive missing: $ARCHIVE_MISSING"
           echo "Delete archived: $DELETE_ARCHIVED"
           echo "Command: ${CMD[*]}"
-          "${CMD[@]}" | tee "source-monitor-results/stdout-${GITHUB_RUN_ID}.jsonl"
+          ./scripts/run-source-monitor-with-retry.sh -- "${CMD[@]}"
 
           echo "jsonl_file=$JSONL_FILE" >> "$GITHUB_OUTPUT"
           echo "summary_file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"

--- a/scripts/run-source-monitor-with-retry.sh
+++ b/scripts/run-source-monitor-with-retry.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ "${1:-}" != "--" ]]; then
+  echo "usage: $0 -- <monitor command...>" >&2
+  exit 64
+fi
+shift
+if [[ "$#" -eq 0 ]]; then
+  echo "monitor command is required" >&2
+  exit 64
+fi
+
+OUTPUT_FILE="${MONITOR_OUTPUT_FILE:?MONITOR_OUTPUT_FILE is required}"
+MAX_ATTEMPTS="${MONITOR_MAX_ATTEMPTS:-2}"
+RETRY_DELAY_SECONDS="${MONITOR_RETRY_DELAY_SECONDS:-15}"
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MONITOR_MAX_ATTEMPTS must be a positive integer" >&2
+  exit 64
+fi
+if ! [[ "$RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "MONITOR_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 64
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+: > "$OUTPUT_FILE"
+attempt_log=""
+cleanup() {
+  [[ -z "$attempt_log" ]] || rm -f "$attempt_log"
+}
+trap cleanup EXIT
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  attempt_log=$(mktemp)
+  echo "Source monitor attempt $attempt/$MAX_ATTEMPTS" | tee -a "$OUTPUT_FILE"
+
+  "$@" 2>&1 | tee "$attempt_log" | tee -a "$OUTPUT_FILE"
+  statuses=("${PIPESTATUS[@]}")
+  command_status="${statuses[0]}"
+  first_tee_status="${statuses[1]}"
+  second_tee_status="${statuses[2]}"
+
+  if [[ "$first_tee_status" -ne 0 || "$second_tee_status" -ne 0 ]]; then
+    echo "Failed to persist source monitor output" >&2
+    exit 74
+  fi
+  if [[ "$command_status" -eq 0 ]]; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]] \
+    && grep -Fqi 'unknown certificate verification error' "$attempt_log"; then
+    echo "Transient certificate verification error detected; retrying once after ${RETRY_DELAY_SECONDS}s" \
+      | tee -a "$OUTPUT_FILE"
+    rm -f "$attempt_log"
+    attempt_log=""
+    sleep "$RETRY_DELAY_SECONDS"
+    continue
+  fi
+
+  exit "$command_status"
+done

--- a/scripts/run-source-monitor-with-retry.sh
+++ b/scripts/run-source-monitor-with-retry.sh
@@ -14,6 +14,7 @@ fi
 OUTPUT_FILE="${MONITOR_OUTPUT_FILE:?MONITOR_OUTPUT_FILE is required}"
 MAX_ATTEMPTS="${MONITOR_MAX_ATTEMPTS:-2}"
 RETRY_DELAY_SECONDS="${MONITOR_RETRY_DELAY_SECONDS:-15}"
+CERTIFICATE_ERROR='Failed to load skills: Error: unknown certificate verification error'
 
 if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   echo "MONITOR_MAX_ATTEMPTS must be a positive integer" >&2
@@ -51,7 +52,20 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   fi
 
   if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]] \
-    && grep -Fqi 'unknown certificate verification error' "$attempt_log"; then
+    && awk -v expected="$CERTIFICATE_ERROR" '
+      {
+        sub(/\r$/, "")
+        if (length($0) > 0) {
+          nonempty_lines++
+          if ($0 != expected) {
+            unexpected_line = 1
+          }
+        }
+      }
+      END {
+        exit !(nonempty_lines == 1 && !unexpected_line)
+      }
+    ' "$attempt_log"; then
     echo "Transient certificate verification error detected; retrying once after ${RETRY_DELAY_SECONDS}s" \
       | tee -a "$OUTPUT_FILE"
     rm -f "$attempt_log"

--- a/scripts/tests/source-monitor-retry.test.mjs
+++ b/scripts/tests/source-monitor-retry.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const wrapper = new URL('../run-source-monitor-with-retry.sh', import.meta.url).pathname;
+const workflow = new URL('../../.github/workflows/monitor-skill-sources.yml', import.meta.url);
+
+async function fixture(mode) {
+  const dir = await mkdtemp(join(tmpdir(), 'source-monitor-retry-'));
+  const counter = join(dir, 'count');
+  const output = join(dir, 'output.log');
+  const fake = join(dir, 'fake-monitor.sh');
+  await writeFile(fake, `#!/usr/bin/env bash
+set -u
+count=0
+[ ! -f "$COUNTER_FILE" ] || count=$(cat "$COUNTER_FILE")
+count=$((count + 1))
+printf '%s' "$count" > "$COUNTER_FILE"
+case "$FAKE_MODE" in
+  cert-once)
+    if [ "$count" -eq 1 ]; then
+      echo 'fatal: unknown certificate verification error'
+      exit 1
+    fi
+    echo 'monitor completed'
+    ;;
+  cert-always)
+    echo 'fatal: unknown certificate verification error'
+    exit 1
+    ;;
+  generic)
+    echo 'fatal: repository contract failed'
+    exit 42
+    ;;
+esac
+`, 'utf8');
+  await chmod(fake, 0o755);
+  return { dir, counter, output, fake, mode };
+}
+
+async function run(mode) {
+  const files = await fixture(mode);
+  const result = spawnSync('/bin/bash', [wrapper, '--', files.fake], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      COUNTER_FILE: files.counter,
+      FAKE_MODE: mode,
+      MONITOR_OUTPUT_FILE: files.output,
+      MONITOR_MAX_ATTEMPTS: '2',
+      MONITOR_RETRY_DELAY_SECONDS: '0',
+    },
+  });
+  const count = Number(await readFile(files.counter, 'utf8').catch(() => '0'));
+  const output = await readFile(files.output, 'utf8').catch(() => '');
+  await rm(files.dir, { recursive: true, force: true });
+  return { result, count, output };
+}
+
+test('retries the exact transient certificate error once and then succeeds', async () => {
+  const { result, count, output } = await run('cert-once');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(count, 2);
+  assert.match(output, /unknown certificate verification error/);
+  assert.match(output, /monitor completed/);
+});
+
+test('does not retry unrelated monitor failures', async () => {
+  const { result, count } = await run('generic');
+  assert.equal(result.status, 42);
+  assert.equal(count, 1);
+});
+
+test('stops after the bounded certificate retry', async () => {
+  const { result, count } = await run('cert-always');
+  assert.notEqual(result.status, 0);
+  assert.equal(count, 2);
+});
+
+test('workflow keeps the 24 hour job budget and uses the bounded retry wrapper', async () => {
+  const content = await readFile(workflow, 'utf8');
+  const scanJob = content.match(/  scan:[\s\S]*?(?=\n  [a-zA-Z0-9_-]+:|$)/)?.[0] ?? '';
+  assert.match(scanJob, /timeout-minutes: 1440/);
+  assert.match(scanJob, /run-source-monitor-with-retry\.sh/);
+  assert.match(scanJob, /MONITOR_MAX_ATTEMPTS: ['"]2['"]/);
+  assert.match(scanJob, /MONITOR_RETRY_DELAY_SECONDS: ['"]15['"]/);
+});

--- a/scripts/tests/source-monitor-retry.test.mjs
+++ b/scripts/tests/source-monitor-retry.test.mjs
@@ -11,6 +11,7 @@ const workflow = new URL('../../.github/workflows/monitor-skill-sources.yml', im
 async function fixture(mode) {
   const dir = await mkdtemp(join(tmpdir(), 'source-monitor-retry-'));
   const counter = join(dir, 'count');
+  const sideEffects = join(dir, 'side-effects');
   const output = join(dir, 'output.log');
   const fake = join(dir, 'fake-monitor.sh');
   await writeFile(fake, `#!/usr/bin/env bash
@@ -19,26 +20,44 @@ count=0
 [ ! -f "$COUNTER_FILE" ] || count=$(cat "$COUNTER_FILE")
 count=$((count + 1))
 printf '%s' "$count" > "$COUNTER_FILE"
+record_side_effect() {
+  side_effects=0
+  [ ! -f "$SIDE_EFFECT_FILE" ] || side_effects=$(cat "$SIDE_EFFECT_FILE")
+  side_effects=$((side_effects + 1))
+  printf '%s' "$side_effects" > "$SIDE_EFFECT_FILE"
+}
 case "$FAKE_MODE" in
   cert-once)
     if [ "$count" -eq 1 ]; then
-      echo 'fatal: unknown certificate verification error'
+      echo 'Failed to load skills: Error: unknown certificate verification error'
       exit 1
     fi
     echo 'monitor completed'
     ;;
   cert-always)
-    echo 'fatal: unknown certificate verification error'
+    echo 'Failed to load skills: Error: unknown certificate verification error'
     exit 1
     ;;
   generic)
     echo 'fatal: repository contract failed'
     exit 42
     ;;
+  cert-before-unrelated-failure)
+    record_side_effect
+    echo 'Failed to load skills: Error: unknown certificate verification error'
+    echo 'fatal: repository contract failed'
+    exit 42
+    ;;
+  mutation-before-cert)
+    record_side_effect
+    echo 'Persisting locally mutated skill rows'
+    echo 'Failed to load skills: Error: unknown certificate verification error'
+    exit 1
+    ;;
 esac
 `, 'utf8');
   await chmod(fake, 0o755);
-  return { dir, counter, output, fake, mode };
+  return { dir, counter, sideEffects, output, fake, mode };
 }
 
 async function run(mode) {
@@ -48,6 +67,7 @@ async function run(mode) {
     env: {
       ...process.env,
       COUNTER_FILE: files.counter,
+      SIDE_EFFECT_FILE: files.sideEffects,
       FAKE_MODE: mode,
       MONITOR_OUTPUT_FILE: files.output,
       MONITOR_MAX_ATTEMPTS: '2',
@@ -55,9 +75,10 @@ async function run(mode) {
     },
   });
   const count = Number(await readFile(files.counter, 'utf8').catch(() => '0'));
+  const sideEffects = Number(await readFile(files.sideEffects, 'utf8').catch(() => '0'));
   const output = await readFile(files.output, 'utf8').catch(() => '');
   await rm(files.dir, { recursive: true, force: true });
-  return { result, count, output };
+  return { result, count, sideEffects, output };
 }
 
 test('retries the exact transient certificate error once and then succeeds', async () => {
@@ -72,6 +93,22 @@ test('does not retry unrelated monitor failures', async () => {
   const { result, count } = await run('generic');
   assert.equal(result.status, 42);
   assert.equal(count, 1);
+});
+
+test('does not retry when certificate text precedes an unrelated terminal failure', async () => {
+  const { result, count, sideEffects, output } = await run('cert-before-unrelated-failure');
+  assert.equal(result.status, 42);
+  assert.match(output, /Failed to load skills: Error: unknown certificate verification error/);
+  assert.match(output, /fatal: repository contract failed/);
+  assert.deepEqual({ attempts: count, sideEffects }, { attempts: 1, sideEffects: 1 });
+});
+
+test('does not retry after a mutation phase marker before the certificate failure', async () => {
+  const { result, count, sideEffects, output } = await run('mutation-before-cert');
+  assert.equal(result.status, 1);
+  assert.match(output, /Persisting locally mutated skill rows/);
+  assert.match(output, /Failed to load skills: Error: unknown certificate verification error/);
+  assert.deepEqual({ attempts: count, sideEffects }, { attempts: 1, sideEffects: 1 });
 });
 
 test('stops after the bounded certificate retry', async () => {


### PR DESCRIPTION
## Retry #1

**上次 FAIL 原因**

wrapper 只要 attempt 日志任意位置含 `unknown certificate verification error` 就重跑整条 `--write --updateLocal` 命令；若证书文本只是早期日志、最终失败来自 DB/审计/本地更新，或命令已经进入可能产生副作用的阶段，就会重复部分 Supabase / local mutation。

**本次修复**

- 本仓 workflow 下载预构建 Skillstore CLI，`monitor-upstream` / `loadSkillRows` 实现不在本仓；为避免跨仓扩大范围，本次只收紧 wrapper。
- 仅当失败命令输出的**唯一非空行**（只归一化 CRLF）大小写敏感、完整等于 `Failed to load skills: Error: unknown certificate verification error` 时，才允许第二次执行。
- 任意其他非空输出——包括 scan / persist / local mutation marker、混合错误或未知阶段文本——都直接 fail closed，保留首次 exit code，不重跑整条写命令。
- 有界预算保持不变：最多 `2` 次、退避 `15s`。

**复现负测**

旧 wrapper 在以下两条新增测试中均复现 `attempts=2, sideEffects=2`；修复后均为 `attempts=1, sideEffects=1`：

1. 证书文本后以无关错误 `42` 终止；
2. 已出现 local mutation marker 后再出现证书错误。

## 背景 / 问题描述

[Monitor run 29318707778](https://github.com/aiskillstore/marketplace/actions/runs/29318707778) 有两个不同结论：

- attempt 1：`skill monitor-upstream` 启动后立即报 `Failed to load skills: Error: unknown certificate verification error`，exit 1。
- attempt 2：CLI 已扫描到 `5025/5276`，随后收到外部 cancellation；job annotation 明确为 `The run was canceled by @mylukin.`。workflow 的 `timeout-minutes` 实际是 `1440`，不是 10 分钟，因此不修改超时预算。

## 做了什么

- 新增 `run-source-monitor-with-retry.sh`，只对经过启动期无副作用边界证明的精确证书根错误自动重试一次。
- stdout 存为 `.log`，避免重试标记伪装成 JSONL；canonical JSONL / summary 路径仍由 CLI 管理。
- Retry #1 将宽泛 substring 检测改为严格的“唯一非空输出行”判定，任何未知阶段输出均 fail closed。

## 为什么改

attempt 2 已证明同一 head、同一 runner/CLI 后续可正常扫描 5000+ 项，因此 attempt 1 是可恢复的启动期证书瞬态错误。有限自动重试可避免整次日巡检因纯启动瞬态失败；但定时模式会执行 `--write --updateLocal`，所以不能在无法证明尚未进入副作用阶段时重跑完整命令。

## Acceptance Criteria

- [x] 仅有精确启动期证书根错误、第二次成功时，wrapper 总体成功且只执行 2 次。— 验收：`scripts/tests/source-monitor-retry.test.mjs::retries the exact transient certificate error once and then succeeds`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)
- [x] 日志含证书文本但 terminal/root failure 为无关错误时，只执行 1 次、保留 exit 42 与原日志。— 验收：`scripts/tests/source-monitor-retry.test.mjs::does not retry when certificate text precedes an unrelated terminal failure`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)
- [x] 已出现 mutation 阶段 marker 后再出现证书错误时，只执行 1 次。— 验收：`scripts/tests/source-monitor-retry.test.mjs::does not retry after a mutation phase marker before the certificate failure`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)
- [x] 完全无关的 monitor failure 不重试，并保留原 exit code。— 验收：`scripts/tests/source-monitor-retry.test.mjs::does not retry unrelated monitor failures`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)
- [x] 连续精确证书失败最多执行 2 次，不产生无限循环。— 验收：`scripts/tests/source-monitor-retry.test.mjs::stops after the bounded certificate retry`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)
- [x] workflow 保持 `timeout-minutes: 1440`，并锁定 2 次 / 15s retry 配置。— 验收：`scripts/tests/source-monitor-retry.test.mjs::workflow keeps the 24 hour job budget and uses the bounded retry wrapper`；CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487)

## 验证证据

- TDD RED：先加 reviewer 指定的 2 条负测；旧 wrapper 为 4 PASS / 2 FAIL，两条失败均明确显示 `actual { attempts: 2, sideEffects: 2 }`。
- Focused GREEN：`node --test scripts/tests/source-monitor-retry.test.mjs` → 6/6 PASS。
- 全量脚本回归：`node --test scripts/tests/*.test.mjs` → 109/109 PASS。
- 静态检查：`bash -n scripts/*.sh scripts/tests/*.sh`、`node --check scripts/*.mjs`、`yq eval '.' .github/workflows/monitor-skill-sources.yml`、`git diff --check` 均通过。
- CI：[Run 29332125487](https://github.com/aiskillstore/marketplace/actions/runs/29332125487) SUCCESS。
- 二进制 evidence：0。
- 新 head：`7b6af7e1e94cc1f7c0a8eae95165d48fbc605a99`。

## 风险点

- 数据写入：未触发 monitor workflow；本 PR 只改 retry wrapper / workflow wiring。
- 权限 / 安全：不改变 token 权限或 PR 创建条件。
- 并发 / 时长：只有日志能证明仍在启动期时才最多增加 15 秒 + 一次重跑；任何额外阶段输出都不重试。
- 兼容性：严格判定可能在 CLI 文案变化时放弃自动重试；这是预期的 fail-closed 行为，不会重复副作用。
- 回滚方式：revert 本 PR 即恢复单次执行。

## 人类 review 关注点

请 reviewer 重点判断：
1. “唯一非空输出行精确匹配”是否足以作为 wrapper 层无副作用边界；任何未知 marker 均会 fail closed。
2. 两条新增负测是否完整封住混合日志与晚期 mutation 两个 blocker 场景。
3. 继续保持 2 次 / 15s 有界预算是否合理。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：修改已上线定时巡检 workflow。禁止自动合并或手动重跑生产 monitor。

Wiki delta: none
