### PR TITLE
fix(sync): materialize changed skills from pinned tree

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -211,6 +211,16 @@ jobs:
           cache-dir: /home/runner/_work/_cache/skillstore-cli
           minimum-version: '2.2.1'
 
+      - name: Materialize changed skills
+        if: steps.changes.outputs.skip_sync != 'true'
+        env:
+          CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
+        run: |
+          set -euo pipefail
+          node ./scripts/materialize-changed-skills.mjs \
+            --commit "$GITHUB_SHA" \
+            --skills "$CHANGED_SKILLS"
+
       - name: Sync skills to Supabase
         id: sync
         if: steps.changes.outputs.skip_sync != 'true'

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
+      - "scripts/materialize-changed-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -20,6 +21,7 @@ on:
     paths:
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
+      - "scripts/materialize-changed-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -56,12 +58,13 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/materialize-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
           bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
           bash -n scripts/refresh-security-research-stats.sh
           bash -n scripts/tests/fake-cli.sh
           node --check scripts/detect-changed-skills.mjs
+          node --check scripts/materialize-changed-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs
           node --test scripts/tests/*.test.mjs

--- a/scripts/materialize-changed-skills.mjs
+++ b/scripts/materialize-changed-skills.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync, rmSync } from 'node:fs';
+import { posix, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+
+function readOption(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+    throw new Error(`missing required option ${name}`);
+  }
+  return args[index + 1];
+}
+
+function git(repositoryRoot, args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: options.encoding ?? 'buffer',
+    input: options.input,
+    maxBuffer: MAX_GIT_OUTPUT,
+    stdio: options.input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+export function parseChangedSkillPaths(rawSkills) {
+  const skillPaths = [...new Set(
+    String(rawSkills ?? '')
+      .split(/[\s,]+/)
+      .map((value) => value.trim())
+      .filter(Boolean),
+  )].sort();
+
+  if (skillPaths.length === 0) {
+    throw new Error('no changed skill paths were provided');
+  }
+
+  for (const skillPath of skillPaths) {
+    const segments = skillPath.split('/');
+    if (
+      skillPath.startsWith('/')
+      || skillPath.startsWith('skills/')
+      || skillPath.includes('\\')
+      || posix.normalize(skillPath) !== skillPath
+      || segments.some((segment) => !segment || segment === '.' || segment === '..')
+    ) {
+      throw new Error(`invalid changed skill path: ${skillPath}`);
+    }
+  }
+
+  return skillPaths;
+}
+
+function resolveExactCommit(repositoryRoot, commit) {
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`commit must be an exact 40-character SHA: ${commit}`);
+  }
+
+  const resolvedCommit = git(
+    repositoryRoot,
+    ['rev-parse', '--verify', `${commit}^{commit}`],
+    { encoding: 'utf8' },
+  ).trim();
+
+  if (resolvedCommit.toLowerCase() !== commit.toLowerCase()) {
+    throw new Error(`commit did not resolve exactly: ${commit}`);
+  }
+
+  return resolvedCommit;
+}
+
+function reportEntriesAtCommit(repositoryRoot, commit) {
+  const output = git(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--full-tree',
+    commit,
+    '--',
+    'skills',
+  ]).toString('utf8');
+  const reports = new Map();
+
+  for (const record of output.split('\0')) {
+    if (!record) continue;
+    const tabIndex = record.indexOf('\t');
+    if (tabIndex === -1) continue;
+
+    const [mode, type, oid] = record.slice(0, tabIndex).split(' ');
+    const treePath = record.slice(tabIndex + 1);
+    if (treePath.endsWith('/skill-report.json')) {
+      reports.set(treePath, { mode, type, oid });
+    }
+  }
+
+  return reports;
+}
+
+function assertSafeRemoval(repositoryRoot, repositoryPath) {
+  const root = resolve(repositoryRoot);
+  const target = resolve(root, ...repositoryPath.split('/'));
+  if (!target.startsWith(`${root}${sep}`)) {
+    throw new Error(`refusing to remove path outside repository: ${repositoryPath}`);
+  }
+  return target;
+}
+
+function hashMaterializedReports(repositoryRoot, reportPaths) {
+  const output = git(
+    repositoryRoot,
+    ['hash-object', '--no-filters', '--stdin-paths'],
+    {
+      encoding: 'utf8',
+      input: `${reportPaths.join('\n')}\n`,
+    },
+  );
+  return output.trim().split('\n').filter(Boolean);
+}
+
+export function materializeChangedSkills({ repositoryRoot = '.', commit, skills }) {
+  const exactCommit = resolveExactCommit(repositoryRoot, commit);
+  const skillPaths = Array.isArray(skills) ? parseChangedSkillPaths(skills.join(' ')) : parseChangedSkillPaths(skills);
+  const treeReports = reportEntriesAtCommit(repositoryRoot, exactCommit);
+  const targets = skillPaths.map((skillPath) => {
+    const directory = `skills/${skillPath}`;
+    const reportPath = `${directory}/skill-report.json`;
+    const report = treeReports.get(reportPath);
+
+    if (!report || report.type !== 'blob' || !report.mode.startsWith('100')) {
+      throw new Error(`published report is missing from ${exactCommit}: ${reportPath}`);
+    }
+
+    return { directory, reportPath, reportOid: report.oid };
+  });
+
+  // Remove only the selected directories first so stale untracked files from a
+  // mutable self-hosted workspace cannot leak into the sync payload.
+  for (const target of targets) {
+    rmSync(assertSafeRemoval(repositoryRoot, target.directory), { recursive: true, force: true });
+  }
+
+  // A NUL-delimited literal pathspec avoids shell expansion and ARG_MAX while
+  // --ignore-skip-worktree-bits materializes paths omitted by sparse checkout.
+  const pathspec = Buffer.from(
+    `${targets.map(({ directory }) => `:(literal)${directory}`).join('\0')}\0`,
+  );
+  git(repositoryRoot, [
+    'restore',
+    `--source=${exactCommit}`,
+    '--worktree',
+    '--ignore-skip-worktree-bits',
+    '--pathspec-from-file=-',
+    '--pathspec-file-nul',
+  ], { input: pathspec });
+
+  for (const target of targets) {
+    let reportStat;
+    try {
+      reportStat = lstatSync(resolve(repositoryRoot, ...target.reportPath.split('/')));
+    } catch {
+      throw new Error(`materialized report is missing: ${target.reportPath}`);
+    }
+    if (!reportStat.isFile() || reportStat.isSymbolicLink()) {
+      throw new Error(`materialized report is not a regular file: ${target.reportPath}`);
+    }
+  }
+
+  const materializedOids = hashMaterializedReports(
+    repositoryRoot,
+    targets.map(({ reportPath }) => reportPath),
+  );
+  if (materializedOids.length !== targets.length) {
+    throw new Error(`verified ${materializedOids.length}/${targets.length} materialized reports`);
+  }
+
+  for (const [index, target] of targets.entries()) {
+    if (materializedOids[index] !== target.reportOid) {
+      throw new Error(`materialized report does not match ${exactCommit}: ${target.reportPath}`);
+    }
+    // Ensure the report is readable before handing the directory to the CLI.
+    readFileSync(resolve(repositoryRoot, ...target.reportPath.split('/')));
+  }
+
+  return targets.map(({ directory }) => directory);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const commit = readOption(args, '--commit');
+  const skills = readOption(args, '--skills');
+  const materialized = materializeChangedSkills({ commit, skills });
+  console.log(`Materialized ${materialized.length} changed skill(s) from ${commit}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`::error::Changed skill materialization failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -105,6 +105,25 @@ test('incremental detection resolves both sides from pinned Git trees', () => {
   assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
 });
 
+test('sync materializes only the detected paths from the exact workflow commit', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const materialize = section(workflow, '      - name: Materialize changed skills', '      - name: Sync skills to Supabase');
+  const sync = section(workflow, '      - name: Sync skills to Supabase', '      - name: Remove generated report evidence');
+
+  assert.ok(
+    workflow.indexOf('      - name: Download skillstore-cli')
+      < workflow.indexOf('      - name: Materialize changed skills'),
+    'materialization must run after the helper checkout is available',
+  );
+  assert.match(materialize, /CHANGED_SKILLS: \$\{\{ steps\.changes\.outputs\.changed_skills \}\}/);
+  assert.match(materialize, /node \.\/scripts\/materialize-changed-skills\.mjs/);
+  assert.match(materialize, /--commit "\$GITHUB_SHA"/);
+  assert.match(materialize, /--skills "\$CHANGED_SKILLS"/);
+  assert.doesNotMatch(materialize, /checkout\s+\.\s*$|sparse-checkout disable|git clean/mi);
+  assert.match(sync, /skill sync --slugs "\$paths"/);
+  assert.match(sync, /--marketplace-commit "\$GITHUB_SHA"/);
+});
+
 test('sync downloads the canonical-hash CLI release', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const download = section(workflow, '      - name: Download skillstore-cli', '      - name: Sync skills to Supabase');
@@ -129,9 +148,11 @@ test('CI tracks and executes the planner, aggregate guard, and full script suite
 
   assert.match(workflow, /scripts\/plan-cache-invalidation\.mjs/);
   assert.match(workflow, /scripts\/detect-changed-skills\.mjs/);
+  assert.match(workflow, /scripts\/materialize-changed-skills\.mjs/);
   assert.match(workflow, /scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --check scripts\/plan-cache-invalidation\.mjs/);
   assert.match(workflow, /node --check scripts\/detect-changed-skills\.mjs/);
+  assert.match(workflow, /node --check scripts\/materialize-changed-skills\.mjs/);
   assert.match(workflow, /bash -n scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --test scripts\/tests\/\*\.test\.mjs/);
 });

--- a/scripts/tests/materialize-changed-skills.test.mjs
+++ b/scripts/tests/materialize-changed-skills.test.mjs
@@ -1,0 +1,138 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  materializeChangedSkills,
+  parseChangedSkillPaths,
+} from '../materialize-changed-skills.mjs';
+
+function git(repositoryRoot, args) {
+  return execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+}
+
+function write(repositoryRoot, relativePath, contents) {
+  const fullPath = join(repositoryRoot, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function makeRepository() {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'materialize-skills-'));
+  git(repositoryRoot, ['init', '--initial-branch=main']);
+  git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+  git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+
+  write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v1\n');
+  write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":1}\n');
+  write(repositoryRoot, 'skills/owner/untouched/SKILL.md', '# Untouched\n');
+  write(repositoryRoot, 'skills/owner/untouched/skill-report.json', '{"revision":1}\n');
+  git(repositoryRoot, ['add', '.']);
+  git(repositoryRoot, ['commit', '-m', 'base']);
+
+  write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v2\n');
+  write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":2}\n');
+  git(repositoryRoot, ['add', '.']);
+  git(repositoryRoot, ['commit', '-m', 'updated report']);
+
+  return { repositoryRoot, commit: git(repositoryRoot, ['rev-parse', 'HEAD']) };
+}
+
+test('parses unique repository-relative skill paths and rejects unsafe inputs', () => {
+  assert.deepEqual(
+    parseChangedSkillPaths('owner/zeta,owner/alpha owner/zeta'),
+    ['owner/alpha', 'owner/zeta'],
+  );
+
+  for (const invalid of [
+    '',
+    '/owner/demo',
+    'skills/owner/demo',
+    '../owner/demo',
+    'owner/../demo',
+    'owner\\demo',
+  ]) {
+    assert.throws(() => parseChangedSkillPaths(invalid), /no changed|invalid changed/);
+  }
+});
+
+test('restores only selected paths from an exact commit through skip-worktree state', () => {
+  const { repositoryRoot, commit } = makeRepository();
+  try {
+    write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v3 at mutable HEAD\n');
+    write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":3}\n');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'newer mutable head']);
+
+    const demoFiles = [
+      'skills/owner/demo/SKILL.md',
+      'skills/owner/demo/skill-report.json',
+    ];
+    git(repositoryRoot, ['update-index', '--skip-worktree', ...demoFiles]);
+    rmSync(join(repositoryRoot, 'skills/owner/demo'), { recursive: true });
+
+    write(repositoryRoot, 'skills/owner/untouched/local-only.txt', 'keep me\n');
+    write(repositoryRoot, 'skills/owner/demo/stale-untracked.txt', 'remove me\n');
+
+    assert.deepEqual(
+      materializeChangedSkills({ repositoryRoot, commit, skills: ['owner/demo'] }),
+      ['skills/owner/demo'],
+    );
+    assert.equal(readFileSync(join(repositoryRoot, 'skills/owner/demo/SKILL.md'), 'utf8'), '# Demo v2\n');
+    assert.equal(
+      readFileSync(join(repositoryRoot, 'skills/owner/demo/skill-report.json'), 'utf8'),
+      '{"revision":2}\n',
+    );
+    assert.equal(existsSync(join(repositoryRoot, 'skills/owner/demo/stale-untracked.txt')), false);
+    assert.equal(
+      readFileSync(join(repositoryRoot, 'skills/owner/untouched/local-only.txt'), 'utf8'),
+      'keep me\n',
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails before mutation when a selected path has no published report at the pinned commit', () => {
+  const { repositoryRoot, commit } = makeRepository();
+  try {
+    write(repositoryRoot, 'skills/owner/not-published/local-only.txt', 'preserve on preflight failure\n');
+
+    assert.throws(
+      () => materializeChangedSkills({
+        repositoryRoot,
+        commit,
+        skills: ['owner/demo', 'owner/not-published'],
+      }),
+      /published report is missing/,
+    );
+    assert.equal(
+      readFileSync(join(repositoryRoot, 'skills/owner/not-published/local-only.txt'), 'utf8'),
+      'preserve on preflight failure\n',
+    );
+    assert.equal(readFileSync(join(repositoryRoot, 'skills/owner/demo/SKILL.md'), 'utf8'), '# Demo v2\n');
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('rejects symbolic commit names instead of materializing mutable HEAD', () => {
+  const { repositoryRoot } = makeRepository();
+  try {
+    assert.throws(
+      () => materializeChangedSkills({ repositoryRoot, commit: 'HEAD', skills: ['owner/demo'] }),
+      /exact 40-character SHA/,
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- materialize only CHANGED_SKILLS paths from the exact GITHUB_SHA before the Supabase sync
- remove stale selected directories, restore through skip-worktree bits, and verify each report blob against the pinned tree
- fail before mutation when any selected skill has no published report
- keep the CLI sync contract and marketplace commit verification unchanged

## Root cause
Run 29375514388 detected the correct five Git-tree paths, but the mutable self-hosted checkout had not materialized those directories. The CLI correctly failed 0/5 with Directory not found.

## Validation
- CI=true node --check scripts/materialize-changed-skills.mjs
- CI=true node --test scripts/tests/materialize-changed-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs
- git diff --check

The integration test advances mutable HEAD past the pinned commit, marks target files skip-worktree, removes the directory, and proves restoration still comes from the exact requested SHA without touching an unselected Skill.