### PR TITLE
fix(sync): classify bounded artifact backfill cohorts

### DIFF
--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Read-only validation or bounded production execution'
+        description: 'Classify only, or reclassify and execute the exact cohort'
         type: choice
         required: true
         default: dry-run
@@ -12,17 +12,22 @@ on:
           - dry-run
           - execute
       cli_version:
-        description: 'Exact stable skillstore-cli version (X.Y.Z; latest is forbidden)'
+        description: 'Exact audited skillstore-cli version (X.Y.Z; latest is forbidden)'
         type: string
         required: true
-        default: '2.2.1'
+        default: '2.2.2'
       batch_size:
-        description: 'Legacy production Skills to inspect in this batch (1-500)'
+        description: 'Maximum legacy Skills in this serial batch (1-500)'
         type: number
         required: true
-        default: 100
+        default: 500
       start_after:
-        description: 'Exact prior production slug cursor (blank starts at the beginning)'
+        description: 'Prior classification range end; blank starts at the beginning'
+        type: string
+        required: false
+        default: ''
+      end_at:
+        description: 'Frozen inclusive range end from dry-run; required for execute'
         type: string
         required: false
         default: ''
@@ -52,6 +57,7 @@ jobs:
           CLI_VERSION: ${{ inputs.cli_version }}
           BATCH_SIZE: ${{ inputs.batch_size }}
           START_AFTER: ${{ inputs.start_after }}
+          END_AT: ${{ inputs.end_at }}
         run: |
           set -euo pipefail
           if [[ "$MODE" != "dry-run" && "$MODE" != "execute" ]]; then
@@ -62,69 +68,77 @@ jobs:
             echo "::error::cli_version must be an exact stable X.Y.Z release"
             exit 1
           fi
-          if [ "$CLI_VERSION" != "2.2.1" ]; then
-            echo "::error::this workflow is pinned to the audited skillstore-cli 2.2.1"
+          if [ "$CLI_VERSION" != "2.2.2" ]; then
+            echo "::error::this workflow is pinned to the audited skillstore-cli 2.2.2"
             exit 1
           fi
           if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ] || [ "$BATCH_SIZE" -gt 500 ]; then
             echo "::error::batch_size must be an integer between 1 and 500"
             exit 1
           fi
-          if [[ "$START_AFTER" == *$'\n'* || "$START_AFTER" == *$'\r'* ]]; then
-            echo "::error::start_after must be one exact production slug"
+          if [[ "$START_AFTER" == *$'\n'* || "$START_AFTER" == *$'\r'* || \
+                "$END_AT" == *$'\n'* || "$END_AT" == *$'\r'* ]]; then
+            echo "::error::cursor inputs must be exact production slugs"
+            exit 1
+          fi
+          if [ "$MODE" = "execute" ] && [ -z "$END_AT" ]; then
+            echo "::error::execute requires the frozen end_at slug produced by a dry-run"
             exit 1
           fi
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "cli_version=$CLI_VERSION" >> "$GITHUB_OUTPUT"
           echo "batch_size=$BATCH_SIZE" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch exact production artifact inventory
+      - name: Fetch exact production Skill catalog
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: |
           set -euo pipefail
           node scripts/fetch-artifact-version-inventory.mjs \
-            --output "$RUNNER_TEMP/artifact-backfill-inventory.json"
+            --skills-only \
+            --output "$RUNNER_TEMP/artifact-backfill-catalog.json"
 
-      - name: Build deterministic DB-driven plan
+      - name: Build bounded deterministic plan
         id: plan
         env:
-          MODE: ${{ steps.inputs.outputs.mode }}
           BATCH_SIZE: ${{ steps.inputs.outputs.batch_size }}
           START_AFTER: ${{ inputs.start_after }}
+          END_AT: ${{ inputs.end_at }}
         run: |
           set -euo pipefail
           PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
           PATHS_FILE="$RUNNER_TEMP/artifact-backfill-paths.txt"
           PLAN_ARGS=(
             --repository-root "$GITHUB_WORKSPACE"
-            --inventory "$RUNNER_TEMP/artifact-backfill-inventory.json"
+            --inventory "$RUNNER_TEMP/artifact-backfill-catalog.json"
             --batch-size "$BATCH_SIZE"
             --output "$PLAN_FILE"
             --paths-output "$PATHS_FILE"
           )
-          if [ -n "$START_AFTER" ]; then
-            PLAN_ARGS+=(--start-after "$START_AFTER")
-          fi
+          if [ -n "$START_AFTER" ]; then PLAN_ARGS+=(--start-after "$START_AFTER"); fi
+          if [ -n "$END_AT" ]; then PLAN_ARGS+=(--end-at "$END_AT"); fi
           node scripts/plan-artifact-version-backfill.mjs "${PLAN_ARGS[@]}"
 
-          EARLIER_LEGACY=$(jq -r '.legacyAtOrBeforeCursor' "$PLAN_FILE")
-          if [ "$MODE" = "execute" ] && [ -n "$START_AFTER" ] && [ "$EARLIER_LEGACY" -ne 0 ]; then
-            echo "::error::$EARLIER_LEGACY legacy row(s) exist at or before start_after; restart from an earlier cursor"
-            exit 1
-          fi
-
           PLAN_SHA=$(sha256sum "$PLAN_FILE" | awk '{print $1}')
-          INVENTORY_SHA=$(sha256sum "$RUNNER_TEMP/artifact-backfill-inventory.json" | awk '{print $1}')
+          INVENTORY_SHA=$(sha256sum "$RUNNER_TEMP/artifact-backfill-catalog.json" | awk '{print $1}')
           echo "plan_sha=$PLAN_SHA" >> "$GITHUB_OUTPUT"
           echo "inventory_sha=$INVENTORY_SHA" >> "$GITHUB_OUTPUT"
           echo "selected_count=$(jq -r '.selectedCount' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
