### PR TITLE
chore: pin legacy governance CLI 2.4.3

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version'
         type: string
         required: true
-        default: '2.4.2'
+        default: '2.4.3'
       batch_size:
         description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
         type: number
@@ -85,7 +85,7 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.4.2' || { echo '::error::workflow is pinned to skillstore-cli 2.4.2'; exit 1; }
+          test "$CLI_VERSION" = '2.4.3' || { echo '::error::workflow is pinned to skillstore-cli 2.4.3'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
           [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
             echo '::error::batch_size must be between 1 and 500'; exit 1;
@@ -144,17 +144,17 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.2'
-          minimum-version: '2.4.2'
+          version: '2.4.3'
+          minimum-version: '2.4.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Verify audited CLI 2.4.2 binary identity
+      - name: Verify audited CLI 2.4.3 binary identity
         run: |
           set -euo pipefail
-          expected='276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125'
+          expected='29ebe6a8e588efbc0b55e3779c39a068eeaec2b3932463a90f7989b239decd94'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
-            echo '::error::CLI 2.4.2 binary does not match the audited linux-x64 digest'; exit 1;
+            echo '::error::CLI 2.4.3 binary does not match the audited linux-x64 digest'; exit 1;
           }
 
       - name: Materialize pinned snapshots
@@ -281,7 +281,7 @@ jobs:
             --pre-inventory "$boundary/pre-inventory.json" --dry-run-results "$boundary/governance-dry-run.json" \
             --source-evidence "$boundary/source-evidence.json" \
             --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
-            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.2' \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.3' \
             --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --output "$boundary/boundary.json"
           (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json boundary.json > SHA256SUMS)
@@ -302,7 +302,7 @@ jobs:
           {
             echo '## Legacy-equivalent frozen boundary'
             echo "- Run ID: \`$GITHUB_RUN_ID\`"
-            echo "- CLI: \`2.4.2\`"
+            echo "- CLI: \`2.4.3\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
             echo "- Hash-equivalent: \`$(jq -r .governance.hashEquivalentCount "$RUNNER_TEMP/classification.json")\`; governable: \`$(jq -r .governance.eligibleCount "$RUNNER_TEMP/classification.json")\`; source-audit unproven: \`$(jq -r .governance.unprovenCount "$RUNNER_TEMP/classification.json")\`"
@@ -357,7 +357,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git sparse-checkout disable
           git reset --hard HEAD
-          test "$CLI_VERSION" = '2.4.2' || { echo '::error::workflow is pinned to skillstore-cli 2.4.2'; exit 1; }
+          test "$CLI_VERSION" = '2.4.3' || { echo '::error::workflow is pinned to skillstore-cli 2.4.3'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
           [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
@@ -424,22 +424,22 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.4.2
+      - name: Download exact audited CLI 2.4.3
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.2'
-          minimum-version: '2.4.2'
+          version: '2.4.3'
+          minimum-version: '2.4.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125'
+          audited='29ebe6a8e588efbc0b55e3779c39a068eeaec2b3932463a90f7989b239decd94'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {
-            echo '::error::CLI 2.4.2 binary differs from the frozen dry-run boundary'; exit 1;
+            echo '::error::CLI 2.4.3 binary differs from the frozen dry-run boundary'; exit 1;
           }
 
       - name: Materialize only frozen legacy groups
@@ -547,7 +547,7 @@ jobs:
           {
             echo '## Legacy-equivalent execution verified'
             echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
-            echo '- CLI: `2.4.2`'
+            echo '- CLI: `2.4.3`'
             echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
             echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
             echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -204,7 +204,7 @@ function createBoundaryFixture() {
       runId: '12345',
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
-      cliVersion: '2.4.2',
+      cliVersion: '2.4.3',
       cliSha256: '9'.repeat(64),
     },
   });
@@ -609,8 +609,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.4\.2'/);
-  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.2'/);
+  assert.match(workflow, /default: '2\.4\.3'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.3'/);
   assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
   assert.match(workflow, /batch_size must be between 1 and 500/);
   assert.match(workflow, /dry_run_id/);
@@ -620,8 +620,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /boundaries may only be created from main/);
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
-  assert.match(workflow, /CLI 2\.4\.2 binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/276eee5369128edc2b70bbc602592434940a57c494b0ee8ffe6b3eef51396125/g) || []).length >= 2);
+  assert.match(workflow, /CLI 2\.4\.3 binary differs from the frozen dry-run boundary/);
+  assert.ok((workflow.match(/29ebe6a8e588efbc0b55e3779c39a068eeaec2b3932463a90f7989b239decd94/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--phase qualify/);
   assert.match(workflow, /skill govern-legacy-equivalent/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const CLI_VERSION = '2.4.2';
+const CLI_VERSION = '2.4.3';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;


### PR DESCRIPTION
## Summary
- pin the legacy-equivalent governance workflow to audited skillstore-cli 2.4.3
- require Linux SHA-256 `29ebe6a8e588efbc0b55e3779c39a068eeaec2b3932463a90f7989b239decd94` in dry-run and execute jobs
- update frozen-boundary verification and workflow contract tests

## Verification
- `CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs scripts/tests/artifact-version-backfill.test.mjs` (18/18)
- `git diff --check`
- Skillstore release workflow 29398252697 passed; release checksum file verified

## Rollout
All prior 2.4.2 dry-run boundaries are intentionally invalid. After merge, create a fresh one-row canary boundary for `mcncarl-wechat-local-vault`, execute it, verify production invariants and install channels, then resume the bounded 500-row scan.