### PR TITLE
chore: pin artifact backfill to CLI 2.3.1

### DIFF
--- a/.github/workflows/backfill-artifact-versions.yml
+++ b/.github/workflows/backfill-artifact-versions.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version (X.Y.Z; latest is forbidden)'
         type: string
         required: true
-        default: '2.2.2'
+        default: '2.3.1'
       batch_size:
         description: 'Maximum legacy Skills in this serial batch (1-500)'
         type: number
@@ -104,8 +104,8 @@ jobs:
             echo "::error::cli_version must be an exact stable X.Y.Z release"
             exit 1
           fi
-          if [ "$CLI_VERSION" != "2.2.2" ]; then
-            echo "::error::this workflow is pinned to the audited skillstore-cli 2.2.2"
+          if [ "$CLI_VERSION" != "2.3.1" ]; then
+            echo "::error::this workflow is pinned to the audited skillstore-cli 2.3.1"
             exit 1
           fi
           if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ] || [ "$BATCH_SIZE" -gt 500 ]; then

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -690,8 +690,8 @@ test('workflow is bounded, exact-only, cursor-safe, and evidence-producing', () 
     resolve(import.meta.dirname, '../fetch-artifact-version-inventory.mjs'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.2\.2'/);
-  assert.match(workflow, /CLI_VERSION" != "2\.2\.2"/);
+  assert.match(workflow, /default: '2\.3\.1'/);
+  assert.match(workflow, /CLI_VERSION" != "2\.3\.1"/);
   assert.match(workflow, /sparse-checkout: ''/);
   assert.match(workflow, /sparse-checkout-cone-mode: false/);
   const checkoutGuard = workflow.indexOf('name: Normalize full checkout and verify backfill runtime');


### PR DESCRIPTION
## Summary
- pin artifact-version governance to the exact audited skillstore-cli 2.3.1 release
- retain the stable-version and minimum-version writer gates
- update the workflow contract test

## Why
CLI 2.3.1 adds bounded retry for transient Supabase/TLS failures on the read-only Skill preflight. Writes remain outside the retry wrapper and incomplete classifications still fail closed.

## Validation
- `CI=true node --test scripts/tests/artifact-version-backfill.test.mjs` (10/10)
- CLI release run 29382849602 passed binary build/test/release
- release assets: `skillstore-cli-linux-x64` and `checksums.txt`

## Rollout
After merge, rerun the frozen batch-7 dry-run with `cli_version=2.3.1`. Do not execute unless all 500 classifications verify.