### PR TITLE
fix(sync): detect changed skills from pinned Git trees

### DIFF
--- a/.github/workflows/audit-skills.yml
+++ b/.github/workflows/audit-skills.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: '4'
       cli_version:
-        description: 'CLI version (default: latest)'
+        description: 'CLI version (minimum and default: 2.2.1)'
         type: string
-        default: 'latest'
+        default: '2.2.1'
       dry_run:
         description: 'Preview changes without creating PR'
         type: boolean
@@ -49,7 +49,7 @@ on:
         default: ''
 
 env:
-  CLI_VERSION: ${{ inputs.cli_version || 'latest' }}
+  CLI_VERSION: ${{ inputs.cli_version || '2.2.1' }}
   SHARD_THRESHOLD: 50
 
 concurrency:
@@ -292,9 +292,10 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./marketplace-repo/.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version || 'latest' }}
+          version: ${{ inputs.cli_version || '2.2.1' }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+          minimum-version: '2.2.1'
 
       - name: Audit shard ${{ matrix.shard }}
         id: audit

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -158,22 +158,6 @@ jobs:
           NODE
           }
           
-          # Get skill slug from a changed file path
-          # Supports both flat (skills/name/) and namespaced (skills/owner/name/)
-          get_skill_slug() {
-            local path="$1"
-            local first=$(echo "$path" | cut -d'/' -f1)
-            local first_two=$(echo "$path" | cut -d'/' -f1,2)
-            
-            # Check if first segment is a published skill (flat structure)
-            if [ -f "skills/$first/skill-report.json" ]; then
-              echo "$first"
-            # Check if first two segments are a published skill (namespaced: owner/name)
-            elif [ -f "skills/$first_two/skill-report.json" ]; then
-              echo "$first_two"
-            fi
-          }
-          
           if [ -n "${{ inputs.slugs }}" ]; then
             echo "Specific slugs requested: ${{ inputs.slugs }}"
             CHANGED=$(resolve_manual_skills "${{ inputs.slugs }}")
@@ -184,17 +168,14 @@ jobs:
             CHANGED=$(find_all_skills | tr '\n' ' ')
             echo "mode=full" >> $GITHUB_OUTPUT
           else
-            # Get changed paths since last successful sync and extract skill slugs
-            # IMPORTANT: Use explicit HEAD to compare commits, not working directory
-            # On self-hosted runners, working directory may have stale files
-            CHANGED=$(git diff "$BASE_SHA" HEAD --name-only 2>/dev/null | \
-              grep '^skills/' | \
-              sed 's|^skills/||' | \
-              while read -r path; do
-                get_skill_slug "$path"
-              done | sort -u | tr '\n' ' ')
+            # Resolve both the diff and the published-skill inventory from pinned
+            # Git trees. A self-hosted runner checkout may be sparse or mutable;
+            # it must never turn a real commit diff into an empty sync plan.
+            CHANGED=$(node ./scripts/detect-changed-skills.mjs \
+              --base "$BASE_SHA" \
+              --head "${{ github.sha }}")
             echo "mode=incremental" >> $GITHUB_OUTPUT
-            echo "Diff range: $BASE_SHA..HEAD"
+            echo "Diff range: $BASE_SHA..${{ github.sha }}"
           fi
           
           echo "changed_skills=$CHANGED" >> $GITHUB_OUTPUT
@@ -225,9 +206,10 @@ jobs:
         if: steps.changes.outputs.skip_sync != 'true'
         uses: ./.github/actions/download-skillstore-cli
         with:
+          version: '2.2.1'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: '2.2.0'
+          minimum-version: '2.2.1'
 
       - name: Sync skills to Supabase
         id: sync

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "scripts/check-cache-invalidation-aggregate.sh"
+      - "scripts/detect-changed-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -15,6 +16,7 @@ on:
     branches: [main]
     paths:
       - "scripts/check-cache-invalidation-aggregate.sh"
+      - "scripts/detect-changed-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -48,10 +50,11 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/tests/fake-cli.sh
           bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
           bash -n scripts/tests/fake-cli.sh
