### PR TITLE
fix: qualify legacy governance source audits

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -205,6 +205,23 @@ jobs:
           jq -s . "$RUNNER_TEMP/classification-results.jsonl" > "$RUNNER_TEMP/classification-results.json"
           node scripts/verify-artifact-version-classification.mjs --phase classification \
             --plan "$RUNNER_TEMP/plan.json" --results "$RUNNER_TEMP/classification-results.json" \
+            --output "$RUNNER_TEMP/hash-classification.json"
+
+      - name: Fetch complete source audit evidence before governance planning
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: >-
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs
+          --classification "$RUNNER_TEMP/hash-classification.json"
+          --output "$RUNNER_TEMP/source-evidence.json"
+
+      - name: Qualify source-audit bindings and plan only governable groups
+        run: |
+          set -euo pipefail
+          node scripts/verify-legacy-equivalent-governance.mjs --phase qualify \
+            --classification "$RUNNER_TEMP/hash-classification.json" \
+            --source-evidence "$RUNNER_TEMP/source-evidence.json" \
             --output "$RUNNER_TEMP/classification.json"
           node scripts/verify-legacy-equivalent-governance.mjs --phase groups \
             --plan "$RUNNER_TEMP/plan.json" --classification "$RUNNER_TEMP/classification.json" \
@@ -236,14 +253,18 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/legacy-groups.json")
           jq -s . "$RUNNER_TEMP/governance-dry-run.jsonl" > "$RUNNER_TEMP/governance-dry-run.json"
 
-      - name: Freeze complete source audit and install metadata evidence
+      - name: Re-fetch and compare source evidence after administrator dry-run
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-        run: >-
-          node scripts/fetch-legacy-equivalent-governance-readback.mjs
-          --classification "$RUNNER_TEMP/classification.json"
-          --output "$RUNNER_TEMP/source-evidence.json"
+        run: |
+          set -euo pipefail
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/classification.json" \
+            --output "$RUNNER_TEMP/source-evidence-after.json"
+          cmp "$RUNNER_TEMP/source-evidence.json" "$RUNNER_TEMP/source-evidence-after.json" || {
+            echo '::error::Skill metadata or source audit changed during administrator dry-run'; exit 1;
+          }
 
       - name: Freeze immutable execution boundary
         run: |
@@ -284,6 +305,7 @@ jobs:
             echo "- CLI: \`2.4.2\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
+            echo "- Hash-equivalent: \`$(jq -r .governance.hashEquivalentCount "$RUNNER_TEMP/classification.json")\`; governable: \`$(jq -r .governance.eligibleCount "$RUNNER_TEMP/classification.json")\`; source-audit unproven: \`$(jq -r .governance.unprovenCount "$RUNNER_TEMP/classification.json")\`"
             echo '- No production write was authorized.'
             echo "- Execute with \`dry_run_id=$GITHUB_RUN_ID\`; no scan cursor is a completion claim."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -294,7 +316,7 @@ jobs:
           set -euo pipefail
           boundary="$RUNNER_TEMP/legacy-boundary"
           mkdir -p "$boundary"
-          for item in plan classification pre-inventory governance-dry-run source-evidence classification-results legacy-groups; do
+          for item in plan hash-classification classification pre-inventory governance-dry-run source-evidence source-evidence-after classification-results legacy-groups; do
             source="$RUNNER_TEMP/$item.json"
             [ ! -f "$source" ] || cp "$source" "$boundary/$item.json"
           done
@@ -470,6 +492,9 @@ jobs:
             --scope-inventory "$RUNNER_TEMP/boundary/plan.json" --output "$RUNNER_TEMP/post-inventory.json"
           node scripts/fetch-legacy-equivalent-governance-readback.mjs \
             --execution-results "$RUNNER_TEMP/execution-results.json" --output "$RUNNER_TEMP/governance-readback.json"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/boundary/classification.json" \
+            --output "$RUNNER_TEMP/post-source-evidence.json"
 
       - name: Verify complete production execution evidence
         run: >-
@@ -482,6 +507,7 @@ jobs:
           --post-inventory "$RUNNER_TEMP/post-inventory.json"
           --readback "$RUNNER_TEMP/governance-readback.json"
           --frozen-source-evidence "$RUNNER_TEMP/boundary/source-evidence.json"
