### PR TITLE
fix: stabilize legacy source evidence order

### DIFF
--- a/scripts/fetch-legacy-equivalent-governance-readback.mjs
+++ b/scripts/fetch-legacy-equivalent-governance-readback.mjs
@@ -14,6 +14,10 @@ function unique(values) {
   return [...new Set(values.filter(Boolean))].sort();
 }
 
+function sortRowsById(rows) {
+  return [...rows].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US'));
+}
+
 function headers(serviceKey) {
   return {
     apikey: serviceKey,
@@ -142,7 +146,13 @@ export async function fetchLegacyGovernanceSourceEvidence({
   if (skills.length !== legacy.length || audits.length !== legacy.length) {
     fail('source evidence readback is incomplete');
   }
-  return { schemaVersion: 1, status: 'source_evidence_fetched', skillIds, skills, audits };
+  return {
+    schemaVersion: 1,
+    status: 'source_evidence_fetched',
+    skillIds,
+    skills: sortRowsById(skills),
+    audits: sortRowsById(audits),
+  };
 }
 
 function parseArgs(argv) {

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -536,14 +536,29 @@ test('fetches bounded independent governance readback tables', async () => {
 });
 
 test('freezes the complete source audit row and unhashed Skill install metadata', async () => {
-  const classification = fixtures().classification;
+  const classification = structuredClone(fixtures().hashClassification);
+  const secondSkillId = '00000000-0000-4000-8000-000000000002';
+  const secondAuditId = '10000000-0000-4000-8000-000000000002';
+  classification.cohorts.legacy_algorithm_equivalent.push({
+    ...classification.cohorts.legacy_algorithm_equivalent[0],
+    id: secondSkillId,
+    slug: 'owner-second',
+    publicEligibilityAuditId: secondAuditId,
+  });
+  classification.counts.legacy_algorithm_equivalent = 2;
   const fetchImpl = async (url) => {
     const table = url.pathname.split('/').at(-1);
     if (table === 'skills') {
-      return { ok: true, json: async () => [{ id: SKILL_ID, name: 'Image', file_structure: [] }] };
+      return { ok: true, json: async () => [
+        { id: secondSkillId, name: 'Second', file_structure: [] },
+        { id: SKILL_ID, name: 'Image', file_structure: [] },
+      ] };
     }
     assert.equal(url.searchParams.get('select'), '*');
-    return { ok: true, json: async () => [{ id: SOURCE_AUDIT_ID, skill_id: SKILL_ID, version: 7 }] };
+    return { ok: true, json: async () => [
+      { id: secondAuditId, skill_id: secondSkillId, version: 8 },
+      { id: SOURCE_AUDIT_ID, skill_id: SKILL_ID, version: 7 },
+    ] };
   };
   const output = await fetchLegacyGovernanceSourceEvidence({
     supabaseUrl: 'https://db.example.test',
@@ -551,8 +566,8 @@ test('freezes the complete source audit row and unhashed Skill install metadata'
     classification,
     fetchImpl,
   });
-  assert.equal(output.skills.length, 1);
-  assert.equal(output.audits[0].id, SOURCE_AUDIT_ID);
+  assert.deepEqual(output.skills.map((row) => row.id), [SKILL_ID, secondSkillId]);
+  assert.deepEqual(output.audits.map((row) => row.id), [SOURCE_AUDIT_ID, secondAuditId]);
 });
 
 test('workflow is two-phase, exactly pinned, bounded, and never executes ordinary sync', () => {


### PR DESCRIPTION
## Summary

- sort frozen Skill and source-audit evidence rows by immutable ID
- keep pre/post source-evidence comparison byte-stable across unordered PostgREST responses
- add a reversed-response regression fixture

## Production evidence

Batch execution 29394337897 governed three eligible rows successfully. Final verification failed because the same four Skill metadata rows were returned in a different order; after sorting by ID, frozen and post evidence are identical. Audit rows and all values were unchanged.

## Verification

- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (7/7)
- node --check scripts/fetch-legacy-equivalent-governance-readback.mjs
- git diff --check
- rebased onto origin/main before push