+          node --check scripts/detect-changed-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs
           node --test scripts/tests/*.test.mjs

--- a/scripts/detect-changed-skills.mjs
+++ b/scripts/detect-changed-skills.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { posix } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function readOption(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+    throw new Error(`missing required option ${name}`);
+  }
+  return args[index + 1];
+}
+
+function gitPaths(repositoryRoot, args) {
+  const output = execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'buffer',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return output.toString('utf8').split('\0').filter(Boolean);
+}
+
+export function resolveChangedSkillPaths(changedPaths, reportPaths) {
+  const published = new Set(
+    reportPaths.flatMap((reportPath) => {
+      if (!reportPath.startsWith('skills/') || posix.basename(reportPath) !== 'skill-report.json') {
+        return [];
+      }
+      const directory = posix.dirname(reportPath).slice('skills/'.length);
+      return directory && directory !== '.' ? [directory] : [];
+    }),
+  );
+  const changedSkills = new Set();
+
+  for (const changedPath of changedPaths) {
+    if (!changedPath.startsWith('skills/')) continue;
+
+    let directory = posix.dirname(changedPath.slice('skills/'.length));
+    while (directory && directory !== '.') {
+      if (published.has(directory)) {
+        changedSkills.add(directory);
+        break;
+      }
+      const parent = posix.dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
+  }
+
+  return [...changedSkills].sort();
+}
+
+export function detectChangedSkillPathsFromGit({ repositoryRoot = '.', base, head }) {
+  const changedPaths = gitPaths(repositoryRoot, [
+    'diff',
+    '--name-only',
+    '-z',
+    base,
+    head,
+    '--',
+    'skills',
+  ]);
+  const headPaths = gitPaths(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '--name-only',
+    '-z',
+    head,
+    '--',
+    'skills',
+  ]);
+
+  return resolveChangedSkillPaths(changedPaths, headPaths);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const base = readOption(args, '--base');
+  const head = readOption(args, '--head');
+  const changedSkills = detectChangedSkillPathsFromGit({ base, head });
+  process.stdout.write(`${changedSkills.join(' ')}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`::error::Incremental skill detection failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/audit-workflow.test.mjs
+++ b/scripts/tests/audit-workflow.test.mjs
@@ -8,6 +8,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const AUDIT_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'audit-skills.yml');
 
+test('audit workflow requires the canonical-hash CLI release', () => {
+	const workflow = readFileSync(AUDIT_WORKFLOW, 'utf8');
+
+	assert.match(workflow, /cli_version:[\s\S]*default: '2\.2\.1'/);
+	assert.match(workflow, /CLI_VERSION: \$\{\{ inputs\.cli_version \|\| '2\.2\.1' \}\}/);
+	assert.match(workflow, /version: \$\{\{ inputs\.cli_version \|\| '2\.2\.1' \}\}/);
+	assert.match(workflow, /minimum-version: '2\.2\.1'/);
+});
+
 test('audit workflow wires risk-level filtering from dispatch input to CLI shards', () => {
 	const workflow = readFileSync(AUDIT_WORKFLOW, 'utf8');
 

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -95,6 +95,24 @@ test('workflow treats an empty sync as a no-op before planning or invalidation',
   assert.match(workflow, /No skills to sync[\s\S]*skip_sync=true/);
 });
 
+test('incremental detection resolves both sides from pinned Git trees', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const detectJob = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+
+  assert.match(detectJob, /node \.\/scripts\/detect-changed-skills\.mjs/);
+  assert.match(detectJob, /--base "\$BASE_SHA"/);
+  assert.match(detectJob, /--head "\$\{\{ github\.sha \}\}"/);
+  assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
+});
+
+test('sync downloads the canonical-hash CLI release', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const download = section(workflow, '      - name: Download skillstore-cli', '      - name: Sync skills to Supabase');
+
+  assert.match(download, /version: '2\.2\.1'/);
+  assert.match(download, /minimum-version: '2\.2\.1'/);
+});
+
 test('one permanently failed shard makes the aggregate fail closed', () => {
   const success = runAggregate();
   assert.equal(success.status, 0, success.stderr);
@@ -110,8 +128,10 @@ test('CI tracks and executes the planner, aggregate guard, and full script suite
   const workflow = readFileSync(TEST_WORKFLOW, 'utf8');
 
   assert.match(workflow, /scripts\/plan-cache-invalidation\.mjs/);
+  assert.match(workflow, /scripts\/detect-changed-skills\.mjs/);
   assert.match(workflow, /scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --check scripts\/plan-cache-invalidation\.mjs/);
+  assert.match(workflow, /node --check scripts\/detect-changed-skills\.mjs/);
   assert.match(workflow, /bash -n scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --test scripts\/tests\/\*\.test\.mjs/);
 });

--- a/scripts/tests/detect-changed-skills.test.mjs
+++ b/scripts/tests/detect-changed-skills.test.mjs
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  detectChangedSkillPathsFromGit,
+  resolveChangedSkillPaths,
+} from '../detect-changed-skills.mjs';
+
+function git(repositoryRoot, args) {
+  return execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+}
+
+function write(repositoryRoot, relativePath, contents) {
+  const fullPath = join(repositoryRoot, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+test('resolves changed files to the closest published skill at arbitrary depth', () => {
+  assert.deepEqual(
+    resolveChangedSkillPaths(
+      [
+        'skills/flat/SKILL.md',
+        'skills/owner/nested/reference.md',
+        'skills/owner/nested/examples/demo/SKILL.md',
+        'skills/owner/other/skill-report.json',
+        'README.md',
+      ],
+      [
+        'skills/flat/skill-report.json',
+        'skills/owner/nested/skill-report.json',
+        'skills/owner/other/skill-report.json',
+      ],
+    ),
+    ['flat', 'owner/nested', 'owner/other'],
+  );
+});
+
+test('uses pinned commit trees instead of the mutable runner working tree', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'changed-skills-git-'));
+  try {
+    git(repositoryRoot, ['init', '--initial-branch=main']);
+    git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+    git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+
+    write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo\n');
+    write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":1}\n');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'base']);
+    const base = git(repositoryRoot, ['rev-parse', 'HEAD']);
+
+    write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":2}\n');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'audit report']);
+    const head = git(repositoryRoot, ['rev-parse', 'HEAD']);
+
+    rmSync(join(repositoryRoot, 'skills/owner/demo/skill-report.json'));
+
+    assert.deepEqual(
+      detectChangedSkillPathsFromGit({ repositoryRoot, base, head }),
+      ['owner/demo'],
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/security-attestation-issuance-workflow.test.mjs
+++ b/scripts/tests/security-attestation-issuance-workflow.test.mjs
@@ -9,7 +9,8 @@ const workflow = readFileSync(
 );
 
 test('sync uses an attestation-capable CLI and a dedicated issuance credential', () => {
-  assert.match(workflow, /minimum-version: '2\.2\.0'/);
+  assert.match(workflow, /version: '2\.2\.1'/);
+  assert.match(workflow, /minimum-version: '2\.2\.1'/);
   assert.match(
     workflow,
     /SECURITY_PASSPORT_MODE: \$\{\{ vars\.SECURITY_PASSPORT_MODE \|\| 'off' \}\}/,


### PR DESCRIPTION
## Summary

- resolve incremental diffs and published-skill inventory from pinned Git commit trees
- remove mutable working-tree file checks from incremental detection
- support flat, namespaced, and deeper published skill paths
- require released CLI 2.2.1 for audit and sync so regenerated reports use the canonical hash contract
- add detector, workflow, and CLI download contract tests

## Incident proof

For base 0e9e4aa690ac48fc59adb2d8bedc45d8a466b4a8 and head 3442662bf481a1532537bbcc59413b1bd711403a, the new detector returns exactly the five canary paths that run 29355615180 incorrectly treated as an empty set.

The integration regression deletes skill-report.json from the mutable working tree after committing it, then proves detection still resolves the changed Skill from the pinned Git objects.

## Verification

- CI=true node --test scripts/tests/detect-changed-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/audit-workflow.test.mjs
- CI=true node --test scripts/tests/detect-changed-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/audit-workflow.test.mjs scripts/tests/recalculate-scores.test.mjs
- node --check scripts/detect-changed-skills.mjs
- exact incident-range detector assertion: five expected paths
- cli-v2.2.1 release and Linux asset verified published
- git diff --check

A local all-script run passed 114 of 116 tests; two unrelated invalidate-cache harness cases failed on macOS. The focused 32-test contract set covering this change passed.