### PR TITLE
feat(sync): add safe artifact version backfill

### DIFF
--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact stable skillstore-cli version (X.Y.Z; latest is forbidden)'
         type: string
         required: true
-        default: '2.0.2'
+        default: '2.1.0'
       batch_size:
         description: 'Legacy production Skills to inspect in this batch (1-500)'
         type: number
@@ -268,7 +268,7 @@ jobs:
                     ((.skipped == true and .writeOccurred == false) or
                      (.skipped != true and (.artifact.revision | type) == "number" and
                       .artifact.revision >= 1 and (.artifact.created | type) == "boolean" and
-                      .writeOccurred == .artifact.created))
+                      .writeOccurred == true))
                   end)
                 )
               )
@@ -282,6 +282,60 @@ jobs:
             '{schemaVersion: 2, status: "verified", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: $groups[0]}' \
             > "$SUMMARY_FILE"
 
+      - name: Invalidate production artifact and detail caches
+        id: cache-invalidate
+        if: >-
+          steps.inputs.outputs.mode == 'execute' &&
+          steps.plan.outputs.selected_count != '0' &&
+          steps.verify.outcome == 'success'
+        env:
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+        run: |
+          set -euo pipefail
+          : "${CACHE_INVALIDATE_SECRET:?CACHE_INVALIDATE_SECRET is required for execute mode}"
+          PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
+          EVIDENCE_DIR="$RUNNER_TEMP/artifact-backfill-cache-invalidation"
+          mkdir -p "$EVIDENCE_DIR"
+          mapfile -t SLUGS < <(jq -r '.selected[].slug' "$PLAN_FILE")
+
+          for ((OFFSET = 0; OFFSET < ${#SLUGS[@]}; OFFSET += 50)); do
+            BATCH=("${SLUGS[@]:OFFSET:50}")
+            BATCH_JSON=$(printf '%s\n' "${BATCH[@]}" | jq -R . | jq -s .)
+            RESPONSE_FILE="$EVIDENCE_DIR/batch-$((OFFSET / 50 + 1)).json"
+            jq -n --argjson slugs "$BATCH_JSON" '{
+              type: "skills",
+              slugs: $slugs,
+              invalidateApi: true,
+              invalidateArtifacts: true,
+              invalidateDependentPacks: true
+            }' | curl \
+              --fail-with-body \
+              --silent \
+              --show-error \
+              --retry 2 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 120 \
+              --request POST \
+              --header "Authorization: Bearer $CACHE_INVALIDATE_SECRET" \
+              --header 'Content-Type: application/json' \
+              --data-binary @- \
+              --output "$RESPONSE_FILE" \
+              https://skillstore.io/api/cache/invalidate
+
+            jq -e --argjson expected "${#BATCH[@]}" '
+              .preflight == false and
+              .type == "skills" and
+              (.slugs | length) == $expected and
+              .invalidated.listVersionBumped == true
+            ' "$RESPONSE_FILE" >/dev/null || {
+              echo "::error::cache invalidation response violated the production contract"
+              exit 1
+            }
+          done
+
+          jq -s . "$EVIDENCE_DIR"/*.json > "$RUNNER_TEMP/artifact-backfill-cache-invalidation.json"
+
       - name: Publish resumable batch summary
         if: always() && steps.plan.outcome == 'success'
         env:
@@ -294,6 +348,7 @@ jobs:
           NEXT_START_AFTER: ${{ steps.plan.outputs.next_start_after }}
           REMAINING: ${{ steps.plan.outputs.remaining }}
           VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          CACHE_OUTCOME: ${{ steps.cache-invalidate.outcome }}
         run: |
           {
             echo "## Artifact-version backfill batch"
@@ -304,7 +359,10 @@ jobs:
             echo "- Plan SHA-256: \`$PLAN_SHA\`"
             echo "- Inventory SHA-256: \`$INVENTORY_SHA\`"
             echo "- Verification: \`$VERIFY_OUTCOME\`"
-            if [ "$VERIFY_OUTCOME" = "success" ] && [ -n "$NEXT_START_AFTER" ]; then
+            echo "- Cache invalidation: \`$CACHE_OUTCOME\`"
+            if [ "$VERIFY_OUTCOME" = "success" ] && \
+               { [ "$MODE" = "dry-run" ] || [ "$CACHE_OUTCOME" = "success" ]; } && \
+               [ -n "$NEXT_START_AFTER" ]; then
               echo "- Verified resume cursor: \`$NEXT_START_AFTER\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -321,6 +379,8 @@ jobs:
             ${{ runner.temp }}/artifact-backfill-result.json
             ${{ runner.temp }}/artifact-backfill-stderr.log
             ${{ runner.temp }}/artifact-backfill-summary.json
+            ${{ runner.temp }}/artifact-backfill-cache-invalidation.json
+            ${{ runner.temp }}/artifact-backfill-cache-invalidation/
             ${{ runner.temp }}/artifact-backfill-group-results/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -1,0 +1,326 @@
+name: Backfill Skill Artifact Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Read-only validation or bounded production execution'
+        type: choice
+        required: true
+        default: dry-run
+        options:
+          - dry-run
+          - execute
+      cli_version:
+        description: 'Exact stable skillstore-cli version (X.Y.Z; latest is forbidden)'
+        type: string
+        required: true
+        default: '2.0.2'
+      batch_size:
+        description: 'Legacy production Skills to inspect in this batch (1-500)'
+        type: number
+        required: true
+        default: 100
+      start_after:
+        description: 'Exact prior production slug cursor (blank starts at the beginning)'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Validate bounded inputs
+        id: inputs
+        env:
+          MODE: ${{ inputs.mode }}
+          CLI_VERSION: ${{ inputs.cli_version }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          START_AFTER: ${{ inputs.start_after }}
+        run: |
+          set -euo pipefail
+          if [[ "$MODE" != "dry-run" && "$MODE" != "execute" ]]; then
+            echo "::error::mode must be dry-run or execute"
+            exit 1
+          fi
+          if ! [[ "$CLI_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::cli_version must be an exact stable X.Y.Z release"
+            exit 1
+          fi
+          if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ] || [ "$BATCH_SIZE" -gt 500 ]; then
+            echo "::error::batch_size must be an integer between 1 and 500"
+            exit 1
+          fi
+          if [[ "$START_AFTER" == *$'\n'* || "$START_AFTER" == *$'\r'* ]]; then
+            echo "::error::start_after must be one exact production slug"
+            exit 1
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "cli_version=$CLI_VERSION" >> "$GITHUB_OUTPUT"
+          echo "batch_size=$BATCH_SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch exact production artifact inventory
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --output "$RUNNER_TEMP/artifact-backfill-inventory.json"
+
+      - name: Build deterministic DB-driven plan
+        id: plan
+        env:
+          MODE: ${{ steps.inputs.outputs.mode }}
+          BATCH_SIZE: ${{ steps.inputs.outputs.batch_size }}
+          START_AFTER: ${{ inputs.start_after }}
+        run: |
+          set -euo pipefail
+          PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
+          PATHS_FILE="$RUNNER_TEMP/artifact-backfill-paths.txt"
+          PLAN_ARGS=(
+            --repository-root "$GITHUB_WORKSPACE"
+            --inventory "$RUNNER_TEMP/artifact-backfill-inventory.json"
+            --batch-size "$BATCH_SIZE"
+            --output "$PLAN_FILE"
+            --paths-output "$PATHS_FILE"
+          )
+          if [ -n "$START_AFTER" ]; then
+            PLAN_ARGS+=(--start-after "$START_AFTER")
+          fi
+          node scripts/plan-artifact-version-backfill.mjs "${PLAN_ARGS[@]}"
+
+          EARLIER_LEGACY=$(jq -r '.legacyAtOrBeforeCursor' "$PLAN_FILE")
+          if [ "$MODE" = "execute" ] && [ -n "$START_AFTER" ] && [ "$EARLIER_LEGACY" -ne 0 ]; then
+            echo "::error::$EARLIER_LEGACY legacy row(s) exist at or before start_after; restart from an earlier cursor"
+            exit 1
+          fi
+
+          PLAN_SHA=$(sha256sum "$PLAN_FILE" | awk '{print $1}')
+          INVENTORY_SHA=$(sha256sum "$RUNNER_TEMP/artifact-backfill-inventory.json" | awk '{print $1}')
+          echo "plan_sha=$PLAN_SHA" >> "$GITHUB_OUTPUT"
+          echo "inventory_sha=$INVENTORY_SHA" >> "$GITHUB_OUTPUT"
+          echo "selected_count=$(jq -r '.selectedCount' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "group_count=$(jq -r '.groups | length' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "has_more=$(jq -r '.hasMore' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "next_start_after=$(jq -r '.nextStartAfter // ""' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "remaining=$(jq -r '.remainingAfterBatch' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "legacy_total=$(jq -r '.totalLegacy' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        if: steps.plan.outputs.selected_count != '0'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact Skillstore CLI
+        if: steps.plan.outputs.selected_count != '0'
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: ${{ steps.inputs.outputs.cli_version }}
+          minimum-version: ${{ steps.inputs.outputs.cli_version }}
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Materialize pinned historical snapshots by commit
+        if: steps.plan.outputs.selected_count != '0'
+        run: |
+          set -euo pipefail
+          ROOT="$RUNNER_TEMP/artifact-backfill-materialized"
+          mkdir -p "$ROOT"
+          while IFS= read -r GROUP; do
+            COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
+            GROUP_DIR="$ROOT/$COMMIT"
+            mkdir -p "$GROUP_DIR"
+            mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
+            git archive --format=tar "$COMMIT" -- "${PATHS[@]}" | tar -xf - -C "$GROUP_DIR"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
+
+      - name: Run artifact-only commit groups
+        id: artifact-sync
+        if: steps.plan.outputs.selected_count != '0'
+        continue-on-error: true
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          MODE: ${{ steps.inputs.outputs.mode }}
+        run: |
+          set -euo pipefail
+          MATERIALIZED_ROOT="$RUNNER_TEMP/artifact-backfill-materialized"
+          RESULT_DIR="$RUNNER_TEMP/artifact-backfill-group-results"
+          RESULT_ROWS="$RUNNER_TEMP/artifact-backfill-result-rows.jsonl"
+          mkdir -p "$RESULT_DIR"
+          : > "$RESULT_ROWS"
+          : > "$RUNNER_TEMP/artifact-backfill-stderr.log"
+          FAILURES=0
+          MODE_ARGS=()
+          if [ "$MODE" = "dry-run" ]; then MODE_ARGS+=(--dry-run); fi
+
+          while IFS= read -r GROUP; do
+            COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
+            COUNT=$(jq -r '.count' <<< "$GROUP")
+            mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
+            SLUG_PATHS=$(printf '%s\n' "${PATHS[@]}" | paste -sd,)
+            RAW_RESULT="$RESULT_DIR/$COMMIT.json"
+            NORMALIZED_RESULT="$RESULT_DIR/$COMMIT.normalized.json"
+            GROUP_STDERR="$RESULT_DIR/$COMMIT.stderr.log"
+
+            set +e
+            (
+              cd "$MATERIALIZED_ROOT/$COMMIT"
+              "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
+                --slugs "$SLUG_PATHS" \
+                --artifact-only \
+                --legacy-only \
+                "${MODE_ARGS[@]}" \
+                --concurrency 5 \
+                --marketplace-commit "$COMMIT" \
+                --output json
+            ) > "$RAW_RESULT" 2> >(tee "$GROUP_STDERR" | tee -a "$RUNNER_TEMP/artifact-backfill-stderr.log" >&2)
+            CLI_EXIT=$?
+            set -e
+
+            if [ -s "$RAW_RESULT" ] && jq -e . "$RAW_RESULT" >/dev/null 2>&1; then
+              jq -c . "$RAW_RESULT" > "$NORMALIZED_RESULT"
+            else
+              echo 'null' > "$NORMALIZED_RESULT"
+            fi
+            jq -n -c \
+              --arg marketplaceCommit "$COMMIT" \
+              --argjson selectedCount "$COUNT" \
+              --argjson exitCode "$CLI_EXIT" \
+              --slurpfile result "$NORMALIZED_RESULT" \
+              '{marketplaceCommit: $marketplaceCommit, selectedCount: $selectedCount, exitCode: $exitCode, result: $result[0]}' \
+              >> "$RESULT_ROWS"
+            if [ "$CLI_EXIT" -ne 0 ]; then FAILURES=$((FAILURES + 1)); fi
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
+
+          jq -s . "$RESULT_ROWS" > "$RUNNER_TEMP/artifact-backfill-result.json"
+          echo "failed_groups=$FAILURES" >> "$GITHUB_OUTPUT"
+          if [ "$FAILURES" -ne 0 ]; then exit 1; fi
+
+      - name: Verify fail-closed result contract
+        id: verify
+        if: always() && steps.plan.outcome == 'success'
+        env:
+          MODE: ${{ steps.inputs.outputs.mode }}
+          PLAN_SHA: ${{ steps.plan.outputs.plan_sha }}
+          INVENTORY_SHA: ${{ steps.plan.outputs.inventory_sha }}
+          SELECTED_COUNT: ${{ steps.plan.outputs.selected_count }}
+          CLI_OUTCOME: ${{ steps.artifact-sync.outcome }}
+        run: |
+          set -euo pipefail
+          PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
+          RESULT_FILE="$RUNNER_TEMP/artifact-backfill-result.json"
+          SUMMARY_FILE="$RUNNER_TEMP/artifact-backfill-summary.json"
+
+          if [ "$SELECTED_COUNT" = "0" ]; then
+            jq -n --arg mode "$MODE" --arg planHash "$PLAN_SHA" --arg inventoryHash "$INVENTORY_SHA" \
+              --slurpfile plan "$PLAN_FILE" \
+              '{schemaVersion: 2, status: "complete", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: []}' \
+              > "$SUMMARY_FILE"
+            exit 0
+          fi
+          if [ "$CLI_OUTCOME" != "success" ] || [ ! -s "$RESULT_FILE" ] || ! jq -e . "$RESULT_FILE" >/dev/null; then
+            echo "::error::one or more artifact-only commit groups failed or produced invalid JSON"
+            exit 1
+          fi
+
+          EXPECTED_MODE="artifact-only"
+          EXPECTED_DRY_RUN=false
+          if [ "$MODE" = "dry-run" ]; then EXPECTED_MODE="dry-run"; EXPECTED_DRY_RUN=true; fi
+          jq -e --slurpfile plan "$PLAN_FILE" --arg mode "$EXPECTED_MODE" \
+            --argjson dryRun "$EXPECTED_DRY_RUN" --argjson selected "$SELECTED_COUNT" '
+              length == ($plan[0].groups | length) and
+              ([.[].marketplaceCommit] == [$plan[0].groups[].marketplaceCommit]) and
+              ([.[].selectedCount] | add) == $selected and
+              ([.[].result.results[].slug] | length == (unique | length)) and
+              all(.[];
+                .exitCode == 0 and .result != null and .result.success == true and
+                .result.artifactOnly == true and .result.dryRun == $dryRun and .result.mode == $mode and
+                .result.errors == 0 and
+                ((.result.synced + .result.skipped) == .selectedCount) and
+                ((.result.results | length) == .selectedCount) and
+                all(.result.results[];
+                  .success == true and
+                  (if $dryRun then
+                    .writeOccurred == false and .artifact.revision == null and
+                    .artifact.created == null and .artifact.changeKind == null
+                  else
+                    ((.skipped == true and .writeOccurred == false) or
+                     (.skipped != true and (.artifact.revision | type) == "number" and
+                      .artifact.revision >= 1 and (.artifact.created | type) == "boolean" and
+                      .writeOccurred == .artifact.created))
+                  end)
+                )
+              )
+            ' "$RESULT_FILE" >/dev/null || {
+              echo "::error::artifact-only CLI results violated the bounded backfill contract"
+              exit 1
+            }
+
+          jq -n --arg mode "$MODE" --arg planHash "$PLAN_SHA" --arg inventoryHash "$INVENTORY_SHA" \
+            --slurpfile plan "$PLAN_FILE" --slurpfile groups "$RESULT_FILE" \
+            '{schemaVersion: 2, status: "verified", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: $groups[0]}' \
+            > "$SUMMARY_FILE"
+
+      - name: Publish resumable batch summary
+        if: always() && steps.plan.outcome == 'success'
+        env:
+          MODE: ${{ steps.inputs.outputs.mode }}
+          CLI_VERSION: ${{ steps.inputs.outputs.cli_version }}
+          PLAN_SHA: ${{ steps.plan.outputs.plan_sha }}
+          INVENTORY_SHA: ${{ steps.plan.outputs.inventory_sha }}
+          SELECTED_COUNT: ${{ steps.plan.outputs.selected_count }}
+          LEGACY_TOTAL: ${{ steps.plan.outputs.legacy_total }}
+          NEXT_START_AFTER: ${{ steps.plan.outputs.next_start_after }}
+          REMAINING: ${{ steps.plan.outputs.remaining }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+        run: |
+          {
+            echo "## Artifact-version backfill batch"
+            echo ""
+            echo "- Mode / CLI: \`$MODE\` / \`$CLI_VERSION\`"
+            echo "- Production legacy rows at plan time: \`$LEGACY_TOTAL\`"
+            echo "- Selected / remaining: \`$SELECTED_COUNT\` / \`$REMAINING\`"
+            echo "- Plan SHA-256: \`$PLAN_SHA\`"
+            echo "- Inventory SHA-256: \`$INVENTORY_SHA\`"
+            echo "- Verification: \`$VERIFY_OUTCOME\`"
+            if [ "$VERIFY_OUTCOME" = "success" ] && [ -n "$NEXT_START_AFTER" ]; then
+              echo "- Verified resume cursor: \`$NEXT_START_AFTER\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable plan and execution evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifact-version-backfill-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/artifact-backfill-inventory.json
+            ${{ runner.temp }}/artifact-backfill-plan.json
+            ${{ runner.temp }}/artifact-backfill-paths.txt
+            ${{ runner.temp }}/artifact-backfill-result.json
+            ${{ runner.temp }}/artifact-backfill-stderr.log
+            ${{ runner.temp }}/artifact-backfill-summary.json
+            ${{ runner.temp }}/artifact-backfill-group-results/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/fetch-artifact-version-inventory.mjs
+++ b/scripts/fetch-artifact-version-inventory.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const PAGE_SIZE = 1000;
+const SELECT = 'slug,plugin_path,marketplace_commit_sha,content_hash,tree_hash,artifact_revision';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+export async function fetchArtifactVersionInventory({ supabaseUrl, serviceKey, fetchImpl = fetch }) {
+  if (!/^https:\/\//.test(supabaseUrl || '')) fail('SUPABASE_URL must be HTTPS');
+  if (!serviceKey) fail('SUPABASE_SERVICE_KEY is required');
+
+  const rows = [];
+  let expectedTotal = null;
+  for (let start = 0; ; start += PAGE_SIZE) {
+    const url = new URL('/rest/v1/skills', supabaseUrl);
+    url.searchParams.set('select', SELECT);
+    url.searchParams.set('order', 'slug.asc');
+    const response = await fetchImpl(url, {
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Accept-Profile': 'skillstore',
+        Prefer: 'count=exact',
+        Range: `${start}-${start + PAGE_SIZE - 1}`,
+        'Range-Unit': 'items',
+      },
+    });
+    if (!response.ok) fail(`Production inventory request failed: HTTP ${response.status}`);
+    const contentRange = response.headers.get('content-range');
+    const match = contentRange?.match(/^(\d+)-(\d+)\/(\d+)$/);
+    if (!match) fail(`Production inventory returned invalid Content-Range: ${contentRange ?? '<missing>'}`);
+    const total = Number(match[3]);
+    if (expectedTotal === null) expectedTotal = total;
+    if (total !== expectedTotal) fail('Production inventory count changed during pagination');
+
+    const page = await response.json();
+    if (!Array.isArray(page)) fail('Production inventory response is not an array');
+    rows.push(...page);
+    if (rows.length >= expectedTotal) break;
+    if (page.length === 0) fail('Production inventory pagination ended before the exact count');
+  }
+  if (rows.length !== expectedTotal) {
+    fail(`Production inventory count mismatch: expected ${expectedTotal}, received ${rows.length}`);
+  }
+  return { schemaVersion: 1, count: rows.length, rows };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const outputIndex = argv.indexOf('--output');
+  const output = outputIndex >= 0 ? argv[outputIndex + 1] : null;
+  if (!output) fail('--output is required');
+  const inventory = await fetchArtifactVersionInventory({
+    supabaseUrl: process.env.SUPABASE_URL,
+    serviceKey: process.env.SUPABASE_SERVICE_KEY,
+  });
+  writeFileSync(resolve(output), `${JSON.stringify(inventory, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ count: inventory.count })}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`artifact inventory fetch failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/plan-artifact-version-backfill.mjs
+++ b/scripts/plan-artifact-version-backfill.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const MAX_BATCH_SIZE = 500;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parsePositiveInteger(value, name) {
+  if (!/^[0-9]+$/.test(String(value ?? ''))) fail(`${name} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) fail(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function normalizePath(value, slug) {
+  const path = String(value ?? '').trim().replace(/^\.\//, '').replace(/\/$/, '');
+  if (
+    !path.startsWith('skills/') ||
+    path.includes('\\') ||
+    path.includes('//') ||
+    /[\u0000-\u001f\u007f?#]/.test(path) ||
+    path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    fail(`Invalid production plugin_path for ${slug}: ${value ?? '<null>'}`);
+  }
+  return path;
+}
+
+function git(repositoryRoot, args) {
+  try {
+    return execFileSync('git', ['-C', repositoryRoot, ...args], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message;
+    fail(`Git evidence check failed (${args.join(' ')}): ${detail}`);
+  }
+}
+
+function validatePinnedSnapshot(repositoryRoot, row) {
+  git(repositoryRoot, ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/SKILL.md`]);
+  const reportText = git(repositoryRoot, ['show', `${row.marketplaceCommit}:${row.path}/skill-report.json`]);
+  let report;
+  try {
+    report = JSON.parse(reportText);
+  } catch (error) {
+    fail(`Invalid pinned skill-report.json for ${row.slug}: ${error.message}`);
+  }
+  if (report?.meta?.slug !== row.slug) {
+    fail(`Pinned report slug mismatch for ${row.slug} at ${row.marketplaceCommit}:${row.path}`);
+  }
+  if (report?.meta?.content_hash !== row.contentHash) {
+    fail(`Pinned report content_hash mismatch for ${row.slug}`);
+  }
+  if (report?.meta?.tree_hash !== row.treeHash) {
+    fail(`Pinned report tree_hash mismatch for ${row.slug}`);
+  }
+  if (report?.meta?.source_path != null && normalizePath(report.meta.source_path, row.slug) !== row.path) {
+    fail(`Pinned report source_path mismatch for ${row.slug}`);
+  }
+}
+
+function normalizeInventory(inventory) {
+  const rows = Array.isArray(inventory) ? inventory : inventory?.rows;
+  if (!Array.isArray(rows) || rows.length === 0) fail('Production inventory contains no Skill rows');
+
+  const seenSlugs = new Set();
+  const seenPaths = new Set();
+  return rows.map((raw) => {
+    const slug = typeof raw?.slug === 'string' ? raw.slug.trim() : '';
+    if (!slug || /[\u0000-\u001f\u007f,\s]/.test(slug)) fail('Production inventory contains an unsafe slug');
+    if (seenSlugs.has(slug)) fail(`Production inventory contains duplicate slug ${slug}`);
+    seenSlugs.add(slug);
+
+    const marketplaceCommit = String(raw.marketplace_commit_sha ?? '').trim();
+    const contentHash = String(raw.content_hash ?? '').trim();
+    const treeHash = String(raw.tree_hash ?? '').trim();
+    const artifactRevision = Number(raw.artifact_revision);
+    if (!COMMIT_RE.test(marketplaceCommit)) fail(`Invalid production marketplace commit for ${slug}`);
+    if (!SHA256_RE.test(contentHash)) fail(`Invalid production content_hash for ${slug}`);
+    if (!SHA256_RE.test(treeHash)) fail(`Invalid production tree_hash for ${slug}`);
+    if (!Number.isSafeInteger(artifactRevision) || artifactRevision < 0) {
+      fail(`Invalid production artifact_revision for ${slug}`);
+    }
+    const path = normalizePath(raw.plugin_path, slug);
+    if (seenPaths.has(path)) fail(`Production inventory contains duplicate plugin_path ${path}`);
+    seenPaths.add(path);
+    return {
+      slug,
+      path,
+      marketplaceCommit,
+      contentHash,
+      treeHash,
+      artifactRevision,
+    };
+  }).sort((left, right) => left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0);
+}
+
+export function buildArtifactBackfillPlan({
+  repositoryRoot,
+  inventory,
+  batchSize,
+  startAfter = null,
+}) {
+  const root = resolve(repositoryRoot);
+  const boundedBatchSize = parsePositiveInteger(batchSize, 'batch-size');
+  if (boundedBatchSize > MAX_BATCH_SIZE) fail(`batch-size must be between 1 and ${MAX_BATCH_SIZE}`);
+
+  const catalog = normalizeInventory(inventory);
+  const cursor = String(startAfter ?? '').trim() || null;
+  if (cursor && !catalog.some((row) => row.slug === cursor)) {
+    fail(`start-after is not an exact production Skill slug: ${cursor}`);
+  }
+
+  const eligible = catalog.filter((row) =>
+    row.artifactRevision === 0 && (!cursor || row.slug > cursor)
+  );
+  const selected = eligible.slice(0, boundedBatchSize);
+  for (const row of selected) validatePinnedSnapshot(root, row);
+
+  const groupMap = new Map();
+  for (const row of selected) {
+    if (!groupMap.has(row.marketplaceCommit)) groupMap.set(row.marketplaceCommit, []);
+    groupMap.get(row.marketplaceCommit).push(row);
+  }
+  const groups = [...groupMap.entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([marketplaceCommit, rows]) => ({
+      marketplaceCommit,
+      count: rows.length,
+      paths: rows.map((row) => row.path),
+      slugs: rows.map((row) => row.slug),
+    }));
+
+  const lastSelected = selected.at(-1)?.slug ?? null;
+  const remainingAfterBatch = Math.max(0, eligible.length - selected.length);
+  const legacyAtOrBeforeCursor = cursor
+    ? catalog.filter((row) => row.artifactRevision === 0 && row.slug <= cursor).length
+    : 0;
+
+  return {
+    schemaVersion: 2,
+    inventoryCount: catalog.length,
+    totalLegacy: catalog.filter((row) => row.artifactRevision === 0).length,
+    batchSize: boundedBatchSize,
+    startAfter: cursor,
+    legacyAtOrBeforeCursor,
+    selectedCount: selected.length,
+    lastSelected,
+    hasMore: remainingAfterBatch > 0,
+    nextStartAfter: remainingAfterBatch > 0 ? lastSelected : null,
+    remainingAfterBatch,
+    selected,
+    groups,
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith('--')) fail(`Unexpected argument: ${key}`);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) fail(`Missing value for ${key}`);
+    values[key.slice(2)] = value;
+    index += 1;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (!args.inventory || !args.output || !args['paths-output']) {
+    fail('--inventory, --output, and --paths-output are required');
+  }
+  const inventory = JSON.parse(readFileSync(resolve(args.inventory), 'utf8'));
+  const plan = buildArtifactBackfillPlan({
+    repositoryRoot: resolve(args['repository-root'] || process.cwd()),
+    inventory,
+    batchSize: args['batch-size'],
+    startAfter: args['start-after'] || null,
+  });
+  writeFileSync(resolve(args.output), `${JSON.stringify(plan, null, 2)}\n`);
+  writeFileSync(
+    resolve(args['paths-output']),
+    plan.selected.length > 0 ? `${plan.selected.map((row) => row.path).join('\n')}\n` : ''
+  );
+  process.stdout.write(`${JSON.stringify({
+    inventoryCount: plan.inventoryCount,
+    totalLegacy: plan.totalLegacy,
+    selectedCount: plan.selectedCount,
+    groupCount: plan.groups.length,
+    hasMore: plan.hasMore,
+    nextStartAfter: plan.nextStartAfter,
+    remainingAfterBatch: plan.remainingAfterBatch,
+  })}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`artifact backfill plan failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { fetchArtifactVersionInventory } from '../fetch-artifact-version-inventory.mjs';
+import { buildArtifactBackfillPlan, main } from '../plan-artifact-version-backfill.mjs';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+function git(root, ...args) {
+  return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+}
+
+function createRepository() {
+  const root = mkdtempSync(join(tmpdir(), 'artifact-backfill-plan-'));
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  const addSkill = (relativePath, slug, contentHash = HASH_A, treeHash = HASH_B) => {
+    const directory = join(root, 'skills', relativePath);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, 'SKILL.md'), `---\nname: ${slug}\nversion: 1.0.0\n---\n`);
+    writeFileSync(join(directory, 'skill-report.json'), JSON.stringify({
+      meta: { slug, content_hash: contentHash, tree_hash: treeHash },
+    }));
+  };
+  const commit = (message) => {
+    git(root, 'add', '.');
+    git(root, 'commit', '-qm', message);
+    return git(root, 'rev-parse', 'HEAD');
+  };
+  return { root, addSkill, commit, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function inventoryRow({ slug, path, commit, revision = 0, contentHash = HASH_A, treeHash = HASH_B }) {
+  return {
+    slug,
+    plugin_path: `skills/${path}`,
+    marketplace_commit_sha: commit,
+    content_hash: contentHash,
+    tree_hash: treeHash,
+    artifact_revision: revision,
+  };
+}
+
+test('plans only production legacy rows from their exact historical commit and path', () => {
+  const repository = createRepository();
+  try {
+    repository.addSkill('owner/legacy', 'legacy-skill');
+    repository.addSkill('owner/versioned', 'already-versioned');
+    const legacyCommit = repository.commit('legacy snapshot');
+    repository.addSkill('owner/repo-only', 'repo-only');
+    writeFileSync(join(repository.root, 'skills/owner/legacy/SKILL.md'), 'newer unapproved bytes\n');
+    repository.commit('newer repository tree');
+
+    const plan = buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows: [
+        inventoryRow({ slug: 'legacy-skill', path: 'owner/legacy', commit: legacyCommit }),
+        inventoryRow({ slug: 'already-versioned', path: 'owner/versioned', commit: legacyCommit, revision: 3 }),
+      ] },
+      batchSize: 100,
+    });
+
+    assert.equal(plan.inventoryCount, 2);
+    assert.equal(plan.totalLegacy, 1);
+    assert.deepEqual(plan.selected.map((row) => row.slug), ['legacy-skill']);
+    assert.equal(plan.selected[0].marketplaceCommit, legacyCommit);
+    assert.equal(plan.groups[0].marketplaceCommit, legacyCommit);
+    assert.deepEqual(plan.groups[0].paths, ['skills/owner/legacy']);
+    assert.equal(plan.selected.some((row) => row.slug === 'repo-only'), false);
+  } finally {
+    repository.cleanup();
+  }
+});
+
+test('uses stable production slug cursors and groups selected rows by commit', () => {
+  const repository = createRepository();
+  try {
+    repository.addSkill('a/one', 'alpha');
+    const firstCommit = repository.commit('alpha');
+    repository.addSkill('b/two', 'beta');
+    repository.addSkill('c/three', 'charlie');
+    const secondCommit = repository.commit('beta and charlie');
+    const rows = [
+      inventoryRow({ slug: 'charlie', path: 'c/three', commit: secondCommit }),
+      inventoryRow({ slug: 'alpha', path: 'a/one', commit: firstCommit, revision: 1 }),
+      inventoryRow({ slug: 'beta', path: 'b/two', commit: secondCommit }),
+    ];
+
+    const plan = buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows },
+      batchSize: 1,
+      startAfter: 'alpha',
+    });
+    assert.deepEqual(plan.selected.map((row) => row.slug), ['beta']);
+    assert.equal(plan.nextStartAfter, 'beta');
+    assert.equal(plan.remainingAfterBatch, 1);
+
+    const resumed = buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows },
+      batchSize: 10,
+      startAfter: plan.nextStartAfter,
+    });
+    assert.deepEqual(resumed.selected.map((row) => row.slug), ['charlie']);
+    assert.equal(resumed.hasMore, false);
+  } finally {
+    repository.cleanup();
+  }
+});
+
+test('fails closed when production identity cannot be reproduced from Git', () => {
+  const repository = createRepository();
+  try {
+    repository.addSkill('owner/legacy', 'legacy-skill');
+    const commit = repository.commit('legacy snapshot');
+    assert.throws(() => buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows: [inventoryRow({
+        slug: 'legacy-skill',
+        path: 'owner/legacy',
+        commit,
+        treeHash: 'c'.repeat(64),
+      })] },
+      batchSize: 10,
+    }), /tree_hash mismatch/);
+    assert.throws(() => buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows: [inventoryRow({ slug: 'legacy-skill', path: 'missing/path', commit })] },
+      batchSize: 10,
+    }), /Git evidence check failed/);
+  } finally {
+    repository.cleanup();
+  }
+});
+
+test('writes plan evidence from a production inventory file', () => {
+  const repository = createRepository();
+  try {
+    repository.addSkill('owner/legacy', 'legacy-skill');
+    const commit = repository.commit('legacy snapshot');
+    const inventory = join(repository.root, 'inventory.json');
+    const output = join(repository.root, 'plan.json');
+    const pathsOutput = join(repository.root, 'paths.txt');
+    writeFileSync(inventory, JSON.stringify({ rows: [
+      inventoryRow({ slug: 'legacy-skill', path: 'owner/legacy', commit }),
+    ] }));
+    main([
+      '--repository-root', repository.root,
+      '--inventory', inventory,
+      '--batch-size', '100',
+      '--output', output,
+      '--paths-output', pathsOutput,
+    ]);
+    assert.equal(JSON.parse(readFileSync(output, 'utf8')).selectedCount, 1);
+    assert.equal(readFileSync(pathsOutput, 'utf8'), 'skills/owner/legacy\n');
+  } finally {
+    repository.cleanup();
+  }
+});
+
+test('fetches an exact paginated production inventory without count drift', async () => {
+  const rows = Array.from({ length: 1001 }, (_, index) => ({ slug: `skill-${index}` }));
+  const ranges = [];
+  const inventory = await fetchArtifactVersionInventory({
+    supabaseUrl: 'https://database.example',
+    serviceKey: 'secret',
+    fetchImpl: async (_url, options) => {
+      const [startText, endText] = options.headers.Range.split('-');
+      const start = Number(startText);
+      const end = Math.min(Number(endText), rows.length - 1);
+      ranges.push(options.headers.Range);
+      return new Response(JSON.stringify(rows.slice(start, end + 1)), {
+        status: 206,
+        headers: { 'content-range': `${start}-${end}/${rows.length}` },
+      });
+    },
+  });
+  assert.equal(inventory.count, 1001);
+  assert.deepEqual(ranges, ['0-999', '1000-1999']);
+});
+
+test('workflow is pinned, evidence-producing, and isolated from normal fan-out', () => {
+  const workflow = readFileSync(
+    resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
+    'utf8'
+  );
+  assert.match(workflow, /cli_version:/);
+  assert.match(workflow, /fetch-artifact-version-inventory\.mjs/);
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /git archive/);
+  assert.match(workflow, /--artifact-only/);
+  assert.match(workflow, /--legacy-only/);
+  assert.match(workflow, /actions\/upload-artifact@v6/);
+  assert.doesNotMatch(workflow, /calculate-scores|trigger-translate|warm-cache|cache-invalidate/);
+});

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -198,5 +198,12 @@ test('workflow is pinned, evidence-producing, and isolated from normal fan-out',
   assert.match(workflow, /--artifact-only/);
   assert.match(workflow, /--legacy-only/);
   assert.match(workflow, /actions\/upload-artifact@v6/);
-  assert.doesNotMatch(workflow, /calculate-scores|trigger-translate|warm-cache|cache-invalidate/);
+  assert.match(workflow, /CACHE_INVALIDATE_SECRET/);
+  assert.match(workflow, /https:\/\/skillstore\.io\/api\/cache\/invalidate/);
+  assert.match(workflow, /--fail-with-body/);
+  assert.match(workflow, /artifact-backfill-cache-invalidation\.json/);
+  assert.match(workflow, /steps\.inputs\.outputs\.mode == 'execute'/);
+  assert.match(workflow, /id: cache-invalidate/);
+  assert.match(workflow, /CACHE_OUTCOME: \$\{\{ steps\.cache-invalidate\.outcome \}\}/);
+  assert.doesNotMatch(workflow, /calculate-scores|trigger-translate|warm-cache/);
 });


### PR DESCRIPTION
## Summary

- add a DB-driven, resumable artifact-version backfill workflow
- materialize each Skill from its stored Marketplace commit and path
- run released CLI 2.1.0 in artifact-only, legacy-only mode
- fail closed on result validation and production cache invalidation
- upload immutable inventory, plan, execution, and cache evidence

## Safety

- dry-run is the default
- execute batches are bounded to 500 and serialized
- production DB inventory is authoritative; current main is not used as artifact truth
- no audit, translation, scoring, or cache-warm fan-out
- execute resume cursors are published only after cache invalidation succeeds

## Verification

- node --test scripts/tests/artifact-version-backfill.test.mjs (6/6)
- node --check scripts/fetch-artifact-version-inventory.mjs
- node --check scripts/plan-artifact-version-backfill.mjs
- workflow YAML parse
- cache-step bash syntax check
- git diff --check