### PR TITLE
fix(backfill): repair inherited sparse checkout

### DIFF
--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -49,6 +49,42 @@ jobs:
         with:
           fetch-depth: 0
           clean: true
+          # A persistent self-hosted workspace can inherit sparse-checkout
+          # configuration from an earlier job. Keep this explicitly empty so
+          # checkout does not intentionally select a subset of the repository.
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize full checkout and verify backfill runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::Checkout identity mismatch: expected $GITHUB_SHA, got $checked_out_sha"
+            exit 1
+          fi
+
+          # actions/checkout attempts this itself, but a reused self-hosted
+          # worktree has previously remained sparse afterwards. Reapply the
+          # normalization and materialize every tracked path from this commit.
+          git sparse-checkout disable
+          git reset --hard HEAD
+
+          required_paths=(
+            .github/actions/download-skillstore-cli/action.yml
+            scripts/fetch-artifact-version-inventory.mjs
+            scripts/plan-artifact-version-backfill.mjs
+            scripts/verify-artifact-version-classification.mjs
+            scripts/verify-artifact-version-backfill.mjs
+          )
+          for required_path in "${required_paths[@]}"; do
+            if [ ! -f "$required_path" ]; then
+              echo "::error file=$required_path::Required backfill runtime file is missing after checkout"
+              exit 1
+            fi
+          done
 
       - name: Validate bounded inputs
         id: inputs

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -692,6 +692,26 @@ test('workflow is bounded, exact-only, cursor-safe, and evidence-producing', () 
   );
   assert.match(workflow, /default: '2\.2\.2'/);
   assert.match(workflow, /CLI_VERSION" != "2\.2\.2"/);
+  assert.match(workflow, /sparse-checkout: ''/);
+  assert.match(workflow, /sparse-checkout-cone-mode: false/);
+  const checkoutGuard = workflow.indexOf('name: Normalize full checkout and verify backfill runtime');
+  const firstProductionRead = workflow.indexOf('name: Fetch exact production Skill catalog');
+  assert.ok(checkoutGuard > workflow.indexOf('uses: actions/checkout@v5'));
+  assert.ok(checkoutGuard < firstProductionRead);
+  const checkoutGuardBlock = workflow.slice(checkoutGuard, firstProductionRead);
+  assert.match(checkoutGuardBlock, /checked_out_sha=\$\(git rev-parse HEAD\)/);
+  assert.match(checkoutGuardBlock, /"\$checked_out_sha" != "\$GITHUB_SHA"/);
+  assert.match(checkoutGuardBlock, /git sparse-checkout disable[\s\S]*git reset --hard HEAD/);
+  assert.match(checkoutGuardBlock, /if \[ ! -f "\$required_path" \]/);
+  for (const requiredPath of [
+    '.github/actions/download-skillstore-cli/action.yml',
+    'scripts/fetch-artifact-version-inventory.mjs',
+    'scripts/plan-artifact-version-backfill.mjs',
+    'scripts/verify-artifact-version-classification.mjs',
+    'scripts/verify-artifact-version-backfill.mjs',
+  ]) {
+    assert.ok(checkoutGuardBlock.includes(requiredPath), `${requiredPath} must be verified before production reads`);
+  }
   assert.match(workflow, /batch_size must be an integer between 1 and 500/);
   assert.match(workflow, /execute requires the frozen end_at slug/);
   assert.match(workflow, /--repair-stale-report-hashes/);


### PR DESCRIPTION
## Summary
- normalize reused self-hosted workspaces after checkout
- verify the checked-out SHA before any production read
- fail closed unless every backfill runtime file is materialized
- add workflow contract coverage for the repair sequence

## Incident
Run 29377235046 showed actions/checkout invoking sparse-checkout disable at HEAD 13e81adc3, but the next production-catalog step could not find scripts/fetch-artifact-version-inventory.mjs. No database write occurred.

## Verification
- `CI=true node --test scripts/tests/artifact-version-backfill.test.mjs` (10/10)
- `git diff --check HEAD^ HEAD`