+          --post-source-evidence "$RUNNER_TEMP/post-source-evidence.json"
           --output "$RUNNER_TEMP/execution-verification.json"
 
       - name: Preserve execution status evidence
@@ -510,6 +536,7 @@ jobs:
             ${{ runner.temp }}/execution-results.json
             ${{ runner.temp }}/post-inventory.json
             ${{ runner.temp }}/governance-readback.json
+            ${{ runner.temp }}/post-source-evidence.json
             ${{ runner.temp }}/execution-verification.json
             ${{ runner.temp }}/execution-evidence/run-status.json
           if-no-files-found: error

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import test from 'node:test';
 import {
   createLegacyGovernanceBoundary,
+  qualifyLegacyGovernanceClassification,
   verifyLegacyGovernanceBoundary,
   verifyLegacyGovernanceExecution,
 } from '../verify-legacy-equivalent-governance.mjs';
@@ -71,7 +72,7 @@ function fixtures() {
       }],
     }],
   };
-  const classification = {
+  const hashClassification = {
     schemaVersion: 1,
     status: 'classified',
     counts: { exact: 0, legacy_algorithm_equivalent: 1, actual_or_unproven_drift: 0 },
@@ -142,9 +143,25 @@ function fixtures() {
       supported_tools: ['claude', 'codex'],
       file_structure: [{ name: 'SKILL.md', type: 'file' }],
     }],
-    audits: [{ id: SOURCE_AUDIT_ID, skill_id: SKILL_ID, version: 7, audit_payload_hash: 'f'.repeat(32) }],
+    audits: [{
+      id: SOURCE_AUDIT_ID,
+      skill_id: SKILL_ID,
+      version: 7,
+      content_hash: `v2:${COMMIT}:${LEGACY_CONTENT}:${LEGACY_TREE}:${'f'.repeat(32)}`,
+      audit_payload_hash: null,
+      subject_marketplace_commit_sha: null,
+      subject_content_hash: null,
+      subject_tree_hash: null,
+      subject_plugin_path: null,
+      derived_from_audit_id: null,
+      derivation_kind: null,
+    }],
   };
-  return { row, plan, classification, rawSkill, preInventory, dryRunResults, sourceEvidence };
+  const classification = qualifyLegacyGovernanceClassification({
+    classification: hashClassification,
+    sourceEvidence,
+  });
+  return { row, plan, hashClassification, classification, rawSkill, preInventory, dryRunResults, sourceEvidence };
 }
 
 function createBoundaryFixture() {
@@ -177,6 +194,86 @@ function createBoundaryFixture() {
   });
   return { ...values, directory, files, boundary };
 }