-          echo "group_count=$(jq -r '.groups | length' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
-          echo "has_more=$(jq -r '.hasMore' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
-          echo "next_start_after=$(jq -r '.nextStartAfter // ""' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
-          echo "remaining=$(jq -r '.remainingAfterBatch' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "last_selected=$(jq -r '.lastSelected // ""' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "unclassified_after=$(jq -r '.unclassifiedLegacyAfterBatch' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+          echo "remaining_outside=$(jq -r '.remainingLegacyOutsideBatch' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
           echo "legacy_total=$(jq -r '.totalLegacy' "$PLAN_FILE")" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch bounded pre-run Skill, Pack, and artifact evidence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/artifact-backfill-plan.json" \
+            --output "$RUNNER_TEMP/artifact-backfill-inventory.json"
 
       - name: Generate GitHub App token
         if: steps.plan.outputs.selected_count != '0'
@@ -144,61 +158,132 @@ jobs:
           minimum-version: ${{ steps.inputs.outputs.cli_version }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Materialize pinned historical snapshots by commit
+      - name: Materialize bounded pinned snapshots
         if: steps.plan.outputs.selected_count != '0'
         run: |
           set -euo pipefail
           ROOT="$RUNNER_TEMP/artifact-backfill-materialized"
           mkdir -p "$ROOT"
-          while IFS= read -r GROUP; do
-            COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
-            GROUP_DIR="$ROOT/$COMMIT"
-            mkdir -p "$GROUP_DIR"
-            mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
-            git archive --format=tar "$COMMIT" -- "${PATHS[@]}" | tar -xf - -C "$GROUP_DIR"
-          done < <(jq -c '.groups[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
+          while IFS= read -r BATCH; do
+            INDEX=$(jq -r '.index' <<< "$BATCH")
+            while IFS= read -r GROUP; do
+              COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
+              GROUP_DIR="$ROOT/batch-$INDEX/$COMMIT"
+              mkdir -p "$GROUP_DIR"
+              mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
+              git archive --format=tar "$COMMIT" -- "${PATHS[@]}" | tar -xf - -C "$GROUP_DIR"
+            done < <(jq -c '.groups[]' <<< "$BATCH")
+          done < <(jq -c '.batches[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
 
-      - name: Run artifact-only commit groups
-        id: artifact-sync
-        if: steps.plan.outputs.selected_count != '0'
-        continue-on-error: true
+      - name: Classify every Skill in the bounded range
+        id: classify-cli
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          MODE: ${{ steps.inputs.outputs.mode }}
         run: |
           set -euo pipefail
           MATERIALIZED_ROOT="$RUNNER_TEMP/artifact-backfill-materialized"
-          RESULT_DIR="$RUNNER_TEMP/artifact-backfill-group-results"
-          RESULT_ROWS="$RUNNER_TEMP/artifact-backfill-result-rows.jsonl"
+          RESULT_DIR="$RUNNER_TEMP/artifact-backfill-classification-groups"
+          RESULT_ROWS="$RUNNER_TEMP/artifact-backfill-classification-rows.jsonl"
           mkdir -p "$RESULT_DIR"
           : > "$RESULT_ROWS"
-          : > "$RUNNER_TEMP/artifact-backfill-stderr.log"
-          FAILURES=0
-          MODE_ARGS=()
-          if [ "$MODE" = "dry-run" ]; then MODE_ARGS+=(--dry-run); fi
+          : > "$RUNNER_TEMP/artifact-backfill-classification-stderr.log"
+
+          while IFS= read -r BATCH; do
+            INDEX=$(jq -r '.index' <<< "$BATCH")
+            while IFS= read -r GROUP; do
+              COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
+              COUNT=$(jq -r '.count' <<< "$GROUP")
+              mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
+              SLUG_PATHS=$(printf '%s\n' "${PATHS[@]}" | paste -sd,)
+              RAW_RESULT="$RESULT_DIR/batch-$INDEX-$COMMIT.json"
+              NORMALIZED_RESULT="$RESULT_DIR/batch-$INDEX-$COMMIT.normalized.json"
+              GROUP_STDERR="$RESULT_DIR/batch-$INDEX-$COMMIT.stderr.log"
+
+              set +e
+              (
+                cd "$MATERIALIZED_ROOT/batch-$INDEX/$COMMIT"
+                "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
+                  --slugs "$SLUG_PATHS" \
+                  --artifact-only \
+                  --legacy-only \
+                  --repair-stale-report-hashes \
+                  --dry-run \
+                  --concurrency 5 \
+                  --marketplace-commit "$COMMIT" \
+                  --output json
+              ) > "$RAW_RESULT" 2> >(tee "$GROUP_STDERR" | tee -a "$RUNNER_TEMP/artifact-backfill-classification-stderr.log" >&2)
+              CLI_EXIT=$?
+              set -e
+
+              if [ -s "$RAW_RESULT" ] && jq -e . "$RAW_RESULT" >/dev/null 2>&1; then
+                jq -c . "$RAW_RESULT" > "$NORMALIZED_RESULT"
+              else
+                echo 'null' > "$NORMALIZED_RESULT"
+              fi
+              jq -n -c \
+                --argjson batchIndex "$INDEX" \
+                --arg marketplaceCommit "$COMMIT" \
+                --argjson selectedCount "$COUNT" \
+                --argjson exitCode "$CLI_EXIT" \
+                --slurpfile result "$NORMALIZED_RESULT" \
+                '{batchIndex: $batchIndex, marketplaceCommit: $marketplaceCommit, selectedCount: $selectedCount, exitCode: $exitCode, result: $result[0]}' \
+                >> "$RESULT_ROWS"
+            done < <(jq -c '.groups[]' <<< "$BATCH")
+          done < <(jq -c '.batches[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
+
+          jq -s . "$RESULT_ROWS" > "$RUNNER_TEMP/artifact-backfill-classification-results.json"
+
+      - name: Verify complete no-write classification evidence
+        id: classification
+        run: |
+          set -euo pipefail
+          node scripts/verify-artifact-version-classification.mjs \
+            --phase classification \
+            --plan "$RUNNER_TEMP/artifact-backfill-plan.json" \
+            --results "$RUNNER_TEMP/artifact-backfill-classification-results.json" \
+            --output "$RUNNER_TEMP/artifact-backfill-classification.json"
+          echo "exact_count=$(jq -r '.counts.exact' "$RUNNER_TEMP/artifact-backfill-classification.json")" >> "$GITHUB_OUTPUT"
+          echo "legacy_count=$(jq -r '.counts.legacy_algorithm_equivalent' "$RUNNER_TEMP/artifact-backfill-classification.json")" >> "$GITHUB_OUTPUT"
+          echo "unproven_count=$(jq -r '.counts.actual_or_unproven_drift' "$RUNNER_TEMP/artifact-backfill-classification.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Execute only the classified exact cohort
+        id: execute-cli
+        if: steps.inputs.outputs.mode == 'execute' && steps.classification.outcome == 'success'
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          MATERIALIZED_ROOT="$RUNNER_TEMP/artifact-backfill-materialized"
+          RESULT_DIR="$RUNNER_TEMP/artifact-backfill-execution-groups"
+          RESULT_ROWS="$RUNNER_TEMP/artifact-backfill-execution-rows.jsonl"
+          mkdir -p "$RESULT_DIR"
+          : > "$RESULT_ROWS"
+          : > "$RUNNER_TEMP/artifact-backfill-execution-stderr.log"
 
           while IFS= read -r GROUP; do
+            INDEX=$(jq -r '.batchIndex' <<< "$GROUP")
             COMMIT=$(jq -r '.marketplaceCommit' <<< "$GROUP")
             COUNT=$(jq -r '.count' <<< "$GROUP")
             mapfile -t PATHS < <(jq -r '.paths[]' <<< "$GROUP")
             SLUG_PATHS=$(printf '%s\n' "${PATHS[@]}" | paste -sd,)
-            RAW_RESULT="$RESULT_DIR/$COMMIT.json"
-            NORMALIZED_RESULT="$RESULT_DIR/$COMMIT.normalized.json"
-            GROUP_STDERR="$RESULT_DIR/$COMMIT.stderr.log"
+            RAW_RESULT="$RESULT_DIR/batch-$INDEX-$COMMIT.json"
+            NORMALIZED_RESULT="$RESULT_DIR/batch-$INDEX-$COMMIT.normalized.json"
+            GROUP_STDERR="$RESULT_DIR/batch-$INDEX-$COMMIT.stderr.log"
 
             set +e
             (
-              cd "$MATERIALIZED_ROOT/$COMMIT"
+              cd "$MATERIALIZED_ROOT/batch-$INDEX/$COMMIT"
               "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
                 --slugs "$SLUG_PATHS" \
                 --artifact-only \
                 --legacy-only \
-                "${MODE_ARGS[@]}" \
+                --repair-stale-report-hashes \
                 --concurrency 5 \
                 --marketplace-commit "$COMMIT" \
                 --output json
-            ) > "$RAW_RESULT" 2> >(tee "$GROUP_STDERR" | tee -a "$RUNNER_TEMP/artifact-backfill-stderr.log" >&2)
+            ) > "$RAW_RESULT" 2> >(tee "$GROUP_STDERR" | tee -a "$RUNNER_TEMP/artifact-backfill-execution-stderr.log" >&2)
             CLI_EXIT=$?
             set -e
 
@@ -208,131 +293,78 @@ jobs:
               echo 'null' > "$NORMALIZED_RESULT"
             fi
             jq -n -c \
+              --argjson batchIndex "$INDEX" \
               --arg marketplaceCommit "$COMMIT" \
               --argjson selectedCount "$COUNT" \
               --argjson exitCode "$CLI_EXIT" \
               --slurpfile result "$NORMALIZED_RESULT" \
-              '{marketplaceCommit: $marketplaceCommit, selectedCount: $selectedCount, exitCode: $exitCode, result: $result[0]}' \
+              '{batchIndex: $batchIndex, marketplaceCommit: $marketplaceCommit, selectedCount: $selectedCount, exitCode: $exitCode, result: $result[0]}' \
               >> "$RESULT_ROWS"
-            if [ "$CLI_EXIT" -ne 0 ]; then FAILURES=$((FAILURES + 1)); fi
-          done < <(jq -c '.groups[]' "$RUNNER_TEMP/artifact-backfill-plan.json")
+          done < <(jq -c '.exactBatches[]' "$RUNNER_TEMP/artifact-backfill-classification.json")
 
-          jq -s . "$RESULT_ROWS" > "$RUNNER_TEMP/artifact-backfill-result.json"
-          echo "failed_groups=$FAILURES" >> "$GITHUB_OUTPUT"
-          if [ "$FAILURES" -ne 0 ]; then exit 1; fi
+          jq -s . "$RESULT_ROWS" > "$RUNNER_TEMP/artifact-backfill-execution-results.json"
 
-      - name: Verify fail-closed result contract
-        id: verify
-        if: always() && steps.plan.outcome == 'success'
-        env:
-          MODE: ${{ steps.inputs.outputs.mode }}
-          PLAN_SHA: ${{ steps.plan.outputs.plan_sha }}
-          INVENTORY_SHA: ${{ steps.plan.outputs.inventory_sha }}
-          SELECTED_COUNT: ${{ steps.plan.outputs.selected_count }}
-          CLI_OUTCOME: ${{ steps.artifact-sync.outcome }}
+      - name: Verify exact-only execution evidence
+        id: execution
+        if: steps.inputs.outputs.mode == 'execute' && steps.classification.outcome == 'success'
         run: |
           set -euo pipefail
-          PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
-          RESULT_FILE="$RUNNER_TEMP/artifact-backfill-result.json"
-          SUMMARY_FILE="$RUNNER_TEMP/artifact-backfill-summary.json"
+          node scripts/verify-artifact-version-classification.mjs \
+            --phase execution \
+            --plan "$RUNNER_TEMP/artifact-backfill-plan.json" \
+            --classification "$RUNNER_TEMP/artifact-backfill-classification.json" \
+            --results "$RUNNER_TEMP/artifact-backfill-execution-results.json" \
+            --output "$RUNNER_TEMP/artifact-backfill-execution.json"
 
-          if [ "$SELECTED_COUNT" = "0" ]; then
-            jq -n --arg mode "$MODE" --arg planHash "$PLAN_SHA" --arg inventoryHash "$INVENTORY_SHA" \
-              --slurpfile plan "$PLAN_FILE" \
-              '{schemaVersion: 2, status: "complete", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: []}' \
-              > "$SUMMARY_FILE"
-            exit 0
-          fi
-          if [ "$CLI_OUTCOME" != "success" ] || [ ! -s "$RESULT_FILE" ] || ! jq -e . "$RESULT_FILE" >/dev/null; then
-            echo "::error::one or more artifact-only commit groups failed or produced invalid JSON"
-            exit 1
-          fi
-
-          EXPECTED_MODE="artifact-only"
-          EXPECTED_DRY_RUN=false
-          if [ "$MODE" = "dry-run" ]; then EXPECTED_MODE="dry-run"; EXPECTED_DRY_RUN=true; fi
-          jq -e --slurpfile plan "$PLAN_FILE" --arg mode "$EXPECTED_MODE" \
-            --argjson dryRun "$EXPECTED_DRY_RUN" --argjson selected "$SELECTED_COUNT" '
-              length == ($plan[0].groups | length) and
-              ([.[].marketplaceCommit] == [$plan[0].groups[].marketplaceCommit]) and
-              ([.[].selectedCount] | add) == $selected and
-              ([.[].result.results[].slug] | length == (unique | length)) and
-              all(.[];
-                .exitCode == 0 and .result != null and .result.success == true and
-                .result.artifactOnly == true and .result.dryRun == $dryRun and .result.mode == $mode and
-                .result.errors == 0 and
-                ((.result.synced + .result.skipped) == .selectedCount) and
-                ((.result.results | length) == .selectedCount) and
-                all(.result.results[];
-                  .success == true and
-                  (if $dryRun then
-                    .writeOccurred == false and .artifact.revision == null and
-                    .artifact.created == null and .artifact.changeKind == null
-                  else
-                    ((.skipped == true and .writeOccurred == false) or
-                     (.skipped != true and (.artifact.revision | type) == "number" and
-                      .artifact.revision >= 1 and (.artifact.created | type) == "boolean" and
-                      .writeOccurred == true))
-                  end)
-                )
-              )
-            ' "$RESULT_FILE" >/dev/null || {
-              echo "::error::artifact-only CLI results violated the bounded backfill contract"
-              exit 1
-            }
-
-          jq -n --arg mode "$MODE" --arg planHash "$PLAN_SHA" --arg inventoryHash "$INVENTORY_SHA" \
-            --slurpfile plan "$PLAN_FILE" --slurpfile groups "$RESULT_FILE" \
-            '{schemaVersion: 2, status: "verified", mode: $mode, planHash: $planHash, inventoryHash: $inventoryHash, plan: $plan[0], groups: $groups[0]}' \
-            > "$SUMMARY_FILE"
-
-      - name: Refetch production state after CLI
+      - name: Refetch scoped production state
         id: post-inventory
         if: >-
           always() &&
-          steps.plan.outcome == 'success' &&
-          steps.plan.outputs.selected_count != '0' &&
-          steps.verify.outcome == 'success'
+          steps.classification.outcome == 'success' &&
+          (steps.inputs.outputs.mode == 'dry-run' || steps.execution.outcome == 'success')
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: |
           set -euo pipefail
           node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/artifact-backfill-inventory.json" \
             --output "$RUNNER_TEMP/artifact-backfill-inventory-post.json"
 
-      - name: Verify production state preservation
+      - name: Verify Skill, Pack, artifact, and observation readback
         id: readback
-        if: >-
-          always() &&
-          steps.verify.outcome == 'success' &&
-          steps.post-inventory.outcome == 'success'
+        if: steps.post-inventory.outcome == 'success'
         env:
           MODE: ${{ steps.inputs.outputs.mode }}
         run: |
           set -euo pipefail
-          node scripts/verify-artifact-version-backfill.mjs \
-            --mode "$MODE" \
-            --plan "$RUNNER_TEMP/artifact-backfill-plan.json" \
-            --post-inventory "$RUNNER_TEMP/artifact-backfill-inventory-post.json" \
+          ARGS=(
+            --mode "$MODE"
+            --plan "$RUNNER_TEMP/artifact-backfill-plan.json"
+            --classification "$RUNNER_TEMP/artifact-backfill-classification.json"
+            --pre-inventory "$RUNNER_TEMP/artifact-backfill-inventory.json"
+            --post-inventory "$RUNNER_TEMP/artifact-backfill-inventory-post.json"
             --output "$RUNNER_TEMP/artifact-backfill-readback.json"
+          )
+          if [ "$MODE" = "execute" ]; then
+            ARGS+=(--execution "$RUNNER_TEMP/artifact-backfill-execution.json")
+          fi
+          node scripts/verify-artifact-version-backfill.mjs "${ARGS[@]}"
 
-      - name: Invalidate production artifact and detail caches
+      - name: Invalidate exact cohort caches in batches of ten
         id: cache-invalidate
         if: >-
           steps.inputs.outputs.mode == 'execute' &&
-          steps.plan.outputs.selected_count != '0' &&
-          steps.verify.outcome == 'success' &&
+          steps.classification.outputs.exact_count != '0' &&
           steps.readback.outcome == 'success'
         env:
           CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
         run: |
           set -euo pipefail
           : "${CACHE_INVALIDATE_SECRET:?CACHE_INVALIDATE_SECRET is required for execute mode}"
-          PLAN_FILE="$RUNNER_TEMP/artifact-backfill-plan.json"
           EVIDENCE_DIR="$RUNNER_TEMP/artifact-backfill-cache-invalidation"
           mkdir -p "$EVIDENCE_DIR"
-          mapfile -t SLUGS < <(jq -r '.selected[].slug' "$PLAN_FILE")
+          mapfile -t SLUGS < <(jq -r '.evidence[].slug' "$RUNNER_TEMP/artifact-backfill-execution.json")
 
           for ((OFFSET = 0; OFFSET < ${#SLUGS[@]}; OFFSET += 10)); do
             BATCH=("${SLUGS[@]:OFFSET:10}")
@@ -359,10 +391,10 @@ jobs:
               --output "$RESPONSE_FILE" \
               https://skillstore.io/api/cache/invalidate
 
-            jq -e --argjson expected "${#BATCH[@]}" '
+            jq -e --argjson requested "$BATCH_JSON" '
               .preflight == false and
               .type == "skills" and
-              (.slugs | length) == $expected and
+              .slugs == $requested and
               .invalidated.listVersionBumped == true
             ' "$RESPONSE_FILE" >/dev/null || {
               echo "::error::cache invalidation response violated the production contract"
@@ -372,55 +404,70 @@ jobs:
 
           jq -s . "$EVIDENCE_DIR"/*.json > "$RUNNER_TEMP/artifact-backfill-cache-invalidation.json"
 
-      - name: Publish resumable batch summary
+      - name: Publish bounded cohort summary
         if: always() && steps.plan.outcome == 'success'
         env:
           MODE: ${{ steps.inputs.outputs.mode }}
           CLI_VERSION: ${{ steps.inputs.outputs.cli_version }}
-          PLAN_SHA: ${{ steps.plan.outputs.plan_sha }}
-          INVENTORY_SHA: ${{ steps.plan.outputs.inventory_sha }}
+          START_AFTER: ${{ inputs.start_after }}
+          REQUESTED_END_AT: ${{ inputs.end_at }}
+          LAST_SELECTED: ${{ steps.plan.outputs.last_selected }}
           SELECTED_COUNT: ${{ steps.plan.outputs.selected_count }}
           LEGACY_TOTAL: ${{ steps.plan.outputs.legacy_total }}
-          NEXT_START_AFTER: ${{ steps.plan.outputs.next_start_after }}
-          REMAINING: ${{ steps.plan.outputs.remaining }}
-          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
-          CACHE_OUTCOME: ${{ steps.cache-invalidate.outcome }}
+          UNCLASSIFIED_AFTER: ${{ steps.plan.outputs.unclassified_after }}
+          REMAINING_OUTSIDE: ${{ steps.plan.outputs.remaining_outside }}
+          EXACT_COUNT: ${{ steps.classification.outputs.exact_count }}
+          LEGACY_COUNT: ${{ steps.classification.outputs.legacy_count }}
+          UNPROVEN_COUNT: ${{ steps.classification.outputs.unproven_count }}
+          PLAN_SHA: ${{ steps.plan.outputs.plan_sha }}
+          INVENTORY_SHA: ${{ steps.plan.outputs.inventory_sha }}
+          CLASSIFICATION_OUTCOME: ${{ steps.classification.outcome }}
+          EXECUTION_OUTCOME: ${{ steps.execution.outcome }}
           READBACK_OUTCOME: ${{ steps.readback.outcome }}
+          CACHE_OUTCOME: ${{ steps.cache-invalidate.outcome }}
         run: |
           {
-            echo "## Artifact-version backfill batch"
+            echo "## Bounded artifact-version cohort batch"
             echo ""
             echo "- Mode / CLI: \`$MODE\` / \`$CLI_VERSION\`"
-            echo "- Production legacy rows at plan time: \`$LEGACY_TOTAL\`"
-            echo "- Selected / remaining: \`$SELECTED_COUNT\` / \`$REMAINING\`"
-            echo "- Plan SHA-256: \`$PLAN_SHA\`"
-            echo "- Inventory SHA-256: \`$INVENTORY_SHA\`"
-            echo "- Verification: \`$VERIFY_OUTCOME\`"
-            echo "- Cache invalidation: \`$CACHE_OUTCOME\`"
-            echo "- Production readback: \`$READBACK_OUTCOME\`"
-            if [ "$VERIFY_OUTCOME" = "success" ] && [ "$READBACK_OUTCOME" = "success" ] && \
-               { [ "$MODE" = "dry-run" ] || [ "$CACHE_OUTCOME" = "success" ]; } && \
-               [ -n "$NEXT_START_AFTER" ]; then
-              echo "- Verified resume cursor: \`$NEXT_START_AFTER\`"
+            echo "- Frozen range: after \`${START_AFTER:-<start>}\`, through \`${REQUESTED_END_AT:-$LAST_SELECTED}\`"
+            echo "- Classified / production legacy at plan time: \`$SELECTED_COUNT\` / \`$LEGACY_TOTAL\`"
+            echo "- Cohorts in this batch: exact \`${EXACT_COUNT:-unknown}\`; legacy-equivalent \`${LEGACY_COUNT:-unknown}\`; unproven \`${UNPROVEN_COUNT:-unknown}\`"
+            echo "- Remaining legacy outside this batch: \`$REMAINING_OUTSIDE\`"
+            echo "- Still unclassified after this range: \`$UNCLASSIFIED_AFTER\`"
+            echo "- Plan / inventory SHA-256: \`$PLAN_SHA\` / \`$INVENTORY_SHA\`"
+            echo "- Classification / execution / readback / cache: \`$CLASSIFICATION_OUTCOME\` / \`$EXECUTION_OUTCOME\` / \`$READBACK_OUTCOME\` / \`$CACHE_OUTCOME\`"
+            echo ""
+            if [ "$MODE" = "dry-run" ] && [ "$CLASSIFICATION_OUTCOME" = "success" ]; then
+              echo "Execute must replay this exact range with \`start_after=$START_AFTER\` and \`end_at=$LAST_SELECTED\`."
+              if [ "$UNCLASSIFIED_AFTER" -gt 0 ]; then
+                echo "Next classification may continue with \`start_after=$LAST_SELECTED\`; this is a scan cursor, not a completion claim."
+              fi
             fi
+            echo "No completion cursor is published. Legacy-equivalent and unproven cohorts remain explicit follow-up work."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload immutable plan and execution evidence
+      - name: Upload immutable cohort evidence
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: artifact-version-backfill-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            ${{ runner.temp }}/artifact-backfill-catalog.json
             ${{ runner.temp }}/artifact-backfill-inventory.json
             ${{ runner.temp }}/artifact-backfill-inventory-post.json
             ${{ runner.temp }}/artifact-backfill-plan.json
             ${{ runner.temp }}/artifact-backfill-paths.txt
-            ${{ runner.temp }}/artifact-backfill-result.json
-            ${{ runner.temp }}/artifact-backfill-stderr.log
-            ${{ runner.temp }}/artifact-backfill-summary.json
+            ${{ runner.temp }}/artifact-backfill-classification-results.json
+            ${{ runner.temp }}/artifact-backfill-classification.json
+            ${{ runner.temp }}/artifact-backfill-classification-stderr.log
+            ${{ runner.temp }}/artifact-backfill-classification-groups/
+            ${{ runner.temp }}/artifact-backfill-execution-results.json
+            ${{ runner.temp }}/artifact-backfill-execution.json
+            ${{ runner.temp }}/artifact-backfill-execution-stderr.log
+            ${{ runner.temp }}/artifact-backfill-execution-groups/
             ${{ runner.temp }}/artifact-backfill-readback.json
             ${{ runner.temp }}/artifact-backfill-cache-invalidation.json
             ${{ runner.temp }}/artifact-backfill-cache-invalidation/
-            ${{ runner.temp }}/artifact-backfill-group-results/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact stable skillstore-cli version (X.Y.Z; latest is forbidden)'
         type: string
         required: true
-        default: '2.1.1'
+        default: '2.2.1'
       batch_size:
         description: 'Legacy production Skills to inspect in this batch (1-500)'
         type: number
@@ -62,8 +62,8 @@ jobs:
             echo "::error::cli_version must be an exact stable X.Y.Z release"
             exit 1
           fi
-          if [ "$CLI_VERSION" != "2.1.1" ]; then
-            echo "::error::this workflow is pinned to the audited skillstore-cli 2.1.1"
+          if [ "$CLI_VERSION" != "2.2.1" ]; then
+            echo "::error::this workflow is pinned to the audited skillstore-cli 2.2.1"
             exit 1
           fi
           if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ] || [ "$BATCH_SIZE" -gt 500 ]; then
@@ -334,10 +334,10 @@ jobs:
           mkdir -p "$EVIDENCE_DIR"
           mapfile -t SLUGS < <(jq -r '.selected[].slug' "$PLAN_FILE")
 
-          for ((OFFSET = 0; OFFSET < ${#SLUGS[@]}; OFFSET += 50)); do
-            BATCH=("${SLUGS[@]:OFFSET:50}")
+          for ((OFFSET = 0; OFFSET < ${#SLUGS[@]}; OFFSET += 10)); do
+            BATCH=("${SLUGS[@]:OFFSET:10}")
             BATCH_JSON=$(printf '%s\n' "${BATCH[@]}" | jq -R . | jq -s .)
-            RESPONSE_FILE="$EVIDENCE_DIR/batch-$((OFFSET / 50 + 1)).json"
+            RESPONSE_FILE="$EVIDENCE_DIR/batch-$((OFFSET / 10 + 1)).json"
             jq -n --argjson slugs "$BATCH_JSON" '{
               type: "skills",
               slugs: $slugs,

--- a/scripts/fetch-artifact-version-inventory.mjs
+++ b/scripts/fetch-artifact-version-inventory.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const PAGE_SIZE = 1000;
+const FILTER_CHUNK_SIZE = 100;
 const SELECT = [
+  'id',
   'slug',
   'plugin_path',
   'marketplace_commit_sha',
@@ -15,18 +17,60 @@ const SELECT = [
   'current_artifact_version_id',
   'status',
   'public_eligible',
+  'public_eligibility_audit_id',
   'published_at',
   'updated_at',
+].join(',');
+const ARTIFACT_SELECT = [
+  'id',
+  'skill_id',
+  'artifact_revision',
+  'upstream_version_raw',
+  'upstream_version_normalized',
+  'upstream_version_source',
+  'upstream_version_status',
+  'content_hash',
+  'tree_hash',
+  'upstream_commit_sha',
+  'marketplace_commit_sha',
+  'source_path',
+  'previous_version_id',
+  'change_kind',
+  'observed_at',
+  'created_at',
+  'install_snapshot_hash',
+  'snapshot_status',
+  'readme_template_version',
+  'artifact_builder_version',
+  'hash_provenance',
+].join(',');
+const OBSERVATION_SELECT = [
+  'id',
+  'skill_id',
+  'artifact_version_id',
+  'marketplace_commit_sha',
+  'source_path',
+  'upstream_commit_sha',
+  'observed_at',
+  'created_at',
 ].join(',');
 
 function fail(message) {
   throw new Error(message);
 }
 
-export async function fetchArtifactVersionInventory({ supabaseUrl, serviceKey, fetchImpl = fetch }) {
-  if (!/^https:\/\//.test(supabaseUrl || '')) fail('SUPABASE_URL must be HTTPS');
-  if (!serviceKey) fail('SUPABASE_SERVICE_KEY is required');
+function requestHeaders(serviceKey, range, exactCount = false) {
+  return {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Accept-Profile': 'skillstore',
+    ...(exactCount ? { Prefer: 'count=exact' } : {}),
+    Range: range,
+    'Range-Unit': 'items',
+  };
+}
 
+async function fetchExactSkills({ supabaseUrl, serviceKey, fetchImpl }) {
   const rows = [];
   let expectedTotal = null;
   for (let start = 0; ; start += PAGE_SIZE) {
@@ -34,14 +78,7 @@ export async function fetchArtifactVersionInventory({ supabaseUrl, serviceKey, f
     url.searchParams.set('select', SELECT);
     url.searchParams.set('order', 'slug.asc');
     const response = await fetchImpl(url, {
-      headers: {
-        apikey: serviceKey,
-        Authorization: `Bearer ${serviceKey}`,
-        'Accept-Profile': 'skillstore',
-        Prefer: 'count=exact',
-        Range: `${start}-${start + PAGE_SIZE - 1}`,
-        'Range-Unit': 'items',
-      },
+      headers: requestHeaders(serviceKey, `${start}-${start + PAGE_SIZE - 1}`, true),
     });
     if (!response.ok) fail(`Production inventory request failed: HTTP ${response.status}`);
     const contentRange = response.headers.get('content-range');
@@ -60,16 +97,143 @@ export async function fetchArtifactVersionInventory({ supabaseUrl, serviceKey, f
   if (rows.length !== expectedTotal) {
     fail(`Production inventory count mismatch: expected ${expectedTotal}, received ${rows.length}`);
   }
-  return { schemaVersion: 1, count: rows.length, rows };
+  return rows;
+}
+
+async function fetchScopedRows({
+  supabaseUrl,
+  serviceKey,
+  fetchImpl,
+  table,
+  select,
+  filterColumn,
+  filterValues,
+  order,
+}) {
+  const values = [...new Set(filterValues)].sort();
+  const rows = [];
+  for (let offset = 0; offset < values.length; offset += FILTER_CHUNK_SIZE) {
+    const chunk = values.slice(offset, offset + FILTER_CHUNK_SIZE);
+    for (let start = 0; ; start += PAGE_SIZE) {
+      const url = new URL(`/rest/v1/${table}`, supabaseUrl);
+      url.searchParams.set('select', select);
+      url.searchParams.set(filterColumn, `in.(${chunk.join(',')})`);
+      url.searchParams.set('order', order);
+      const response = await fetchImpl(url, {
+        headers: requestHeaders(serviceKey, `${start}-${start + PAGE_SIZE - 1}`),
+      });
+      if (!response.ok) fail(`Production ${table} request failed: HTTP ${response.status}`);
+      const page = await response.json();
+      if (!Array.isArray(page)) fail(`Production ${table} response is not an array`);
+      rows.push(...page);
+      if (page.length < PAGE_SIZE) break;
+    }
+  }
+  return rows;
+}
+
+export async function fetchArtifactVersionInventory({
+  supabaseUrl,
+  serviceKey,
+  fetchImpl = fetch,
+  scopeInventory = null,
+  skillsOnly = false,
+}) {
+  if (!/^https:\/\//.test(supabaseUrl || '')) fail('SUPABASE_URL must be HTTPS');
+  if (!serviceKey) fail('SUPABASE_SERVICE_KEY is required');
+
+  const rows = await fetchExactSkills({ supabaseUrl, serviceKey, fetchImpl });
+  if (skillsOnly) {
+    return {
+      schemaVersion: 2,
+      count: rows.length,
+      scopedSkillIds: [],
+      rows,
+      packMemberships: [],
+      packs: [],
+      artifacts: [],
+      observations: [],
+    };
+  }
+  const explicitScopeIds = scopeInventory?.scopedSkillIds;
+  const scopedRows = scopeInventory
+    ? (Array.isArray(scopeInventory)
+        ? scopeInventory
+        : scopeInventory?.selected || scopeInventory?.rows)
+    : rows.filter((row) => Number(row.artifact_revision) === 0);
+  if (!Array.isArray(scopedRows)) fail('Scope inventory has no rows or selected array');
+  const skillIds = Array.isArray(explicitScopeIds)
+    ? explicitScopeIds
+    : scopedRows.map((row) => row.id);
+  if (skillIds.some((id) => typeof id !== 'string' || id.length === 0)) {
+    fail('Scope inventory contains a Skill without an id');
+  }
+
+  const packMemberships = await fetchScopedRows({
+    supabaseUrl,
+    serviceKey,
+    fetchImpl,
+    table: 'pack_skills',
+    select: 'skill_id,pack_id',
+    filterColumn: 'skill_id',
+    filterValues: skillIds,
+    order: 'skill_id.asc,pack_id.asc',
+  });
+  const packs = await fetchScopedRows({
+    supabaseUrl,
+    serviceKey,
+    fetchImpl,
+    table: 'packs',
+    select: 'id,slug,published_at,updated_at',
+    filterColumn: 'id',
+    filterValues: packMemberships.map((row) => row.pack_id),
+    order: 'id.asc',
+  });
+  const artifacts = await fetchScopedRows({
+    supabaseUrl,
+    serviceKey,
+    fetchImpl,
+    table: 'skill_artifact_versions',
+    select: ARTIFACT_SELECT,
+    filterColumn: 'skill_id',
+    filterValues: skillIds,
+    order: 'skill_id.asc,artifact_revision.asc',
+  });
+  const observations = await fetchScopedRows({
+    supabaseUrl,
+    serviceKey,
+    fetchImpl,
+    table: 'skill_artifact_observations',
+    select: OBSERVATION_SELECT,
+    filterColumn: 'skill_id',
+    filterValues: skillIds,
+    order: 'skill_id.asc,created_at.asc,id.asc',
+  });
+
+  return {
+    schemaVersion: 2,
+    count: rows.length,
+    scopedSkillIds: [...new Set(skillIds)].sort(),
+    rows,
+    packMemberships,
+    packs,
+    artifacts,
+    observations,
+  };
 }
 
 export async function main(argv = process.argv.slice(2)) {
   const outputIndex = argv.indexOf('--output');
   const output = outputIndex >= 0 ? argv[outputIndex + 1] : null;
   if (!output) fail('--output is required');
+  const scopeIndex = argv.indexOf('--scope-inventory');
+  const scopePath = scopeIndex >= 0 ? argv[scopeIndex + 1] : null;
+  if (scopeIndex >= 0 && !scopePath) fail('--scope-inventory requires a path');
   const inventory = await fetchArtifactVersionInventory({
     supabaseUrl: process.env.SUPABASE_URL,
     serviceKey: process.env.SUPABASE_SERVICE_KEY,
+    scopeInventory: scopePath ? JSON.parse(readFileSync(resolve(scopePath), 'utf8')) : null,
+    skillsOnly: argv.includes('--skills-only'),
   });
   writeFileSync(resolve(output), `${JSON.stringify(inventory, null, 2)}\n`);
   process.stdout.write(`${JSON.stringify({ count: inventory.count })}\n`);

--- a/scripts/fetch-artifact-version-inventory.mjs
+++ b/scripts/fetch-artifact-version-inventory.mjs
@@ -15,6 +15,8 @@ const SELECT = [
   'current_artifact_version_id',
   'status',
   'public_eligible',
+  'published_at',
+  'updated_at',
 ].join(',');
 
 function fail(message) {

--- a/scripts/plan-artifact-version-backfill.mjs
+++ b/scripts/plan-artifact-version-backfill.mjs
@@ -92,6 +92,8 @@ function normalizeInventory(inventory) {
       : String(raw.current_artifact_version_id).trim();
     const status = typeof raw.status === 'string' ? raw.status.trim() : '';
     const publicEligible = raw.public_eligible;
+    const publishedAt = typeof raw.published_at === 'string' ? raw.published_at.trim() : '';
+    const updatedAt = typeof raw.updated_at === 'string' ? raw.updated_at.trim() : '';
     if (!COMMIT_RE.test(marketplaceCommit)) fail(`Invalid production marketplace commit for ${slug}`);
     if (!SHA256_RE.test(contentHash)) fail(`Invalid production content_hash for ${slug}`);
     if (!SHA256_RE.test(treeHash)) fail(`Invalid production tree_hash for ${slug}`);
@@ -100,6 +102,12 @@ function normalizeInventory(inventory) {
     }
     if (!status) fail(`Invalid production status for ${slug}`);
     if (typeof publicEligible !== 'boolean') fail(`Invalid production public_eligible for ${slug}`);
+    if (!publishedAt || !Number.isFinite(Date.parse(publishedAt))) {
+      fail(`Invalid production published_at for ${slug}`);
+    }
+    if (!updatedAt || !Number.isFinite(Date.parse(updatedAt))) {
+      fail(`Invalid production updated_at for ${slug}`);
+    }
     if (artifactRevision === 0 && currentArtifactVersionId !== null) {
       fail(`Legacy production row has a current artifact id for ${slug}`);
     }
@@ -119,6 +127,8 @@ function normalizeInventory(inventory) {
       currentArtifactVersionId,
       status,
       publicEligible,
+      publishedAt,
+      updatedAt,
     };
   }).sort((left, right) => left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0);
 }

--- a/scripts/plan-artifact-version-backfill.mjs
+++ b/scripts/plan-artifact-version-backfill.mjs
@@ -27,7 +27,7 @@ function normalizePath(value, slug) {
     !path.startsWith('skills/') ||
     path.includes('\\') ||
     path.includes('//') ||
-    /[\u0000-\u001f\u007f?#]/.test(path) ||
+    /[\u0000-\u001f\u007f,?#]/.test(path) ||
     path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
   ) {
     fail(`Invalid production plugin_path for ${slug}: ${value ?? '<null>'}`);
@@ -79,9 +79,11 @@ function normalizeInventory(inventory) {
   const seenPaths = new Set();
   return rows.map((raw) => {
     const slug = typeof raw?.slug === 'string' ? raw.slug.trim() : '';
+    const id = raw?.id == null ? '' : String(raw.id).trim();
     if (!slug || /[\u0000-\u001f\u007f,\s]/.test(slug)) fail('Production inventory contains an unsafe slug');
     if (seenSlugs.has(slug)) fail(`Production inventory contains duplicate slug ${slug}`);
     seenSlugs.add(slug);
+    if (!UUID_RE.test(id)) fail(`Invalid production id for ${slug}`);
 
     const marketplaceCommit = String(raw.marketplace_commit_sha ?? '').trim();
     const contentHash = String(raw.content_hash ?? '').trim();
@@ -92,6 +94,9 @@ function normalizeInventory(inventory) {
       : String(raw.current_artifact_version_id).trim();
     const status = typeof raw.status === 'string' ? raw.status.trim() : '';
     const publicEligible = raw.public_eligible;
+    const publicEligibilityAuditId = raw.public_eligibility_audit_id == null
+      ? null
+      : String(raw.public_eligibility_audit_id).trim();
     const publishedAt = typeof raw.published_at === 'string' ? raw.published_at.trim() : '';
     const updatedAt = typeof raw.updated_at === 'string' ? raw.updated_at.trim() : '';
     if (!COMMIT_RE.test(marketplaceCommit)) fail(`Invalid production marketplace commit for ${slug}`);
@@ -102,6 +107,9 @@ function normalizeInventory(inventory) {
     }
     if (!status) fail(`Invalid production status for ${slug}`);
     if (typeof publicEligible !== 'boolean') fail(`Invalid production public_eligible for ${slug}`);
+    if (publicEligibilityAuditId !== null && !UUID_RE.test(publicEligibilityAuditId)) {
+      fail(`Invalid production public_eligibility_audit_id for ${slug}`);
+    }
     if (!publishedAt || !Number.isFinite(Date.parse(publishedAt))) {
       fail(`Invalid production published_at for ${slug}`);
     }
@@ -118,6 +126,7 @@ function normalizeInventory(inventory) {
     if (seenPaths.has(path)) fail(`Production inventory contains duplicate plugin_path ${path}`);
     seenPaths.add(path);
     return {
+      id,
       slug,
       path,
       marketplaceCommit,
@@ -127,6 +136,7 @@ function normalizeInventory(inventory) {
       currentArtifactVersionId,
       status,
       publicEligible,
+      publicEligibilityAuditId,
       publishedAt,
       updatedAt,
     };
@@ -138,6 +148,7 @@ export function buildArtifactBackfillPlan({
   inventory,
   batchSize,
   startAfter = null,
+  endAt = null,
 }) {
   const root = resolve(repositoryRoot);
   const boundedBatchSize = parsePositiveInteger(batchSize, 'batch-size');
@@ -145,50 +156,78 @@ export function buildArtifactBackfillPlan({
 
   const catalog = normalizeInventory(inventory);
   const cursor = String(startAfter ?? '').trim() || null;
-  if (cursor && !catalog.some((row) => row.slug === cursor)) {
+  const rangeEnd = String(endAt ?? '').trim() || null;
+  const cursorIndex = cursor ? catalog.findIndex((row) => row.slug === cursor) : -1;
+  const rangeEndIndex = rangeEnd ? catalog.findIndex((row) => row.slug === rangeEnd) : catalog.length - 1;
+  if (cursor && cursorIndex < 0) {
     fail(`start-after is not an exact production Skill slug: ${cursor}`);
   }
+  if (rangeEnd && rangeEndIndex < 0) {
+    fail(`end-at is not an exact production Skill slug: ${rangeEnd}`);
+  }
+  if (cursor && rangeEnd && rangeEndIndex <= cursorIndex) {
+    fail('end-at must sort after start-after');
+  }
 
-  const eligible = catalog.filter((row) =>
-    row.artifactRevision === 0 && (!cursor || row.slug > cursor)
-  );
+  const indexedLegacy = catalog
+    .map((row, index) => ({ row, index }))
+    .filter(({ row }) => row.artifactRevision === 0);
+  const allLegacy = indexedLegacy.map(({ row }) => row);
+  const eligible = indexedLegacy.filter(({ index }) =>
+    index > cursorIndex && index <= rangeEndIndex
+  ).map(({ row }) => row);
+  if (rangeEnd && eligible.length > boundedBatchSize) {
+    fail(`Pinned slug range contains ${eligible.length} legacy rows; maximum is ${boundedBatchSize}`);
+  }
   const selected = eligible.slice(0, boundedBatchSize);
   for (const row of selected) validatePinnedSnapshot(root, row);
 
-  const groupMap = new Map();
-  for (const row of selected) {
-    if (!groupMap.has(row.marketplaceCommit)) groupMap.set(row.marketplaceCommit, []);
-    groupMap.get(row.marketplaceCommit).push(row);
-  }
-  const groups = [...groupMap.entries()]
-    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-    .map(([marketplaceCommit, rows]) => ({
-      marketplaceCommit,
+  const batches = [];
+  for (let offset = 0; offset < selected.length; offset += boundedBatchSize) {
+    const rows = selected.slice(offset, offset + boundedBatchSize);
+    const groupMap = new Map();
+    for (const row of rows) {
+      if (!groupMap.has(row.marketplaceCommit)) groupMap.set(row.marketplaceCommit, []);
+      groupMap.get(row.marketplaceCommit).push(row);
+    }
+    const groups = [...groupMap.entries()]
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([marketplaceCommit, groupRows]) => ({
+        marketplaceCommit,
+        count: groupRows.length,
+        paths: groupRows.map((row) => row.path),
+        slugs: groupRows.map((row) => row.slug),
+      }));
+    batches.push({
+      index: batches.length + 1,
       count: rows.length,
-      paths: rows.map((row) => row.path),
-      slugs: rows.map((row) => row.slug),
-    }));
+      firstSlug: rows[0].slug,
+      lastSlug: rows.at(-1).slug,
+      groups,
+    });
+  }
 
-  const lastSelected = selected.at(-1)?.slug ?? null;
-  const remainingAfterBatch = Math.max(0, eligible.length - selected.length);
-  const legacyAtOrBeforeCursor = cursor
-    ? catalog.filter((row) => row.artifactRevision === 0 && row.slug <= cursor).length
-    : 0;
+  const selectedEndIndex = selected.length > 0
+    ? catalog.findIndex((row) => row.slug === selected.at(-1).slug)
+    : cursorIndex;
 
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     inventoryCount: catalog.length,
-    totalLegacy: catalog.filter((row) => row.artifactRevision === 0).length,
+    totalLegacy: allLegacy.length,
     batchSize: boundedBatchSize,
     startAfter: cursor,
-    legacyAtOrBeforeCursor,
+    endAt: rangeEnd,
     selectedCount: selected.length,
-    lastSelected,
-    hasMore: remainingAfterBatch > 0,
-    nextStartAfter: remainingAfterBatch > 0 ? lastSelected : null,
-    remainingAfterBatch,
+    lastSelected: selected.at(-1)?.slug ?? null,
+    nextClassificationCursor: selected.at(-1)?.slug ?? null,
+    legacyAtOrBeforeCursor: cursor
+      ? indexedLegacy.filter(({ index }) => index <= cursorIndex).length
+      : 0,
+    remainingLegacyOutsideBatch: allLegacy.length - selected.length,
+    unclassifiedLegacyAfterBatch: indexedLegacy.filter(({ index }) => index > selectedEndIndex).length,
     selected,
-    groups,
+    batches,
   };
 }
 
@@ -216,6 +255,7 @@ export function main(argv = process.argv.slice(2)) {
     inventory,
     batchSize: args['batch-size'],
     startAfter: args['start-after'] || null,
+    endAt: args['end-at'] || null,
   });
   writeFileSync(resolve(args.output), `${JSON.stringify(plan, null, 2)}\n`);
   writeFileSync(
@@ -226,10 +266,12 @@ export function main(argv = process.argv.slice(2)) {
     inventoryCount: plan.inventoryCount,
     totalLegacy: plan.totalLegacy,
     selectedCount: plan.selectedCount,
-    groupCount: plan.groups.length,
-    hasMore: plan.hasMore,
-    nextStartAfter: plan.nextStartAfter,
-    remainingAfterBatch: plan.remainingAfterBatch,
+    lastSelected: plan.lastSelected,
+    nextClassificationCursor: plan.nextClassificationCursor,
+    remainingLegacyOutsideBatch: plan.remainingLegacyOutsideBatch,
+    unclassifiedLegacyAfterBatch: plan.unclassifiedLegacyAfterBatch,
+    batchCount: plan.batches.length,
+    groupCount: plan.batches.reduce((count, batch) => count + batch.groups.length, 0),
   })}\n`);
 }
 

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -48,6 +48,8 @@ function inventoryRow({ slug, path, commit, revision = 0, contentHash = HASH_A, 
     current_artifact_version_id: revision > 0 ? '123e4567-e89b-42d3-a456-426614174000' : null,
     status: 'approved',
     public_eligible: true,
+    published_at: '2026-01-02T03:04:05.000Z',
+    updated_at: '2026-07-14T16:50:53.000Z',
   };
 }
 
@@ -77,6 +79,8 @@ test('plans only production legacy rows from their exact historical commit and p
     assert.equal(plan.selected[0].status, 'approved');
     assert.equal(plan.selected[0].publicEligible, true);
     assert.equal(plan.selected[0].currentArtifactVersionId, null);
+    assert.equal(plan.selected[0].publishedAt, '2026-01-02T03:04:05.000Z');
+    assert.equal(plan.selected[0].updatedAt, '2026-07-14T16:50:53.000Z');
     assert.equal(plan.groups[0].marketplaceCommit, legacyCommit);
     assert.deepEqual(plan.groups[0].paths, ['skills/owner/legacy']);
     assert.equal(plan.selected.some((row) => row.slug === 'repo-only'), false);
@@ -205,6 +209,8 @@ test('readback proves dry-run immutability and execute initialization', () => {
     currentArtifactVersionId: null,
     status: 'approved',
     publicEligible: true,
+    publishedAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-07-14T16:50:53.000Z',
   };
   const unchanged = inventoryRow({ slug: before.slug, path: 'owner/legacy', commit });
   const dryRun = verifyArtifactVersionReadback({
@@ -244,6 +250,8 @@ test('readback fails closed on visibility or immutable identity drift', () => {
     currentArtifactVersionId: null,
     status: 'approved',
     publicEligible: true,
+    publishedAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-07-14T16:50:53.000Z',
   };
   const changed = {
     ...inventoryRow({ slug: before.slug, path: 'owner/legacy', commit }),
@@ -261,6 +269,21 @@ test('readback fails closed on visibility or immutable identity drift', () => {
     plan: { selected: [before] },
     postInventory: { rows: [{ ...changed, public_eligible: true }] },
   }), /Dry-run changed artifact_revision/);
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan: { selected: [before] },
+    postInventory: { rows: [{ ...changed, public_eligible: true, published_at: '2026-07-15T00:00:00.000Z' }] },
+  }), /publishedAt changed/);
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'dry-run',
+    plan: { selected: [before] },
+    postInventory: { rows: [{ ...inventoryRow({ slug: before.slug, path: 'owner/legacy', commit }), published_at: '2026-07-15T00:00:00.000Z' }] },
+  }), /publishedAt changed/);
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan: { selected: [before] },
+    postInventory: { rows: [{ ...changed, public_eligible: true, updated_at: '2026-07-15T00:00:00.000Z' }] },
+  }), /updatedAt changed/);
 });
 
 test('workflow is pinned, evidence-producing, and isolated from normal fan-out', () => {
@@ -273,8 +296,8 @@ test('workflow is pinned, evidence-producing, and isolated from normal fan-out',
     'utf8'
   );
   assert.match(workflow, /cli_version:/);
-  assert.match(workflow, /default: '2\.1\.1'/);
-  assert.match(workflow, /CLI_VERSION" != "2\.1\.1"/);
+  assert.match(workflow, /default: '2\.2\.1'/);
+  assert.match(workflow, /CLI_VERSION" != "2\.2\.1"/);
   assert.match(workflow, /fetch-artifact-version-inventory\.mjs/);
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /git archive/);
@@ -291,6 +314,11 @@ test('workflow is pinned, evidence-producing, and isolated from normal fan-out',
   assert.match(workflow, /verify-artifact-version-backfill\.mjs/);
   assert.match(inventoryFetcher, /current_artifact_version_id/);
   assert.match(inventoryFetcher, /public_eligible/);
+  assert.match(inventoryFetcher, /published_at/);
+  assert.match(inventoryFetcher, /updated_at/);
+  assert.match(workflow, /OFFSET \+= 10/);
+  assert.match(workflow, /OFFSET \/ 10 \+ 1/);
+  assert.doesNotMatch(workflow, /OFFSET \+= 50|OFFSET \/ 50|OFFSET:50/);
   assert.match(workflow, /steps\.inputs\.outputs\.mode == 'execute'/);
   assert.match(workflow, /id: cache-invalidate/);
   assert.match(workflow, /steps\.readback\.outcome == 'success'/);

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -6,11 +6,22 @@ import { join, resolve } from 'node:path';
 import test from 'node:test';
 
 import { fetchArtifactVersionInventory } from '../fetch-artifact-version-inventory.mjs';
-import { buildArtifactBackfillPlan, main } from '../plan-artifact-version-backfill.mjs';
+import { buildArtifactBackfillPlan } from '../plan-artifact-version-backfill.mjs';
+import {
+  classifyArtifactVersionResults,
+  verifyArtifactVersionExecution,
+} from '../verify-artifact-version-classification.mjs';
 import { verifyArtifactVersionReadback } from '../verify-artifact-version-backfill.mjs';
 
 const HASH_A = 'a'.repeat(64);
 const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+const HASH_D = 'd'.repeat(64);
+const SKILL_ID = '00000000-0000-4000-8000-000000000001';
+const AUDIT_ID = '00000000-0000-4000-8000-000000000002';
+const ARTIFACT_ID = '00000000-0000-4000-8000-000000000003';
+const OBSERVATION_ID = '00000000-0000-4000-8000-000000000004';
+const PACK_ID = '00000000-0000-4000-8000-000000000005';
 
 function git(root, ...args) {
   return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
@@ -37,171 +48,313 @@ function createRepository() {
   return { root, addSkill, commit, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
 
-function inventoryRow({ slug, path, commit, revision = 0, contentHash = HASH_A, treeHash = HASH_B }) {
+function uuidFor(index) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+}
+
+function inventoryRow({
+  slug,
+  path,
+  commit,
+  id = SKILL_ID,
+  revision = 0,
+  contentHash = HASH_A,
+  treeHash = HASH_B,
+}) {
   return {
+    id,
     slug,
     plugin_path: `skills/${path}`,
     marketplace_commit_sha: commit,
     content_hash: contentHash,
     tree_hash: treeHash,
     artifact_revision: revision,
-    current_artifact_version_id: revision > 0 ? '123e4567-e89b-42d3-a456-426614174000' : null,
+    current_artifact_version_id: revision > 0 ? ARTIFACT_ID : null,
     status: 'approved',
     public_eligible: true,
+    public_eligibility_audit_id: AUDIT_ID,
     published_at: '2026-01-02T03:04:05.000Z',
     updated_at: '2026-07-14T16:50:53.000Z',
   };
 }
 
-test('plans only production legacy rows from their exact historical commit and path', () => {
+function hashRepair(before, classification) {
+  const exact = classification === 'exact';
+  const legacyEquivalent = classification === 'legacy_algorithm_equivalent';
+  return {
+    requested: true,
+    applied: false,
+    classification,
+    eligibleForExecution: exact,
+    reason: exact
+      ? 'report_matches_canonical_packaged_hashes'
+      : legacyEquivalent
+        ? 'report_matches_complete_legacy_scheme_but_audit_rebinding_is_required'
+        : 'report_hashes_do_not_match_one_complete_known_scheme',
+    contentHashMismatch: !exact,
+    treeHashMismatch: !exact,
+    reportContentHash: before.contentHash,
+    reportContentHashScheme: exact
+      ? 'skill_md_raw_bytes_v1'
+      : legacyEquivalent
+        ? 'skill_md_strip_version_trim_v1'
+        : 'unproven',
+    packagedContentHash: exact ? before.contentHash : HASH_C,
+    packagedContentHashScheme: 'skill_md_raw_bytes_v1',
+    reportTreeHash: before.treeHash,
+    reportTreeHashScheme: exact
+      ? 'canonical_entries_v1'
+      : legacyEquivalent
+        ? 'legacy_path_sha256_merkle_v1'
+        : 'unproven',
+    packagedTreeHash: exact ? before.treeHash : HASH_D,
+    packagedTreeHashScheme: 'canonical_entries_v1',
+    legacyCalculatedContentHash: legacyEquivalent ? before.contentHash : HASH_D,
+    legacyCalculatedContentHashScheme: 'skill_md_strip_version_trim_v1',
+    legacyCalculatedTreeHash: legacyEquivalent ? before.treeHash : HASH_C,
+    legacyCalculatedTreeHashScheme: 'legacy_path_sha256_merkle_v1',
+    observationTimeSource: exact ? 'report_generated_at' : 'backfill_execution_time',
+    observedAt: exact ? '2026-01-01T00:00:00.000Z' : '2026-07-15T00:00:00.000Z',
+  };
+}
+
+function dryRunResult(before, classification) {
+  const repair = hashRepair(before, classification);
+  return {
+    slug: before.slug,
+    skillId: before.id,
+    success: true,
+    blocked: classification !== 'exact',
+    mode: 'dry-run',
+    writeOccurred: false,
+    artifact: {
+      candidateAuthorVersion: '1.0.0',
+      versionStatus: 'valid',
+      contentHash: repair.packagedContentHash,
+      treeHash: repair.packagedTreeHash,
+      marketplaceCommit: before.marketplaceCommit,
+      sourcePath: before.path,
+      upstreamCommit: null,
+      observedAt: repair.observedAt,
+      observationTimeSource: repair.observationTimeSource,
+      currentArtifactVersionId: null,
+      currentRevision: 0,
+      artifactVersionId: null,
+      revision: null,
+      created: null,
+      changeKind: null,
+      skillPublishedAt: before.publishedAt,
+      skillUpdatedAt: before.updatedAt,
+      publicEligible: before.publicEligible,
+      publicEligibilityAuditId: before.publicEligibilityAuditId,
+      hashRepair: repair,
+    },
+  };
+}
+
+function groupWrappers(plan, classificationBySlug) {
+  return plan.batches.flatMap((batch) => batch.groups.map((group) => {
+    const results = group.slugs.map((slug) => {
+      const before = plan.selected.find((row) => row.slug === slug);
+      return dryRunResult(before, classificationBySlug[slug]);
+    });
+    return {
+      batchIndex: batch.index,
+      marketplaceCommit: group.marketplaceCommit,
+      selectedCount: group.count,
+      exitCode: 0,
+      result: {
+        success: true,
+        mode: 'dry-run',
+        dryRun: true,
+        artifactOnly: true,
+        repairStaleReportHashes: true,
+        synced: results.length,
+        skipped: 0,
+        blocked: results.filter((row) => row.blocked).length,
+        errors: 0,
+        slugs: results.map((row) => row.slug),
+        results,
+      },
+    };
+  }));
+}
+
+function executionResult(before) {
+  const row = dryRunResult(before, 'exact');
+  return {
+    ...row,
+    blocked: false,
+    mode: 'artifact-only',
+    writeOccurred: true,
+    artifact: {
+      ...row.artifact,
+      artifactVersionId: ARTIFACT_ID,
+      revision: 1,
+      created: true,
+      changeKind: 'initial',
+    },
+  };
+}
+
+function executionWrappers(plan, classification) {
+  return classification.exactBatches.map((group) => {
+    const results = group.slugs.map((slug) => executionResult(
+      plan.selected.find((row) => row.slug === slug)
+    ));
+    return {
+      batchIndex: group.batchIndex,
+      marketplaceCommit: group.marketplaceCommit,
+      selectedCount: group.count,
+      exitCode: 0,
+      result: {
+        success: true,
+        mode: 'artifact-only',
+        dryRun: false,
+        artifactOnly: true,
+        repairStaleReportHashes: true,
+        synced: results.length,
+        skipped: 0,
+        blocked: 0,
+        errors: 0,
+        slugs: results.map((row) => row.slug),
+        results,
+      },
+    };
+  });
+}
+
+test('plans a bounded legacy batch from pinned historical commits and paths', () => {
   const repository = createRepository();
   try {
-    repository.addSkill('owner/legacy', 'legacy-skill');
-    repository.addSkill('owner/versioned', 'already-versioned');
-    const legacyCommit = repository.commit('legacy snapshot');
-    repository.addSkill('owner/repo-only', 'repo-only');
-    writeFileSync(join(repository.root, 'skills/owner/legacy/SKILL.md'), 'newer unapproved bytes\n');
-    repository.commit('newer repository tree');
-
+    repository.addSkill('a/one', 'alpha');
+    repository.addSkill('b/two', 'beta');
+    repository.addSkill('c/three', 'charlie');
+    const commit = repository.commit('snapshots');
+    const rows = [
+      inventoryRow({ slug: 'alpha', path: 'a/one', commit, id: uuidFor(10) }),
+      inventoryRow({ slug: 'beta', path: 'b/two', commit, id: uuidFor(11) }),
+      inventoryRow({ slug: 'charlie', path: 'c/three', commit, id: uuidFor(12) }),
+    ];
     const plan = buildArtifactBackfillPlan({
       repositoryRoot: repository.root,
-      inventory: { rows: [
-        inventoryRow({ slug: 'legacy-skill', path: 'owner/legacy', commit: legacyCommit }),
-        inventoryRow({ slug: 'already-versioned', path: 'owner/versioned', commit: legacyCommit, revision: 3 }),
-      ] },
-      batchSize: 100,
+      inventory: { rows: [rows[2], rows[0], rows[1]] },
+      batchSize: 2,
     });
-
-    assert.equal(plan.inventoryCount, 2);
-    assert.equal(plan.totalLegacy, 1);
-    assert.deepEqual(plan.selected.map((row) => row.slug), ['legacy-skill']);
-    assert.equal(plan.selected[0].marketplaceCommit, legacyCommit);
-    assert.equal(plan.selected[0].status, 'approved');
-    assert.equal(plan.selected[0].publicEligible, true);
-    assert.equal(plan.selected[0].currentArtifactVersionId, null);
-    assert.equal(plan.selected[0].publishedAt, '2026-01-02T03:04:05.000Z');
-    assert.equal(plan.selected[0].updatedAt, '2026-07-14T16:50:53.000Z');
-    assert.equal(plan.groups[0].marketplaceCommit, legacyCommit);
-    assert.deepEqual(plan.groups[0].paths, ['skills/owner/legacy']);
-    assert.equal(plan.selected.some((row) => row.slug === 'repo-only'), false);
+    assert.equal(plan.totalLegacy, 3);
+    assert.deepEqual(plan.selected.map((row) => row.slug), ['alpha', 'beta']);
+    assert.equal(plan.lastSelected, 'beta');
+    assert.equal(plan.unclassifiedLegacyAfterBatch, 1);
+    assert.equal(plan.batches.length, 1);
+    assert.equal(plan.batches[0].count, 2);
   } finally {
     repository.cleanup();
   }
 });
 
-test('uses stable production slug cursors and groups selected rows by commit', () => {
+test('frozen execute ranges cannot slide forward after exact rows become versioned', () => {
   const repository = createRepository();
   try {
     repository.addSkill('a/one', 'alpha');
-    const firstCommit = repository.commit('alpha');
     repository.addSkill('b/two', 'beta');
     repository.addSkill('c/three', 'charlie');
-    const secondCommit = repository.commit('beta and charlie');
+    const commit = repository.commit('snapshots');
     const rows = [
-      inventoryRow({ slug: 'charlie', path: 'c/three', commit: secondCommit }),
-      inventoryRow({ slug: 'alpha', path: 'a/one', commit: firstCommit, revision: 1 }),
-      inventoryRow({ slug: 'beta', path: 'b/two', commit: secondCommit }),
+      inventoryRow({ slug: 'alpha', path: 'a/one', commit, id: uuidFor(20), revision: 1 }),
+      inventoryRow({ slug: 'beta', path: 'b/two', commit, id: uuidFor(21) }),
+      inventoryRow({ slug: 'charlie', path: 'c/three', commit, id: uuidFor(22) }),
     ];
-
-    const plan = buildArtifactBackfillPlan({
+    const dryRun = buildArtifactBackfillPlan({
       repositoryRoot: repository.root,
       inventory: { rows },
       batchSize: 1,
       startAfter: 'alpha',
     });
-    assert.deepEqual(plan.selected.map((row) => row.slug), ['beta']);
-    assert.equal(plan.nextStartAfter, 'beta');
-    assert.equal(plan.remainingAfterBatch, 1);
+    assert.deepEqual(dryRun.selected.map((row) => row.slug), ['beta']);
 
-    const resumed = buildArtifactBackfillPlan({
+    const afterPartialExecute = rows.map((row) => row.slug === 'beta'
+      ? { ...row, artifact_revision: 1, current_artifact_version_id: ARTIFACT_ID }
+      : row);
+    const replay = buildArtifactBackfillPlan({
+      repositoryRoot: repository.root,
+      inventory: { rows: afterPartialExecute },
+      batchSize: 1,
+      startAfter: 'alpha',
+      endAt: 'beta',
+    });
+    assert.deepEqual(replay.selected, []);
+    assert.equal(replay.selected.some((row) => row.slug === 'charlie'), false);
+  } finally {
+    repository.cleanup();
+  }
+});
+
+test('fails closed on an oversized frozen range or unreproducible report identity', () => {
+  const repository = createRepository();
+  try {
+    repository.addSkill('a/one', 'alpha');
+    repository.addSkill('b/two', 'beta');
+    const commit = repository.commit('snapshots');
+    const rows = [
+      inventoryRow({ slug: 'alpha', path: 'a/one', commit, id: uuidFor(30) }),
+      inventoryRow({ slug: 'beta', path: 'b/two', commit, id: uuidFor(31) }),
+    ];
+    assert.throws(() => buildArtifactBackfillPlan({
       repositoryRoot: repository.root,
       inventory: { rows },
-      batchSize: 10,
-      startAfter: plan.nextStartAfter,
-    });
-    assert.deepEqual(resumed.selected.map((row) => row.slug), ['charlie']);
-    assert.equal(resumed.hasMore, false);
-  } finally {
-    repository.cleanup();
-  }
-});
-
-test('fails closed when production identity cannot be reproduced from Git', () => {
-  const repository = createRepository();
-  try {
-    repository.addSkill('owner/legacy', 'legacy-skill');
-    const commit = repository.commit('legacy snapshot');
+      batchSize: 1,
+      endAt: 'beta',
+    }), /maximum is 1/);
     assert.throws(() => buildArtifactBackfillPlan({
       repositoryRoot: repository.root,
-      inventory: { rows: [inventoryRow({
-        slug: 'legacy-skill',
-        path: 'owner/legacy',
-        commit,
-        treeHash: 'c'.repeat(64),
-      })] },
-      batchSize: 10,
+      inventory: { rows: [{ ...rows[0], tree_hash: HASH_C }] },
+      batchSize: 1,
     }), /tree_hash mismatch/);
-    assert.throws(() => buildArtifactBackfillPlan({
-      repositoryRoot: repository.root,
-      inventory: { rows: [inventoryRow({ slug: 'legacy-skill', path: 'missing/path', commit })] },
-      batchSize: 10,
-    }), /Git evidence check failed/);
   } finally {
     repository.cleanup();
   }
 });
 
-test('writes plan evidence from a production inventory file', () => {
-  const repository = createRepository();
-  try {
-    repository.addSkill('owner/legacy', 'legacy-skill');
-    const commit = repository.commit('legacy snapshot');
-    const inventory = join(repository.root, 'inventory.json');
-    const output = join(repository.root, 'plan.json');
-    const pathsOutput = join(repository.root, 'paths.txt');
-    writeFileSync(inventory, JSON.stringify({ rows: [
-      inventoryRow({ slug: 'legacy-skill', path: 'owner/legacy', commit }),
-    ] }));
-    main([
-      '--repository-root', repository.root,
-      '--inventory', inventory,
-      '--batch-size', '100',
-      '--output', output,
-      '--paths-output', pathsOutput,
-    ]);
-    assert.equal(JSON.parse(readFileSync(output, 'utf8')).selectedCount, 1);
-    assert.equal(readFileSync(pathsOutput, 'utf8'), 'skills/owner/legacy\n');
-  } finally {
-    repository.cleanup();
-  }
-});
-
-test('fetches an exact paginated production inventory without count drift', async () => {
-  const rows = Array.from({ length: 1001 }, (_, index) => ({ slug: `skill-${index}` }));
-  const ranges = [];
+test('fetches exact Skills then bounded Pack and artifact evidence', async () => {
+  const skill = inventoryRow({
+    slug: 'alpha',
+    path: 'a/one',
+    commit: 'a'.repeat(40),
+  });
+  const requestedTables = [];
   const inventory = await fetchArtifactVersionInventory({
     supabaseUrl: 'https://database.example',
     serviceKey: 'secret',
-    fetchImpl: async (_url, options) => {
-      const [startText, endText] = options.headers.Range.split('-');
-      const start = Number(startText);
-      const end = Math.min(Number(endText), rows.length - 1);
-      ranges.push(options.headers.Range);
-      return new Response(JSON.stringify(rows.slice(start, end + 1)), {
-        status: 206,
-        headers: { 'content-range': `${start}-${end}/${rows.length}` },
-      });
+    scopeInventory: { selected: [{ id: skill.id }] },
+    fetchImpl: async (input) => {
+      const url = new URL(input);
+      const table = url.pathname.split('/').at(-1);
+      requestedTables.push(table);
+      if (table === 'skills') {
+        return new Response(JSON.stringify([skill]), {
+          status: 206,
+          headers: { 'content-range': '0-0/1' },
+        });
+      }
+      return new Response('[]', { status: 200 });
     },
   });
-  assert.equal(inventory.count, 1001);
-  assert.deepEqual(ranges, ['0-999', '1000-1999']);
+  assert.equal(inventory.count, 1);
+  assert.deepEqual(inventory.scopedSkillIds, [SKILL_ID]);
+  assert.deepEqual(requestedTables, [
+    'skills',
+    'pack_skills',
+    'skill_artifact_versions',
+    'skill_artifact_observations',
+  ]);
 });
 
-test('readback proves dry-run immutability and execute initialization', () => {
+test('classifies every planned row and derives an exact-only execution cohort', () => {
   const commit = 'a'.repeat(40);
-  const before = {
-    slug: 'legacy-skill',
-    path: 'skills/owner/legacy',
+  const selected = ['alpha', 'beta', 'charlie'].map((slug, index) => ({
+    id: uuidFor(40 + index),
+    slug,
+    path: `skills/owner/${slug}`,
     marketplaceCommit: commit,
     contentHash: HASH_A,
     treeHash: HASH_B,
@@ -209,84 +362,290 @@ test('readback proves dry-run immutability and execute initialization', () => {
     currentArtifactVersionId: null,
     status: 'approved',
     publicEligible: true,
+    publicEligibilityAuditId: AUDIT_ID,
     publishedAt: '2026-01-02T03:04:05.000Z',
     updatedAt: '2026-07-14T16:50:53.000Z',
+  }));
+  const plan = {
+    selected,
+    batches: [{
+      index: 1,
+      groups: [{
+        marketplaceCommit: commit,
+        count: 3,
+        slugs: selected.map((row) => row.slug),
+        paths: selected.map((row) => row.path),
+      }],
+    }],
   };
-  const unchanged = inventoryRow({ slug: before.slug, path: 'owner/legacy', commit });
-  const dryRun = verifyArtifactVersionReadback({
-    mode: 'dry-run',
-    plan: { selected: [before] },
-    postInventory: { rows: [unchanged] },
+  const classification = classifyArtifactVersionResults({
+    plan,
+    groupResults: groupWrappers(plan, {
+      alpha: 'exact',
+      beta: 'legacy_algorithm_equivalent',
+      charlie: 'actual_or_unproven_drift',
+    }),
   });
-  assert.equal(dryRun.verifiedCount, 1);
-
-  const initialized = {
-    ...unchanged,
-    artifact_revision: 1,
-    current_artifact_version_id: '123e4567-e89b-42d3-a456-426614174000',
-  };
-  const execute = verifyArtifactVersionReadback({
-    mode: 'execute',
-    plan: { selected: [before] },
-    postInventory: { rows: [initialized] },
+  assert.deepEqual(classification.counts, {
+    exact: 1,
+    legacy_algorithm_equivalent: 1,
+    actual_or_unproven_drift: 1,
   });
-  assert.equal(execute.evidence[0].after.artifactRevision, 1);
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'execute',
-    plan: { selected: [before] },
-    postInventory: { rows: [{ ...initialized, artifact_revision: 2 }] },
-  }), /unexpected artifact_revision/);
+  assert.deepEqual(classification.exactBatches[0].slugs, ['alpha']);
+  assert.equal(classification.remainingCohorts.total, 2);
 });
 
-test('readback fails closed on visibility or immutable identity drift', () => {
-  const commit = 'a'.repeat(40);
+test('classification rejects operational failures or incomplete evidence', () => {
   const before = {
-    slug: 'legacy-skill',
-    path: 'skills/owner/legacy',
-    marketplaceCommit: commit,
+    id: SKILL_ID,
+    slug: 'alpha',
+    path: 'skills/a/one',
+    marketplaceCommit: 'a'.repeat(40),
     contentHash: HASH_A,
     treeHash: HASH_B,
     artifactRevision: 0,
     currentArtifactVersionId: null,
     status: 'approved',
     publicEligible: true,
+    publicEligibilityAuditId: AUDIT_ID,
     publishedAt: '2026-01-02T03:04:05.000Z',
     updatedAt: '2026-07-14T16:50:53.000Z',
   };
-  const changed = {
-    ...inventoryRow({ slug: before.slug, path: 'owner/legacy', commit }),
-    artifact_revision: 1,
-    current_artifact_version_id: '123e4567-e89b-42d3-a456-426614174000',
-    public_eligible: false,
+  const plan = {
+    selected: [before],
+    batches: [{ index: 1, groups: [{
+      marketplaceCommit: before.marketplaceCommit,
+      count: 1,
+      slugs: [before.slug],
+      paths: [before.path],
+    }] }],
   };
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'execute',
-    plan: { selected: [before] },
-    postInventory: { rows: [changed] },
-  }), /publicEligible changed/);
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'dry-run',
-    plan: { selected: [before] },
-    postInventory: { rows: [{ ...changed, public_eligible: true }] },
-  }), /Dry-run changed artifact_revision/);
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'execute',
-    plan: { selected: [before] },
-    postInventory: { rows: [{ ...changed, public_eligible: true, published_at: '2026-07-15T00:00:00.000Z' }] },
-  }), /publishedAt changed/);
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'dry-run',
-    plan: { selected: [before] },
-    postInventory: { rows: [{ ...inventoryRow({ slug: before.slug, path: 'owner/legacy', commit }), published_at: '2026-07-15T00:00:00.000Z' }] },
-  }), /publishedAt changed/);
-  assert.throws(() => verifyArtifactVersionReadback({
-    mode: 'execute',
-    plan: { selected: [before] },
-    postInventory: { rows: [{ ...changed, public_eligible: true, updated_at: '2026-07-15T00:00:00.000Z' }] },
-  }), /updatedAt changed/);
+  const wrappers = groupWrappers(plan, { alpha: 'exact' });
+  wrappers[0].exitCode = 1;
+  assert.throws(() => classifyArtifactVersionResults({ plan, groupResults: wrappers }), /summary\/exit/);
+  assert.throws(() => classifyArtifactVersionResults({ plan, groupResults: [] }), /group count mismatch/);
+  const wrongSlugs = groupWrappers(plan, { alpha: 'exact' });
+  wrongSlugs[0].result.slugs = ['different'];
+  assert.throws(
+    () => classifyArtifactVersionResults({ plan, groupResults: wrongSlugs }),
+    /top-level slugs/
+  );
 });
 
-test('workflow is pinned, evidence-producing, and isolated from normal fan-out', () => {
+test('execution verifier accepts only the exact cohort', () => {
+  const before = {
+    id: SKILL_ID,
+    slug: 'alpha',
+    path: 'skills/a/one',
+    marketplaceCommit: 'a'.repeat(40),
+    contentHash: HASH_A,
+    treeHash: HASH_B,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+    publicEligibilityAuditId: AUDIT_ID,
+    publishedAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-07-14T16:50:53.000Z',
+  };
+  const plan = {
+    selected: [before],
+    batches: [{ index: 1, groups: [{
+      marketplaceCommit: before.marketplaceCommit,
+      count: 1,
+      slugs: [before.slug],
+      paths: [before.path],
+    }] }],
+  };
+  const classification = classifyArtifactVersionResults({
+    plan,
+    groupResults: groupWrappers(plan, { alpha: 'exact' }),
+  });
+  const execution = verifyArtifactVersionExecution({
+    plan,
+    classification,
+    groupResults: executionWrappers(plan, classification),
+  });
+  assert.equal(execution.executedCount, 1);
+  const invalid = executionWrappers(plan, classification);
+  invalid[0].result.results[0].artifact.hashRepair.classification = 'legacy_algorithm_equivalent';
+  assert.throws(() => verifyArtifactVersionExecution({
+    plan,
+    classification,
+    groupResults: invalid,
+  }), /hash classification/);
+});
+
+function readbackFixture() {
+  const raw = inventoryRow({
+    slug: 'alpha',
+    path: 'a/one',
+    commit: 'a'.repeat(40),
+  });
+  const planned = {
+    id: raw.id,
+    slug: raw.slug,
+    path: raw.plugin_path,
+    marketplaceCommit: raw.marketplace_commit_sha,
+    contentHash: raw.content_hash,
+    treeHash: raw.tree_hash,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: raw.status,
+    publicEligible: raw.public_eligible,
+    publicEligibilityAuditId: raw.public_eligibility_audit_id,
+    publishedAt: raw.published_at,
+    updatedAt: raw.updated_at,
+  };
+  const plan = { selected: [planned] };
+  const packMemberships = [{ skill_id: SKILL_ID, pack_id: PACK_ID }];
+  const packs = [{
+    id: PACK_ID,
+    slug: 'demo-pack',
+    published_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-02-01T00:00:00.000Z',
+  }];
+  const preInventory = {
+    scopedSkillIds: [SKILL_ID],
+    rows: [raw],
+    packMemberships,
+    packs,
+    artifacts: [],
+    observations: [],
+  };
+  return { raw, planned, plan, preInventory };
+}
+
+test('dry-run readback proves Skill, Pack, artifact, and observation immutability', () => {
+  const { planned, plan, preInventory } = readbackFixture();
+  const classification = {
+    classifiedCount: 1,
+    cohorts: {
+      exact: [{ ...planned }],
+      legacy_algorithm_equivalent: [],
+      actual_or_unproven_drift: [],
+    },
+    remainingCohorts: { legacyAlgorithmEquivalent: 0, actualOrUnprovenDrift: 0, total: 0 },
+  };
+  const readback = verifyArtifactVersionReadback({
+    mode: 'dry-run',
+    plan,
+    classification,
+    execution: { evidence: [] },
+    preInventory,
+    postInventory: structuredClone(preInventory),
+  });
+  assert.equal(readback.verifiedCount, 1);
+  const drift = structuredClone(preInventory);
+  drift.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'dry-run', plan, classification, execution: { evidence: [] }, preInventory, postInventory: drift,
+  }), /Dependent Pack timestamps changed/);
+});
+
+test('execute readback proves exact artifact hash provenance and observation identity', () => {
+  const { raw, planned, plan, preInventory } = readbackFixture();
+  const result = executionResult(planned);
+  const classification = {
+    classifiedCount: 1,
+    cohorts: {
+      exact: [{ ...planned }],
+      legacy_algorithm_equivalent: [],
+      actual_or_unproven_drift: [],
+    },
+    remainingCohorts: { legacyAlgorithmEquivalent: 0, actualOrUnprovenDrift: 0, total: 0 },
+  };
+  const repair = result.artifact.hashRepair;
+  const postInventory = {
+    ...structuredClone(preInventory),
+    rows: [{ ...raw, artifact_revision: 1, current_artifact_version_id: ARTIFACT_ID }],
+    artifacts: [{
+      id: ARTIFACT_ID,
+      skill_id: SKILL_ID,
+      artifact_revision: 1,
+      upstream_version_raw: '1.0.0',
+      upstream_version_normalized: '1.0.0',
+      upstream_version_source: 'version',
+      upstream_version_status: 'valid',
+      content_hash: HASH_A,
+      tree_hash: HASH_B,
+      upstream_commit_sha: null,
+      marketplace_commit_sha: planned.marketplaceCommit,
+      source_path: planned.path,
+      previous_version_id: null,
+      change_kind: 'initial',
+      observed_at: result.artifact.observedAt,
+      created_at: '2026-07-15T00:00:01.000Z',
+      install_snapshot_hash: HASH_C,
+      snapshot_status: 'exact',
+      readme_template_version: 3,
+      artifact_builder_version: 1,
+      hash_provenance: {
+        schemaVersion: 1,
+        classification: 'exact',
+        report: {
+          contentHash: repair.reportContentHash,
+          contentHashScheme: repair.reportContentHashScheme,
+          treeHash: repair.reportTreeHash,
+          treeHashScheme: repair.reportTreeHashScheme,
+        },
+        packaged: {
+          contentHash: repair.packagedContentHash,
+          contentHashScheme: repair.packagedContentHashScheme,
+          treeHash: repair.packagedTreeHash,
+          treeHashScheme: repair.packagedTreeHashScheme,
+        },
+        legacyCalculated: {
+          contentHash: repair.legacyCalculatedContentHash,
+          contentHashScheme: repair.legacyCalculatedContentHashScheme,
+          treeHash: repair.legacyCalculatedTreeHash,
+          treeHashScheme: repair.legacyCalculatedTreeHashScheme,
+        },
+        observationTimeSource: repair.observationTimeSource,
+      },
+    }],
+    observations: [{
+      id: OBSERVATION_ID,
+      skill_id: SKILL_ID,
+      artifact_version_id: ARTIFACT_ID,
+      marketplace_commit_sha: planned.marketplaceCommit,
+      source_path: planned.path,
+      upstream_commit_sha: null,
+      observed_at: result.artifact.observedAt,
+      created_at: '2026-07-15T00:00:01.000Z',
+    }],
+  };
+  const readback = verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory,
+  });
+  assert.equal(readback.executedCount, 1);
+  const installIdentityDrift = structuredClone(postInventory);
+  installIdentityDrift.artifacts[0].upstream_version_status = 'missing';
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory: installIdentityDrift,
+  }), /install identity\/hash provenance readback mismatch/);
+  postInventory.artifacts[0].hash_provenance.packaged.treeHash = HASH_D;
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory,
+  }), /install identity\/hash provenance readback mismatch/);
+});
+
+test('workflow is bounded, exact-only, cursor-safe, and evidence-producing', () => {
   const workflow = readFileSync(
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
@@ -295,37 +654,23 @@ test('workflow is pinned, evidence-producing, and isolated from normal fan-out',
     resolve(import.meta.dirname, '../fetch-artifact-version-inventory.mjs'),
     'utf8'
   );
-  assert.match(workflow, /cli_version:/);
-  assert.match(workflow, /default: '2\.2\.1'/);
-  assert.match(workflow, /CLI_VERSION" != "2\.2\.1"/);
-  assert.match(workflow, /fetch-artifact-version-inventory\.mjs/);
-  assert.match(workflow, /fetch-depth: 0/);
-  assert.match(workflow, /git archive/);
-  assert.match(workflow, /--artifact-only/);
-  assert.match(workflow, /--legacy-only/);
-  assert.match(workflow, /actions\/upload-artifact@v6/);
-  assert.match(workflow, /CACHE_INVALIDATE_SECRET: \$\{\{ secrets\.CACHE_INVALIDATE_SECRET \}\}/);
-  assert.match(workflow, /CACHE_INVALIDATE_SECRET:\?CACHE_INVALIDATE_SECRET is required for execute mode/);
-  assert.match(workflow, /jq -r '\.selected\[\]\.slug'/);
-  assert.match(workflow, /https:\/\/skillstore\.io\/api\/cache\/invalidate/);
-  assert.match(workflow, /--fail-with-body/);
-  assert.match(workflow, /artifact-backfill-cache-invalidation\.json/);
-  assert.match(workflow, /artifact-backfill-inventory-post\.json/);
+  assert.match(workflow, /default: '2\.2\.2'/);
+  assert.match(workflow, /CLI_VERSION" != "2\.2\.2"/);
+  assert.match(workflow, /batch_size must be an integer between 1 and 500/);
+  assert.match(workflow, /execute requires the frozen end_at slug/);
+  assert.match(workflow, /--repair-stale-report-hashes/);
+  assert.match(workflow, /--dry-run/);
+  assert.match(workflow, /\.exactBatches\[\]/);
+  assert.match(workflow, /No completion cursor is published/);
+  assert.doesNotMatch(workflow, /legacyAtOrBeforeCursor.*exit|Verified resume cursor|status: "complete"/);
+  assert.match(workflow, /verify-artifact-version-classification\.mjs/);
   assert.match(workflow, /verify-artifact-version-backfill\.mjs/);
-  assert.match(inventoryFetcher, /current_artifact_version_id/);
-  assert.match(inventoryFetcher, /public_eligible/);
-  assert.match(inventoryFetcher, /published_at/);
-  assert.match(inventoryFetcher, /updated_at/);
   assert.match(workflow, /OFFSET \+= 10/);
-  assert.match(workflow, /OFFSET \/ 10 \+ 1/);
+  assert.match(workflow, /\.slugs == \$requested/);
   assert.doesNotMatch(workflow, /OFFSET \+= 50|OFFSET \/ 50|OFFSET:50/);
-  assert.match(workflow, /steps\.inputs\.outputs\.mode == 'execute'/);
-  assert.match(workflow, /id: cache-invalidate/);
-  assert.match(workflow, /steps\.readback\.outcome == 'success'/);
-  assert.ok(
-    workflow.indexOf('id: readback') < workflow.indexOf('id: cache-invalidate'),
-    'production readback must pass before cache invalidation publishes the new projection'
-  );
-  assert.match(workflow, /CACHE_OUTCOME: \$\{\{ steps\.cache-invalidate\.outcome \}\}/);
+  assert.match(workflow, /\.evidence\[\]\.slug/);
+  assert.match(inventoryFetcher, /hash_provenance/);
+  assert.match(inventoryFetcher, /packMemberships/);
+  assert.match(workflow, /actions\/upload-artifact@v6/);
   assert.doesNotMatch(workflow, /calculate-scores|trigger-translate|warm-cache/);
 });

--- a/scripts/verify-artifact-version-backfill.mjs
+++ b/scripts/verify-artifact-version-backfill.mjs
@@ -1,105 +1,252 @@
 #!/usr/bin/env node
 
+import { isDeepStrictEqual } from 'node:util';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+const SHA256_RE = /^[0-9a-f]{64}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function fail(message) {
   throw new Error(message);
 }
 
-function rowsFromInventory(inventory) {
-  const rows = Array.isArray(inventory) ? inventory : inventory?.rows;
-  if (!Array.isArray(rows)) fail('Post-run inventory has no rows array');
-  const bySlug = new Map();
+function rowsByKey(rows, key, label) {
+  if (!Array.isArray(rows)) fail(`${label} is not an array`);
+  const map = new Map();
   for (const row of rows) {
-    if (typeof row?.slug !== 'string' || bySlug.has(row.slug)) {
-      fail(`Post-run inventory contains an invalid or duplicate slug: ${row?.slug ?? '<missing>'}`);
+    const value = row?.[key];
+    if (typeof value !== 'string' || !value || map.has(value)) {
+      fail(`${label} contains an invalid or duplicate ${key}: ${value ?? '<missing>'}`);
     }
-    bySlug.set(row.slug, row);
+    map.set(value, row);
   }
-  return bySlug;
+  return map;
 }
 
-export function verifyArtifactVersionReadback({ mode, plan, postInventory }) {
+function rowsBySkill(rows, label) {
+  if (!Array.isArray(rows)) fail(`${label} is not an array`);
+  const map = new Map();
+  for (const row of rows) {
+    if (typeof row?.skill_id !== 'string' || !row.skill_id) {
+      fail(`${label} contains a row without skill_id`);
+    }
+    if (!map.has(row.skill_id)) map.set(row.skill_id, []);
+    map.get(row.skill_id).push(row);
+  }
+  return map;
+}
+
+function sortedJson(rows) {
+  return [...rows].sort((left, right) => {
+    const a = JSON.stringify(left);
+    const b = JSON.stringify(right);
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+}
+
+function assertSameRows(before, after, label) {
+  if (!isDeepStrictEqual(sortedJson(before), sortedJson(after))) {
+    fail(`${label} changed during the backfill`);
+  }
+}
+
+function expectedHashProvenance(artifact) {
+  const repair = artifact.hashRepair;
+  return {
+    schemaVersion: 1,
+    classification: 'exact',
+    report: {
+      contentHash: repair.reportContentHash,
+      contentHashScheme: repair.reportContentHashScheme,
+      treeHash: repair.reportTreeHash,
+      treeHashScheme: repair.reportTreeHashScheme,
+    },
+    packaged: {
+      contentHash: repair.packagedContentHash,
+      contentHashScheme: repair.packagedContentHashScheme,
+      treeHash: repair.packagedTreeHash,
+      treeHashScheme: repair.packagedTreeHashScheme,
+    },
+    legacyCalculated: {
+      contentHash: repair.legacyCalculatedContentHash,
+      contentHashScheme: repair.legacyCalculatedContentHashScheme,
+      treeHash: repair.legacyCalculatedTreeHash,
+      treeHashScheme: repair.legacyCalculatedTreeHashScheme,
+    },
+    observationTimeSource: repair.observationTimeSource,
+  };
+}
+
+export function verifyArtifactVersionReadback({
+  mode,
+  plan,
+  classification,
+  execution,
+  preInventory,
+  postInventory,
+}) {
   if (mode !== 'dry-run' && mode !== 'execute') fail('mode must be dry-run or execute');
   if (!Array.isArray(plan?.selected)) fail('Plan has no selected rows');
-  const postBySlug = rowsFromInventory(postInventory);
+  if (classification?.classifiedCount !== plan.selected.length) {
+    fail('Classification does not cover the full legacy plan');
+  }
+
+  const expectedScope = plan.selected.map((row) => row.id).sort();
+  if (
+    !isDeepStrictEqual(preInventory?.scopedSkillIds, expectedScope)
+    || !isDeepStrictEqual(postInventory?.scopedSkillIds, expectedScope)
+  ) {
+    fail('Pre/post evidence scope does not match the complete bounded plan');
+  }
+
+  const preSkills = rowsByKey(preInventory?.rows, 'slug', 'pre-run Skills');
+  const postSkills = rowsByKey(postInventory?.rows, 'slug', 'post-run Skills');
+  const preArtifacts = rowsBySkill(preInventory?.artifacts, 'pre-run artifacts');
+  const postArtifacts = rowsBySkill(postInventory?.artifacts, 'post-run artifacts');
+  const preObservations = rowsBySkill(preInventory?.observations, 'pre-run observations');
+  const postObservations = rowsBySkill(postInventory?.observations, 'post-run observations');
+  const exactSlugs = new Set((classification?.cohorts?.exact || []).map((row) => row.slug));
+  const executionBySlug = new Map(
+    (execution?.evidence || []).map((row) => [row.slug, row.result])
+  );
+  if (mode === 'execute' && executionBySlug.size !== exactSlugs.size) {
+    fail('Execution evidence does not cover the complete exact cohort');
+  }
+
+  assertSameRows(
+    preInventory?.packMemberships || [],
+    postInventory?.packMemberships || [],
+    'Dependent Pack membership closure'
+  );
+  assertSameRows(preInventory?.packs || [], postInventory?.packs || [], 'Dependent Pack timestamps');
+
   const evidence = [];
-
-  for (const before of plan.selected) {
-    const after = postBySlug.get(before.slug);
-    if (!after) fail(`Selected Skill disappeared from production: ${before.slug}`);
-
+  for (const planned of plan.selected) {
+    const before = preSkills.get(planned.slug);
+    const after = postSkills.get(planned.slug);
+    if (!before || !after) fail(`Selected Skill disappeared from inventory: ${planned.slug}`);
     const preserved = {
-      status: after.status === before.status,
-      publicEligible: after.public_eligible === before.publicEligible,
-      path: after.plugin_path === before.path,
-      marketplaceCommit: after.marketplace_commit_sha === before.marketplaceCommit,
-      contentHash: after.content_hash === before.contentHash,
-      treeHash: after.tree_hash === before.treeHash,
-      publishedAt: after.published_at === before.publishedAt,
-      updatedAt: after.updated_at === before.updatedAt,
+      id: after.id === before.id && before.id === planned.id,
+      status: after.status === before.status && before.status === planned.status,
+      publicEligible:
+        after.public_eligible === before.public_eligible
+        && before.public_eligible === planned.publicEligible,
+      publicEligibilityAuditId:
+        after.public_eligibility_audit_id === before.public_eligibility_audit_id
+        && before.public_eligibility_audit_id === planned.publicEligibilityAuditId,
+      path: after.plugin_path === before.plugin_path && before.plugin_path === planned.path,
+      marketplaceCommit:
+        after.marketplace_commit_sha === before.marketplace_commit_sha
+        && before.marketplace_commit_sha === planned.marketplaceCommit,
+      contentHash:
+        after.content_hash === before.content_hash && before.content_hash === planned.contentHash,
+      treeHash: after.tree_hash === before.tree_hash && before.tree_hash === planned.treeHash,
+      publishedAt:
+        after.published_at === before.published_at && before.published_at === planned.publishedAt,
+      updatedAt: after.updated_at === before.updated_at && before.updated_at === planned.updatedAt,
     };
     for (const [field, matches] of Object.entries(preserved)) {
-      if (!matches) fail(`Post-run ${field} changed for ${before.slug}`);
+      if (!matches) fail(`Post-run ${field} changed for ${planned.slug}`);
     }
 
-    const afterRevision = Number(after.artifact_revision);
-    const afterCurrentId = after.current_artifact_version_id ?? null;
-    if (mode === 'dry-run') {
-      if (afterRevision !== before.artifactRevision) {
-        fail(`Dry-run changed artifact_revision for ${before.slug}`);
+    const beforeArtifactRows = preArtifacts.get(planned.id) || [];
+    const afterArtifactRows = postArtifacts.get(planned.id) || [];
+    const beforeObservationRows = preObservations.get(planned.id) || [];
+    const afterObservationRows = postObservations.get(planned.id) || [];
+    const shouldExecute = mode === 'execute' && exactSlugs.has(planned.slug);
+    if (!shouldExecute) {
+      if (
+        Number(after.artifact_revision) !== Number(before.artifact_revision)
+        || after.current_artifact_version_id !== before.current_artifact_version_id
+      ) {
+        fail(`Non-executed cohort artifact projection changed for ${planned.slug}`);
       }
-      if (afterCurrentId !== before.currentArtifactVersionId) {
-        fail(`Dry-run changed current_artifact_version_id for ${before.slug}`);
-      }
+      assertSameRows(beforeArtifactRows, afterArtifactRows, `Artifact history for ${planned.slug}`);
+      assertSameRows(beforeObservationRows, afterObservationRows, `Observation history for ${planned.slug}`);
     } else {
-      const expectedRevision = before.artifactRevision + 1;
-      if (!Number.isSafeInteger(afterRevision) || afterRevision !== expectedRevision) {
-        fail(
-          `Execute initialized unexpected artifact_revision for ${before.slug}: ` +
-          `expected ${expectedRevision}, got ${after.artifact_revision}`
-        );
+      if (beforeArtifactRows.length !== 0 || beforeObservationRows.length !== 0) {
+        fail(`Exact legacy row already had artifact history for ${planned.slug}`);
       }
-      if (!UUID_RE.test(String(afterCurrentId ?? ''))) {
-        fail(`Execute did not initialize current_artifact_version_id for ${before.slug}`);
+      const result = executionBySlug.get(planned.slug);
+      const artifactEvidence = result?.artifact;
+      if (!artifactEvidence) fail(`Missing execution artifact evidence for ${planned.slug}`);
+      if (
+        Number(after.artifact_revision) !== 1
+        || after.current_artifact_version_id !== artifactEvidence.artifactVersionId
+        || afterArtifactRows.length !== 1
+        || afterObservationRows.length !== 1
+      ) {
+        fail(`Exact cohort did not initialize one artifact and observation for ${planned.slug}`);
+      }
+      const artifact = afterArtifactRows[0];
+      const observation = afterObservationRows[0];
+      if (
+        artifact.id !== artifactEvidence.artifactVersionId
+        || artifact.skill_id !== planned.id
+        || artifact.artifact_revision !== 1
+        || artifact.upstream_version_normalized !== artifactEvidence.candidateAuthorVersion
+        || artifact.upstream_version_status !== artifactEvidence.versionStatus
+        || artifact.content_hash !== artifactEvidence.contentHash
+        || artifact.tree_hash !== artifactEvidence.treeHash
+        || artifact.marketplace_commit_sha !== planned.marketplaceCommit
+        || artifact.source_path !== planned.path
+        || artifact.upstream_commit_sha !== artifactEvidence.upstreamCommit
+        || artifact.observed_at !== artifactEvidence.observedAt
+        || artifact.previous_version_id !== null
+        || artifact.change_kind !== 'initial'
+        || artifact.snapshot_status !== 'exact'
+        || !SHA256_RE.test(String(artifact.install_snapshot_hash ?? ''))
+        || !Number.isSafeInteger(artifact.readme_template_version)
+        || artifact.readme_template_version < 1
+        || !Number.isSafeInteger(artifact.artifact_builder_version)
+        || artifact.artifact_builder_version < 1
+        || !isDeepStrictEqual(artifact.hash_provenance, expectedHashProvenance(artifactEvidence))
+      ) {
+        fail(`Artifact install identity/hash provenance readback mismatch for ${planned.slug}`);
+      }
+      if (
+        !UUID_RE.test(String(observation.id ?? ''))
+        || observation.skill_id !== planned.id
+        || observation.artifact_version_id !== artifact.id
+        || observation.marketplace_commit_sha !== planned.marketplaceCommit
+        || observation.source_path !== planned.path
+        || observation.upstream_commit_sha !== artifactEvidence.upstreamCommit
+        || observation.observed_at !== artifactEvidence.observedAt
+      ) {
+        fail(`Artifact observation readback mismatch for ${planned.slug}`);
       }
     }
 
     evidence.push({
-      slug: before.slug,
+      slug: planned.slug,
+      cohort: exactSlugs.has(planned.slug)
+        ? 'exact'
+        : classification.cohorts.legacy_algorithm_equivalent.some((row) => row.slug === planned.slug)
+          ? 'legacy_algorithm_equivalent'
+          : 'actual_or_unproven_drift',
+      executed: shouldExecute,
       preserved,
       before: {
-        artifactRevision: before.artifactRevision,
-        currentArtifactVersionId: before.currentArtifactVersionId,
-        status: before.status,
-        publicEligible: before.publicEligible,
-        path: before.path,
-        marketplaceCommit: before.marketplaceCommit,
-        contentHash: before.contentHash,
-        treeHash: before.treeHash,
-        publishedAt: before.publishedAt,
-        updatedAt: before.updatedAt,
+        artifactRevision: Number(before.artifact_revision),
+        currentArtifactVersionId: before.current_artifact_version_id,
       },
       after: {
-        artifactRevision: afterRevision,
-        currentArtifactVersionId: afterCurrentId,
-        status: after.status,
-        publicEligible: after.public_eligible,
-        path: after.plugin_path,
-        marketplaceCommit: after.marketplace_commit_sha,
-        contentHash: after.content_hash,
-        treeHash: after.tree_hash,
-        publishedAt: after.published_at,
-        updatedAt: after.updated_at,
+        artifactRevision: Number(after.artifact_revision),
+        currentArtifactVersionId: after.current_artifact_version_id,
       },
     });
   }
 
-  return { schemaVersion: 1, mode, verifiedCount: evidence.length, evidence };
+  return {
+    schemaVersion: 2,
+    mode,
+    verifiedCount: evidence.length,
+    executedCount: evidence.filter((row) => row.executed).length,
+    remainingCohorts: classification.remainingCohorts,
+    evidence,
+  };
 }
 
 function parseArgs(argv) {
@@ -115,12 +262,19 @@ function parseArgs(argv) {
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-  if (!args.mode || !args.plan || !args['post-inventory'] || !args.output) {
-    fail('--mode, --plan, --post-inventory, and --output are required');
+  const required = ['mode', 'plan', 'classification', 'pre-inventory', 'post-inventory', 'output'];
+  if (required.some((name) => !args[name])) {
+    fail(`Missing required argument; expected ${required.map((name) => `--${name}`).join(', ')}`);
   }
+  if (args.mode === 'execute' && !args.execution) fail('--execution is required in execute mode');
   const result = verifyArtifactVersionReadback({
     mode: args.mode,
     plan: JSON.parse(readFileSync(resolve(args.plan), 'utf8')),
+    classification: JSON.parse(readFileSync(resolve(args.classification), 'utf8')),
+    execution: args.execution
+      ? JSON.parse(readFileSync(resolve(args.execution), 'utf8'))
+      : { evidence: [] },
+    preInventory: JSON.parse(readFileSync(resolve(args['pre-inventory']), 'utf8')),
     postInventory: JSON.parse(readFileSync(resolve(args['post-inventory']), 'utf8')),
   });
   writeFileSync(resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);

--- a/scripts/verify-artifact-version-backfill.mjs
+++ b/scripts/verify-artifact-version-backfill.mjs
@@ -40,6 +40,8 @@ export function verifyArtifactVersionReadback({ mode, plan, postInventory }) {
       marketplaceCommit: after.marketplace_commit_sha === before.marketplaceCommit,
       contentHash: after.content_hash === before.contentHash,
       treeHash: after.tree_hash === before.treeHash,
+      publishedAt: after.published_at === before.publishedAt,
+      updatedAt: after.updated_at === before.updatedAt,
     };
     for (const [field, matches] of Object.entries(preserved)) {
       if (!matches) fail(`Post-run ${field} changed for ${before.slug}`);
@@ -79,6 +81,8 @@ export function verifyArtifactVersionReadback({ mode, plan, postInventory }) {
         marketplaceCommit: before.marketplaceCommit,
         contentHash: before.contentHash,
         treeHash: before.treeHash,
+        publishedAt: before.publishedAt,
+        updatedAt: before.updatedAt,
       },
       after: {
         artifactRevision: afterRevision,
@@ -89,6 +93,8 @@ export function verifyArtifactVersionReadback({ mode, plan, postInventory }) {
         marketplaceCommit: after.marketplace_commit_sha,
         contentHash: after.content_hash,
         treeHash: after.tree_hash,
+        publishedAt: after.published_at,
+        updatedAt: after.updated_at,
       },
     });
   }

--- a/scripts/verify-artifact-version-classification.mjs
+++ b/scripts/verify-artifact-version-classification.mjs
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CLASSIFICATIONS = [
+  'exact',
+  'legacy_algorithm_equivalent',
+  'actual_or_unproven_drift',
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function asMap(rows, key, label) {
+  if (!Array.isArray(rows)) fail(`${label} is not an array`);
+  const map = new Map();
+  for (const row of rows) {
+    const value = row?.[key];
+    if (typeof value !== 'string' || !value || map.has(value)) {
+      fail(`${label} contains an invalid or duplicate ${key}: ${value ?? '<missing>'}`);
+    }
+    map.set(value, row);
+  }
+  return map;
+}
+
+function expectedGroups(plan, allowedSlugs = null) {
+  if (!Array.isArray(plan?.batches) || !Array.isArray(plan?.selected)) {
+    fail('Plan lacks batches or selected rows');
+  }
+  const groups = [];
+  for (const batch of plan.batches) {
+    for (const group of batch.groups || []) {
+      const slugs = allowedSlugs
+        ? group.slugs.filter((slug) => allowedSlugs.has(slug))
+        : [...group.slugs];
+      if (slugs.length > 0) {
+        groups.push({
+          batchIndex: batch.index,
+          marketplaceCommit: group.marketplaceCommit,
+          slugs,
+        });
+      }
+    }
+  }
+  return groups;
+}
+
+function validateWrapperShape(wrapper, expected, phase) {
+  if (wrapper?.batchIndex !== expected.batchIndex) {
+    fail(`${phase} batch index mismatch for ${expected.marketplaceCommit}`);
+  }
+  if (wrapper?.marketplaceCommit !== expected.marketplaceCommit) {
+    fail(`${phase} marketplace commit order mismatch`);
+  }
+  if (wrapper?.selectedCount !== expected.slugs.length) {
+    fail(`${phase} selected count mismatch for ${expected.marketplaceCommit}`);
+  }
+  if (!Number.isSafeInteger(wrapper?.exitCode) || wrapper.exitCode < 0) {
+    fail(`${phase} has an invalid CLI exit code`);
+  }
+  const result = wrapper.result;
+  if (!result || typeof result !== 'object' || !Array.isArray(result.results)) {
+    fail(`${phase} CLI output is missing valid JSON results`);
+  }
+  if (
+    result.artifactOnly !== true
+    || result.repairStaleReportHashes !== true
+    || result.dryRun !== (phase === 'classification')
+    || result.mode !== (phase === 'classification' ? 'dry-run' : 'artifact-only')
+  ) {
+    fail(`${phase} CLI mode contract mismatch for ${expected.marketplaceCommit}`);
+  }
+  if (result.results.length !== expected.slugs.length) {
+    fail(`${phase} result count mismatch for ${expected.marketplaceCommit}`);
+  }
+  if (
+    !Array.isArray(result.slugs)
+    || result.slugs.length !== expected.slugs.length
+    || result.slugs.some((slug, index) => slug !== expected.slugs[index])
+  ) {
+    fail(`${phase} top-level slugs do not match the pinned plan`);
+  }
+  const bySlug = asMap(result.results, 'slug', `${phase} results`);
+  if (
+    bySlug.size !== expected.slugs.length
+    || expected.slugs.some((slug) => !bySlug.has(slug))
+  ) {
+    fail(`${phase} result slugs do not match the pinned plan`);
+  }
+  return { result, bySlug };
+}
+
+function validateHashEvidence(artifact, before, expectedClassification) {
+  const repair = artifact?.hashRepair;
+  if (!repair || typeof repair !== 'object') fail(`Missing hash evidence for ${before.slug}`);
+  if (
+    repair.requested !== true
+    || repair.applied !== false
+    || repair.classification !== expectedClassification
+    || repair.eligibleForExecution !== (expectedClassification === 'exact')
+  ) {
+    fail(`Invalid hash classification contract for ${before.slug}`);
+  }
+  const hashes = [
+    repair.reportContentHash,
+    repair.packagedContentHash,
+    repair.reportTreeHash,
+    repair.packagedTreeHash,
+    repair.legacyCalculatedContentHash,
+    repair.legacyCalculatedTreeHash,
+  ];
+  if (hashes.some((value) => !SHA256_RE.test(String(value ?? '')))) {
+    fail(`Invalid hash evidence for ${before.slug}`);
+  }
+  if (
+    repair.reportContentHash !== before.contentHash
+    || repair.reportTreeHash !== before.treeHash
+    || repair.packagedContentHash !== artifact.contentHash
+    || repair.packagedTreeHash !== artifact.treeHash
+    || artifact.observedAt !== repair.observedAt
+    || artifact.observationTimeSource !== repair.observationTimeSource
+  ) {
+    fail(`Hash/provenance evidence does not match the pinned identity for ${before.slug}`);
+  }
+  for (const field of [
+    'reportContentHashScheme',
+    'packagedContentHashScheme',
+    'reportTreeHashScheme',
+    'packagedTreeHashScheme',
+    'legacyCalculatedContentHashScheme',
+    'legacyCalculatedTreeHashScheme',
+    'observationTimeSource',
+  ]) {
+    if (typeof repair[field] !== 'string' || repair[field].length === 0) {
+      fail(`Missing ${field} evidence for ${before.slug}`);
+    }
+  }
+  if (!Number.isFinite(Date.parse(repair.observedAt))) {
+    fail(`Invalid observation time for ${before.slug}`);
+  }
+
+  const contentMismatch = repair.reportContentHash !== repair.packagedContentHash;
+  const treeMismatch = repair.reportTreeHash !== repair.packagedTreeHash;
+  const canonicalMatch = !contentMismatch && !treeMismatch;
+  const legacyMatch =
+    repair.reportContentHash === repair.legacyCalculatedContentHash
+    && repair.reportTreeHash === repair.legacyCalculatedTreeHash;
+  if (
+    repair.contentHashMismatch !== contentMismatch
+    || repair.treeHashMismatch !== treeMismatch
+    || repair.packagedContentHashScheme !== 'skill_md_raw_bytes_v1'
+    || repair.packagedTreeHashScheme !== 'canonical_entries_v1'
+    || repair.legacyCalculatedContentHashScheme !== 'skill_md_strip_version_trim_v1'
+    || repair.legacyCalculatedTreeHashScheme !== 'legacy_path_sha256_merkle_v1'
+  ) {
+    fail(`Hash algorithm evidence is internally inconsistent for ${before.slug}`);
+  }
+
+  const classificationEvidence = {
+    exact: {
+      reason: 'report_matches_canonical_packaged_hashes',
+      contentScheme: 'skill_md_raw_bytes_v1',
+      treeScheme: 'canonical_entries_v1',
+      matches: canonicalMatch,
+    },
+    legacy_algorithm_equivalent: {
+      reason: 'report_matches_complete_legacy_scheme_but_audit_rebinding_is_required',
+      contentScheme: 'skill_md_strip_version_trim_v1',
+      treeScheme: 'legacy_path_sha256_merkle_v1',
+      matches: !canonicalMatch && legacyMatch,
+    },
+    actual_or_unproven_drift: {
+      reason: 'report_hashes_do_not_match_one_complete_known_scheme',
+      contentScheme: 'unproven',
+      treeScheme: 'unproven',
+      matches: !canonicalMatch && !legacyMatch,
+    },
+  }[expectedClassification];
+  if (
+    repair.reason !== classificationEvidence.reason
+    || repair.reportContentHashScheme !== classificationEvidence.contentScheme
+    || repair.reportTreeHashScheme !== classificationEvidence.treeScheme
+    || classificationEvidence.matches !== true
+  ) {
+    fail(`Hash classification is not independently proven for ${before.slug}`);
+  }
+}
+
+function validatePinnedArtifact(artifact, before) {
+  if (
+    artifact?.marketplaceCommit !== before.marketplaceCommit
+    || artifact?.sourcePath !== before.path
+    || !SHA256_RE.test(String(artifact?.contentHash ?? ''))
+    || !SHA256_RE.test(String(artifact?.treeHash ?? ''))
+  ) {
+    fail(`Artifact identity does not match the pinned plan for ${before.slug}`);
+  }
+}
+
+export function classifyArtifactVersionResults({ plan, groupResults }) {
+  const selectedBySlug = asMap(plan?.selected, 'slug', 'plan selected rows');
+  const expected = expectedGroups(plan);
+  if (!Array.isArray(groupResults) || groupResults.length !== expected.length) {
+    fail(`Classification group count mismatch: expected ${expected.length}, got ${groupResults?.length ?? '<invalid>'}`);
+  }
+
+  const cohortRows = Object.fromEntries(CLASSIFICATIONS.map((name) => [name, []]));
+  for (let index = 0; index < expected.length; index += 1) {
+    const expectedGroup = expected[index];
+    const wrapper = groupResults[index];
+    const { result, bySlug } = validateWrapperShape(wrapper, expectedGroup, 'classification');
+    let groupSynced = 0;
+    let groupBlocked = 0;
+
+    for (const slug of expectedGroup.slugs) {
+      const before = selectedBySlug.get(slug);
+      const row = bySlug.get(slug);
+      const artifact = row.artifact;
+      const classification = artifact?.hashRepair?.classification;
+      if (!CLASSIFICATIONS.includes(classification)) {
+        fail(`Missing supported classification for ${slug}`);
+      }
+      validatePinnedArtifact(artifact, before);
+      validateHashEvidence(artifact, before, classification);
+      if (
+        row.mode !== 'dry-run'
+        || row.writeOccurred !== false
+        || row.skipped === true
+        || artifact.artifactVersionId !== null
+        || artifact.revision !== null
+        || artifact.created !== null
+        || artifact.changeKind !== null
+      ) {
+        fail(`Classification attempted or reported a write for ${slug}`);
+      }
+
+      groupSynced += 1;
+      if (classification !== 'exact') groupBlocked += 1;
+      if (
+        row.success !== true
+        || row.blocked !== (classification !== 'exact')
+        || row.skillId !== before.id
+        || row.error !== undefined
+        || artifact.currentArtifactVersionId !== null
+        || artifact.currentRevision !== 0
+        || artifact.skillPublishedAt !== before.publishedAt
+        || artifact.skillUpdatedAt !== before.updatedAt
+        || artifact.publicEligible !== before.publicEligible
+        || artifact.publicEligibilityAuditId !== before.publicEligibilityAuditId
+      ) {
+        fail(`Dry-run database projection evidence mismatch for ${slug}`);
+      }
+      cohortRows[classification].push({ ...before, evidence: row });
+    }
+
+    if (
+      result.synced !== groupSynced
+      || result.skipped !== 0
+      || result.blocked !== groupBlocked
+      || result.errors !== 0
+      || result.success !== true
+      || wrapper.exitCode !== 0
+    ) {
+      fail(`Classification summary/exit contract mismatch for ${expectedGroup.marketplaceCommit}`);
+    }
+  }
+
+  const classifiedCount = CLASSIFICATIONS.reduce(
+    (count, name) => count + cohortRows[name].length,
+    0
+  );
+  if (classifiedCount !== selectedBySlug.size) {
+    fail(`Classification coverage mismatch: expected ${selectedBySlug.size}, got ${classifiedCount}`);
+  }
+  const exactSlugs = new Set(cohortRows.exact.map((row) => row.slug));
+  const exactBatches = expectedGroups(plan, exactSlugs).map((group) => ({
+    ...group,
+    count: group.slugs.length,
+    paths: group.slugs.map((slug) => selectedBySlug.get(slug).path),
+  }));
+  const counts = Object.fromEntries(CLASSIFICATIONS.map((name) => [name, cohortRows[name].length]));
+
+  return {
+    schemaVersion: 1,
+    status: 'classified',
+    classifiedCount,
+    counts,
+    executionEligibleCount: counts.exact,
+    remainingCohorts: {
+      legacyAlgorithmEquivalent: counts.legacy_algorithm_equivalent,
+      actualOrUnprovenDrift: counts.actual_or_unproven_drift,
+      total: counts.legacy_algorithm_equivalent + counts.actual_or_unproven_drift,
+    },
+    cohorts: cohortRows,
+    exactBatches,
+  };
+}
+
+export function verifyArtifactVersionExecution({ plan, classification, groupResults }) {
+  const selectedBySlug = asMap(plan?.selected, 'slug', 'plan selected rows');
+  const exactRows = classification?.cohorts?.exact;
+  const exactBySlug = asMap(exactRows, 'slug', 'exact cohort');
+  const expected = expectedGroups(plan, new Set(exactBySlug.keys()));
+  if (!Array.isArray(groupResults) || groupResults.length !== expected.length) {
+    fail(`Execution group count mismatch: expected ${expected.length}, got ${groupResults?.length ?? '<invalid>'}`);
+  }
+
+  const evidence = [];
+  for (let index = 0; index < expected.length; index += 1) {
+    const expectedGroup = expected[index];
+    const wrapper = groupResults[index];
+    const { result, bySlug } = validateWrapperShape(wrapper, expectedGroup, 'execution');
+    for (const slug of expectedGroup.slugs) {
+      if (!exactBySlug.has(slug)) fail(`Execution attempted a non-exact cohort row: ${slug}`);
+      const before = selectedBySlug.get(slug);
+      const row = bySlug.get(slug);
+      const artifact = row.artifact;
+      validatePinnedArtifact(artifact, before);
+      validateHashEvidence(artifact, before, 'exact');
+      if (
+        row.success !== true
+        || row.skipped === true
+        || row.skillId !== before.id
+        || row.mode !== 'artifact-only'
+        || row.writeOccurred !== true
+        || row.error !== undefined
+        || artifact.currentArtifactVersionId !== null
+        || artifact.currentRevision !== 0
+        || !UUID_RE.test(String(artifact.artifactVersionId ?? ''))
+        || artifact.revision !== 1
+        || artifact.created !== true
+        || artifact.changeKind !== 'initial'
+        || artifact.skillPublishedAt !== before.publishedAt
+        || artifact.skillUpdatedAt !== before.updatedAt
+        || artifact.publicEligible !== before.publicEligible
+        || artifact.publicEligibilityAuditId !== before.publicEligibilityAuditId
+      ) {
+        fail(`Exact cohort execution contract mismatch for ${slug}`);
+      }
+      evidence.push({ slug, before, result: row });
+    }
+    if (
+      wrapper.exitCode !== 0
+      || result.success !== true
+      || result.synced !== expectedGroup.slugs.length
+      || result.skipped !== 0
+      || result.blocked !== 0
+      || result.errors !== 0
+    ) {
+      fail(`Execution summary/exit contract mismatch for ${expectedGroup.marketplaceCommit}`);
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    status: 'executed',
+    executedCount: evidence.length,
+    remainingCohorts: classification.remainingCohorts,
+    evidence,
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) fail(`Invalid argument: ${key ?? '<missing>'}`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (!args.phase || !args.plan || !args.results || !args.output) {
+    fail('--phase, --plan, --results, and --output are required');
+  }
+  const plan = JSON.parse(readFileSync(resolve(args.plan), 'utf8'));
+  const groupResults = JSON.parse(readFileSync(resolve(args.results), 'utf8'));
+  let output;
+  if (args.phase === 'classification') {
+    output = classifyArtifactVersionResults({ plan, groupResults });
+  } else if (args.phase === 'execution') {
+    if (!args.classification) fail('--classification is required for execution verification');
+    output = verifyArtifactVersionExecution({
+      plan,
+      classification: JSON.parse(readFileSync(resolve(args.classification), 'utf8')),
+      groupResults,
+    });
+  } else {
+    fail('--phase must be classification or execution');
+  }
+  writeFileSync(resolve(args.output), `${JSON.stringify(output, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ phase: args.phase, status: output.status })}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`artifact backfill ${process.argv.includes('execution') ? 'execution' : 'classification'} verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- pin the administrative backfill workflow to corrective `skillstore-cli 2.2.2`
- cap every dispatch at 500 legacy Skills and freeze execution to the dry-run `start_after` / `end_at` range
- classify every selected Skill as `exact`, `legacy_algorithm_equivalent`, or `actual_or_unproven_drift`
- execute only derived `exactBatches`; non-exact rows remain no-write follow-up cohorts and never produce a completion claim
- invalidate only executed exact Skills, serially in batches of 10

## Fail-closed evidence
- independently prove canonical and legacy hash classifications instead of trusting the label alone
- preserve and read back Skill `published_at`, `updated_at`, visibility, and public eligibility audit pointer
- preserve dependent Pack membership and timestamps
- verify the inserted artifact revision, install identity, immutable `hash_provenance`, and linked observation
- upload catalog, plan, raw CLI outputs, classification, execution, readback, stderr, and cache responses for each run

## Validation
- `CI=true node --check` for all four backfill scripts
- `CI=true node --test scripts/tests/artifact-version-backfill.test.mjs` — 10/10 passed before and after rebase
- Ruby YAML parse passed
- `git diff --check origin/main...HEAD` passed
- rebased onto `origin/main` at `fa47385ca`

## Release gate
Do not dispatch or merge this workflow until Skillstore PR #219 is merged, its migration is applied, and `skillstore-cli 2.2.2` is published and verified. This PR does not merge, dispatch, or write production data.