### PR TITLE
chore: pin legacy governance CLI 2.4.2

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version'
         type: string
         required: true
-        default: '2.4.1'
+        default: '2.4.2'
       batch_size:
         description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
         type: number
@@ -85,7 +85,7 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.4.1' || { echo '::error::workflow is pinned to skillstore-cli 2.4.1'; exit 1; }
+          test "$CLI_VERSION" = '2.4.2' || { echo '::error::workflow is pinned to skillstore-cli 2.4.2'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
           [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
             echo '::error::batch_size must be between 1 and 500'; exit 1;
@@ -144,17 +144,17 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.1'
-          minimum-version: '2.4.1'
+          version: '2.4.2'
+          minimum-version: '2.4.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Verify audited CLI 2.4.1 binary identity
+      - name: Verify audited CLI 2.4.2 binary identity
         run: |
           set -euo pipefail
-          expected='02d55512c05b7b7f1476cc876a4ae7e4f91ceccd8d38414dd6f6788c96cba474'
+          expected='276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
-            echo '::error::CLI 2.4.1 binary does not match the audited linux-x64 digest'; exit 1;
+            echo '::error::CLI 2.4.2 binary does not match the audited linux-x64 digest'; exit 1;
           }
 
       - name: Materialize pinned snapshots
@@ -260,7 +260,7 @@ jobs:
             --pre-inventory "$boundary/pre-inventory.json" --dry-run-results "$boundary/governance-dry-run.json" \
             --source-evidence "$boundary/source-evidence.json" \
             --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
-            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.1' \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.2' \
             --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --output "$boundary/boundary.json"
           (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json boundary.json > SHA256SUMS)
@@ -281,7 +281,7 @@ jobs:
           {
             echo '## Legacy-equivalent frozen boundary'
             echo "- Run ID: \`$GITHUB_RUN_ID\`"
-            echo "- CLI: \`2.4.1\`"
+            echo "- CLI: \`2.4.2\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
             echo '- No production write was authorized.'
@@ -335,7 +335,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git sparse-checkout disable
           git reset --hard HEAD
-          test "$CLI_VERSION" = '2.4.1' || { echo '::error::workflow is pinned to skillstore-cli 2.4.1'; exit 1; }
+          test "$CLI_VERSION" = '2.4.2' || { echo '::error::workflow is pinned to skillstore-cli 2.4.2'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
           [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
@@ -402,22 +402,22 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.4.1
+      - name: Download exact audited CLI 2.4.2
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.1'
-          minimum-version: '2.4.1'
+          version: '2.4.2'
+          minimum-version: '2.4.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='02d55512c05b7b7f1476cc876a4ae7e4f91ceccd8d38414dd6f6788c96cba474'
+          audited='276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {
-            echo '::error::CLI 2.4.1 binary differs from the frozen dry-run boundary'; exit 1;
+            echo '::error::CLI 2.4.2 binary differs from the frozen dry-run boundary'; exit 1;
           }
 
       - name: Materialize only frozen legacy groups
@@ -520,7 +520,7 @@ jobs:
           {
             echo '## Legacy-equivalent execution verified'
             echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
-            echo '- CLI: `2.4.1`'
+            echo '- CLI: `2.4.2`'
             echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
             echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
             echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -171,7 +171,7 @@ function createBoundaryFixture() {
       runId: '12345',
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
-      cliVersion: '2.4.1',
+      cliVersion: '2.4.2',
       cliSha256: '9'.repeat(64),
     },
   });
@@ -447,8 +447,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.4\.1'/);
-  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.1'/);
+  assert.match(workflow, /default: '2\.4\.2'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.2'/);
   assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
   assert.match(workflow, /batch_size must be between 1 and 500/);
   assert.match(workflow, /dry_run_id/);
@@ -458,8 +458,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /boundaries may only be created from main/);
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
-  assert.match(workflow, /CLI 2\.4\.1 binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/02d55512c05b7b7f1476cc876a4ae7e4f91ceccd8d38414dd6f6788c96cba474/g) || []).length >= 2);
+  assert.match(workflow, /CLI 2\.4\.2 binary differs from the frozen dry-run boundary/);
+  assert.ok((workflow.match(/276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /skill govern-legacy-equivalent/);
   assert.match(workflow, /cache batches of at most ten/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const CLI_VERSION = '2.4.1';
+const CLI_VERSION = '2.4.2';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
## Summary

- pin both governance phases to skillstore-cli 2.4.2
- verify the audited Linux binary SHA-256 276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125
- update frozen-boundary verification and workflow contract tests to 2.4.2

## Verification

- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (5/5)
- git diff --check
- rebased onto origin/main before push

## Rollout

This pin is required before resuming the stopped legacy-equivalent governance batches. CLI 2.4.2 and migration 20260731 are already live; the repaired canary and full production download/install/NPX/Pack/MCP smoke matrices are green.