### PR TITLE
feat(security): refresh research stats after source writes

### DIFF
--- a/.github/workflows/refresh-security-research-stats.yml
+++ b/.github/workflows/refresh-security-research-stats.yml
@@ -1,0 +1,31 @@
+name: Refresh Security Research Snapshot (Stale Only)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '43 */6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-security-research-stats
+  cancel-in-progress: false
+
+jobs:
+  refresh-if-stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout research refresh helper
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/refresh-security-research-stats.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Refresh only when the published snapshot is stale
+        env:
+          SKILLSTORE_API_URL: https://skillstore.io
+          SECURITY_RESEARCH_AUTOMATION_KEY: ${{ secrets.SECURITY_RESEARCH_AUTOMATION_KEY }}
+        run: ./scripts/refresh-security-research-stats.sh --stale-only

--- a/.github/workflows/sync-audit-compute.yml
+++ b/.github/workflows/sync-audit-compute.yml
@@ -24,7 +24,15 @@ jobs:
       LEGACY_TOKENS: '1308077250'
       LEGACY_COST_USD: '2568.41704016099988706'
     steps:
+      - name: Checkout research refresh helper
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/refresh-security-research-stats.sh
+          sparse-checkout-cone-mode: false
+
       - name: Sync audit compute snapshot
+        id: sync-compute
         run: |
           set -euo pipefail
 
@@ -111,3 +119,21 @@ jobs:
             echo "- Public total: \`$total_tokens\` tokens / \`$total_cost\` USD"
             echo "- RPC response: \`$response\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Refresh security research snapshot
+        id: security-research-refresh
+        continue-on-error: true
+        env:
+          SKILLSTORE_API_URL: https://skillstore.io
+          SECURITY_RESEARCH_AUTOMATION_KEY: ${{ secrets.SECURITY_RESEARCH_AUTOMATION_KEY }}
+        run: ./scripts/refresh-security-research-stats.sh
+
+      - name: Report security research refresh failure
+        if: steps.sync-compute.outcome == 'success' && steps.security-research-refresh.outcome == 'failure'
+        run: |
+          echo "::warning::Audit compute snapshot sync succeeded, but the security research snapshot refresh failed"
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Security Research Refresh Warning
+
+          The audit-compute snapshot remains committed. The dedicated refresh endpoint failed after bounded retries; the stale-only safety-net workflow will retry without replaying the compute sync.
+          EOF

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -597,6 +597,25 @@ jobs:
         run: |
           echo "::notice::Sync completed - Mode: ${{ steps.changes.outputs.mode }}, Skills: ${{ steps.changes.outputs.changed_skills }}"
 
+      - name: Refresh security research snapshot
+        id: security-research-refresh
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
+        continue-on-error: true
+        env:
+          SKILLSTORE_API_URL: https://skillstore.io
+          SECURITY_RESEARCH_AUTOMATION_KEY: ${{ secrets.SECURITY_RESEARCH_AUTOMATION_KEY }}
+        run: ./scripts/refresh-security-research-stats.sh
+
+      - name: Report security research refresh failure
+        if: steps.security-research-refresh.outcome == 'failure'
+        run: |
+          echo "::warning::Skill sync succeeded, but the security research snapshot refresh failed"
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Security Research Refresh Warning
+
+          The Skill sync remains committed. The dedicated refresh endpoint failed after bounded retries; the stale-only safety-net workflow will retry without replaying the core sync.
+          EOF
+
       - name: Save synced slugs to artifact
         id: synced-plan
         if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -9,7 +9,10 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
+      - ".github/workflows/refresh-security-research-stats.yml"
+      - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
       - ".github/workflows/test-recalculate-scores.yml"
   push:
@@ -20,7 +23,10 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
+      - ".github/workflows/refresh-security-research-stats.yml"
+      - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
   workflow_dispatch:
 
@@ -50,10 +56,11 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
           bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
