### PR TITLE
feat(sync): issue signed audit attestations

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -227,7 +227,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: '2.0.1'
+          minimum-version: '2.2.0'
 
       - name: Sync skills to Supabase
         id: sync
@@ -237,6 +237,9 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
           SYNC_MODE: ${{ steps.changes.outputs.mode }}
+          SECURITY_PASSPORT_MODE: ${{ vars.SECURITY_PASSPORT_MODE || 'off' }}
+          PUBLIC_SITE_URL: https://skillstore.io
+          AUTOMATION_API_KEY: ${{ secrets.SECURITY_ATTESTATION_AUTOMATION_KEY }}
         run: |
           echo "Sync mode: $SYNC_MODE"
           echo "Syncing skills: $CHANGED_SKILLS"

--- a/scripts/tests/security-attestation-issuance-workflow.test.mjs
+++ b/scripts/tests/security-attestation-issuance-workflow.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/sync-to-supabase.yml'),
+  'utf8',
+);
+
+test('sync uses an attestation-capable CLI and a dedicated issuance credential', () => {
+  assert.match(workflow, /minimum-version: '2\.2\.0'/);
+  assert.match(
+    workflow,
+    /SECURITY_PASSPORT_MODE: \$\{\{ vars\.SECURITY_PASSPORT_MODE \|\| 'off' \}\}/,
+  );
+  assert.match(workflow, /PUBLIC_SITE_URL: https:\/\/skillstore\.io/);
+  assert.match(
+    workflow,
+    /AUTOMATION_API_KEY: \$\{\{ secrets\.SECURITY_ATTESTATION_AUTOMATION_KEY \}\}/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /AUTOMATION_API_KEY: \$\{\{ secrets\.(?:AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN) \}\}/,
+  );
+});


### PR DESCRIPTION
## Summary
- require Skillstore CLI 2.2.0 for explicit immutable audit subjects
- pass Passport rollout mode and the Skillstore origin into incremental sync
- use a dedicated attestation-only bearer secret for post-audit issuance
- add a workflow contract test preventing credential scope regressions

## Verification
- `CI=true node --test scripts/tests/security-attestation-issuance-workflow.test.mjs`
- Ruby YAML parse passed

Note: the existing `scripts/tests/invalidate-cache.test.mjs` has two unrelated macOS fixture failures on current main; this change does not touch that script.