### PR TITLE
fix(scores): serialize production score writers

### DIFF
--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -24,9 +24,9 @@ on:
         type: string
         default: ''
       concurrency:
-        description: 'Parallel database updates (1-10)'
+        description: 'Parallel database updates (production-safe default: 1)'
         type: string
-        default: '5'
+        default: '1'
       dry_run:
         description: 'Preview without updating database'
         type: boolean
@@ -48,6 +48,9 @@ jobs:
   recalculate:
     runs-on: self-hosted
     timeout-minutes: 1440
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -84,7 +87,7 @@ jobs:
           CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           INPUT_SLUG: ${{ inputs.slug }}
           INPUT_LIMIT: ${{ inputs.limit }}
-          INPUT_CONCURRENCY: ${{ inputs.concurrency || '5' }}
+          INPUT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '180' }}
         run: |
@@ -128,7 +131,9 @@ jobs:
           WRAPPER_ARGS=(
             --cli "$GITHUB_WORKSPACE/skillstore-cli"
             --concurrency "$INPUT_CONCURRENCY"
-            --max-attempts 3
+            # The CLI already retries transient Supabase requests. A second
+            # wrapper retry layer can multiply a slow database wave.
+            --max-attempts 1
             --retry-base-seconds 5
             --timeout-seconds "$INPUT_TIMEOUT_SECONDS"
           )

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -784,6 +784,9 @@ jobs:
     if: needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0'
     runs-on: self-hosted
     timeout-minutes: 120
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -836,8 +839,8 @@ jobs:
           bash scripts/recalculate-scores.sh \
             --cli "$GITHUB_WORKSPACE/skillstore-cli" \
             --slugs "$SYNCED_SLUGS" \
-            --concurrency 5 \
-            --max-attempts 3 \
+            --concurrency 1 \
+            --max-attempts 1 \
             --retry-base-seconds 5 2>&1 | tee score-output.log
           EXIT_CODE=${PIPESTATUS[0]}
           set -e

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -366,6 +366,21 @@ test('recalculate-scores workflow default all-skills path uses per-slug wrapper'
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --recalculate \)/, 'workflow must fall back to legacy --recalculate when the release asset is older than the tag');
 });
 
+test('production score writers serialize and avoid multiplicative retries', () => {
+	const recalc = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
+	const sync = readFileSync(SYNC_WORKFLOW, 'utf8');
+	for (const workflow of [recalc, sync]) {
+		assert.match(workflow, /group:\s*production-skill-score-writes/,
+			'production score jobs must share one cross-workflow concurrency group');
+		assert.match(workflow, /--max-attempts 1/,
+			'the workflow wrapper must not multiply the CLI request retry layer');
+	}
+	assert.match(recalc, /default:\s*'1'/, 'scheduled score concurrency must default to one');
+	assert.match(recalc, /INPUT_CONCURRENCY:\s*\$\{\{ inputs\.concurrency \|\| '1' \}\}/,
+		'recalculate fallback concurrency must remain one');
+	assert.match(sync, /--concurrency 1/, 'incremental sync scoring must remain single-writer');
+});
+
 test('workflows fail no-success/global scoring failures instead of masking them', () => {
 	const recalc = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
 	const sync = readFileSync(SYNC_WORKFLOW, 'utf8');


### PR DESCRIPTION
## Summary
- serialize score writes across incremental sync and scheduled recalculation jobs
- use production-safe concurrency 1
- remove the wrapper retry layer because the CLI already retries transient Supabase requests
- add regression coverage for shared backpressure and retry ownership

## Production evidence
Overlapping scorer retries saturated all 10 PostgREST database connections with CPU-bound evidence canonicalization, causing system-wide 504 responses.

## Validation
- `node --test scripts/tests/recalculate-scores.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` (24/24)
- `bash -n scripts/recalculate-scores.sh`
- `git diff --check`

## Rollout
Merge after the Skillstore RPC timeout migration is available. Re-enable Recalculate Skill Scores, then run one canary slug only.