### PR TITLE
fix(workflow): pin score job sparse checkout

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -787,6 +787,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          # Self-hosted workspaces can retain sparse-checkout state from an
+          # earlier job. Declare both runtime dependencies explicitly instead
+          # of assuming a previous checkout left a full working tree.
+          sparse-checkout: |
+            .github/actions/download-skillstore-cli
+            scripts/recalculate-scores.sh
+          sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -34,6 +34,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Do not inherit a sparse working tree from another self-hosted job.
+          # Tests read workflow fixtures as well as the complete scripts tree.
+          sparse-checkout: |
+            .github
+            scripts
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Cause
The r3 canary artifact sync succeeded, but the score job inherited stale sparse-checkout state on a self-hosted runner and could not find `scripts/recalculate-scores.sh`. Cache invalidation correctly stopped.

## Fix
Explicitly sparse-checkout the local CLI-download action and the score wrapper in the `calculate-scores` job.

## Validation
- Workflow YAML parses
- A clean local sparse-checkout simulation contains both required paths
- Diff check passed

After merge, replay the same one-Skill canary. It must remain r3 (idempotent), complete scoring, and invalidate cache.
