### PR TITLE
feat(security): schedule durable event reconciliation

### DIFF
--- a/.github/workflows/reconcile-security-events.yml
+++ b/.github/workflows/reconcile-security-events.yml
@@ -1,0 +1,51 @@
+name: Reconcile Security Events
+
+on:
+  schedule:
+    # Stagger the 15-minute durable-outbox drain away from top-of-hour jobs.
+    - cron: '7,22,37,52 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-event-reconciler
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout CLI download action
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/download-skillstore-cli
+          sparse-checkout-cone-mode: false
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download skillstore-cli
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          version: '2.3.0'
+          token: ${{ steps.app-token.outputs.token }}
+          minimum-version: '2.3.0'
+
+      - name: Reconcile durable security change events
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SECURITY_NOTIFICATIONS_ENABLED: ${{ vars.SECURITY_NOTIFICATIONS_ENABLED || 'false' }}
+        run: |
+          set -euo pipefail
+          timeout --signal=TERM --kill-after=30s 15m \
+            "$GITHUB_WORKSPACE/skillstore-cli" skill reconcile-security-events --batch-size 100

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+  schedule:
+    # Stagger the 15-minute durable-outbox drain away from top-of-hour jobs.
+    - cron: '7,22,37,52 * * * *'
   workflow_run:
     workflows: ["On PR Merge - Approve Skill"]
     types: [completed]
@@ -52,6 +55,7 @@ jobs:
 
       - name: Find last successful sync commit
         id: last_sync
+        if: github.event_name != 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -90,7 +94,11 @@ jobs:
             done | sort -u
           }
 
-          if [ -n "${{ inputs.slugs }}" ]; then
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Scheduled reconcile-only run; skill sync and downstream side effects are disabled"
+            CHANGED=""
+            echo "mode=reconcile-only" >> $GITHUB_OUTPUT
+          elif [ -n "${{ inputs.slugs }}" ]; then
             echo "Specific slugs requested: ${{ inputs.slugs }}"
             # Resolve against the immutable workflow commit. A mutable self-hosted
             # checkout may not have a skills/ directory at all.
@@ -139,13 +147,13 @@ jobs:
           echo "Cache matrix preflight: $TARGET_COUNT target(s) within $MAX_CACHE_ITEMS capacity"
 
       - name: Download skillstore-cli
-        if: steps.changes.outputs.skip_sync != 'true'
+        id: download-cli
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: '2.2.1'
+          version: '2.3.0'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: '2.2.1'
+          minimum-version: '2.3.0'
 
       - name: Materialize changed skills
         if: steps.changes.outputs.skip_sync != 'true'
@@ -166,6 +174,7 @@ jobs:
           CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
           SYNC_MODE: ${{ steps.changes.outputs.mode }}
           SECURITY_PASSPORT_MODE: ${{ vars.SECURITY_PASSPORT_MODE || 'off' }}
+          SECURITY_NOTIFICATIONS_ENABLED: ${{ vars.SECURITY_NOTIFICATIONS_ENABLED || 'false' }}
           PUBLIC_SITE_URL: https://skillstore.io
           AUTOMATION_API_KEY: ${{ secrets.SECURITY_ATTESTATION_AUTOMATION_KEY }}
         run: |
@@ -370,6 +379,29 @@ jobs:
           SYNCED_COUNT=$(wc -l < synced-slugs.txt | tr -d ' ')
           echo "synced_count=$SYNCED_COUNT" >> "$GITHUB_OUTPUT"
           echo "::notice::Synced $SYNCED_COUNT skill(s); slug payload saved to artifact input"
+
+      - name: Reconcile durable security change events
+        id: reconcile-security-events
+        if: ${{ !cancelled() && steps.download-cli.outcome == 'success' }}
+        continue-on-error: ${{ github.event_name != 'schedule' }}
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SECURITY_NOTIFICATIONS_ENABLED: ${{ vars.SECURITY_NOTIFICATIONS_ENABLED || 'false' }}
+        run: |
+          set -euo pipefail
+          timeout --signal=TERM --kill-after=30s 15m \
+            "$GITHUB_WORKSPACE/skillstore-cli" skill reconcile-security-events --batch-size 100
+
+      - name: Report security event reconciliation failure
+        if: ${{ always() && steps.reconcile-security-events.outcome == 'failure' }}
+        run: |
+          echo "::warning::Durable security event reconciliation failed; queued jobs remain retryable"
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Security event reconciliation warning
+
+          The bounded audit and attestation projection drain failed. Skill sync results remain committed, and the durable jobs will be retried by the next scheduled or sync-triggered run.
+          EOF
 
       - name: Remove generated report evidence from synced audits
         if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
