### PR TITLE
fix: compare legacy source evidence canonically

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
 import {
+  canonicalSourceEvidence,
   createLegacyGovernanceBoundary,
   qualifyLegacyGovernanceClassification,
   verifyLegacyGovernanceBoundary,
@@ -24,6 +25,20 @@ const LEGACY_CONTENT = 'b'.repeat(64);
 const LEGACY_TREE = 'c'.repeat(64);
 const CONTENT = 'd'.repeat(64);
 const TREE = 'e'.repeat(64);
+
+test('canonicalizes source evidence row order without hiding value drift', () => {
+  const left = {
+    schemaVersion: 1,
+    skills: [{ id: '2', name: 'Second' }, { id: '1', name: 'First' }],
+    audits: [{ id: 'a', version: 1 }, { id: 'b', version: 2 }],
+  };
+  const reordered = structuredClone(left);
+  reordered.skills.reverse();
+  reordered.audits.reverse();
+  assert.equal(canonicalSourceEvidence(left), canonicalSourceEvidence(reordered));
+  reordered.audits[0].version = 3;
+  assert.notEqual(canonicalSourceEvidence(left), canonicalSourceEvidence(reordered));
+});
 
 function frozenRow() {
   return {
@@ -292,6 +307,20 @@ test('freezes and verifies one exact dry-run boundary', () => {
       expectedRunId: '12345',
     });
     assert.equal(verified.status, 'execution_preflight_verified');
+    const reorderedSourceEvidence = structuredClone(fixture.sourceEvidence);
+    reorderedSourceEvidence.skills.reverse();
+    reorderedSourceEvidence.audits.reverse();
+    assert.equal(verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: structuredClone(fixture.preInventory),
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: reorderedSourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }).status, 'execution_preflight_verified');
     const drift = structuredClone(fixture.preInventory);
     drift.rows[0].updated_at = '2026-07-15T00:00:00.000Z';
     assert.throws(() => verifyLegacyGovernanceBoundary({

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -31,6 +31,14 @@ function canonicalJson(value) {
   return JSON.stringify(canonicalize(value));
 }
 
+export function canonicalSourceEvidence(value) {
+  return canonicalJson({
+    ...value,
+    skills: [...(value?.skills || [])].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US')),
+    audits: [...(value?.audits || [])].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US')),
+  });
+}
+
 function sha256File(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
@@ -413,7 +421,7 @@ export function verifyLegacyGovernanceBoundary({
   if (canonicalJson(boundary.groups) !== canonicalJson(expectedGroups)) {
     fail('downloaded boundary groups do not match plan/classification');
   }
-  if (canonicalJson(frozenSourceEvidence) !== canonicalJson(currentSourceEvidence)) {
+  if (canonicalSourceEvidence(frozenSourceEvidence) !== canonicalSourceEvidence(currentSourceEvidence)) {
     fail('Skill metadata or source audit changed after the frozen dry-run boundary');
   }
   assertQualificationMatchesEvidence(classification, frozenSourceEvidence);
@@ -503,7 +511,7 @@ export function verifyLegacyGovernanceExecution({
   frozenSourceEvidence,
   postSourceEvidence,
 }) {
-  if (canonicalJson(frozenSourceEvidence) !== canonicalJson(postSourceEvidence)) {
+  if (canonicalSourceEvidence(frozenSourceEvidence) !== canonicalSourceEvidence(postSourceEvidence)) {
     fail('Skill metadata or source audit changed during governance execution');
   }
   assertQualificationMatchesEvidence(classification, frozenSourceEvidence);


### PR DESCRIPTION
## Summary

- canonicalize frozen/current/post source evidence by immutable row ID before comparison
- preserve strict value comparison while accepting unordered PostgREST arrays
- add regression coverage proving reorder is accepted and value drift is rejected

## Production evidence

Execution 29394337897 committed three valid rows, then final verification failed. Downloaded frozen/post artifacts are identical after sorting Skill rows by ID; audit rows and every value are unchanged. This patch allows the frozen 2.4.2 boundary to be replayed idempotently.

## Verification

- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (8/8)
- git diff --check
- rebased onto origin/main before push