### PR TITLE
fix(sync): verify artifact backfill readback

### DIFF
--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact stable skillstore-cli version (X.Y.Z; latest is forbidden)'
         type: string
         required: true
-        default: '2.1.0'
+        default: '2.1.1'
       batch_size:
         description: 'Legacy production Skills to inspect in this batch (1-500)'
         type: number
@@ -60,6 +60,10 @@ jobs:
           fi
           if ! [[ "$CLI_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::cli_version must be an exact stable X.Y.Z release"
+            exit 1
+          fi
+          if [ "$CLI_VERSION" != "2.1.1" ]; then
+            echo "::error::this workflow is pinned to the audited skillstore-cli 2.1.1"
             exit 1
           fi
           if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ] || [ "$BATCH_SIZE" -gt 500 ]; then
@@ -282,12 +286,44 @@ jobs:
             '{schemaVersion: 2, status: "verified", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: $groups[0]}' \
             > "$SUMMARY_FILE"
 
+      - name: Refetch production state after CLI
+        id: post-inventory
+        if: >-
+          always() &&
+          steps.plan.outcome == 'success' &&
+          steps.plan.outputs.selected_count != '0' &&
+          steps.verify.outcome == 'success'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --output "$RUNNER_TEMP/artifact-backfill-inventory-post.json"
+
+      - name: Verify production state preservation
+        id: readback
+        if: >-
+          always() &&
+          steps.verify.outcome == 'success' &&
+          steps.post-inventory.outcome == 'success'
+        env:
+          MODE: ${{ steps.inputs.outputs.mode }}
+        run: |
+          set -euo pipefail
+          node scripts/verify-artifact-version-backfill.mjs \
+            --mode "$MODE" \
+            --plan "$RUNNER_TEMP/artifact-backfill-plan.json" \
+            --post-inventory "$RUNNER_TEMP/artifact-backfill-inventory-post.json" \
+            --output "$RUNNER_TEMP/artifact-backfill-readback.json"
+
       - name: Invalidate production artifact and detail caches
         id: cache-invalidate
         if: >-
           steps.inputs.outputs.mode == 'execute' &&
           steps.plan.outputs.selected_count != '0' &&
-          steps.verify.outcome == 'success'
+          steps.verify.outcome == 'success' &&
+          steps.readback.outcome == 'success'
         env:
           CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
         run: |
@@ -349,6 +385,7 @@ jobs:
           REMAINING: ${{ steps.plan.outputs.remaining }}
           VERIFY_OUTCOME: ${{ steps.verify.outcome }}
           CACHE_OUTCOME: ${{ steps.cache-invalidate.outcome }}
+          READBACK_OUTCOME: ${{ steps.readback.outcome }}
         run: |
           {
             echo "## Artifact-version backfill batch"
@@ -360,7 +397,8 @@ jobs:
             echo "- Inventory SHA-256: \`$INVENTORY_SHA\`"
             echo "- Verification: \`$VERIFY_OUTCOME\`"
             echo "- Cache invalidation: \`$CACHE_OUTCOME\`"
-            if [ "$VERIFY_OUTCOME" = "success" ] && \
+            echo "- Production readback: \`$READBACK_OUTCOME\`"
+            if [ "$VERIFY_OUTCOME" = "success" ] && [ "$READBACK_OUTCOME" = "success" ] && \
                { [ "$MODE" = "dry-run" ] || [ "$CACHE_OUTCOME" = "success" ]; } && \
                [ -n "$NEXT_START_AFTER" ]; then
               echo "- Verified resume cursor: \`$NEXT_START_AFTER\`"
@@ -374,11 +412,13 @@ jobs:
           name: artifact-version-backfill-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/artifact-backfill-inventory.json
+            ${{ runner.temp }}/artifact-backfill-inventory-post.json
             ${{ runner.temp }}/artifact-backfill-plan.json
             ${{ runner.temp }}/artifact-backfill-paths.txt
             ${{ runner.temp }}/artifact-backfill-result.json
             ${{ runner.temp }}/artifact-backfill-stderr.log
             ${{ runner.temp }}/artifact-backfill-summary.json
+            ${{ runner.temp }}/artifact-backfill-readback.json
             ${{ runner.temp }}/artifact-backfill-cache-invalidation.json
             ${{ runner.temp }}/artifact-backfill-cache-invalidation/
             ${{ runner.temp }}/artifact-backfill-group-results/

--- a/scripts/fetch-artifact-version-inventory.mjs
+++ b/scripts/fetch-artifact-version-inventory.mjs
@@ -5,7 +5,17 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const PAGE_SIZE = 1000;
-const SELECT = 'slug,plugin_path,marketplace_commit_sha,content_hash,tree_hash,artifact_revision';
+const SELECT = [
+  'slug',
+  'plugin_path',
+  'marketplace_commit_sha',
+  'content_hash',
+  'tree_hash',
+  'artifact_revision',
+  'current_artifact_version_id',
+  'status',
+  'public_eligible',
+].join(',');
 
 function fail(message) {
   throw new Error(message);

--- a/scripts/plan-artifact-version-backfill.mjs
+++ b/scripts/plan-artifact-version-backfill.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'node:url';
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const MAX_BATCH_SIZE = 500;
 
 function fail(message) {
@@ -86,11 +87,24 @@ function normalizeInventory(inventory) {
     const contentHash = String(raw.content_hash ?? '').trim();
     const treeHash = String(raw.tree_hash ?? '').trim();
     const artifactRevision = Number(raw.artifact_revision);
+    const currentArtifactVersionId = raw.current_artifact_version_id == null
+      ? null
+      : String(raw.current_artifact_version_id).trim();
+    const status = typeof raw.status === 'string' ? raw.status.trim() : '';
+    const publicEligible = raw.public_eligible;
     if (!COMMIT_RE.test(marketplaceCommit)) fail(`Invalid production marketplace commit for ${slug}`);
     if (!SHA256_RE.test(contentHash)) fail(`Invalid production content_hash for ${slug}`);
     if (!SHA256_RE.test(treeHash)) fail(`Invalid production tree_hash for ${slug}`);
     if (!Number.isSafeInteger(artifactRevision) || artifactRevision < 0) {
       fail(`Invalid production artifact_revision for ${slug}`);
+    }
+    if (!status) fail(`Invalid production status for ${slug}`);
+    if (typeof publicEligible !== 'boolean') fail(`Invalid production public_eligible for ${slug}`);
+    if (artifactRevision === 0 && currentArtifactVersionId !== null) {
+      fail(`Legacy production row has a current artifact id for ${slug}`);
+    }
+    if (artifactRevision > 0 && !UUID_RE.test(currentArtifactVersionId || '')) {
+      fail(`Versioned production row lacks a valid current artifact id for ${slug}`);
     }
     const path = normalizePath(raw.plugin_path, slug);
     if (seenPaths.has(path)) fail(`Production inventory contains duplicate plugin_path ${path}`);
@@ -102,6 +116,9 @@ function normalizeInventory(inventory) {
       contentHash,
       treeHash,
       artifactRevision,
+      currentArtifactVersionId,
+      status,
+      publicEligible,
     };
   }).sort((left, right) => left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0);
 }

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 
 import { fetchArtifactVersionInventory } from '../fetch-artifact-version-inventory.mjs';
 import { buildArtifactBackfillPlan, main } from '../plan-artifact-version-backfill.mjs';
+import { verifyArtifactVersionReadback } from '../verify-artifact-version-backfill.mjs';
 
 const HASH_A = 'a'.repeat(64);
 const HASH_B = 'b'.repeat(64);
@@ -44,6 +45,9 @@ function inventoryRow({ slug, path, commit, revision = 0, contentHash = HASH_A, 
     content_hash: contentHash,
     tree_hash: treeHash,
     artifact_revision: revision,
+    current_artifact_version_id: revision > 0 ? '123e4567-e89b-42d3-a456-426614174000' : null,
+    status: 'approved',
+    public_eligible: true,
   };
 }
 
@@ -70,6 +74,9 @@ test('plans only production legacy rows from their exact historical commit and p
     assert.equal(plan.totalLegacy, 1);
     assert.deepEqual(plan.selected.map((row) => row.slug), ['legacy-skill']);
     assert.equal(plan.selected[0].marketplaceCommit, legacyCommit);
+    assert.equal(plan.selected[0].status, 'approved');
+    assert.equal(plan.selected[0].publicEligible, true);
+    assert.equal(plan.selected[0].currentArtifactVersionId, null);
     assert.equal(plan.groups[0].marketplaceCommit, legacyCommit);
     assert.deepEqual(plan.groups[0].paths, ['skills/owner/legacy']);
     assert.equal(plan.selected.some((row) => row.slug === 'repo-only'), false);
@@ -186,24 +193,111 @@ test('fetches an exact paginated production inventory without count drift', asyn
   assert.deepEqual(ranges, ['0-999', '1000-1999']);
 });
 
+test('readback proves dry-run immutability and execute initialization', () => {
+  const commit = 'a'.repeat(40);
+  const before = {
+    slug: 'legacy-skill',
+    path: 'skills/owner/legacy',
+    marketplaceCommit: commit,
+    contentHash: HASH_A,
+    treeHash: HASH_B,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+  };
+  const unchanged = inventoryRow({ slug: before.slug, path: 'owner/legacy', commit });
+  const dryRun = verifyArtifactVersionReadback({
+    mode: 'dry-run',
+    plan: { selected: [before] },
+    postInventory: { rows: [unchanged] },
+  });
+  assert.equal(dryRun.verifiedCount, 1);
+
+  const initialized = {
+    ...unchanged,
+    artifact_revision: 1,
+    current_artifact_version_id: '123e4567-e89b-42d3-a456-426614174000',
+  };
+  const execute = verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan: { selected: [before] },
+    postInventory: { rows: [initialized] },
+  });
+  assert.equal(execute.evidence[0].after.artifactRevision, 1);
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan: { selected: [before] },
+    postInventory: { rows: [{ ...initialized, artifact_revision: 2 }] },
+  }), /unexpected artifact_revision/);
+});
+
+test('readback fails closed on visibility or immutable identity drift', () => {
+  const commit = 'a'.repeat(40);
+  const before = {
+    slug: 'legacy-skill',
+    path: 'skills/owner/legacy',
+    marketplaceCommit: commit,
+    contentHash: HASH_A,
+    treeHash: HASH_B,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+  };
+  const changed = {
+    ...inventoryRow({ slug: before.slug, path: 'owner/legacy', commit }),
+    artifact_revision: 1,
+    current_artifact_version_id: '123e4567-e89b-42d3-a456-426614174000',
+    public_eligible: false,
+  };
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan: { selected: [before] },
+    postInventory: { rows: [changed] },
+  }), /publicEligible changed/);
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'dry-run',
+    plan: { selected: [before] },
+    postInventory: { rows: [{ ...changed, public_eligible: true }] },
+  }), /Dry-run changed artifact_revision/);
+});
+
 test('workflow is pinned, evidence-producing, and isolated from normal fan-out', () => {
   const workflow = readFileSync(
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
+  const inventoryFetcher = readFileSync(
+    resolve(import.meta.dirname, '../fetch-artifact-version-inventory.mjs'),
+    'utf8'
+  );
   assert.match(workflow, /cli_version:/);
+  assert.match(workflow, /default: '2\.1\.1'/);
+  assert.match(workflow, /CLI_VERSION" != "2\.1\.1"/);
   assert.match(workflow, /fetch-artifact-version-inventory\.mjs/);
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /git archive/);
   assert.match(workflow, /--artifact-only/);
   assert.match(workflow, /--legacy-only/);
   assert.match(workflow, /actions\/upload-artifact@v6/);
-  assert.match(workflow, /CACHE_INVALIDATE_SECRET/);
+  assert.match(workflow, /CACHE_INVALIDATE_SECRET: \$\{\{ secrets\.CACHE_INVALIDATE_SECRET \}\}/);
+  assert.match(workflow, /CACHE_INVALIDATE_SECRET:\?CACHE_INVALIDATE_SECRET is required for execute mode/);
+  assert.match(workflow, /jq -r '\.selected\[\]\.slug'/);
   assert.match(workflow, /https:\/\/skillstore\.io\/api\/cache\/invalidate/);
   assert.match(workflow, /--fail-with-body/);
   assert.match(workflow, /artifact-backfill-cache-invalidation\.json/);
+  assert.match(workflow, /artifact-backfill-inventory-post\.json/);
+  assert.match(workflow, /verify-artifact-version-backfill\.mjs/);
+  assert.match(inventoryFetcher, /current_artifact_version_id/);
+  assert.match(inventoryFetcher, /public_eligible/);
   assert.match(workflow, /steps\.inputs\.outputs\.mode == 'execute'/);
   assert.match(workflow, /id: cache-invalidate/);
+  assert.match(workflow, /steps\.readback\.outcome == 'success'/);
+  assert.ok(
+    workflow.indexOf('id: readback') < workflow.indexOf('id: cache-invalidate'),
+    'production readback must pass before cache invalidation publishes the new projection'
+  );
   assert.match(workflow, /CACHE_OUTCOME: \$\{\{ steps\.cache-invalidate\.outcome \}\}/);
   assert.doesNotMatch(workflow, /calculate-scores|trigger-translate|warm-cache/);
 });

--- a/scripts/verify-artifact-version-backfill.mjs
+++ b/scripts/verify-artifact-version-backfill.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function rowsFromInventory(inventory) {
+  const rows = Array.isArray(inventory) ? inventory : inventory?.rows;
+  if (!Array.isArray(rows)) fail('Post-run inventory has no rows array');
+  const bySlug = new Map();
+  for (const row of rows) {
+    if (typeof row?.slug !== 'string' || bySlug.has(row.slug)) {
+      fail(`Post-run inventory contains an invalid or duplicate slug: ${row?.slug ?? '<missing>'}`);
+    }
+    bySlug.set(row.slug, row);
+  }
+  return bySlug;
+}
+
+export function verifyArtifactVersionReadback({ mode, plan, postInventory }) {
+  if (mode !== 'dry-run' && mode !== 'execute') fail('mode must be dry-run or execute');
+  if (!Array.isArray(plan?.selected)) fail('Plan has no selected rows');
+  const postBySlug = rowsFromInventory(postInventory);
+  const evidence = [];
+
+  for (const before of plan.selected) {
+    const after = postBySlug.get(before.slug);
+    if (!after) fail(`Selected Skill disappeared from production: ${before.slug}`);
+
+    const preserved = {
+      status: after.status === before.status,
+      publicEligible: after.public_eligible === before.publicEligible,
+      path: after.plugin_path === before.path,
+      marketplaceCommit: after.marketplace_commit_sha === before.marketplaceCommit,
+      contentHash: after.content_hash === before.contentHash,
+      treeHash: after.tree_hash === before.treeHash,
+    };
+    for (const [field, matches] of Object.entries(preserved)) {
+      if (!matches) fail(`Post-run ${field} changed for ${before.slug}`);
+    }
+
+    const afterRevision = Number(after.artifact_revision);
+    const afterCurrentId = after.current_artifact_version_id ?? null;
+    if (mode === 'dry-run') {
+      if (afterRevision !== before.artifactRevision) {
+        fail(`Dry-run changed artifact_revision for ${before.slug}`);
+      }
+      if (afterCurrentId !== before.currentArtifactVersionId) {
+        fail(`Dry-run changed current_artifact_version_id for ${before.slug}`);
+      }
+    } else {
+      const expectedRevision = before.artifactRevision + 1;
+      if (!Number.isSafeInteger(afterRevision) || afterRevision !== expectedRevision) {
+        fail(
+          `Execute initialized unexpected artifact_revision for ${before.slug}: ` +
+          `expected ${expectedRevision}, got ${after.artifact_revision}`
+        );
+      }
+      if (!UUID_RE.test(String(afterCurrentId ?? ''))) {
+        fail(`Execute did not initialize current_artifact_version_id for ${before.slug}`);
+      }
+    }
+
+    evidence.push({
+      slug: before.slug,
+      preserved,
+      before: {
+        artifactRevision: before.artifactRevision,
+        currentArtifactVersionId: before.currentArtifactVersionId,
+        status: before.status,
+        publicEligible: before.publicEligible,
+        path: before.path,
+        marketplaceCommit: before.marketplaceCommit,
+        contentHash: before.contentHash,
+        treeHash: before.treeHash,
+      },
+      after: {
+        artifactRevision: afterRevision,
+        currentArtifactVersionId: afterCurrentId,
+        status: after.status,
+        publicEligible: after.public_eligible,
+        path: after.plugin_path,
+        marketplaceCommit: after.marketplace_commit_sha,
+        contentHash: after.content_hash,
+        treeHash: after.tree_hash,
+      },
+    });
+  }
+
+  return { schemaVersion: 1, mode, verifiedCount: evidence.length, evidence };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) fail(`Invalid argument: ${key ?? '<missing>'}`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (!args.mode || !args.plan || !args['post-inventory'] || !args.output) {
+    fail('--mode, --plan, --post-inventory, and --output are required');
+  }
+  const result = verifyArtifactVersionReadback({
+    mode: args.mode,
+    plan: JSON.parse(readFileSync(resolve(args.plan), 'utf8')),
+    postInventory: JSON.parse(readFileSync(resolve(args['post-inventory']), 'utf8')),
+  });
+  writeFileSync(resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ mode: result.mode, verifiedCount: result.verifiedCount })}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`artifact backfill readback failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Incident addressed

Run 29347130456 proved the compiled CLI 2.1.0 silently ignored the new kebab-case boolean flags. The fail-closed workflow stopped after verification, but 285 rows had already been written.

## Changes

- pin the workflow to the audited CLI 2.1.1 release
- fetch pre/post production state for every selected Skill
- prove dry-run leaves revision/current ID unchanged
- prove execute initializes exactly r1/current ID
- prove status, public eligibility, commit, path, content hash, and tree hash are preserved
- allow cache invalidation and cursor publication only after readback succeeds
- retain post-inventory/readback/cache evidence

## Verification

- focused tests: 8/8
- Node syntax checks: 3/3
- YAML parse: passed
- critical Bash steps: syntax passed
- git diff --check: passed