### PR TITLE
feat: orchestrate legacy-equivalent artifact governance

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -1,0 +1,527 @@
+name: Govern Legacy-Equivalent Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Freeze a dry-run boundary, or execute one prior successful boundary'
+        type: choice
+        required: true
+        default: dry-run
+        options:
+          - dry-run
+          - execute
+      cli_version:
+        description: 'Exact audited skillstore-cli version'
+        type: string
+        required: true
+        default: '2.4.0'
+      batch_size:
+        description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
+        type: number
+        required: true
+        default: 500
+      start_after:
+        description: 'Prior classification scan end; dry-run only'
+        type: string
+        required: false
+        default: ''
+      end_at:
+        description: 'Optional inclusive dry-run range end'
+        type: string
+        required: false
+        default: ''
+      dry_run_id:
+        description: 'Successful dry-run workflow run ID; required for execute'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+jobs:
+  freeze-boundary:
+    if: inputs.mode == 'dry-run'
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize checkout and verify governance runtime
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          for path in \
+            .github/actions/download-skillstore-cli/action.yml \
+            scripts/fetch-artifact-version-inventory.mjs \
+            scripts/plan-artifact-version-backfill.mjs \
+            scripts/verify-artifact-version-classification.mjs \
+            scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            scripts/verify-legacy-equivalent-governance.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing governance runtime"; exit 1; }
+          done
+
+      - name: Validate frozen-boundary inputs
+        id: inputs
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          START_AFTER: ${{ inputs.start_after }}
+          END_AT: ${{ inputs.end_at }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$CLI_VERSION" = '2.4.0' || { echo '::error::workflow is pinned to skillstore-cli 2.4.0'; exit 1; }
+          test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
+          [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
+            echo '::error::batch_size must be between 1 and 500'; exit 1;
+          }
+          [ -z "$DRY_RUN_ID" ] || { echo '::error::dry_run_id is execute-only'; exit 1; }
+          [[ "$START_AFTER$END_AT" != *$'\n'* && "$START_AFTER$END_AT" != *$'\r'* ]] || {
+            echo '::error::cursor inputs must be exact production slugs'; exit 1;
+          }
+          echo "cli_version=$CLI_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch exact production catalog
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: node scripts/fetch-artifact-version-inventory.mjs --skills-only --output "$RUNNER_TEMP/catalog.json"
+
+      - name: Build bounded deterministic plan
+        id: plan
+        env:
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          START_AFTER: ${{ inputs.start_after }}
+          END_AT: ${{ inputs.end_at }}
+        run: |
+          set -euo pipefail
+          args=(
+            --repository-root "$GITHUB_WORKSPACE"
+            --inventory "$RUNNER_TEMP/catalog.json"
+            --batch-size "$BATCH_SIZE"
+            --output "$RUNNER_TEMP/plan.json"
+            --paths-output "$RUNNER_TEMP/paths.txt"
+          )
+          [ -z "$START_AFTER" ] || args+=(--start-after "$START_AFTER")
+          [ -z "$END_AT" ] || args+=(--end-at "$END_AT")
+          node scripts/plan-artifact-version-backfill.mjs "${args[@]}"
+          echo "selected_count=$(jq -r .selectedCount "$RUNNER_TEMP/plan.json")" >> "$GITHUB_OUTPUT"
+          echo "last_selected=$(jq -r '.lastSelected // ""' "$RUNNER_TEMP/plan.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch frozen pre-inventory
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: >-
+          node scripts/fetch-artifact-version-inventory.mjs
+          --scope-inventory "$RUNNER_TEMP/plan.json"
+          --output "$RUNNER_TEMP/pre-inventory.json"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact unpublished-gated CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.4.0'
+          minimum-version: '2.4.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify audited CLI 2.4.0 binary identity
+        run: |
+          set -euo pipefail
+          expected='eec024fd85af15a50103b80bfca2e00dcc30f62f94f1dbb32c7a5eba0061b461'
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          test "$actual" = "$expected" || {
+            echo '::error::CLI 2.4.0 binary does not match the audited linux-x64 digest'; exit 1;
+          }
+
+      - name: Materialize pinned snapshots
+        run: |
+          set -euo pipefail
+          while IFS= read -r batch; do
+            index=$(jq -r .index <<< "$batch")
+            while IFS= read -r group; do
+              commit=$(jq -r .marketplaceCommit <<< "$group")
+              root="$RUNNER_TEMP/materialized/batch-$index/$commit"
+              mkdir -p "$root"
+              mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+              git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+            done < <(jq -c '.groups[]' <<< "$batch")
+          done < <(jq -c '.batches[]' "$RUNNER_TEMP/plan.json")
+
+      - name: Classify all rows without writes
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/classification-groups"
+          : > "$RUNNER_TEMP/classification-results.jsonl"
+          while IFS= read -r batch; do
+            index=$(jq -r .index <<< "$batch")
+            while IFS= read -r group; do
+              commit=$(jq -r .marketplaceCommit <<< "$group")
+              count=$(jq -r .count <<< "$group")
+              mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+              slug_paths=$(printf '%s\n' "${paths[@]}" | paste -sd,)
+              raw="$RUNNER_TEMP/classification-groups/$index-$commit.raw.json"
+              normalized="$RUNNER_TEMP/classification-groups/$index-$commit.json"
+              set +e
+              (cd "$RUNNER_TEMP/materialized/batch-$index/$commit" && "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
+                --slugs "$slug_paths" --artifact-only --legacy-only --repair-stale-report-hashes \
+                --dry-run --concurrency 5 --marketplace-commit "$commit" --output json) > "$raw"
+              exit_code=$?
+              set -e
+              jq -e . "$raw" > "$normalized"
+              jq -n -c --argjson batchIndex "$index" --arg marketplaceCommit "$commit" \
+                --argjson selectedCount "$count" --argjson exitCode "$exit_code" \
+                --slurpfile result "$normalized" \
+                '{batchIndex:$batchIndex,marketplaceCommit:$marketplaceCommit,selectedCount:$selectedCount,exitCode:$exitCode,result:$result[0]}' \
+                >> "$RUNNER_TEMP/classification-results.jsonl"
+            done < <(jq -c '.groups[]' <<< "$batch")
+          done < <(jq -c '.batches[]' "$RUNNER_TEMP/plan.json")
+          jq -s . "$RUNNER_TEMP/classification-results.jsonl" > "$RUNNER_TEMP/classification-results.json"
+          node scripts/verify-artifact-version-classification.mjs --phase classification \
+            --plan "$RUNNER_TEMP/plan.json" --results "$RUNNER_TEMP/classification-results.json" \
+            --output "$RUNNER_TEMP/classification.json"
+          node scripts/verify-legacy-equivalent-governance.mjs --phase groups \
+            --plan "$RUNNER_TEMP/plan.json" --classification "$RUNNER_TEMP/classification.json" \
+            --output "$RUNNER_TEMP/legacy-groups.json"
+
+      - name: Run administrator governance dry-run
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/governance-dry-run-groups"
+          : > "$RUNNER_TEMP/governance-dry-run.jsonl"
+          while IFS= read -r group; do
+            index=$(jq -r .batchIndex <<< "$group")
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            count=$(jq -r .count <<< "$group")
+            slugs=$(jq -r '.slugs | join(",")' <<< "$group")
+            result="$RUNNER_TEMP/governance-dry-run-groups/$index-$commit.json"
+            "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+              --classification "$RUNNER_TEMP/classification.json" \
+              --root "$RUNNER_TEMP/materialized/batch-$index/$commit" \
+              --slugs "$slugs" --dry-run --concurrency 1 --result-file "$result"
+            jq -n -c --argjson batchIndex "$index" --arg marketplaceCommit "$commit" \
+              --argjson selectedCount "$count" --argjson slugs "$(jq -c .slugs <<< "$group")" \
+              --slurpfile result "$result" \
+              '{batchIndex:$batchIndex,marketplaceCommit:$marketplaceCommit,selectedCount:$selectedCount,slugs:$slugs,exitCode:0,result:$result[0]}' \
+              >> "$RUNNER_TEMP/governance-dry-run.jsonl"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/legacy-groups.json")
+          jq -s . "$RUNNER_TEMP/governance-dry-run.jsonl" > "$RUNNER_TEMP/governance-dry-run.json"
+
+      - name: Freeze complete source audit and install metadata evidence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: >-
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs
+          --classification "$RUNNER_TEMP/classification.json"
+          --output "$RUNNER_TEMP/source-evidence.json"
+
+      - name: Freeze immutable execution boundary
+        run: |
+          set -euo pipefail
+          boundary="$RUNNER_TEMP/legacy-boundary"
+          mkdir -p "$boundary"
+          cp "$RUNNER_TEMP/plan.json" "$boundary/plan.json"
+          cp "$RUNNER_TEMP/classification.json" "$boundary/classification.json"
+          cp "$RUNNER_TEMP/pre-inventory.json" "$boundary/pre-inventory.json"
+          cp "$RUNNER_TEMP/governance-dry-run.json" "$boundary/governance-dry-run.json"
+          cp "$RUNNER_TEMP/source-evidence.json" "$boundary/source-evidence.json"
+          node scripts/verify-legacy-equivalent-governance.mjs --phase freeze \
+            --plan "$boundary/plan.json" --classification "$boundary/classification.json" \
+            --pre-inventory "$boundary/pre-inventory.json" --dry-run-results "$boundary/governance-dry-run.json" \
+            --source-evidence "$boundary/source-evidence.json" \
+            --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.0' \
+            --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
+            --output "$boundary/boundary.json"
+          (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json boundary.json > SHA256SUMS)
+
+      - name: Upload strict frozen-boundary evidence
+        if: success()
+        id: boundary-evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-equivalent-boundary-${{ github.run_id }}
+          path: ${{ runner.temp }}/legacy-boundary/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish dry-run boundary summary
+        if: always() && steps.plan.outcome == 'success'
+        run: |
+          {
+            echo '## Legacy-equivalent frozen boundary'
+            echo "- Run ID: \`$GITHUB_RUN_ID\`"
+            echo "- CLI: \`2.4.0\`"
+            echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
+            echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
+            echo '- No production write was authorized.'
+            echo "- Execute with \`dry_run_id=$GITHUB_RUN_ID\`; no scan cursor is a completion claim."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Preserve failed dry-run evidence
+        if: failure()
+        run: |
+          set -euo pipefail
+          boundary="$RUNNER_TEMP/legacy-boundary"
+          mkdir -p "$boundary"
+          for item in plan classification pre-inventory governance-dry-run source-evidence classification-results legacy-groups; do
+            source="$RUNNER_TEMP/$item.json"
+            [ ! -f "$source" ] || cp "$source" "$boundary/$item.json"
+          done
+          jq -n --arg status failed --arg runId "$GITHUB_RUN_ID" --arg sha "$GITHUB_SHA" \
+            '{schemaVersion:1,status:$status,runId:$runId,workflowCommit:$sha}' > "$boundary/failure.json"
+          (cd "$boundary" && find . -maxdepth 1 -name '*.json' -print0 | sort -z | xargs -0 sha256sum > FAILURE_SHA256SUMS)
+
+      - name: Upload failed dry-run evidence
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-equivalent-failed-dry-run-${{ github.run_id }}
+          path: ${{ runner.temp }}/legacy-boundary/
+          if-no-files-found: error
+          retention-days: 30
+
+  execute-boundary:
+    if: inputs.mode == 'execute'
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize checkout and validate execute inputs
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+          END_AT: ${{ inputs.end_at }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          test "$CLI_VERSION" = '2.4.0' || { echo '::error::workflow is pinned to skillstore-cli 2.4.0'; exit 1; }
+          test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
+          [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
+          [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
+          for path in scripts/fetch-artifact-version-inventory.mjs \
+            scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            scripts/verify-legacy-equivalent-governance.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing governance runtime"; exit 1; }
+          done
+
+      - name: Download exact successful dry-run boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName,url)
+          jq -e --argjson id "$DRY_RUN_ID" '
+            .databaseId == $id and .conclusion == "success" and .event == "workflow_dispatch" and
+            .headBranch == "main" and .workflowName == "Govern Legacy-Equivalent Artifacts"
+          ' <<< "$run_json" >/dev/null || { echo '::error::dry_run_id is not a successful governance workflow'; exit 1; }
+          mkdir -p "$RUNNER_TEMP/boundary"
+          gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-equivalent-boundary-$DRY_RUN_ID" --dir "$RUNNER_TEMP/boundary"
+          (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
+          test "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" = "$(jq -r .headSha <<< "$run_json")" || {
+            echo '::error::boundary workflow commit does not match its source run'; exit 1;
+          }
+          git merge-base --is-ancestor "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" "$GITHUB_SHA" || {
+            echo '::error::boundary workflow commit is not an ancestor of this main execution'; exit 1;
+          }
+
+      - name: Refetch current scoped production state
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/boundary/plan.json" \
+            --output "$RUNNER_TEMP/current-inventory.json"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/boundary/classification.json" \
+            --output "$RUNNER_TEMP/current-source-evidence.json"
+
+      - name: Verify frozen boundary before any write
+        run: |
+          set -euo pipefail
+          node scripts/verify-legacy-equivalent-governance.mjs --phase execute-preflight \
+            --boundary "$RUNNER_TEMP/boundary/boundary.json" --plan "$RUNNER_TEMP/boundary/plan.json" \
+            --classification "$RUNNER_TEMP/boundary/classification.json" \
+            --frozen-inventory "$RUNNER_TEMP/boundary/pre-inventory.json" \
+            --current-inventory "$RUNNER_TEMP/current-inventory.json" \
+            --frozen-source-evidence "$RUNNER_TEMP/boundary/source-evidence.json" \
+            --current-source-evidence "$RUNNER_TEMP/current-source-evidence.json" \
+            --dry-run-results "$RUNNER_TEMP/boundary/governance-dry-run.json" \
+            --expected-run-id '${{ inputs.dry_run_id }}' --output "$RUNNER_TEMP/execution-preflight.json"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact audited CLI 2.4.0
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.4.0'
+          minimum-version: '2.4.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify frozen CLI binary identity
+        run: |
+          set -euo pipefail
+          audited='eec024fd85af15a50103b80bfca2e00dcc30f62f94f1dbb32c7a5eba0061b461'
+          expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          test "$expected" = "$audited" && test "$actual" = "$audited" || {
+            echo '::error::CLI 2.4.0 binary differs from the frozen dry-run boundary'; exit 1;
+          }
+
+      - name: Materialize only frozen legacy groups
+        run: |
+          set -euo pipefail
+          while IFS= read -r group; do
+            index=$(jq -r .batchIndex <<< "$group")
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            root="$RUNNER_TEMP/materialized/batch-$index/$commit"
+            mkdir -p "$root"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/boundary.json")
+
+      - name: Execute frozen legacy cohort serially with cache batches of at most ten
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SKILLSTORE_SITE_URL: https://skillstore.io
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/execution-groups"
+          : > "$RUNNER_TEMP/execution-results.jsonl"
+          while IFS= read -r group; do
+            index=$(jq -r .batchIndex <<< "$group")
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            count=$(jq -r .count <<< "$group")
+            slugs=$(jq -r '.slugs | join(",")' <<< "$group")
+            result="$RUNNER_TEMP/execution-groups/$index-$commit.json"
+            "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+              --classification "$RUNNER_TEMP/boundary/classification.json" \
+              --root "$RUNNER_TEMP/materialized/batch-$index/$commit" \
+              --slugs "$slugs" --concurrency 1 --result-file "$result"
+            jq -n -c --argjson batchIndex "$index" --arg marketplaceCommit "$commit" \
+              --argjson selectedCount "$count" --argjson slugs "$(jq -c .slugs <<< "$group")" \
+              --slurpfile result "$result" \
+              '{batchIndex:$batchIndex,marketplaceCommit:$marketplaceCommit,selectedCount:$selectedCount,slugs:$slugs,exitCode:0,result:$result[0]}' \
+              >> "$RUNNER_TEMP/execution-results.jsonl"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/boundary.json")
+          jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
+
+      - name: Fetch post-execution inventory and governance evidence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/boundary/plan.json" --output "$RUNNER_TEMP/post-inventory.json"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --execution-results "$RUNNER_TEMP/execution-results.json" --output "$RUNNER_TEMP/governance-readback.json"
+
+      - name: Verify complete production execution evidence
+        run: >-
+          node scripts/verify-legacy-equivalent-governance.mjs --phase execution
+          --boundary "$RUNNER_TEMP/boundary/boundary.json"
+          --plan "$RUNNER_TEMP/boundary/plan.json"
+          --classification "$RUNNER_TEMP/boundary/classification.json"
+          --execution-results "$RUNNER_TEMP/execution-results.json"
+          --frozen-inventory "$RUNNER_TEMP/boundary/pre-inventory.json"
+          --post-inventory "$RUNNER_TEMP/post-inventory.json"
+          --readback "$RUNNER_TEMP/governance-readback.json"
+          --frozen-source-evidence "$RUNNER_TEMP/boundary/source-evidence.json"
+          --output "$RUNNER_TEMP/execution-verification.json"
+
+      - name: Preserve execution status evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/execution-evidence"
+          mkdir -p "$evidence"
+          if [ ! -f "$RUNNER_TEMP/execution-results.json" ] && [ -f "$RUNNER_TEMP/execution-results.jsonl" ]; then
+            jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
+          fi
+          jq -n --arg runId "$GITHUB_RUN_ID" --arg boundaryRun '${{ inputs.dry_run_id }}' \
+            --arg sha "$GITHUB_SHA" --arg jobStatus '${{ job.status }}' \
+            '{schemaVersion:1,runId:$runId,boundaryRunId:$boundaryRun,workflowCommit:$sha,jobStatus:$jobStatus}' \
+            > "$evidence/run-status.json"
+
+      - name: Upload strict execution evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-equivalent-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/boundary/
+            ${{ runner.temp }}/execution-preflight.json
+            ${{ runner.temp }}/current-source-evidence.json
+            ${{ runner.temp }}/execution-results.json
+            ${{ runner.temp }}/post-inventory.json
+            ${{ runner.temp }}/governance-readback.json
+            ${{ runner.temp }}/execution-verification.json
+            ${{ runner.temp }}/execution-evidence/run-status.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish verified execution summary
+        run: |
+          {
+            echo '## Legacy-equivalent execution verified'
+            echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
+            echo '- CLI: `2.4.0`'
+            echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
+            echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
+            echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/fetch-legacy-equivalent-governance-readback.mjs
+++ b/scripts/fetch-legacy-equivalent-governance-readback.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const FILTER_CHUNK_SIZE = 100;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function headers(serviceKey) {
+  return {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Accept-Profile': 'skillstore',
+    Range: '0-999',
+    'Range-Unit': 'items',
+  };
+}
+
+async function fetchRows({ supabaseUrl, serviceKey, table, select, filter, values, fetchImpl }) {
+  const rows = [];
+  for (let offset = 0; offset < values.length; offset += FILTER_CHUNK_SIZE) {
+    const chunk = values.slice(offset, offset + FILTER_CHUNK_SIZE);
+    const url = new URL(`/rest/v1/${table}`, supabaseUrl);
+    url.searchParams.set('select', select);
+    url.searchParams.set(filter, `in.(${chunk.join(',')})`);
+    const response = await fetchImpl(url, { headers: headers(serviceKey) });
+    if (!response.ok) fail(`readback ${table} failed: HTTP ${response.status}`);
+    const page = await response.json();
+    if (!Array.isArray(page)) fail(`readback ${table} returned a non-array`);
+    if (page.length >= 1000) fail(`readback ${table} exceeded the bounded page`);
+    rows.push(...page);
+  }
+  return rows;
+}
+
+export async function fetchLegacyGovernanceReadback({
+  supabaseUrl,
+  serviceKey,
+  executionResults,
+  fetchImpl = fetch,
+}) {
+  if (!Array.isArray(executionResults)) fail('execution results must be an array');
+  const results = executionResults.flatMap((wrapper) => wrapper?.result?.results || []);
+  const skillIds = unique(results.map((row) => row.skillId));
+  const auditIds = unique(results.flatMap((row) => [row.sourceAuditId, row.derivedAuditId]));
+  const snapshotIds = unique(results.map((row) => row.scoreSnapshotId));
+  const derivedAuditIds = unique(results.map((row) => row.derivedAuditId));
+  if (skillIds.length !== results.length || snapshotIds.length !== results.length) {
+    fail('execution results contain duplicate or missing immutable ids');
+  }
+  const request = (table, select, filter, values) => fetchRows({
+    supabaseUrl,
+    serviceKey,
+    table,
+    select,
+    filter,
+    values,
+    fetchImpl,
+  });
+  const [skills, audits, scoreSnapshots, scoreBreakdowns, attestations] = await Promise.all([
+    request(
+      'skills',
+      'id,slug,name,description,author_name,supported_tools,file_structure,current_artifact_version_id,artifact_revision,content_hash,tree_hash,marketplace_commit_sha,plugin_path,public_eligible,public_eligibility_audit_id,published_at,updated_at,current_quality_score_snapshot_id,quality_score',
+      'id',
+      skillIds
+    ),
+    request(
+      'skill_security_audit',
+      '*',
+      'id',
+      auditIds
+    ),
+    request(
+      'skill_quality_score_snapshots',
+      'id,skill_id,score_subject,score_subject_hash,score_input_hash,scorer_version',
+      'id',
+      snapshotIds
+    ),
+    request(
+      'skill_quality_breakdown',
+      'skill_id,score_snapshot_id,stale_at,stale_reason',
+      'skill_id',
+      skillIds
+    ),
+    request(
+      'security_audit_attestations',
+      'id,audit_id',
+      'audit_id',
+      derivedAuditIds
+    ),
+  ]);
+  return {
+    schemaVersion: 1,
+    skillIds,
+    skills,
+    audits,
+    scoreSnapshots,
+    scoreBreakdowns,
+    attestations,
+  };
+}
+
+export async function fetchLegacyGovernanceSourceEvidence({
+  supabaseUrl,
+  serviceKey,
+  classification,
+  fetchImpl = fetch,
+}) {
+  const legacy = classification?.cohorts?.legacy_algorithm_equivalent;
+  if (!Array.isArray(legacy)) fail('classification lacks the legacy-equivalent cohort');
+  const skillIds = unique(legacy.map((row) => row.id));
+  const auditIds = unique(legacy.map((row) => row.publicEligibilityAuditId));
+  if (skillIds.length !== legacy.length || auditIds.length !== legacy.length) {
+    fail('classification contains duplicate or missing Skill/audit ids');
+  }
+  const request = (table, select, filter, values) => fetchRows({
+    supabaseUrl,
+    serviceKey,
+    table,
+    select,
+    filter,
+    values,
+    fetchImpl,
+  });
+  const [skills, audits] = await Promise.all([
+    request(
+      'skills',
+      'id,slug,name,description,author_name,supported_tools,file_structure',
+      'id',
+      skillIds
+    ),
+    request('skill_security_audit', '*', 'id', auditIds),
+  ]);
+  if (skills.length !== legacy.length || audits.length !== legacy.length) {
+    fail('source evidence readback is incomplete');
+  }
+  return { schemaVersion: 1, status: 'source_evidence_fetched', skillIds, skills, audits };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) fail(`invalid argument: ${key || '<missing>'}`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+  if (!supabaseUrl || !serviceKey) fail('SUPABASE_URL and SUPABASE_SERVICE_KEY are required');
+  const finalOutput = args.classification
+    ? await fetchLegacyGovernanceSourceEvidence({
+        supabaseUrl,
+        serviceKey,
+        classification: JSON.parse(readFileSync(resolve(args.classification), 'utf8')),
+      })
+    : await fetchLegacyGovernanceReadback({
+        supabaseUrl,
+        serviceKey,
+        executionResults: JSON.parse(readFileSync(resolve(args['execution-results']), 'utf8')),
+      });
+  writeFileSync(resolve(args.output), `${JSON.stringify(finalOutput, null, 2)}\n`, { flag: 'wx' });
+  process.stdout.write(`${JSON.stringify({ status: finalOutput.status || 'fetched', skills: finalOutput.skills.length })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`legacy-equivalent governance readback failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -1,0 +1,477 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import {
+  createLegacyGovernanceBoundary,
+  verifyLegacyGovernanceBoundary,
+  verifyLegacyGovernanceExecution,
+} from '../verify-legacy-equivalent-governance.mjs';
+import {
+  fetchLegacyGovernanceReadback,
+  fetchLegacyGovernanceSourceEvidence,
+} from '../fetch-legacy-equivalent-governance-readback.mjs';
+
+const SKILL_ID = '00000000-0000-4000-8000-000000000001';
+const SOURCE_AUDIT_ID = '10000000-0000-4000-8000-000000000001';
+const DERIVED_AUDIT_ID = '20000000-0000-4000-8000-000000000001';
+const ARTIFACT_ID = '30000000-0000-4000-8000-000000000001';
+const SNAPSHOT_ID = '40000000-0000-4000-8000-000000000001';
+const COMMIT = 'a'.repeat(40);
+const LEGACY_CONTENT = 'b'.repeat(64);
+const LEGACY_TREE = 'c'.repeat(64);
+const CONTENT = 'd'.repeat(64);
+const TREE = 'e'.repeat(64);
+
+function frozenRow() {
+  return {
+    id: SKILL_ID,
+    slug: 'owner-image',
+    path: 'skills/owner/image',
+    marketplaceCommit: COMMIT,
+    contentHash: LEGACY_CONTENT,
+    treeHash: LEGACY_TREE,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+    publicEligibilityAuditId: SOURCE_AUDIT_ID,
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    evidence: {
+      artifact: {
+        contentHash: CONTENT,
+        treeHash: TREE,
+        hashRepair: {
+          reportContentHash: LEGACY_CONTENT,
+          reportTreeHash: LEGACY_TREE,
+          packagedContentHash: CONTENT,
+          packagedTreeHash: TREE,
+        },
+      },
+    },
+  };
+}
+
+function fixtures() {
+  const row = frozenRow();
+  const plan = {
+    schemaVersion: 3,
+    selectedCount: 1,
+    selected: [row],
+    lastSelected: row.slug,
+    batches: [{
+      index: 1,
+      groups: [{
+        marketplaceCommit: COMMIT,
+        count: 1,
+        slugs: [row.slug],
+        paths: [row.path],
+      }],
+    }],
+  };
+  const classification = {
+    schemaVersion: 1,
+    status: 'classified',
+    counts: { exact: 0, legacy_algorithm_equivalent: 1, actual_or_unproven_drift: 0 },
+    cohorts: { exact: [], legacy_algorithm_equivalent: [row], actual_or_unproven_drift: [] },
+  };
+  const rawSkill = {
+    id: SKILL_ID,
+    slug: row.slug,
+    plugin_path: row.path,
+    marketplace_commit_sha: COMMIT,
+    content_hash: LEGACY_CONTENT,
+    tree_hash: LEGACY_TREE,
+    artifact_revision: 0,
+    current_artifact_version_id: null,
+    status: 'approved',
+    public_eligible: true,
+    public_eligibility_audit_id: SOURCE_AUDIT_ID,
+    published_at: row.publishedAt,
+    updated_at: row.updatedAt,
+  };
+  const preInventory = {
+    scopedSkillIds: [SKILL_ID],
+    rows: [rawSkill],
+    packMemberships: [{ skill_id: SKILL_ID, pack_id: '50000000-0000-4000-8000-000000000001' }],
+    packs: [{
+      id: '50000000-0000-4000-8000-000000000001',
+      slug: 'image-pack',
+      published_at: '2026-01-03T00:00:00.000Z',
+      updated_at: '2026-01-04T00:00:00.000Z',
+    }],
+    artifacts: [],
+    observations: [],
+  };
+  const dryRunResults = [{
+    batchIndex: 1,
+    marketplaceCommit: COMMIT,
+    selectedCount: 1,
+    slugs: [row.slug],
+    exitCode: 0,
+    result: {
+      success: true,
+      mode: 'dry-run',
+      governed: 0,
+      validated: 1,
+      results: [{
+        slug: row.slug,
+        mode: 'dry-run',
+        skillId: SKILL_ID,
+        sourceAuditId: SOURCE_AUDIT_ID,
+        derivedAuditId: null,
+        artifactVersionId: null,
+        artifactRevision: null,
+        artifactCreated: null,
+        scoreSnapshotId: null,
+      }],
+    },
+  }];
+  const sourceEvidence = {
+    schemaVersion: 1,
+    status: 'source_evidence_fetched',
+    skillIds: [SKILL_ID],
+    skills: [{
+      id: SKILL_ID,
+      slug: row.slug,
+      name: 'Image',
+      description: 'Legacy image skill',
+      author_name: 'owner',
+      supported_tools: ['claude', 'codex'],
+      file_structure: [{ name: 'SKILL.md', type: 'file' }],
+    }],
+    audits: [{ id: SOURCE_AUDIT_ID, skill_id: SKILL_ID, version: 7, audit_payload_hash: 'f'.repeat(32) }],
+  };
+  return { row, plan, classification, rawSkill, preInventory, dryRunResults, sourceEvidence };
+}
+
+function createBoundaryFixture() {
+  const values = fixtures();
+  const directory = mkdtempSync(join(tmpdir(), 'legacy-governance-test-'));
+  const files = {
+    plan: join(directory, 'plan.json'),
+    classification: join(directory, 'classification.json'),
+    preInventory: join(directory, 'pre-inventory.json'),
+    dryRunResults: join(directory, 'dry-run.json'),
+    sourceEvidence: join(directory, 'source-evidence.json'),
+  };
+  writeFileSync(files.plan, JSON.stringify(values.plan));
+  writeFileSync(files.classification, JSON.stringify(values.classification));
+  writeFileSync(files.preInventory, JSON.stringify(values.preInventory));
+  writeFileSync(files.dryRunResults, JSON.stringify(values.dryRunResults));
+  writeFileSync(files.sourceEvidence, JSON.stringify(values.sourceEvidence));
+  const boundary = createLegacyGovernanceBoundary({
+    plan: values.plan,
+    classification: values.classification,
+    dryRunResults: values.dryRunResults,
+    paths: files,
+    metadata: {
+      runId: '12345',
+      repository: 'aiskillstore/marketplace',
+      workflowCommit: 'f'.repeat(40),
+      cliVersion: '2.4.0',
+      cliSha256: '9'.repeat(64),
+    },
+  });
+  return { ...values, directory, files, boundary };
+}
+
+test('freezes and verifies one exact dry-run boundary', () => {
+  const fixture = createBoundaryFixture();
+  try {
+    assert.equal(fixture.boundary.status, 'frozen');
+    assert.equal(fixture.boundary.legacyCount, 1);
+    const verified = verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: structuredClone(fixture.preInventory),
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: structuredClone(fixture.sourceEvidence),
+      paths: fixture.files,
+      expectedRunId: '12345',
+    });
+    assert.equal(verified.status, 'execution_preflight_verified');
+    const drift = structuredClone(fixture.preInventory);
+    drift.rows[0].updated_at = '2026-07-15T00:00:00.000Z';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: drift,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /production state changed/);
+    const resumable = structuredClone(fixture.preInventory);
+    resumable.rows[0] = {
+      ...resumable.rows[0],
+      content_hash: CONTENT,
+      tree_hash: TREE,
+      artifact_revision: 1,
+      current_artifact_version_id: ARTIFACT_ID,
+      public_eligibility_audit_id: DERIVED_AUDIT_ID,
+    };
+    resumable.artifacts = [{
+      id: ARTIFACT_ID,
+      skill_id: SKILL_ID,
+      artifact_revision: 1,
+      content_hash: CONTENT,
+      tree_hash: TREE,
+      marketplace_commit_sha: COMMIT,
+      source_path: fixture.row.path,
+      hash_provenance: {
+        classification: 'legacy_algorithm_equivalent',
+        report: { contentHash: LEGACY_CONTENT, treeHash: LEGACY_TREE },
+      },
+    }];
+    resumable.observations = [{
+      skill_id: SKILL_ID,
+      artifact_version_id: ARTIFACT_ID,
+      marketplace_commit_sha: COMMIT,
+      source_path: fixture.row.path,
+    }];
+    const resumed = verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: resumable,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    });
+    assert.equal(resumed.resumableCount, 1);
+    const changedAudit = structuredClone(fixture.sourceEvidence);
+    changedAudit.audits[0].summary = 'changed after dry-run';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: fixture.preInventory,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: changedAudit,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /source audit changed/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test('verifies artifact, derived audit, score, Pack, and attestation execution evidence', () => {
+  const fixture = createBoundaryFixture();
+  try {
+    const result = {
+      slug: fixture.row.slug,
+      mode: 'execute',
+      skillId: SKILL_ID,
+      sourceAuditId: SOURCE_AUDIT_ID,
+      derivedAuditId: DERIVED_AUDIT_ID,
+      artifactVersionId: ARTIFACT_ID,
+      artifactRevision: 1,
+      artifactCreated: true,
+      scoreSnapshotId: SNAPSHOT_ID,
+    };
+    const executionResults = [{
+      batchIndex: 1,
+      marketplaceCommit: COMMIT,
+      selectedCount: 1,
+      slugs: [fixture.row.slug],
+      exitCode: 0,
+      result: { success: true, mode: 'execute', governed: 1, validated: 1, results: [result] },
+    }];
+    const postInventory = {
+      ...structuredClone(fixture.preInventory),
+      rows: [{
+        ...fixture.rawSkill,
+        content_hash: CONTENT,
+        tree_hash: TREE,
+        artifact_revision: 1,
+        current_artifact_version_id: ARTIFACT_ID,
+        public_eligibility_audit_id: DERIVED_AUDIT_ID,
+      }],
+      artifacts: [{
+        id: ARTIFACT_ID,
+        skill_id: SKILL_ID,
+        artifact_revision: 1,
+        content_hash: CONTENT,
+        tree_hash: TREE,
+        marketplace_commit_sha: COMMIT,
+        source_path: fixture.row.path,
+        hash_provenance: {
+          classification: 'legacy_algorithm_equivalent',
+          report: { contentHash: LEGACY_CONTENT, treeHash: LEGACY_TREE },
+          packaged: { contentHash: CONTENT, treeHash: TREE },
+        },
+      }],
+      observations: [{
+        skill_id: SKILL_ID,
+        artifact_version_id: ARTIFACT_ID,
+        marketplace_commit_sha: COMMIT,
+        source_path: fixture.row.path,
+      }],
+    };
+    const readback = {
+      skills: [{
+        ...fixture.sourceEvidence.skills[0],
+        current_quality_score_snapshot_id: SNAPSHOT_ID,
+        quality_score: 88,
+      }],
+      audits: [
+        { ...fixture.sourceEvidence.audits[0] },
+        {
+          id: DERIVED_AUDIT_ID,
+          skill_id: SKILL_ID,
+          version: 8,
+          derived_from_audit_id: SOURCE_AUDIT_ID,
+          derivation_kind: 'legacy_algorithm_equivalent_hash_rebind',
+          subject_content_hash: CONTENT,
+          subject_tree_hash: TREE,
+        },
+      ],
+      scoreSnapshots: [{
+        id: SNAPSHOT_ID,
+        skill_id: SKILL_ID,
+        score_subject: {
+          auditId: DERIVED_AUDIT_ID,
+          auditVersion: 8,
+          contentHash: CONTENT,
+          treeHash: TREE,
+        },
+      }],
+      scoreBreakdowns: [{ skill_id: SKILL_ID, score_snapshot_id: SNAPSHOT_ID, stale_at: null, stale_reason: null }],
+      attestations: [],
+    };
+    const verified = verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+    });
+    assert.equal(verified.executedCount, 1);
+    readback.scoreSnapshots[0].score_subject.auditId = SOURCE_AUDIT_ID;
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+    }), /production readback mismatch/);
+    readback.scoreSnapshots[0].score_subject.auditId = DERIVED_AUDIT_ID;
+    readback.audits[0].summary = 'changed during execution';
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+    }), /production readback mismatch/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test('fetches bounded independent governance readback tables', async () => {
+  const executionResults = [{ result: { results: [{
+    skillId: SKILL_ID,
+    sourceAuditId: SOURCE_AUDIT_ID,
+    derivedAuditId: DERIVED_AUDIT_ID,
+    scoreSnapshotId: SNAPSHOT_ID,
+  }] } }];
+  const requested = [];
+  const fetchImpl = async (url, options) => {
+    requested.push({ table: url.pathname.split('/').at(-1), auth: options.headers.Authorization });
+    return { ok: true, json: async () => [] };
+  };
+  const output = await fetchLegacyGovernanceReadback({
+    supabaseUrl: 'https://db.example.test',
+    serviceKey: 'service-key',
+    executionResults,
+    fetchImpl,
+  });
+  assert.equal(output.schemaVersion, 1);
+  assert.deepEqual(requested.map((entry) => entry.table).sort(), [
+    'security_audit_attestations',
+    'skill_quality_breakdown',
+    'skill_quality_score_snapshots',
+    'skill_security_audit',
+    'skills',
+  ]);
+  assert.ok(requested.every((entry) => entry.auth === 'Bearer service-key'));
+});
+
+test('freezes the complete source audit row and unhashed Skill install metadata', async () => {
+  const classification = fixtures().classification;
+  const fetchImpl = async (url) => {
+    const table = url.pathname.split('/').at(-1);
+    if (table === 'skills') {
+      return { ok: true, json: async () => [{ id: SKILL_ID, name: 'Image', file_structure: [] }] };
+    }
+    assert.equal(url.searchParams.get('select'), '*');
+    return { ok: true, json: async () => [{ id: SOURCE_AUDIT_ID, skill_id: SKILL_ID, version: 7 }] };
+  };
+  const output = await fetchLegacyGovernanceSourceEvidence({
+    supabaseUrl: 'https://db.example.test',
+    serviceKey: 'service-key',
+    classification,
+    fetchImpl,
+  });
+  assert.equal(output.skills.length, 1);
+  assert.equal(output.audits[0].id, SOURCE_AUDIT_ID);
+});
+
+test('workflow is two-phase, exactly pinned, bounded, and never executes ordinary sync', () => {
+  const workflow = readFileSync(
+    resolve(import.meta.dirname, '../../.github/workflows/govern-legacy-equivalent-artifacts.yml'),
+    'utf8'
+  );
+  const ordinaryWorkflow = readFileSync(
+    resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
+    'utf8'
+  );
+  assert.match(workflow, /default: '2\.4\.0'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.0'/);
+  assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
+  assert.match(workflow, /batch_size must be between 1 and 500/);
+  assert.match(workflow, /dry_run_id/);
+  assert.match(workflow, /gh run download "\$DRY_RUN_ID"/);
+  assert.match(workflow, /headBranch == "main"/);
+  assert.match(workflow, /git merge-base --is-ancestor/);
+  assert.match(workflow, /boundaries may only be created from main/);
+  assert.match(workflow, /execute may only run from main/);
+  assert.match(workflow, /sha256sum --check SHA256SUMS/);
+  assert.match(workflow, /CLI 2\.4\.0 binary differs from the frozen dry-run boundary/);
+  assert.ok((workflow.match(/eec024fd85af15a50103b80bfca2e00dcc30f62f94f1dbb32c7a5eba0061b461/g) || []).length >= 2);
+  assert.match(workflow, /--phase execute-preflight/);
+  assert.match(workflow, /skill govern-legacy-equivalent/);
+  assert.match(workflow, /cache batches of at most ten/);
+  assert.match(workflow, /--concurrency 1/);
+  assert.match(workflow, /legacy-equivalent-boundary-/);
+  assert.match(workflow, /legacy-equivalent-execution-/);
+  assert.match(workflow, /legacy-equivalent-failed-dry-run-/);
+  assert.match(workflow, /Preserve execution status evidence/);
+  const syncCalls = workflow.match(/skill sync[\s\S]{0,250}/g) || [];
+  assert.equal(syncCalls.length, 1);
+  assert.match(syncCalls[0], /--dry-run/);
+  assert.match(syncCalls[0], /--repair-stale-report-hashes/);
+  assert.match(ordinaryWorkflow, /\.exactBatches\[\]/);
+  assert.match(ordinaryWorkflow, /CLI_VERSION" != "2\.3\.1"/);
+});

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CLI_VERSION = '2.4.0';
+const MAX_BATCH_SIZE = 500;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right, 'en-US'))
+      .map(([key, item]) => [key, canonicalize(item)]));
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function asMap(rows, key, label) {
+  if (!Array.isArray(rows)) fail(`${label} is not an array`);
+  const map = new Map();
+  for (const row of rows) {
+    const value = row?.[key];
+    if (typeof value !== 'string' || !value || map.has(value)) {
+      fail(`${label} contains an invalid or duplicate ${key}`);
+    }
+    map.set(value, row);
+  }
+  return map;
+}
+
+function legacyGroups(plan, classification) {
+  const legacyRows = classification?.cohorts?.legacy_algorithm_equivalent;
+  const selected = asMap(plan?.selected, 'slug', 'plan selected rows');
+  const legacy = asMap(legacyRows, 'slug', 'legacy cohort');
+  if (plan?.selectedCount !== plan?.selected?.length || plan.selectedCount > MAX_BATCH_SIZE) {
+    fail('plan is not a bounded complete batch');
+  }
+  if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
+    fail('classification contract is not frozen');
+  }
+  for (const slug of legacy.keys()) {
+    if (!selected.has(slug)) fail(`legacy cohort contains an unplanned slug: ${slug}`);
+  }
+  const groups = [];
+  for (const batch of plan.batches || []) {
+    for (const group of batch.groups || []) {
+      const slugs = group.slugs.filter((slug) => legacy.has(slug));
+      if (slugs.length === 0) continue;
+      groups.push({
+        batchIndex: batch.index,
+        marketplaceCommit: group.marketplaceCommit,
+        count: slugs.length,
+        slugs,
+        paths: slugs.map((slug) => selected.get(slug).path),
+      });
+    }
+  }
+  if (groups.reduce((count, group) => count + group.count, 0) !== legacy.size) {
+    fail('legacy execution groups do not cover the frozen cohort exactly once');
+  }
+  return groups;
+}
+
+function validateAdminWrapper(wrapper, expected, mode, classification) {
+  if (
+    wrapper?.batchIndex !== expected.batchIndex
+    || wrapper?.marketplaceCommit !== expected.marketplaceCommit
+    || wrapper?.selectedCount !== expected.count
+    || wrapper?.exitCode !== 0
+    || canonicalJson(wrapper?.slugs) !== canonicalJson(expected.slugs)
+  ) {
+    fail(`${mode} wrapper does not match the frozen group`);
+  }
+  const result = wrapper.result;
+  if (
+    result?.success !== true
+    || result?.mode !== mode
+    || result?.validated !== expected.count
+    || result?.governed !== (mode === 'execute' ? expected.count : 0)
+    || !Array.isArray(result?.results)
+    || result.results.length !== expected.count
+  ) {
+    fail(`${mode} administrator result has an invalid summary`);
+  }
+  const legacy = asMap(classification.cohorts.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
+  const results = asMap(result.results, 'slug', `${mode} administrator rows`);
+  for (const slug of expected.slugs) {
+    const frozen = legacy.get(slug);
+    const row = results.get(slug);
+    if (
+      !frozen
+      || row?.mode !== mode
+      || row?.skillId !== frozen.id
+      || row?.sourceAuditId !== frozen.publicEligibilityAuditId
+    ) {
+      fail(`${mode} administrator row is not bound to frozen evidence for ${slug}`);
+    }
+    if (mode === 'dry-run') {
+      if (
+        row.derivedAuditId !== null
+        || row.artifactVersionId !== null
+        || row.artifactRevision !== null
+        || row.artifactCreated !== null
+        || row.scoreSnapshotId !== null
+      ) {
+        fail(`dry-run reported a write for ${slug}`);
+      }
+    } else if (
+      !UUID_RE.test(String(row.derivedAuditId || ''))
+      || !UUID_RE.test(String(row.artifactVersionId || ''))
+      || row.artifactRevision !== 1
+      || typeof row.artifactCreated !== 'boolean'
+      || !UUID_RE.test(String(row.scoreSnapshotId || ''))
+    ) {
+      fail(`execute result lacks immutable identities for ${slug}`);
+    }
+  }
+}
+
+export function createLegacyGovernanceBoundary({
+  plan,
+  classification,
+  dryRunResults,
+  paths,
+  metadata,
+}) {
+  if (
+    metadata.cliVersion !== CLI_VERSION
+    || !SHA256_RE.test(String(metadata.cliSha256 || ''))
+    || !/^\d+$/.test(String(metadata.runId))
+    || !/^[0-9a-f]{40}$/.test(String(metadata.workflowCommit || ''))
+    || metadata.repository !== 'aiskillstore/marketplace'
+  ) {
+    fail('invalid dry-run workflow metadata');
+  }
+  const groups = legacyGroups(plan, classification);
+  if (!Array.isArray(dryRunResults) || dryRunResults.length !== groups.length) {
+    fail('dry-run result group count does not match the frozen legacy cohort');
+  }
+  for (let index = 0; index < groups.length; index++) {
+    validateAdminWrapper(dryRunResults[index], groups[index], 'dry-run', classification);
+  }
+  return {
+    schemaVersion: 1,
+    status: 'frozen',
+    workflow: 'govern-legacy-equivalent-artifacts',
+    repository: metadata.repository,
+    runId: String(metadata.runId),
+    workflowCommit: metadata.workflowCommit,
+    cliVersion: CLI_VERSION,
+    cliSha256: metadata.cliSha256,
+    selectedCount: plan.selectedCount,
+    legacyCount: classification.counts.legacy_algorithm_equivalent,
+    lastSelected: plan.lastSelected,
+    hashes: {
+      plan: sha256File(paths.plan),
+      classification: sha256File(paths.classification),
+      preInventory: sha256File(paths.preInventory),
+      dryRunResults: sha256File(paths.dryRunResults),
+      sourceEvidence: sha256File(paths.sourceEvidence),
+    },
+    groups,
+  };
+}
+
+export function verifyLegacyGovernanceBoundary({
+  boundary,
+  plan,
+  classification,
+  frozenInventory,
+  currentInventory,
+  frozenSourceEvidence,
+  currentSourceEvidence,
+  paths,
+  expectedRunId,
+}) {
+  if (
+    boundary?.schemaVersion !== 1
+    || boundary?.status !== 'frozen'
+    || boundary?.workflow !== 'govern-legacy-equivalent-artifacts'
+    || boundary?.repository !== 'aiskillstore/marketplace'
+    || boundary?.runId !== String(expectedRunId)
+    || boundary?.cliVersion !== CLI_VERSION
+    || !SHA256_RE.test(String(boundary?.cliSha256 || ''))
+  ) {
+    fail('downloaded boundary metadata is invalid');
+  }
+  for (const [key, path] of Object.entries(paths)) {
+    if (boundary.hashes?.[key] !== sha256File(path)) {
+      fail(`downloaded boundary ${key} hash mismatch`);
+    }
+  }
+  const expectedGroups = legacyGroups(plan, classification);
+  if (canonicalJson(boundary.groups) !== canonicalJson(expectedGroups)) {
+    fail('downloaded boundary groups do not match plan/classification');
+  }
+  if (canonicalJson(frozenSourceEvidence) !== canonicalJson(currentSourceEvidence)) {
+    fail('Skill metadata or source audit changed after the frozen dry-run boundary');
+  }
+  const frozenSkills = asMap(frozenInventory.rows, 'slug', 'frozen Skills');
+  const currentSkills = asMap(currentInventory.rows, 'slug', 'current Skills');
+  const artifacts = asMap(currentInventory.artifacts, 'skill_id', 'current artifacts');
+  const observations = asMap(currentInventory.observations, 'skill_id', 'current observations');
+  const legacySlugs = new Set(classification.cohorts.legacy_algorithm_equivalent.map((row) => row.slug));
+  if (
+    canonicalJson(frozenInventory.packMemberships) !== canonicalJson(currentInventory.packMemberships)
+    || canonicalJson(frozenInventory.packs) !== canonicalJson(currentInventory.packs)
+    || frozenSkills.size !== currentSkills.size
+  ) {
+    fail('production state changed after the frozen dry-run boundary');
+  }
+  let resumableCount = 0;
+  for (const selected of plan.selected) {
+    const before = frozenSkills.get(selected.slug);
+    const current = currentSkills.get(selected.slug);
+    if (!before || !current) fail(`production state changed for ${selected.slug}`);
+    if (!legacySlugs.has(selected.slug)) {
+      if (canonicalJson(before) !== canonicalJson(current)) {
+        fail(`non-legacy production state changed for ${selected.slug}`);
+      }
+      continue;
+    }
+    if (canonicalJson(before) === canonicalJson(current)) continue;
+    const repair = selected.evidence.artifact.hashRepair;
+    const artifact = artifacts.get(selected.id);
+    const observation = observations.get(selected.id);
+    if (
+      current.artifact_revision !== 1
+      || !UUID_RE.test(String(current.current_artifact_version_id || ''))
+      || current.content_hash !== repair.packagedContentHash
+      || current.tree_hash !== repair.packagedTreeHash
+      || current.marketplace_commit_sha !== selected.marketplaceCommit
+      || current.plugin_path !== selected.path
+      || current.public_eligible !== true
+      || !UUID_RE.test(String(current.public_eligibility_audit_id || ''))
+      || current.public_eligibility_audit_id === selected.publicEligibilityAuditId
+      || !sameTimestamp(current.published_at, selected.publishedAt)
+      || !sameTimestamp(current.updated_at, selected.updatedAt)
+      || artifact?.id !== current.current_artifact_version_id
+      || artifact?.artifact_revision !== 1
+      || artifact?.content_hash !== repair.packagedContentHash
+      || artifact?.tree_hash !== repair.packagedTreeHash
+      || artifact?.marketplace_commit_sha !== selected.marketplaceCommit
+      || artifact?.source_path !== selected.path
+      || artifact?.hash_provenance?.classification !== 'legacy_algorithm_equivalent'
+      || artifact?.hash_provenance?.report?.contentHash !== repair.reportContentHash
+      || artifact?.hash_provenance?.report?.treeHash !== repair.reportTreeHash
+      || observation?.artifact_version_id !== artifact.id
+      || observation?.marketplace_commit_sha !== selected.marketplaceCommit
+      || observation?.source_path !== selected.path
+    ) {
+      fail(`production state changed incompatibly for ${selected.slug}`);
+    }
+    resumableCount++;
+  }
+  if (artifacts.size !== resumableCount || observations.size !== resumableCount) {
+    fail('resumable artifact/observation scope contains unexpected rows');
+  }
+  return {
+    schemaVersion: 1,
+    status: 'execution_preflight_verified',
+    runId: boundary.runId,
+    legacyCount: boundary.legacyCount,
+    resumableCount,
+    groups: expectedGroups,
+  };
+}
+
+function sameTimestamp(left, right) {
+  return Number.isFinite(Date.parse(left))
+    && Number.isFinite(Date.parse(right))
+    && Date.parse(left) === Date.parse(right);
+}
+
+export function verifyLegacyGovernanceExecution({
+  boundary,
+  plan,
+  classification,
+  executionResults,
+  frozenInventory,
+  postInventory,
+  readback,
+  frozenSourceEvidence,
+}) {
+  const groups = legacyGroups(plan, classification);
+  if (!Array.isArray(executionResults) || executionResults.length !== groups.length) {
+    fail('execute result group count mismatch');
+  }
+  const resultRows = [];
+  for (let index = 0; index < groups.length; index++) {
+    validateAdminWrapper(executionResults[index], groups[index], 'execute', classification);
+    resultRows.push(...executionResults[index].result.results);
+  }
+  if (resultRows.length !== boundary.legacyCount) fail('executed count differs from frozen boundary');
+
+  const results = asMap(resultRows, 'slug', 'execution results');
+  const frozenSkills = asMap(frozenInventory.rows, 'slug', 'frozen Skills');
+  const postSkills = asMap(postInventory.rows, 'slug', 'post Skills');
+  const artifacts = asMap(postInventory.artifacts, 'id', 'post artifacts');
+  const observationsBySkill = asMap(postInventory.observations, 'skill_id', 'post observations');
+  const audits = asMap(readback.audits, 'id', 'audit readback');
+  const snapshots = asMap(readback.scoreSnapshots, 'id', 'score snapshots');
+  const breakdowns = asMap(readback.scoreBreakdowns, 'skill_id', 'score breakdowns');
+  const skillReadback = asMap(readback.skills, 'id', 'Skill score readback');
+  const frozenSourceAudits = asMap(frozenSourceEvidence?.audits, 'id', 'frozen source audits');
+  const frozenSkillMetadata = asMap(frozenSourceEvidence?.skills, 'id', 'frozen Skill metadata');
+  const attestations = readback.attestations || [];
+  const legacyRows = classification.cohorts.legacy_algorithm_equivalent;
+  const legacySlugs = new Set(legacyRows.map((row) => row.slug));
+
+  if (
+    canonicalJson(frozenInventory.packMemberships) !== canonicalJson(postInventory.packMemberships)
+    || canonicalJson(frozenInventory.packs) !== canonicalJson(postInventory.packs)
+  ) {
+    fail('dependent Pack identity or timestamps changed during governance');
+  }
+
+  for (const frozen of classification.cohorts.exact.concat(
+    classification.cohorts.actual_or_unproven_drift
+  )) {
+    if (canonicalJson(frozenSkills.get(frozen.slug)) !== canonicalJson(postSkills.get(frozen.slug))) {
+      fail(`non-legacy cohort row changed: ${frozen.slug}`);
+    }
+  }
+
+  for (const frozen of legacyRows) {
+    const result = results.get(frozen.slug);
+    const before = frozenSkills.get(frozen.slug);
+    const skill = postSkills.get(frozen.slug);
+    const scoredSkill = skillReadback.get(frozen.id);
+    const artifact = artifacts.get(result.artifactVersionId);
+    const observation = observationsBySkill.get(frozen.id);
+    const sourceAudit = audits.get(result.sourceAuditId);
+    const frozenSourceAudit = frozenSourceAudits.get(result.sourceAuditId);
+    const frozenMetadata = frozenSkillMetadata.get(frozen.id);
+    const derivedAudit = audits.get(result.derivedAuditId);
+    const snapshot = snapshots.get(result.scoreSnapshotId);
+    const breakdown = breakdowns.get(frozen.id);
+    const repair = frozen.evidence.artifact.hashRepair;
+    if (
+      !before || !skill || !scoredSkill || !artifact || !observation
+      || !sourceAudit || !frozenSourceAudit || !frozenMetadata
+      || !derivedAudit || !snapshot || !breakdown
+      || canonicalJson(sourceAudit) !== canonicalJson(frozenSourceAudit)
+      || scoredSkill.name !== frozenMetadata.name
+      || scoredSkill.description !== frozenMetadata.description
+      || scoredSkill.author_name !== frozenMetadata.author_name
+      || canonicalJson(scoredSkill.supported_tools) !== canonicalJson(frozenMetadata.supported_tools)
+      || canonicalJson(scoredSkill.file_structure) !== canonicalJson(frozenMetadata.file_structure)
+      || before.artifact_revision !== 0
+      || skill.artifact_revision !== 1
+      || skill.current_artifact_version_id !== result.artifactVersionId
+      || skill.content_hash !== frozen.evidence.artifact.contentHash
+      || skill.tree_hash !== frozen.evidence.artifact.treeHash
+      || skill.public_eligibility_audit_id !== result.derivedAuditId
+      || !sameTimestamp(skill.published_at, frozen.publishedAt)
+      || !sameTimestamp(skill.updated_at, frozen.updatedAt)
+      || scoredSkill.current_quality_score_snapshot_id !== result.scoreSnapshotId
+      || typeof scoredSkill.quality_score !== 'number'
+      || artifact.skill_id !== frozen.id
+      || artifact.artifact_revision !== 1
+      || artifact.content_hash !== frozen.evidence.artifact.contentHash
+      || artifact.tree_hash !== frozen.evidence.artifact.treeHash
+      || artifact.marketplace_commit_sha !== frozen.marketplaceCommit
+      || artifact.source_path !== frozen.path
+      || artifact.hash_provenance?.classification !== 'legacy_algorithm_equivalent'
+      || artifact.hash_provenance?.report?.contentHash !== repair.reportContentHash
+      || artifact.hash_provenance?.report?.treeHash !== repair.reportTreeHash
+      || artifact.hash_provenance?.packaged?.contentHash !== repair.packagedContentHash
+      || artifact.hash_provenance?.packaged?.treeHash !== repair.packagedTreeHash
+      || observation.artifact_version_id !== result.artifactVersionId
+      || observation.marketplace_commit_sha !== frozen.marketplaceCommit
+      || observation.source_path !== frozen.path
+      || sourceAudit.id !== frozen.publicEligibilityAuditId
+      || derivedAudit.derived_from_audit_id !== sourceAudit.id
+      || derivedAudit.derivation_kind !== 'legacy_algorithm_equivalent_hash_rebind'
+      || derivedAudit.version !== sourceAudit.version + 1
+      || derivedAudit.subject_content_hash !== repair.packagedContentHash
+      || derivedAudit.subject_tree_hash !== repair.packagedTreeHash
+      || snapshot.skill_id !== frozen.id
+      || snapshot.score_subject?.auditId !== derivedAudit.id
+      || snapshot.score_subject?.auditVersion !== derivedAudit.version
+      || snapshot.score_subject?.contentHash !== repair.packagedContentHash
+      || snapshot.score_subject?.treeHash !== repair.packagedTreeHash
+      || breakdown.score_snapshot_id !== snapshot.id
+      || breakdown.stale_at !== null
+      || breakdown.stale_reason !== null
+      || attestations.some((attestation) => attestation.audit_id === derivedAudit.id)
+    ) {
+      fail(`production readback mismatch for ${frozen.slug}`);
+    }
+  }
+
+  if (postInventory.artifacts.length !== legacySlugs.size
+      || postInventory.observations.length !== legacySlugs.size) {
+    fail('scoped artifact/observation counts differ from the frozen legacy cohort');
+  }
+  return {
+    schemaVersion: 1,
+    status: 'executed_and_verified',
+    boundaryRunId: boundary.runId,
+    executedCount: resultRows.length,
+    slugs: resultRows.map((row) => row.slug),
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) fail(`invalid argument: ${key || '<missing>'}`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  let output;
+  if (args.phase === 'groups') {
+    output = {
+      schemaVersion: 1,
+      status: 'legacy_groups_planned',
+      groups: legacyGroups(readJson(args.plan), readJson(args.classification)),
+    };
+  } else if (args.phase === 'freeze') {
+    output = createLegacyGovernanceBoundary({
+      plan: readJson(args.plan),
+      classification: readJson(args.classification),
+      dryRunResults: readJson(args['dry-run-results']),
+      paths: {
+        plan: resolve(args.plan),
+        classification: resolve(args.classification),
+        preInventory: resolve(args['pre-inventory']),
+        dryRunResults: resolve(args['dry-run-results']),
+        sourceEvidence: resolve(args['source-evidence']),
+      },
+      metadata: {
+        runId: args['run-id'],
+        repository: args.repository,
+        workflowCommit: args['workflow-commit'],
+        cliVersion: args['cli-version'],
+        cliSha256: args['cli-sha256'],
+      },
+    });
+  } else if (args.phase === 'execute-preflight') {
+    output = verifyLegacyGovernanceBoundary({
+      boundary: readJson(args.boundary),
+      plan: readJson(args.plan),
+      classification: readJson(args.classification),
+      frozenInventory: readJson(args['frozen-inventory']),
+      currentInventory: readJson(args['current-inventory']),
+      frozenSourceEvidence: readJson(args['frozen-source-evidence']),
+      currentSourceEvidence: readJson(args['current-source-evidence']),
+      paths: {
+        plan: resolve(args.plan),
+        classification: resolve(args.classification),
+        preInventory: resolve(args['frozen-inventory']),
+        dryRunResults: resolve(args['dry-run-results']),
+        sourceEvidence: resolve(args['frozen-source-evidence']),
+      },
+      expectedRunId: args['expected-run-id'],
+    });
+  } else if (args.phase === 'execution') {
+    output = verifyLegacyGovernanceExecution({
+      boundary: readJson(args.boundary),
+      plan: readJson(args.plan),
+      classification: readJson(args.classification),
+      executionResults: readJson(args['execution-results']),
+      frozenInventory: readJson(args['frozen-inventory']),
+      postInventory: readJson(args['post-inventory']),
+      readback: readJson(args.readback),
+      frozenSourceEvidence: readJson(args['frozen-source-evidence']),
+    });
+  } else {
+    fail('--phase must be groups, freeze, execute-preflight, or execution');
+  }
+  writeFileSync(resolve(args.output), `${JSON.stringify(output, null, 2)}\n`, { flag: 'wx' });
+  process.stdout.write(`${JSON.stringify({ status: output.status })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`legacy-equivalent governance verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add a two-phase dry-run and execute workflow for legacy-algorithm-equivalent artifacts
- freeze exact production inventory, classification, source audits, Skill install metadata, workflow commit, CLI version, and audited CLI binary SHA-256
- execute only a successful frozen boundary, serially, with bounded batches and fail-closed production readback
- preserve failure evidence and support safe response-loss retries

## Safety boundaries

- CLI is pinned to 2.4.0 and linux-x64 SHA-256 eec024fd85af15a50103b80bfca2e00dcc30f62f94f1dbb32c7a5eba0061b461
- ordinary skill sync is classification-only and always dry-run
- production writes use only skill govern-legacy-equivalent with concurrency 1
- boundary source run and execution must both be main, and the source commit must be an ancestor
- no governance run or production write was executed by this PR

## Verification

- CI=true node --test scripts/tests/artifact-version-backfill.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs (15/15)
- workflow YAML parse passed
- node syntax checks passed
- git diff check passed
- independent P0/P1 review found no remaining P0/P1