+
+test('qualifies only exact v2/v3 source bindings and preserves hash classification', () => {
+  const base = fixtures();
+  assert.equal(base.classification.governance.eligibleCount, 1);
+  assert.equal(base.classification.governance.unprovenCount, 0);
+  assert.equal(base.classification.governance.eligible[0].reason, 'eligible_v2');
+  assert.deepEqual(base.classification.cohorts, base.hashClassification.cohorts);
+
+  const v3Evidence = structuredClone(base.sourceEvidence);
+  const v3Audit = v3Evidence.audits[0];
+  const payloadHash = 'f'.repeat(32);
+  v3Audit.content_hash = `v3:${COMMIT}:${LEGACY_CONTENT}:${LEGACY_TREE}:${Buffer.from(base.row.path).toString('hex')}:${payloadHash}`;
+  v3Audit.audit_payload_hash = payloadHash;
+  v3Audit.subject_marketplace_commit_sha = COMMIT;
+  v3Audit.subject_content_hash = LEGACY_CONTENT;
+  v3Audit.subject_tree_hash = LEGACY_TREE;
+  v3Audit.subject_plugin_path = base.row.path;
+  const v3Qualified = qualifyLegacyGovernanceClassification({
+    classification: base.hashClassification,
+    sourceEvidence: v3Evidence,
+  });
+  assert.equal(v3Qualified.governance.eligible[0].reason, 'eligible_v3');
+
+  const cases = [
+    {
+      name: 'plain legacy digest',
+      mutate: (audit) => { audit.content_hash = 'f'.repeat(32); },
+      reason: 'source_audit_binding_unproven_legacy_digest',
+    },
+    {
+      name: 'malformed binding',
+      mutate: (audit) => { audit.content_hash = 'v2:broken'; },
+      reason: 'source_audit_binding_malformed_or_unsupported',
+    },
+    {
+      name: 'subject mismatch',
+      mutate: (audit) => {
+        audit.content_hash = `v2:${'9'.repeat(40)}:${LEGACY_CONTENT}:${LEGACY_TREE}:${'f'.repeat(32)}`;
+      },
+      reason: 'source_audit_binding_subject_mismatch',
+    },
+    {
+      name: 'projection mismatch',
+      mutate: (audit) => { audit.audit_payload_hash = 'f'.repeat(32); },
+      reason: 'source_audit_projection_mismatch',
+    },
+    {
+      name: 'derived audit',
+      mutate: (audit) => { audit.derived_from_audit_id = DERIVED_AUDIT_ID; },
+      reason: 'source_audit_identity_unproven',
+    },
+    {
+      name: 'invalid audit version',
+      mutate: (audit) => { audit.version = 0; },
+      reason: 'source_audit_identity_unproven',
+    },
+  ];
+  for (const item of cases) {
+    const sourceEvidence = structuredClone(base.sourceEvidence);
+    item.mutate(sourceEvidence.audits[0]);
+    const qualified = qualifyLegacyGovernanceClassification({
+      classification: base.hashClassification,
+      sourceEvidence,
+    });
+    assert.equal(qualified.governance.eligibleCount, 0, item.name);
+    assert.equal(qualified.governance.unprovenCount, 1, item.name);
+    assert.equal(qualified.governance.unproven[0].reason, item.reason, item.name);
+    assert.deepEqual(qualified.cohorts, base.hashClassification.cohorts, item.name);
+  }
+});
+
+test('aborts instead of classifying incomplete source evidence', () => {
+  const fixture = fixtures();
+  const incomplete = structuredClone(fixture.sourceEvidence);
+  incomplete.audits = [];
+  assert.throws(() => qualifyLegacyGovernanceClassification({
+    classification: fixture.hashClassification,
+    sourceEvidence: incomplete,
+  }), /cover.*exactly once/);
+});
 
 test('freezes and verifies one exact dry-run boundary', () => {
   const fixture = createBoundaryFixture();
@@ -359,6 +456,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: structuredClone(fixture.sourceEvidence),
     });
     assert.equal(verified.executedCount, 1);
     readback.scoreSnapshots[0].score_subject.auditId = SOURCE_AUDIT_ID;
@@ -371,6 +469,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: structuredClone(fixture.sourceEvidence),
     }), /production readback mismatch/);
     readback.scoreSnapshots[0].score_subject.auditId = DERIVED_AUDIT_ID;
     readback.audits[0].summary = 'changed during execution';
@@ -383,7 +482,25 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: structuredClone(fixture.sourceEvidence),
     }), /production readback mismatch/);
+
+    const changedPostEvidence = structuredClone(fixture.sourceEvidence);
+    changedPostEvidence.audits[0].summary = 'changed during execution';
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      postInventory,
+      readback: {
+        ...readback,
+        audits: [{ ...fixture.sourceEvidence.audits[0] }, readback.audits[1]],
+      },
+      frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: changedPostEvidence,
+    }), /source audit changed during governance execution/);
   } finally {
     rmSync(fixture.directory, { recursive: true, force: true });
   }