-  schedule:
-    # Stagger the 15-minute durable-outbox drain away from top-of-hour jobs.
-    - cron: '7,22,37,52 * * * *'
   workflow_run:
     workflows: ["On PR Merge - Approve Skill"]
     types: [completed]
@@ -55,7 +52,6 @@ jobs:
 
       - name: Find last successful sync commit
         id: last_sync
-        if: github.event_name != 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -94,11 +90,7 @@ jobs:
             done | sort -u
           }
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Scheduled reconcile-only run; skill sync and downstream side effects are disabled"
-            CHANGED=""
-            echo "mode=reconcile-only" >> $GITHUB_OUTPUT
-          elif [ -n "${{ inputs.slugs }}" ]; then
+          if [ -n "${{ inputs.slugs }}" ]; then
             echo "Specific slugs requested: ${{ inputs.slugs }}"
             # Resolve against the immutable workflow commit. A mutable self-hosted
             # checkout may not have a skills/ directory at all.
@@ -148,6 +140,7 @@ jobs:
 
       - name: Download skillstore-cli
         id: download-cli
+        if: steps.changes.outputs.skip_sync != 'true'
         uses: ./.github/actions/download-skillstore-cli
         with:
           version: '2.3.0'
@@ -383,7 +376,7 @@ jobs:
       - name: Reconcile durable security change events
         id: reconcile-security-events
         if: ${{ !cancelled() && steps.download-cli.outcome == 'success' }}
-        continue-on-error: ${{ github.event_name != 'schedule' }}
+        continue-on-error: true
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
+      - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
       - ".github/workflows/test-recalculate-scores.yml"
@@ -30,6 +31,7 @@ on:
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
+      - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
   workflow_dispatch:

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -126,12 +126,12 @@ test('sync materializes only the detected paths from the exact workflow commit',
   assert.match(sync, /--marketplace-commit "\$GITHUB_SHA"/);
 });
 
