### PR TITLE
fix(sync): resolve manual skills from pinned tree

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -90,77 +90,13 @@ jobs:
             done | sort -u
           }
 
-          # Resolve workflow_dispatch input to repository skill paths. Operators
-          # usually pass public slugs such as "sickn33-mtls-configuration", while
-          # the CLI expects paths such as "skills/sickn33/mtls-configuration".
-          resolve_manual_skills() {
-            MANUAL_SKILL_INPUT="$1" node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-
-          const raw = process.env.MANUAL_SKILL_INPUT || '';
-          const requested = [
-            ...new Set(
-              raw
-                .split(/[,\s]+/)
-                .map((item) => item.trim().replace(/^skills\//, '').replace(/\/skill-report\.json$/, ''))
-                .filter(Boolean),
-            ),
-          ];
-
-          const reports = [];
-          function walk(dir) {
-            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-              const fullPath = path.join(dir, entry.name);
-              if (entry.isDirectory()) {
-                walk(fullPath);
-              } else if (entry.name === 'skill-report.json') {
-                reports.push(fullPath);
-              }
-            }
-          }
-
-          walk('skills');
-
-          const byPath = new Map();
-          const bySlug = new Map();
-          for (const reportPath of reports) {
-            const relativePath = path.dirname(reportPath).replace(/^skills\//, '');
-            byPath.set(relativePath, relativePath);
-            bySlug.set(relativePath.replace(/\//g, '-'), relativePath);
-
-            try {
-              const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
-              const slug = report?.meta?.slug;
-              if (slug) bySlug.set(slug, relativePath);
-            } catch {
-              // Keep path-derived fallback mappings.
-            }
-          }
-
-          const resolved = [];
-          const missing = [];
-          for (const item of requested) {
-            const skillPath = byPath.get(item) || bySlug.get(item);
-            if (skillPath) {
-              resolved.push(skillPath);
-            } else {
-              missing.push(item);
-            }
-          }
-
-          if (missing.length > 0) {
-            console.error(`Could not resolve skill identifier(s): ${missing.join(', ')}`);
-            process.exit(1);
-          }
-
-          process.stdout.write([...new Set(resolved)].sort().join(' '));
-          NODE
-          }
-          
           if [ -n "${{ inputs.slugs }}" ]; then
             echo "Specific slugs requested: ${{ inputs.slugs }}"
-            CHANGED=$(resolve_manual_skills "${{ inputs.slugs }}")
+            # Resolve against the immutable workflow commit. A mutable self-hosted
+            # checkout may not have a skills/ directory at all.
+            CHANGED=$(node ./scripts/resolve-manual-skills.mjs \
+              --commit "${{ github.sha }}" \
+              --skills "${{ inputs.slugs }}")
             echo "Resolved manual skill paths: $CHANGED"
             echo "mode=manual-slugs" >> $GITHUB_OUTPUT
           elif [ "${{ inputs.full_sync }}" = "true" ]; then

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -7,6 +7,7 @@ on:
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/resolve-manual-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -22,6 +23,7 @@ on:
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/resolve-manual-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
@@ -58,7 +60,7 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/materialize-changed-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/materialize-changed-skills.mjs scripts/resolve-manual-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
           bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
@@ -66,5 +68,6 @@ jobs:
           bash -n scripts/tests/fake-cli.sh
           node --check scripts/detect-changed-skills.mjs
           node --check scripts/materialize-changed-skills.mjs
+          node --check scripts/resolve-manual-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs
           node --test scripts/tests/*.test.mjs

--- a/scripts/resolve-manual-skills.mjs
+++ b/scripts/resolve-manual-skills.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { posix } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+
+function readOption(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+    throw new Error(`missing required option ${name}`);
+  }
+  return args[index + 1];
+}
+
+function git(repositoryRoot, args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: options.encoding ?? 'buffer',
+    maxBuffer: MAX_GIT_OUTPUT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function resolveExactCommit(repositoryRoot, commit) {
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`commit must be an exact 40-character SHA: ${commit}`);
+  }
+
+  const resolved = git(
+    repositoryRoot,
+    ['rev-parse', '--verify', `${commit}^{commit}`],
+    { encoding: 'utf8' },
+  ).trim();
+  if (resolved.toLowerCase() !== commit.toLowerCase()) {
+    throw new Error(`commit did not resolve exactly: ${commit}`);
+  }
+  return resolved;
+}
+
+export function parseManualSkillIdentifiers(rawSkills) {
+  const identifiers = [...new Set(
+    String(rawSkills ?? '')
+      .split(/[\s,]+/)
+      .map((value) => value.trim().replace(/^skills\//, '').replace(/\/skill-report\.json$/, ''))
+      .filter(Boolean),
+  )];
+  if (identifiers.length === 0) throw new Error('no manual skill identifiers were provided');
+
+  for (const identifier of identifiers) {
+    const segments = identifier.split('/');
+    if (
+      identifier.startsWith('/')
+      || identifier.includes('\\')
+      || posix.normalize(identifier) !== identifier
+      || segments.some((segment) => !segment || segment === '.' || segment === '..')
+    ) {
+      throw new Error(`invalid manual skill identifier: ${identifier}`);
+    }
+  }
+  return identifiers;
+}
+
+function reportBlobsAtCommit(repositoryRoot, commit) {
+  const output = git(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--full-tree',
+    commit,
+    '--',
+    'skills',
+  ]).toString('utf8');
+  const reports = [];
+
+  for (const record of output.split('\0')) {
+    if (!record) continue;
+    const tabIndex = record.indexOf('\t');
+    if (tabIndex === -1) continue;
+    const [mode, type, oid] = record.slice(0, tabIndex).split(' ');
+    const treePath = record.slice(tabIndex + 1);
+    if (
+      type !== 'blob'
+      || !mode.startsWith('100')
+      || !treePath.startsWith('skills/')
+      || posix.basename(treePath) !== 'skill-report.json'
+    ) {
+      continue;
+    }
+    reports.push({ oid, treePath });
+  }
+  return reports;
+}
+
+function addMapping(index, key, relativePath) {
+  if (!key) return;
+  const existing = index.get(key);
+  if (existing && existing !== relativePath) {
+    index.set(key, null);
+    return;
+  }
+  if (existing !== null) index.set(key, relativePath);
+}
+
+export function resolveManualSkillPaths({ repositoryRoot = '.', commit, skills }) {
+  const exactCommit = resolveExactCommit(repositoryRoot, commit);
+  const requested = Array.isArray(skills)
+    ? parseManualSkillIdentifiers(skills.join(' '))
+    : parseManualSkillIdentifiers(skills);
+  const byPath = new Map();
+  const bySlug = new Map();
+
+  for (const report of reportBlobsAtCommit(repositoryRoot, exactCommit)) {
+    const relativePath = posix.dirname(report.treePath).slice('skills/'.length);
+    if (!relativePath || relativePath === '.') continue;
+    addMapping(byPath, relativePath, relativePath);
+    addMapping(bySlug, relativePath.replaceAll('/', '-'), relativePath);
+
+    try {
+      const document = JSON.parse(
+        git(repositoryRoot, ['cat-file', 'blob', report.oid], { encoding: 'utf8' }),
+      );
+      if (typeof document?.meta?.slug === 'string' && document.meta.slug.trim()) {
+        addMapping(bySlug, document.meta.slug.trim(), relativePath);
+      }
+    } catch {
+      // Path-derived lookup remains available for malformed legacy reports.
+    }
+  }
+
+  const resolved = [];
+  const missing = [];
+  const ambiguous = [];
+  for (const identifier of requested) {
+    const pathMatch = byPath.get(identifier);
+    const slugMatch = bySlug.get(identifier);
+    const match = pathMatch ?? slugMatch;
+    if (pathMatch === null || slugMatch === null) {
+      ambiguous.push(identifier);
+    } else if (match) {
+      resolved.push(match);
+    } else {
+      missing.push(identifier);
+    }
+  }
+
+  if (ambiguous.length > 0) {
+    throw new Error(`ambiguous skill identifier(s): ${ambiguous.join(', ')}`);
+  }
+  if (missing.length > 0) {
+    throw new Error(`could not resolve skill identifier(s) at ${exactCommit}: ${missing.join(', ')}`);
+  }
+  return [...new Set(resolved)].sort();
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const commit = readOption(args, '--commit');
+  const skills = readOption(args, '--skills');
+  process.stdout.write(`${resolveManualSkillPaths({ commit, skills }).join(' ')}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`::error::Manual skill resolution failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -100,6 +100,8 @@ test('incremental detection resolves both sides from pinned Git trees', () => {
   const detectJob = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
 
   assert.match(detectJob, /node \.\/scripts\/detect-changed-skills\.mjs/);
+  assert.match(detectJob, /node \.\/scripts\/resolve-manual-skills\.mjs/);
+  assert.match(detectJob, /--commit "\$\{\{ github\.sha \}\}"/);
   assert.match(detectJob, /--base "\$BASE_SHA"/);
   assert.match(detectJob, /--head "\$\{\{ github\.sha \}\}"/);
   assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
@@ -149,10 +151,12 @@ test('CI tracks and executes the planner, aggregate guard, and full script suite
   assert.match(workflow, /scripts\/plan-cache-invalidation\.mjs/);
   assert.match(workflow, /scripts\/detect-changed-skills\.mjs/);
   assert.match(workflow, /scripts\/materialize-changed-skills\.mjs/);
+  assert.match(workflow, /scripts\/resolve-manual-skills\.mjs/);
   assert.match(workflow, /scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --check scripts\/plan-cache-invalidation\.mjs/);
   assert.match(workflow, /node --check scripts\/detect-changed-skills\.mjs/);
   assert.match(workflow, /node --check scripts\/materialize-changed-skills\.mjs/);
+  assert.match(workflow, /node --check scripts\/resolve-manual-skills\.mjs/);
   assert.match(workflow, /bash -n scripts\/check-cache-invalidation-aggregate\.sh/);
   assert.match(workflow, /node --test scripts\/tests\/\*\.test\.mjs/);
 });

--- a/scripts/tests/resolve-manual-skills.test.mjs
+++ b/scripts/tests/resolve-manual-skills.test.mjs
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  parseManualSkillIdentifiers,
+  resolveManualSkillPaths,
+} from '../resolve-manual-skills.mjs';
+
+function git(repositoryRoot, args) {
+  return execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+}
+
+function write(repositoryRoot, relativePath, contents) {
+  const fullPath = join(repositoryRoot, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function makeRepository() {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'resolve-manual-skills-'));
+  git(repositoryRoot, ['init', '--initial-branch=main']);
+  git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+  git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+  write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo\n');
+  write(repositoryRoot, 'skills/owner/demo/skill-report.json', JSON.stringify({ meta: { slug: 'custom-demo' } }));
+  write(repositoryRoot, 'skills/other/tool/SKILL.md', '# Tool\n');
+  write(repositoryRoot, 'skills/other/tool/skill-report.json', JSON.stringify({ meta: { slug: 'other-tool' } }));
+  git(repositoryRoot, ['add', '.']);
+  git(repositoryRoot, ['commit', '-m', 'catalog']);
+  return { repositoryRoot, commit: git(repositoryRoot, ['rev-parse', 'HEAD']) };
+}
+
+test('normalizes manual identifiers and rejects traversal', () => {
+  assert.deepEqual(
+    parseManualSkillIdentifiers('skills/owner/demo/skill-report.json,custom-demo custom-demo'),
+    ['owner/demo', 'custom-demo'],
+  );
+  for (const invalid of ['', '../owner/demo', 'owner/../demo', '/owner/demo', 'owner\\demo']) {
+    assert.throws(() => parseManualSkillIdentifiers(invalid), /no manual|invalid manual/);
+  }
+});
+
+test('resolves paths and report slugs from the exact Git tree when skills is absent on disk', () => {
+  const { repositoryRoot, commit } = makeRepository();
+  try {
+    rmSync(join(repositoryRoot, 'skills'), { recursive: true, force: true });
+    assert.deepEqual(
+      resolveManualSkillPaths({
+        repositoryRoot,
+        commit,
+        skills: 'custom-demo,other/tool owner/demo',
+      }),
+      ['other/tool', 'owner/demo'],
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails closed for missing identifiers and symbolic commits', () => {
+  const { repositoryRoot, commit } = makeRepository();
+  try {
+    assert.throws(
+      () => resolveManualSkillPaths({ repositoryRoot, commit, skills: 'missing-skill' }),
+      /could not resolve skill identifier/,
+    );
+    assert.throws(
+      () => resolveManualSkillPaths({ repositoryRoot, commit: 'HEAD', skills: 'custom-demo' }),
+      /exact 40-character SHA/,
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- resolve workflow_dispatch skill identifiers from the exact GitHub SHA instead of the mutable self-hosted checkout
- fail closed on missing or ambiguous identifiers before materialization or Supabase writes
- add sparse/missing-worktree regression coverage and wire the resolver into CI

## Verification
- `CI=true node --check scripts/resolve-manual-skills.mjs`
- `CI=true node --test scripts/tests/resolve-manual-skills.test.mjs scripts/tests/materialize-changed-skills.test.mjs scripts/tests/detect-changed-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` (18/18)
- `git diff --check`

## Incident evidence
Shadow canary run 29376672190 failed before writes because the self-hosted checkout had no `skills/` directory. This patch resolves the same manual plan from the pinned commit tree.