@@ -461,6 +578,7 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /CLI 2\.4\.2 binary differs from the frozen dry-run boundary/);
   assert.ok((workflow.match(/276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
+  assert.match(workflow, /--phase qualify/);
   assert.match(workflow, /skill govern-legacy-equivalent/);
   assert.match(workflow, /cache batches of at most ten/);
   assert.match(workflow, /--concurrency 1/);
@@ -468,6 +586,14 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /legacy-equivalent-execution-/);
   assert.match(workflow, /legacy-equivalent-failed-dry-run-/);
   assert.match(workflow, /Preserve execution status evidence/);
+  const sourceEvidenceIndex = workflow.indexOf('Fetch complete source audit evidence before governance planning');
+  const qualificationIndex = workflow.indexOf('Qualify source-audit bindings and plan only governable groups');
+  const governanceDryRunIndex = workflow.indexOf('Run administrator governance dry-run');
+  assert(sourceEvidenceIndex > 0 && sourceEvidenceIndex < qualificationIndex);
+  assert(qualificationIndex < governanceDryRunIndex);
+  assert.match(workflow, /cmp "\$RUNNER_TEMP\/source-evidence\.json" "\$RUNNER_TEMP\/source-evidence-after\.json"/);
+  assert.match(workflow, /--post-source-evidence "\$RUNNER_TEMP\/post-source-evidence\.json"/);
+  assert.match(workflow, /\$\{\{ runner\.temp \}\}\/post-source-evidence\.json/);
   const syncCalls = workflow.match(/skill sync[\s\S]{0,250}/g) || [];
   assert.equal(syncCalls.length, 1);
   assert.match(syncCalls[0], /--dry-run/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -8,6 +8,9 @@ import { pathToFileURL } from 'node:url';
 const CLI_VERSION = '2.4.2';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const AUDIT_PAYLOAD_HASH_RE = /^[0-9a-f]{32}$/;
+const LOWER_HEX_RE = /^[0-9a-f]+$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function fail(message) {
@@ -45,15 +48,208 @@ function asMap(rows, key, label) {
   return map;
 }
 
+function decodePluginPath(value) {
+  if (!value || value.length % 2 !== 0 || !LOWER_HEX_RE.test(value)) return null;
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < value.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(value.slice(index, index + 2), 16);
+  }
+  let path;
+  try {
+    path = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+  if (
+    !path
+    || path.trim() !== path
+    || path.startsWith('/')
+    || path.includes('\\')
+    || path.includes('\0')
+    || path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) return null;
+  return path;
+}
+
+function qualifySourceAudit(audit, row) {
+  if (
+    audit.skill_id !== row.id
+    || audit.derived_from_audit_id != null
+    || audit.derivation_kind != null
+    || !Number.isSafeInteger(audit.version)
+    || audit.version < 1
+    || typeof audit.content_hash !== 'string'
+  ) {
+    return { eligible: false, reason: 'source_audit_identity_unproven' };
+  }
+  if (AUDIT_PAYLOAD_HASH_RE.test(audit.content_hash)) {
+    return { eligible: false, reason: 'source_audit_binding_unproven_legacy_digest' };
+  }
+
+  const parts = audit.content_hash.split(':');
+  let binding;
+  if (
+    parts[0] === 'v2'
+    && parts.length === 5
+    && COMMIT_RE.test(parts[1])
+    && SHA256_RE.test(parts[2])
+    && SHA256_RE.test(parts[3])
+    && AUDIT_PAYLOAD_HASH_RE.test(parts[4])
+  ) {
+    binding = {
+      version: 'v2', marketplaceCommit: parts[1], contentHash: parts[2], treeHash: parts[3],
+      pluginPath: null, auditPayloadHash: parts[4],
+    };
+  } else if (
+    parts[0] === 'v3'
+    && parts.length === 6
+    && COMMIT_RE.test(parts[1])
+    && SHA256_RE.test(parts[2])
+    && SHA256_RE.test(parts[3])
+    && AUDIT_PAYLOAD_HASH_RE.test(parts[5])
+  ) {
+    const pluginPath = decodePluginPath(parts[4]);
+    if (pluginPath) {
+      binding = {
+        version: 'v3', marketplaceCommit: parts[1], contentHash: parts[2], treeHash: parts[3],
+        pluginPath, auditPayloadHash: parts[5],
+      };
+    }
+  }
+  if (!binding) return { eligible: false, reason: 'source_audit_binding_malformed_or_unsupported' };
+  if (
+    binding.marketplaceCommit !== row.marketplaceCommit
+    || binding.contentHash !== row.contentHash
+    || binding.treeHash !== row.treeHash
+    || (binding.version === 'v3' && binding.pluginPath !== row.path)
+  ) {
+    return { eligible: false, reason: 'source_audit_binding_subject_mismatch' };
+  }
+
+  const projections = [
+    audit.subject_marketplace_commit_sha,
+    audit.subject_content_hash,
+    audit.subject_tree_hash,
+    audit.subject_plugin_path,
+  ];
+  if (binding.version === 'v2') {
+    if (audit.audit_payload_hash === null && projections.every((value) => value === null)) {
+      return { eligible: true, reason: 'eligible_v2' };
+    }
+    return { eligible: false, reason: 'source_audit_projection_mismatch' };
+  }
+  if (
+    audit.audit_payload_hash === binding.auditPayloadHash
+    && audit.subject_marketplace_commit_sha === binding.marketplaceCommit
+    && audit.subject_content_hash === binding.contentHash
+    && audit.subject_tree_hash === binding.treeHash
+    && audit.subject_plugin_path === binding.pluginPath
+  ) {
+    return { eligible: true, reason: 'eligible_v3' };
+  }
+  return { eligible: false, reason: 'source_audit_projection_mismatch' };
+}
+
+export function qualifyLegacyGovernanceClassification({ classification, sourceEvidence }) {
+  if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
+    fail('classification contract is not frozen');
+  }
+  if (sourceEvidence?.schemaVersion !== 1 || sourceEvidence?.status !== 'source_evidence_fetched') {
+    fail('source evidence contract is not complete');
+  }
+  const legacy = asMap(classification?.cohorts?.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
+  const skills = asMap(sourceEvidence.skills, 'id', 'source evidence Skills');
+  const audits = asMap(sourceEvidence.audits, 'id', 'source evidence audits');
+  if (
+    skills.size !== legacy.size
+    || audits.size !== legacy.size
+    || canonicalJson(sourceEvidence.skillIds) !== canonicalJson([...legacy.values()].map((row) => row.id).sort())
+  ) {
+    fail('source evidence does not cover the hash-equivalent cohort exactly once');
+  }
+
+  const eligible = [];
+  const unproven = [];
+  for (const row of legacy.values()) {
+    const skill = skills.get(row.id);
+    const audit = audits.get(row.publicEligibilityAuditId);
+    if (!skill || skill.slug !== row.slug || !audit || audit.id !== row.publicEligibilityAuditId) {
+      fail(`source evidence identity mismatch for ${row.slug}`);
+    }
+    const decision = qualifySourceAudit(audit, row);
+    const frozen = {
+      slug: row.slug,
+      skillId: row.id,
+      sourceAuditId: row.publicEligibilityAuditId,
+      reason: decision.reason,
+    };
+    (decision.eligible ? eligible : unproven).push(frozen);
+  }
+  if (eligible.length + unproven.length !== legacy.size) {
+    fail('source audit qualification lost a hash-equivalent row');
+  }
+  return {
+    ...classification,
+    governance: {
+      schemaVersion: 1,
+      status: 'source_audit_qualified',
+      hashEquivalentCount: legacy.size,
+      eligibleCount: eligible.length,
+      unprovenCount: unproven.length,
+      eligible,
+      unproven,
+    },
+  };
+}
+
+function assertQualificationMatchesEvidence(classification, sourceEvidence) {
+  const requalified = qualifyLegacyGovernanceClassification({ classification, sourceEvidence });
+  if (canonicalJson(requalified.governance) !== canonicalJson(classification.governance)) {
+    fail('frozen source audit qualification does not match source evidence');
+  }
+}
+
+function governableLegacyRows(classification) {
+  const rawLegacy = asMap(classification?.cohorts?.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
+  const governance = classification?.governance;
+  const eligible = asMap(governance?.eligible, 'slug', 'governable legacy cohort');
+  const unproven = asMap(governance?.unproven, 'slug', 'unproven source-audit cohort');
+  if (
+    governance?.schemaVersion !== 1
+    || governance?.status !== 'source_audit_qualified'
+    || governance.hashEquivalentCount !== rawLegacy.size
+    || governance.eligibleCount !== eligible.size
+    || governance.unprovenCount !== unproven.size
+    || eligible.size + unproven.size !== rawLegacy.size
+  ) {
+    fail('source audit qualification coverage is invalid');
+  }
+  for (const slug of rawLegacy.keys()) {
+    if (eligible.has(slug) === unproven.has(slug)) {
+      fail(`source audit qualification is not a disjoint cover for ${slug}`);
+    }
+  }
+  for (const decision of [...eligible.values(), ...unproven.values()]) {
+    const row = rawLegacy.get(decision.slug);
+    if (
+      !row
+      || decision.skillId !== row.id
+      || decision.sourceAuditId !== row.publicEligibilityAuditId
+      || typeof decision.reason !== 'string'
+      || !decision.reason
+    ) {
+      fail(`source audit qualification identity mismatch for ${decision.slug}`);
+    }
+  }
+  return [...eligible.keys()].map((slug) => rawLegacy.get(slug));
+}
+
 function legacyGroups(plan, classification) {
-  const legacyRows = classification?.cohorts?.legacy_algorithm_equivalent;
+  const legacyRows = governableLegacyRows(classification);
   const selected = asMap(plan?.selected, 'slug', 'plan selected rows');
   const legacy = asMap(legacyRows, 'slug', 'legacy cohort');
   if (plan?.selectedCount !== plan?.selected?.length || plan.selectedCount > MAX_BATCH_SIZE) {
     fail('plan is not a bounded complete batch');
-  }
-  if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
-    fail('classification contract is not frozen');
   }
   for (const slug of legacy.keys()) {
     if (!selected.has(slug)) fail(`legacy cohort contains an unplanned slug: ${slug}`);
@@ -99,7 +295,7 @@ function validateAdminWrapper(wrapper, expected, mode, classification) {
   ) {
     fail(`${mode} administrator result has an invalid summary`);
   }
-  const legacy = asMap(classification.cohorts.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
+  const legacy = asMap(governableLegacyRows(classification), 'slug', 'governable legacy cohort');
   const results = asMap(result.results, 'slug', `${mode} administrator rows`);
   for (const slug of expected.slugs) {
     const frozen = legacy.get(slug);
@@ -150,6 +346,10 @@ export function createLegacyGovernanceBoundary({
   ) {
     fail('invalid dry-run workflow metadata');
   }
+  assertQualificationMatchesEvidence(
+    classification,
+    JSON.parse(readFileSync(paths.sourceEvidence, 'utf8'))
+  );
   const groups = legacyGroups(plan, classification);
   if (!Array.isArray(dryRunResults) || dryRunResults.length !== groups.length) {
     fail('dry-run result group count does not match the frozen legacy cohort');
@@ -167,7 +367,9 @@ export function createLegacyGovernanceBoundary({
     cliVersion: CLI_VERSION,
     cliSha256: metadata.cliSha256,
     selectedCount: plan.selectedCount,
-    legacyCount: classification.counts.legacy_algorithm_equivalent,
+    hashEquivalentCount: classification.counts.legacy_algorithm_equivalent,
+    legacyCount: classification.governance.eligibleCount,
+    unprovenSourceAuditCount: classification.governance.unprovenCount,
     lastSelected: plan.lastSelected,
     hashes: {
       plan: sha256File(paths.plan),
@@ -214,11 +416,12 @@ export function verifyLegacyGovernanceBoundary({
   if (canonicalJson(frozenSourceEvidence) !== canonicalJson(currentSourceEvidence)) {
     fail('Skill metadata or source audit changed after the frozen dry-run boundary');
   }
+  assertQualificationMatchesEvidence(classification, frozenSourceEvidence);
   const frozenSkills = asMap(frozenInventory.rows, 'slug', 'frozen Skills');
   const currentSkills = asMap(currentInventory.rows, 'slug', 'current Skills');
   const artifacts = asMap(currentInventory.artifacts, 'skill_id', 'current artifacts');
   const observations = asMap(currentInventory.observations, 'skill_id', 'current observations');
-  const legacySlugs = new Set(classification.cohorts.legacy_algorithm_equivalent.map((row) => row.slug));
+  const legacySlugs = new Set(governableLegacyRows(classification).map((row) => row.slug));
   if (
     canonicalJson(frozenInventory.packMemberships) !== canonicalJson(currentInventory.packMemberships)
     || canonicalJson(frozenInventory.packs) !== canonicalJson(currentInventory.packs)
@@ -298,7 +501,12 @@ export function verifyLegacyGovernanceExecution({
   postInventory,
   readback,
   frozenSourceEvidence,
+  postSourceEvidence,
 }) {
+  if (canonicalJson(frozenSourceEvidence) !== canonicalJson(postSourceEvidence)) {
+    fail('Skill metadata or source audit changed during governance execution');
+  }
+  assertQualificationMatchesEvidence(classification, frozenSourceEvidence);
   const groups = legacyGroups(plan, classification);
   if (!Array.isArray(executionResults) || executionResults.length !== groups.length) {
     fail('execute result group count mismatch');
@@ -322,8 +530,10 @@ export function verifyLegacyGovernanceExecution({
   const frozenSourceAudits = asMap(frozenSourceEvidence?.audits, 'id', 'frozen source audits');
   const frozenSkillMetadata = asMap(frozenSourceEvidence?.skills, 'id', 'frozen Skill metadata');
   const attestations = readback.attestations || [];
-  const legacyRows = classification.cohorts.legacy_algorithm_equivalent;
+  const legacyRows = governableLegacyRows(classification);
   const legacySlugs = new Set(legacyRows.map((row) => row.slug));
+  const rawLegacy = asMap(classification.cohorts.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
+  const sourceAuditUnproven = classification.governance.unproven.map((decision) => rawLegacy.get(decision.slug));
 
   if (
     canonicalJson(frozenInventory.packMemberships) !== canonicalJson(postInventory.packMemberships)
@@ -333,7 +543,8 @@ export function verifyLegacyGovernanceExecution({
   }
 
   for (const frozen of classification.cohorts.exact.concat(
-    classification.cohorts.actual_or_unproven_drift
+    classification.cohorts.actual_or_unproven_drift,
+    sourceAuditUnproven
   )) {
     if (canonicalJson(frozenSkills.get(frozen.slug)) !== canonicalJson(postSkills.get(frozen.slug))) {
       fail(`non-legacy cohort row changed: ${frozen.slug}`);
@@ -439,7 +650,12 @@ function readJson(path) {
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   let output;
-  if (args.phase === 'groups') {
+  if (args.phase === 'qualify') {
+    output = qualifyLegacyGovernanceClassification({
+      classification: readJson(args.classification),
+      sourceEvidence: readJson(args['source-evidence']),
+    });
+  } else if (args.phase === 'groups') {
     output = {
       schemaVersion: 1,
       status: 'legacy_groups_planned',
@@ -493,9 +709,10 @@ export function main(argv = process.argv.slice(2)) {
       postInventory: readJson(args['post-inventory']),
       readback: readJson(args.readback),
       frozenSourceEvidence: readJson(args['frozen-source-evidence']),
+      postSourceEvidence: readJson(args['post-source-evidence']),
     });
   } else {
-    fail('--phase must be groups, freeze, execute-preflight, or execution');
+    fail('--phase must be qualify, groups, freeze, execute-preflight, or execution');
   }
   writeFileSync(resolve(args.output), `${JSON.stringify(output, null, 2)}\n`, { flag: 'wx' });
   process.stdout.write(`${JSON.stringify({ status: output.status })}\n`);


### PR DESCRIPTION
## Summary

- preserve raw legacy hash-equivalence while separately qualifying immutable source-audit trust
- allow governance groups only for exact v2/v3 bindings matching frozen commit/content/tree/path and projection rules
- classify legacy, malformed, mismatched, derived, or conflicting audit evidence as source-audit-unproven with stable reason codes
- freeze/recompute qualification and compare full raw-legacy source evidence before dry-run, at execute preflight, and after execution

## Safety

- incomplete or duplicate source evidence aborts; transport failure is never reclassified
- eligible plus source-audit-unproven is an exact disjoint cover of the original hash-equivalent cohort
- unproven Skill rows and source audits must remain unchanged through execution
- CLI 2.4.2 and database RPC independently retain their strict v2/v3 write gates

## Verification

- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (7/7)
- node --check scripts/verify-legacy-equivalent-governance.mjs
- git diff --check
- two independent P0/P1 reviews: no remaining findings
- rebased onto origin/main before push

## Production evidence

Dry-run 29392847982 classified 500 rows and found four hash-equivalent candidates. Three passed administrator validation; emilkowalski-apple-design had a plain 32-hex legacy audit digest and correctly failed the immutable subject gate. This change records that row as audit-unproven instead of aborting the batch or weakening trust.