-test('sync downloads the canonical-hash CLI release', () => {
+test('sync downloads the security-event-capable CLI release', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const download = section(workflow, '      - name: Download skillstore-cli', '      - name: Sync skills to Supabase');
 
-  assert.match(download, /version: '2\.2\.1'/);
-  assert.match(download, /minimum-version: '2\.2\.1'/);
+  assert.match(download, /version: '2\.3\.0'/);
+  assert.match(download, /minimum-version: '2\.3\.0'/);
 });
 
 test('one permanently failed shard makes the aggregate fail closed', () => {

--- a/scripts/tests/security-attestation-issuance-workflow.test.mjs
+++ b/scripts/tests/security-attestation-issuance-workflow.test.mjs
@@ -9,13 +9,17 @@ const workflow = readFileSync(
 );
 
 test('sync uses an attestation-capable CLI and a dedicated issuance credential', () => {
-  assert.match(workflow, /version: '2\.2\.1'/);
-  assert.match(workflow, /minimum-version: '2\.2\.1'/);
+  assert.match(workflow, /version: '2\.3\.0'/);
+  assert.match(workflow, /minimum-version: '2\.3\.0'/);
   assert.match(
     workflow,
     /SECURITY_PASSPORT_MODE: \$\{\{ vars\.SECURITY_PASSPORT_MODE \|\| 'off' \}\}/,
   );
   assert.match(workflow, /PUBLIC_SITE_URL: https:\/\/skillstore\.io/);
+  assert.match(
+    workflow,
+    /SECURITY_NOTIFICATIONS_ENABLED: \$\{\{ vars\.SECURITY_NOTIFICATIONS_ENABLED \|\| 'false' \}\}/,
+  );
   assert.match(
     workflow,
     /AUTOMATION_API_KEY: \$\{\{ secrets\.SECURITY_ATTESTATION_AUTOMATION_KEY \}\}/,

--- a/scripts/tests/security-event-reconciler-workflow.test.mjs
+++ b/scripts/tests/security-event-reconciler-workflow.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/sync-to-supabase.yml'),
+  'utf8',
+);
+
+function stepBlock(name) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  const end = workflow.indexOf('\n      - name:', start + marker.length);
+  return workflow.slice(start, end === -1 ? workflow.length : end);
+}
+
+function jobBlock(name) {
+  const marker = `  ${name}:`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow job: ${name}`);
+  const end = workflow.indexOf('\n  # ===', start + marker.length);
+  return workflow.slice(start, end === -1 ? workflow.length : end);
+}
+
+test('a staggered bounded schedule drains the durable outbox without cancelling writers', () => {
+  assert.match(workflow, /schedule:\n\s+#.*\n\s+- cron: '7,22,37,52 \* \* \* \*'/);
+  assert.match(workflow, /concurrency:\n\s+group: sync-supabase\n\s+cancel-in-progress: false/);
+
+  const download = stepBlock('Download skillstore-cli');
+  assert.match(download, /id: download-cli/);
+  assert.match(download, /version: '2\.3\.0'/);
+  assert.match(download, /minimum-version: '2\.3\.0'/);
+  assert.doesNotMatch(download, /skip_sync|changed_skills/);
+});
+
+test('sync and reconciliation share the explicit notifications rollout flag', () => {
+  const expectedFlag = /SECURITY_NOTIFICATIONS_ENABLED: \$\{\{ vars\.SECURITY_NOTIFICATIONS_ENABLED \|\| 'false' \}\}/;
+  assert.match(stepBlock('Sync skills to Supabase'), expectedFlag);
+
+  const reconcile = stepBlock('Reconcile durable security change events');
+  assert.match(reconcile, expectedFlag);
+  assert.match(reconcile, /PUBLIC_SUPABASE_URL: \$\{\{ secrets\.SUPABASE_URL \}\}/);
+  assert.match(reconcile, /SUPABASE_SERVICE_ROLE_KEY: \$\{\{ secrets\.SUPABASE_SERVICE_KEY \}\}/);
+  assert.match(reconcile, /if: \$\{\{ !cancelled\(\) && steps\.download-cli\.outcome == 'success' \}\}/);
+  assert.match(reconcile, /continue-on-error: \$\{\{ github\.event_name != 'schedule' \}\}/);
+  assert.match(reconcile, /timeout --signal=TERM --kill-after=30s 15m/);
+  assert.match(reconcile, /skill reconcile-security-events --batch-size 100/);
+  assert.doesNotMatch(reconcile, /skip_sync|changed_skills|AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN/);
+});
+
+test('scheduled no-change runs do not enter score, cache, or translation side effects', () => {
+  assert.match(stepBlock('Find last successful sync commit'), /if: github\.event_name != 'schedule'/);
+  const detection = stepBlock('Detect changed skills');
+  assert.match(detection, /if \[ "\$\{\{ github\.event_name \}\}" = "schedule" \]; then/);
+  assert.match(detection, /CHANGED=""/);
+  assert.match(detection, /mode=reconcile-only/);
+  assert.match(detection, /if \[ -z "\$CHANGED" \]; then[\s\S]*skip_sync=true/);
+  assert.ok(
+    detection.indexOf('github.event_name') < detection.indexOf('inputs.slugs'),
+    'schedule must bypass all skill-selection modes',
+  );
+
+  for (const name of [
+    'calculate-scores',
+    'plan-cache-invalidation',
+    'cache-invalidate-shard',
+    'cache-invalidate',
+    'finalize-english-cache',
+    'trigger-translate',
+  ]) {
+    assert.match(jobBlock(name), /needs\.sync\.outputs\.skip_sync != 'true'/, name);
+  }
+
+  const reconcileStart = workflow.indexOf('      - name: Reconcile durable security change events');
+  const syncStart = workflow.indexOf('      - name: Sync skills to Supabase');
+  const cleanupStart = workflow.indexOf('      - name: Remove generated report evidence from synced audits');
+  assert.ok(syncStart < reconcileStart && reconcileStart < cleanupStart);
+});
+
+test('a failed bounded drain stays observable and leaves durable jobs for retry', () => {
+  const report = stepBlock('Report security event reconciliation failure');
+  assert.match(report, /always\(\) && steps\.reconcile-security-events\.outcome == 'failure'/);
+  assert.match(report, /queued jobs remain retryable/);
+  assert.match(report, /next scheduled or sync-triggered run/);
+});

--- a/scripts/tests/security-event-reconciler-workflow.test.mjs
+++ b/scripts/tests/security-event-reconciler-workflow.test.mjs
@@ -3,12 +3,20 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import test from 'node:test';
 
-const workflow = readFileSync(
+const syncWorkflow = readFileSync(
   resolve(process.cwd(), '.github/workflows/sync-to-supabase.yml'),
   'utf8',
 );
+const scheduledWorkflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/reconcile-security-events.yml'),
+  'utf8',
+);
+const testWorkflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/test-recalculate-scores.yml'),
+  'utf8',
+);
 
-function stepBlock(name) {
+function stepBlock(workflow, name) {
   const marker = `      - name: ${name}`;
   const start = workflow.indexOf(marker);
   assert.notEqual(start, -1, `missing workflow step: ${name}`);
@@ -16,72 +24,67 @@ function stepBlock(name) {
   return workflow.slice(start, end === -1 ? workflow.length : end);
 }
 
-function jobBlock(name) {
-  const marker = `  ${name}:`;
-  const start = workflow.indexOf(marker);
-  assert.notEqual(start, -1, `missing workflow job: ${name}`);
-  const end = workflow.indexOf('\n  # ===', start + marker.length);
-  return workflow.slice(start, end === -1 ? workflow.length : end);
-}
+test('the scheduled drain is isolated from the incremental sync baseline', () => {
+  assert.doesNotMatch(syncWorkflow, /^\s{2}schedule:/m);
+  assert.match(syncWorkflow, /concurrency:\n\s+group: sync-supabase\n\s+cancel-in-progress: false/);
+  assert.doesNotMatch(syncWorkflow, /mode=reconcile-only/);
 
-test('a staggered bounded schedule drains the durable outbox without cancelling writers', () => {
-  assert.match(workflow, /schedule:\n\s+#.*\n\s+- cron: '7,22,37,52 \* \* \* \*'/);
-  assert.match(workflow, /concurrency:\n\s+group: sync-supabase\n\s+cancel-in-progress: false/);
+  assert.match(scheduledWorkflow, /schedule:\n\s+#.*\n\s+- cron: '7,22,37,52 \* \* \* \*'/);
+  assert.match(scheduledWorkflow, /workflow_dispatch:/);
+  assert.match(
+    scheduledWorkflow,
+    /concurrency:\n\s+group: security-event-reconciler\n\s+cancel-in-progress: false/,
+  );
+  assert.match(scheduledWorkflow, /runs-on: ubuntu-latest/);
+  assert.match(scheduledWorkflow, /timeout-minutes: 20/);
+});
 
-  const download = stepBlock('Download skillstore-cli');
-  assert.match(download, /id: download-cli/);
+test('the scheduled drain uses the pinned CLI and least required credentials', () => {
+  const checkout = stepBlock(scheduledWorkflow, 'Checkout CLI download action');
+  assert.match(checkout, /persist-credentials: false/);
+  assert.match(checkout, /sparse-checkout: \.github\/actions\/download-skillstore-cli/);
+
+  const token = stepBlock(scheduledWorkflow, 'Generate GitHub App Token');
+  assert.match(token, /repositories: marketplace,skillstore/);
+
+  const download = stepBlock(scheduledWorkflow, 'Download skillstore-cli');
   assert.match(download, /version: '2\.3\.0'/);
   assert.match(download, /minimum-version: '2\.3\.0'/);
-  assert.doesNotMatch(download, /skip_sync|changed_skills/);
-});
 
-test('sync and reconciliation share the explicit notifications rollout flag', () => {
-  const expectedFlag = /SECURITY_NOTIFICATIONS_ENABLED: \$\{\{ vars\.SECURITY_NOTIFICATIONS_ENABLED \|\| 'false' \}\}/;
-  assert.match(stepBlock('Sync skills to Supabase'), expectedFlag);
-
-  const reconcile = stepBlock('Reconcile durable security change events');
-  assert.match(reconcile, expectedFlag);
+  const reconcile = stepBlock(scheduledWorkflow, 'Reconcile durable security change events');
   assert.match(reconcile, /PUBLIC_SUPABASE_URL: \$\{\{ secrets\.SUPABASE_URL \}\}/);
   assert.match(reconcile, /SUPABASE_SERVICE_ROLE_KEY: \$\{\{ secrets\.SUPABASE_SERVICE_KEY \}\}/);
-  assert.match(reconcile, /if: \$\{\{ !cancelled\(\) && steps\.download-cli\.outcome == 'success' \}\}/);
-  assert.match(reconcile, /continue-on-error: \$\{\{ github\.event_name != 'schedule' \}\}/);
+  assert.match(
+    reconcile,
+    /SECURITY_NOTIFICATIONS_ENABLED: \$\{\{ vars\.SECURITY_NOTIFICATIONS_ENABLED \|\| 'false' \}\}/,
+  );
   assert.match(reconcile, /timeout --signal=TERM --kill-after=30s 15m/);
   assert.match(reconcile, /skill reconcile-security-events --batch-size 100/);
-  assert.doesNotMatch(reconcile, /skip_sync|changed_skills|AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN/);
+  assert.doesNotMatch(reconcile, /continue-on-error|AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN/);
 });
 
-test('scheduled no-change runs do not enter score, cache, or translation side effects', () => {
-  assert.match(stepBlock('Find last successful sync commit'), /if: github\.event_name != 'schedule'/);
-  const detection = stepBlock('Detect changed skills');
-  assert.match(detection, /if \[ "\$\{\{ github\.event_name \}\}" = "schedule" \]; then/);
-  assert.match(detection, /CHANGED=""/);
-  assert.match(detection, /mode=reconcile-only/);
-  assert.match(detection, /if \[ -z "\$CHANGED" \]; then[\s\S]*skip_sync=true/);
-  assert.ok(
-    detection.indexOf('github.event_name') < detection.indexOf('inputs.slugs'),
-    'schedule must bypass all skill-selection modes',
+test('the scheduled workflow cannot trigger sync, score, cache, or translation side effects', () => {
+  assert.doesNotMatch(
+    scheduledWorkflow,
+    /skill sync|changed_skills|sync-supabase|calculate-scores|cache-invalidate|trigger-translate|repository_dispatch/,
   );
-
-  for (const name of [
-    'calculate-scores',
-    'plan-cache-invalidation',
-    'cache-invalidate-shard',
-    'cache-invalidate',
-    'finalize-english-cache',
-    'trigger-translate',
-  ]) {
-    assert.match(jobBlock(name), /needs\.sync\.outputs\.skip_sync != 'true'/, name);
-  }
-
-  const reconcileStart = workflow.indexOf('      - name: Reconcile durable security change events');
-  const syncStart = workflow.indexOf('      - name: Sync skills to Supabase');
-  const cleanupStart = workflow.indexOf('      - name: Remove generated report evidence from synced audits');
-  assert.ok(syncStart < reconcileStart && reconcileStart < cleanupStart);
 });
 
-test('a failed bounded drain stays observable and leaves durable jobs for retry', () => {
-  const report = stepBlock('Report security event reconciliation failure');
-  assert.match(report, /always\(\) && steps\.reconcile-security-events\.outcome == 'failure'/);
-  assert.match(report, /queued jobs remain retryable/);
-  assert.match(report, /next scheduled or sync-triggered run/);
+test('normal syncs use 2.3.0 and keep reconciliation best-effort', () => {
+  const download = stepBlock(syncWorkflow, 'Download skillstore-cli');
+  assert.match(download, /if: steps\.changes\.outputs\.skip_sync != 'true'/);
+  assert.match(download, /version: '2\.3\.0'/);
+  assert.match(download, /minimum-version: '2\.3\.0'/);
+
+  const expectedFlag = /SECURITY_NOTIFICATIONS_ENABLED: \$\{\{ vars\.SECURITY_NOTIFICATIONS_ENABLED \|\| 'false' \}\}/;
+  assert.match(stepBlock(syncWorkflow, 'Sync skills to Supabase'), expectedFlag);
+  const reconcile = stepBlock(syncWorkflow, 'Reconcile durable security change events');
+  assert.match(reconcile, expectedFlag);
+  assert.match(reconcile, /continue-on-error: true/);
+  assert.match(reconcile, /skill reconcile-security-events --batch-size 100/);
+});
+
+test('CI tracks the isolated scheduled workflow contract', () => {
+  assert.match(testWorkflow, /\.github\/workflows\/reconcile-security-events\.yml/);
+  assert.match(testWorkflow, /node --test scripts\/tests\/\*\.test\.mjs/);
 });


### PR DESCRIPTION
## Summary

- add a staggered 15-minute durable security-event reconciliation schedule
- make scheduled runs explicitly reconcile-only so they cannot sync Skills or trigger score, cache, or translation side effects
- pin the writer CLI and minimum version to 2.3.0
- pass `SECURITY_NOTIFICATIONS_ENABLED` with a fail-closed `false` default to both sync and reconciliation
- drain up to 100 audit and attestation projection jobs within a 15-minute timeout

## Failure and concurrency behavior

- preserve `sync-supabase` serialization with `cancel-in-progress: false`
- scheduled drain failures remain red and visible
- push/manual syncs keep committed writes and warn; durable jobs retry on the next run
- no variables are changed and no workflow is manually triggered by this PR

## Validation

- `CI=true node --test scripts/tests/security-attestation-issuance-workflow.test.mjs scripts/tests/security-event-reconciler-workflow.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/security-research-refresh-workflows.test.mjs` — 21 passed
- workflow YAML parses successfully
- `git diff --check`

## Dependency

Merge only after `cli-v2.3.0` is published from aiskillstore/skillstore#225.