### PR TITLE
fix(backfill): compare observation timestamps by instant

### DIFF
--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -624,6 +624,42 @@ test('execute readback proves exact artifact hash provenance and observation ide
     postInventory,
   });
   assert.equal(readback.executedCount, 1);
+
+  const equivalentUtcOffset = structuredClone(postInventory);
+  equivalentUtcOffset.artifacts[0].observed_at = '2026-01-01T00:00:00.000+00:00';
+  equivalentUtcOffset.observations[0].observed_at = '2026-01-01T00:00:00.000+00:00';
+  const offsetReadback = verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory: equivalentUtcOffset,
+  });
+  assert.equal(offsetReadback.executedCount, 1);
+
+  const invalidObservedAt = structuredClone(postInventory);
+  invalidObservedAt.artifacts[0].observed_at = '2026-02-31T00:00:00.000Z';
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory: invalidObservedAt,
+  }), /install identity\/hash provenance readback mismatch/);
+
+  const microsecondDrift = structuredClone(postInventory);
+  microsecondDrift.observations[0].observed_at = '2026-01-01T00:00:00.000001+00:00';
+  assert.throws(() => verifyArtifactVersionReadback({
+    mode: 'execute',
+    plan,
+    classification,
+    execution: { evidence: [{ slug: planned.slug, result }] },
+    preInventory,
+    postInventory: microsecondDrift,
+  }), /Artifact observation readback mismatch/);
+
   const installIdentityDrift = structuredClone(postInventory);
   installIdentityDrift.artifacts[0].upstream_version_status = 'missing';
   assert.throws(() => verifyArtifactVersionReadback({

--- a/scripts/verify-artifact-version-backfill.mjs
+++ b/scripts/verify-artifact-version-backfill.mjs
@@ -7,9 +7,57 @@ import { pathToFileURL } from 'node:url';
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_TIMESTAMP_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(Z|([+-])(\d{2}):(\d{2}))$/;
 
 function fail(message) {
   throw new Error(message);
+}
+
+function parseStrictIsoTimestamp(value) {
+  if (typeof value !== 'string') return null;
+  const match = ISO_TIMESTAMP_RE.exec(value);
+  if (!match) return null;
+
+  const [
+    , yearText, monthText, dayText, hourText, minuteText, secondText,
+    fractionText, , offsetSign, offsetHourText, offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  const offsetHour = Number(offsetHourText ?? 0);
+  const offsetMinute = Number(offsetMinuteText ?? 0);
+  if (
+    month < 1 || month > 12
+    || day < 1 || day > daysInMonth
+    || hour > 23
+    || minute > 59
+    || second > 59
+    || offsetHour > 23
+    || offsetMinute > 59
+  ) {
+    return null;
+  }
+
+  const localTime = new Date(0);
+  localTime.setUTCFullYear(year, month - 1, day);
+  localTime.setUTCHours(hour, minute, second, 0);
+  const offsetDirection = offsetSign === '-' ? -1 : 1;
+  const offsetMilliseconds = offsetDirection * (offsetHour * 60 + offsetMinute) * 60_000;
+  const epochMilliseconds = localTime.getTime() - offsetMilliseconds;
+  const fractionMicroseconds = BigInt((fractionText ?? '').padEnd(6, '0') || '0');
+  return BigInt(epochMilliseconds) * 1_000n + fractionMicroseconds;
+}
+
+function isSameIsoInstant(left, right) {
+  const leftEpoch = parseStrictIsoTimestamp(left);
+  const rightEpoch = parseStrictIsoTimestamp(right);
+  return leftEpoch !== null && rightEpoch !== null && leftEpoch === rightEpoch;
 }
 
 function rowsByKey(rows, key, label) {
@@ -193,7 +241,7 @@ export function verifyArtifactVersionReadback({
         || artifact.marketplace_commit_sha !== planned.marketplaceCommit
         || artifact.source_path !== planned.path
         || artifact.upstream_commit_sha !== artifactEvidence.upstreamCommit
-        || artifact.observed_at !== artifactEvidence.observedAt
+        || !isSameIsoInstant(artifact.observed_at, artifactEvidence.observedAt)
         || artifact.previous_version_id !== null
         || artifact.change_kind !== 'initial'
         || artifact.snapshot_status !== 'exact'
@@ -213,7 +261,7 @@ export function verifyArtifactVersionReadback({
         || observation.marketplace_commit_sha !== planned.marketplaceCommit
         || observation.source_path !== planned.path
         || observation.upstream_commit_sha !== artifactEvidence.upstreamCommit
-        || observation.observed_at !== artifactEvidence.observedAt
+        || !isSameIsoInstant(observation.observed_at, artifactEvidence.observedAt)
       ) {
         fail(`Artifact observation readback mismatch for ${planned.slug}`);
       }


### PR DESCRIPTION
## Summary
- compare artifact and observation timestamps as strict ISO instants instead of raw strings
- preserve microsecond precision and reject invalid calendar dates
- add regression coverage for equivalent UTC offsets and microsecond drift

## Production incident
Run 29375733209 wrote and verified 157 exact artifacts, then readback incorrectly rejected `2026-07-07T19:13:46.703Z` versus PostgREST `2026-07-07T19:13:46.703+00:00`. Production database invariants remain intact.

## Verification
- `CI=true node --test scripts/tests/artifact-version-backfill.test.mjs` (10/10)
- replayed immutable run 29375733209 evidence: verified 500, executed 157
- `git diff --check HEAD^ HEAD`