### PR TITLE
fix: read replay evidence from classification

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -72,10 +72,11 @@ function frozenRow() {
 
 function fixtures() {
   const row = frozenRow();
+  const { evidence: _classificationOnlyEvidence, ...plannedRow } = row;
   const plan = {
     schemaVersion: 3,
     selectedCount: 1,
-    selected: [row],
+    selected: [plannedRow],
     lastSelected: row.slug,
     batches: [{
       index: 1,

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -429,7 +429,8 @@ export function verifyLegacyGovernanceBoundary({
   const currentSkills = asMap(currentInventory.rows, 'slug', 'current Skills');
   const artifacts = asMap(currentInventory.artifacts, 'skill_id', 'current artifacts');
   const observations = asMap(currentInventory.observations, 'skill_id', 'current observations');
-  const legacySlugs = new Set(governableLegacyRows(classification).map((row) => row.slug));
+  const governableLegacy = asMap(governableLegacyRows(classification), 'slug', 'governable legacy cohort');
+  const legacySlugs = new Set(governableLegacy.keys());
   if (
     canonicalJson(frozenInventory.packMemberships) !== canonicalJson(currentInventory.packMemberships)
     || canonicalJson(frozenInventory.packs) !== canonicalJson(currentInventory.packs)
@@ -449,7 +450,7 @@ export function verifyLegacyGovernanceBoundary({
       continue;
     }
     if (canonicalJson(before) === canonicalJson(current)) continue;
-    const repair = selected.evidence.artifact.hashRepair;
+    const repair = governableLegacy.get(selected.slug).evidence.artifact.hashRepair;
     const artifact = artifacts.get(selected.id);
     const observation = observations.get(selected.id);
     if (


### PR DESCRIPTION
## Summary

- use the frozen governance classification for hash-repair evidence during resumable execution preflight
- keep the plan limited to immutable selection identity as designed
- update the test fixture so plan rows no longer carry classification-only evidence

## Production evidence

Replay 29394827780 failed before writes because the verifier read selected.evidence from plan.json. Real plan rows intentionally omit that field; classification.json is the frozen evidence authority.

## Verification

- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (8/8)
- git diff --check
- rebased onto origin/main before push