+          bash -n scripts/refresh-security-research-stats.sh
           bash -n scripts/tests/fake-cli.sh
           node --check scripts/detect-changed-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs

--- a/scripts/refresh-security-research-stats.sh
+++ b/scripts/refresh-security-research-stats.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stale_only=false
+if [[ "${1:-}" == "--stale-only" ]]; then
+  stale_only=true
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "Usage: $0 [--stale-only]" >&2
+  exit 2
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "::error::Security research refresh requires $1"
+    exit 1
+  fi
+}
+
+require_command curl
+require_command python3
+
+if [[ -z "${SKILLSTORE_API_URL:-}" ]]; then
+  echo "::error::SKILLSTORE_API_URL is required for the security research refresh"
+  exit 1
+fi
+if [[ -z "${SECURITY_RESEARCH_AUTOMATION_KEY:-}" ]]; then
+  echo "::error::SECURITY_RESEARCH_AUTOMATION_KEY is required for the security research refresh"
+  exit 1
+fi
+if [[ "$SECURITY_RESEARCH_AUTOMATION_KEY" == *$'\n'* || "$SECURITY_RESEARCH_AUTOMATION_KEY" == *$'\r'* ]]; then
+  echo "::error::SECURITY_RESEARCH_AUTOMATION_KEY must be a single-line value"
+  exit 1
+fi
+
+site_url="${SKILLSTORE_API_URL%/}"
+public_url="$site_url/api/security/research-stats"
+refresh_url="$site_url/api/automation/security/research-stats/refresh"
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+append_summary() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+json_field() {
+  local file="$1"
+  local path="$2"
+  python3 - "$file" "$path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)
+for part in sys.argv[2].split("."):
+    if not isinstance(value, dict) or part not in value:
+        raise SystemExit(f"missing JSON field: {sys.argv[2]}")
+    value = value[part]
+if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+    raise SystemExit(f"invalid JSON field: {sys.argv[2]}")
+print(value)
+PY
+}
+
+safe_error_message() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        payload = json.load(handle)
+    message = payload.get("error") if isinstance(payload, dict) else None
+except Exception:
+    message = None
+message = "request failed" if not isinstance(message, str) else message
+print(" ".join(message.split())[:300])
+PY
+}
+
+if [[ "$stale_only" == "true" ]]; then
+  set +e
+  probe_status="$(
+    curl --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 30 \
+      --output "$response_file" \
+      --write-out '%{http_code}' \
+      "$public_url"
+  )"
+  probe_rc=$?
+  set -e
+
+  if [[ "$probe_rc" -ne 0 || "$probe_status" != "200" ]]; then
+    echo "::error::Security research stale probe failed (curl=$probe_rc, http=${probe_status:-000})"
+    append_summary "- ❌ Stale probe failed; no refresh was attempted."
+    exit 1
+  fi
+
+  if ! snapshot_state="$(json_field "$response_file" snapshot_state 2>/dev/null)"; then
+    echo "::error::Security research stale probe returned an invalid response"
+    append_summary "- ❌ Stale probe returned an invalid response; no refresh was attempted."
+    exit 1
+  fi
+
+  case "$snapshot_state" in
+    current)
+      echo "::notice::Security research snapshot is current; stale-only refresh skipped"
+      append_summary "- ✅ Snapshot is current; stale-only refresh skipped."
+      exit 0
+      ;;
+    stale)
+      echo "::notice::Security research snapshot is stale; starting bounded refresh"
+      ;;
+    *)
+      echo "::error::Security research stale probe returned unexpected state: $snapshot_state"
+      append_summary "- ❌ Unexpected snapshot state; no refresh was attempted."
+      exit 1
+      ;;
+  esac
+fi
+
+for attempt in 1 2 3; do
+  : > "$response_file"
+  set +e
+  refresh_status="$(
+    printf 'Authorization: Bearer %s\n' "$SECURITY_RESEARCH_AUTOMATION_KEY" \
+      | curl --silent --show-error \
+        --header @- \
+        --header 'Accept: application/json' \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --request POST \
+        --output "$response_file" \
+        --write-out '%{http_code}' \
+        "$refresh_url"
+  )"
+  refresh_rc=$?
+  set -e
+
+  if [[ "$refresh_rc" -eq 0 && "$refresh_status" == "200" ]]; then
+    if ! snapshot_state="$(json_field "$response_file" data.snapshot_state 2>/dev/null)" \
+      || [[ "$snapshot_state" != "current" ]]; then
+      echo "::error::Security research refresh returned HTTP 200 without a current snapshot"
+      append_summary "- ❌ Refresh returned an invalid success response."
+      exit 1
+    fi
+
+    captured_at="$(json_field "$response_file" data.captured_at 2>/dev/null || echo unknown)"
+    source_version="$(json_field "$response_file" data.source.version 2>/dev/null || echo unknown)"
+    echo "::notice::Security research snapshot refreshed (captured_at=$captured_at, source_version=$source_version)"
+    append_summary "- ✅ Snapshot refreshed: captured_at=\`$captured_at\`, source_version=\`$source_version\`."
+    exit 0
+  fi
+
+  message="$(safe_error_message "$response_file")"
+  echo "::warning::Security research refresh failed (attempt=$attempt/3, curl=$refresh_rc, http=${refresh_status:-000}, error=$message)"
+
+  if [[ "$attempt" -lt 3 ]] && {
+    [[ "$refresh_rc" -ne 0 ]] || [[ "$refresh_status" =~ ^(429|500|502|503|504)$ ]];
+  }; then
+    sleep $((attempt * 5))
+    continue
+  fi
+  break
+done
+
+echo "::error::Security research snapshot refresh did not complete; the source write remains committed and the safety-net workflow can retry"
+append_summary "- ⚠️ Source write succeeded, but the research snapshot refresh failed after bounded retries."
+exit 1

