### PR TITLE
fix(sync): require admin CLI 2.0.1

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -227,7 +227,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: '2.0.0'
+          minimum-version: '2.0.1'
 
       - name: Sync skills to Supabase
         id: sync


### PR DESCRIPTION
## Summary
- require the append-only packaging-status fix in admin CLI 2.0.1 before any artifact writer runs
- create a new immutable Marketplace observation for the bounded r3 canary

## Rollout dependency
Merge only after Skillstore PR #202 is merged, migration 20260722 is applied, and cli-v2.0.1 is published. The sync workflow remains enabled but stable cli-v2.0.0 continues to be the current writer until this gate merges.

## Validation
- branch is rebased onto current main
- workflow YAML parses successfully
- one-line minimum-version change only