--- a/scripts/tests/security-research-refresh-workflows.test.mjs
+++ b/scripts/tests/security-research-refresh-workflows.test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = process.cwd();
+const syncWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/sync-to-supabase.yml'),
+  'utf8',
+);
+const computeWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/sync-audit-compute.yml'),
+  'utf8',
+);
+const safetyWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/refresh-security-research-stats.yml'),
+  'utf8',
+);
+const testWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/test-recalculate-scores.yml'),
+  'utf8',
+);
+const refreshScript = resolve(repoRoot, 'scripts/refresh-security-research-stats.sh');
+const refreshScriptSource = readFileSync(refreshScript, 'utf8');
+
+function section(source, start, end) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing section: ${start}`);
+  const endIndex = end ? source.indexOf(end, startIndex + start.length) : source.length;
+  assert.notEqual(endIndex, -1, `missing section boundary: ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function assertDedicatedRefreshContract(source) {
+  assert.match(
+    source,
+    /SECURITY_RESEARCH_AUTOMATION_KEY: \$\{\{ secrets\.SECURITY_RESEARCH_AUTOMATION_KEY \}\}/,
+  );
+  assert.doesNotMatch(source, /SECURITY_ATTESTATION_AUTOMATION_KEY|SKILLSTORE_CALLBACK_TOKEN/);
+  assert.match(source, /run: \.\/scripts\/refresh-security-research-stats\.sh/);
+}
+
+test('Skill sync refreshes after every successful audit write without rolling back the sync', () => {
+  const refresh = section(
+    syncWorkflow,
+    '      - name: Refresh security research snapshot',
+    '      - name: Save synced slugs to artifact',
+  );
+
+  assert.ok(
+    syncWorkflow.indexOf('      - name: Remove generated report evidence from synced audits')
+      < syncWorkflow.indexOf('      - name: Refresh security research snapshot'),
+    'research refresh must run after the final audit mutation in the sync job',
+  );
+  assert.match(
+    refresh,
+    /if: steps\.changes\.outputs\.skip_sync != 'true' && steps\.sync\.outputs\.synced_count != '0'/,
+  );
+  assert.match(refresh, /continue-on-error: true/);
+  assertDedicatedRefreshContract(refresh);
+  assert.match(refresh, /Skill sync succeeded, but the security research snapshot refresh failed/);
+  assert.match(refresh, /stale-only safety-net workflow will retry/);
+});
+
+test('audit compute writer refreshes only after its RPC succeeds and keeps that write committed', () => {
+  const refresh = section(
+    computeWorkflow,
+    '      - name: Refresh security research snapshot',
+  );
+
+  assert.ok(
+    computeWorkflow.indexOf('record_audit_compute_snapshot')
+      < computeWorkflow.indexOf('      - name: Refresh security research snapshot'),
+    'research refresh must follow the cumulative snapshot RPC',
+  );
+  assert.match(computeWorkflow, /id: sync-compute/);
+  assert.match(refresh, /continue-on-error: true/);
+  assertDedicatedRefreshContract(refresh);
+  assert.match(
+    refresh,
+    /if: steps\.sync-compute\.outcome == 'success' && steps\.security-research-refresh\.outcome == 'failure'/,
+  );
+  assert.match(refresh, /audit-compute snapshot remains committed/);
+});
+
+test('the low-frequency safety net probes first and refreshes stale snapshots only', () => {
+  assert.match(safetyWorkflow, /cron: '43 \*\/6 \* \* \*'/);
+  assert.match(safetyWorkflow, /timeout-minutes: 10/);
+  assertDedicatedRefreshContract(safetyWorkflow);
+  assert.match(
+    safetyWorkflow,
+    /run: \.\/scripts\/refresh-security-research-stats\.sh --stale-only/,
+  );
+  assert.doesNotMatch(safetyWorkflow, /continue-on-error: true/);
+
+  assert.ok(
+    refreshScriptSource.indexOf('"$public_url"')
+      < refreshScriptSource.indexOf('"$refresh_url"'),
+    'stale-only mode must probe the public snapshot before calling the private refresh endpoint',
+  );
+  assert.match(
+    refreshScriptSource,
+    /current\)[\s\S]*stale-only refresh skipped[\s\S]*exit 0[\s\S]*stale\)/,
+  );
+  assert.match(refreshScriptSource, /data\.snapshot_state/);
+  assert.match(refreshScriptSource, /snapshot_state" != "current"/);
+});
+
+test('refresh helper keeps the dedicated secret out of curl argv and bounds retries', () => {
+  assert.match(refreshScriptSource, /printf 'Authorization: Bearer %s\\n'/);
+  assert.match(refreshScriptSource, /--header @-/);
+  assert.doesNotMatch(refreshScriptSource, /--header ['"]Authorization: Bearer \$SECURITY_RESEARCH_AUTOMATION_KEY/);
+  assert.doesNotMatch(
+    refreshScriptSource,
+    /SECURITY_ATTESTATION_AUTOMATION_KEY|AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN/,
+  );
+  assert.match(refreshScriptSource, /for attempt in 1 2 3/);
+  assert.match(refreshScriptSource, /\^\(429\|500\|502\|503\|504\)\$/);
+  assert.match(refreshScriptSource, /--max-time 120/);
+});
+
+test('CI tracks and syntax-checks every refresh contract input', () => {
+  for (const path of [
+    'scripts/refresh-security-research-stats.sh',
+    '.github/workflows/refresh-security-research-stats.yml',
+    '.github/workflows/sync-audit-compute.yml',
+    '.github/workflows/sync-to-supabase.yml',
+  ]) {
+    assert.match(testWorkflow, new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(testWorkflow, /bash -n scripts\/refresh-security-research-stats\.sh/);
+  assert.match(testWorkflow, /node --test scripts\/tests\/\*\.test\.mjs/);
+});
+
+function installFakeCurl(probeState) {
+  const root = mkdtempSync(join(tmpdir(), 'security-research-refresh-'));
+  const bin = join(root, 'bin');
+  const mkdir = spawnSync('mkdir', ['-p', bin]);
+  assert.equal(mkdir.status, 0, mkdir.stderr?.toString());
+  const log = join(root, 'curl.log');
+  const fakeCurl = join(bin, 'curl');
+  writeFileSync(fakeCurl, `#!/usr/bin/env bash
+set -euo pipefail
+method=GET
+output=''
+read_header=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --request) method="$2"; shift 2 ;;
+    --output) output="$2"; shift 2 ;;
+    --header)
+      [[ "$2" == '@-' ]] && read_header=true
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+if [[ "$read_header" == true ]]; then
+  IFS= read -r authorization
+  [[ "$authorization" == 'Authorization: Bearer test-research-secret' ]]
+fi
+echo "$method" >> '${log}'
+if [[ "$method" == GET ]]; then
+  printf '%s' '{"snapshot_state":"${probeState}"}' > "$output"
+else
+  printf '%s' '{"data":{"snapshot_state":"current","captured_at":"2026-07-15T00:00:00Z","source":{"version":"0123456789abcdef0123456789abcdef"}}}' > "$output"
+fi
+printf '200'
+`);
+  chmodSync(fakeCurl, 0o755);
+  return { root, bin, log };
+}
+
+function runStaleOnly(probeState) {
+  const fixture = installFakeCurl(probeState);
+  const summary = join(fixture.root, 'summary.md');
+  const result = spawnSync(refreshScript, ['--stale-only'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env.PATH}`,
+      GITHUB_STEP_SUMMARY: summary,
+      SECURITY_RESEARCH_AUTOMATION_KEY: 'test-research-secret',
+      SKILLSTORE_API_URL: 'https://skillstore.example',
+    },
+  });
+  return {
+    ...result,
+    calls: readFileSync(fixture.log, 'utf8').trim().split(/\r?\n/),
+    summary: readFileSync(summary, 'utf8'),
+  };
+}
+
+test('stale-only runtime skips current snapshots without sending the credential', () => {
+  const result = runStaleOnly('current');
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.deepEqual(result.calls, ['GET']);
+  assert.match(result.stdout, /stale-only refresh skipped/);
+  assert.match(result.summary, /Snapshot is current/);
+});
+
+test('stale-only runtime performs one authenticated POST for a stale snapshot', () => {
+  const result = runStaleOnly('stale');
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.deepEqual(result.calls, ['GET', 'POST']);
+  assert.match(result.stdout, /snapshot refreshed/);
+  assert.match(result.summary, /source_version=`0123456789abcdef0123456789abcdef`/);
+});


### PR DESCRIPTION
## Summary

- call the dedicated Skillstore research-refresh endpoint after successful Skill/audit sync writes and after the cumulative audit-compute RPC
- keep both hooks best-effort but observable: bounded retries, strict `snapshot_state == current` validation, GitHub warnings, and step summaries without rolling back committed source writes
- add a six-hour stale-only safety net that probes the public snapshot and sends no authenticated POST while the snapshot is current
- use only `SECURITY_RESEARCH_AUTOMATION_KEY`; no general, callback, or attestation credential fallback

## Dependency

- requires the private endpoint from `aiskillstore/skillstore#211` to be deployed
- requires the Marketplace Actions secret `SECURITY_RESEARCH_AUTOMATION_KEY` to match the dedicated Cloudflare secret

## Verification

- `bash -n scripts/refresh-security-research-stats.sh`
- `CI=true node --test scripts/tests/security-attestation-issuance-workflow.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/security-research-refresh-workflows.test.mjs` — 14 passed
- `git diff --check`

Draft until the Skillstore endpoint and dedicated secrets are live.