### PR TITLE
fix: resume legacy governance after Pack timestamp drift

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -335,6 +335,9 @@ jobs:
 
   execute-boundary:
     if: inputs.mode == 'execute'
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
     runs-on: self-hosted
     timeout-minutes: 120
     steps:
@@ -504,6 +507,7 @@ jobs:
           --classification "$RUNNER_TEMP/boundary/classification.json"
           --execution-results "$RUNNER_TEMP/execution-results.json"
           --frozen-inventory "$RUNNER_TEMP/boundary/pre-inventory.json"
+          --current-inventory "$RUNNER_TEMP/current-inventory.json"
           --post-inventory "$RUNNER_TEMP/post-inventory.json"
           --readback "$RUNNER_TEMP/governance-readback.json"
           --frozen-source-evidence "$RUNNER_TEMP/boundary/source-evidence.json"
@@ -532,6 +536,7 @@ jobs:
           path: |
             ${{ runner.temp }}/boundary/
             ${{ runner.temp }}/execution-preflight.json
+            ${{ runner.temp }}/current-inventory.json
             ${{ runner.temp }}/current-source-evidence.json
             ${{ runner.temp }}/execution-results.json
             ${{ runner.temp }}/post-inventory.json

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -322,6 +322,51 @@ test('freezes and verifies one exact dry-run boundary', () => {
       paths: fixture.files,
       expectedRunId: '12345',
     }).status, 'execution_preflight_verified');
+    const packTimestampAdvance = structuredClone(fixture.preInventory);
+    packTimestampAdvance.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
+    const advancedPreflight = verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: packTimestampAdvance,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    });
+    assert.equal(advancedPreflight.status, 'execution_preflight_verified');
+    assert.deepEqual(advancedPreflight.packUpdatedAtAdvances, [{
+      packId: fixture.preInventory.packs[0].id,
+      frozenUpdatedAt: fixture.preInventory.packs[0].updated_at,
+      currentUpdatedAt: packTimestampAdvance.packs[0].updated_at,
+    }]);
+    const packTimestampRegression = structuredClone(fixture.preInventory);
+    packTimestampRegression.packs[0].updated_at = '2025-07-15T00:00:00.000Z';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: packTimestampRegression,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /Pack updated_at regressed/);
+    const packTopologyDrift = structuredClone(fixture.preInventory);
+    packTopologyDrift.packs[0].slug = 'changed-pack';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: packTopologyDrift,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /production state changed/);
     const drift = structuredClone(fixture.preInventory);
     drift.rows[0].updated_at = '2026-07-15T00:00:00.000Z';
     assert.throws(() => verifyLegacyGovernanceBoundary({
@@ -446,6 +491,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
         source_path: fixture.row.path,
       }],
     };
+    postInventory.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
     const readback = {
       skills: [{
         ...fixture.sourceEvidence.skills[0],
@@ -477,18 +523,35 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       scoreBreakdowns: [{ skill_id: SKILL_ID, score_snapshot_id: SNAPSHOT_ID, stale_at: null, stale_reason: null }],
       attestations: [],
     };
+    const currentInventory = structuredClone(fixture.preInventory);
+    currentInventory.packs[0].updated_at = postInventory.packs[0].updated_at;
     const verified = verifyLegacyGovernanceExecution({
       boundary: fixture.boundary,
       plan: fixture.plan,
       classification: fixture.classification,
       executionResults,
       frozenInventory: fixture.preInventory,
+      currentInventory,
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
       postSourceEvidence: structuredClone(fixture.sourceEvidence),
     });
     assert.equal(verified.executedCount, 1);
+    postInventory.packs[0].updated_at = '2026-07-15T00:00:01.000Z';
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      currentInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: structuredClone(fixture.sourceEvidence),
+    }), /Pack state changed during governance execution/);
+    postInventory.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
     readback.scoreSnapshots[0].score_subject.auditId = SOURCE_AUDIT_ID;
     assert.throws(() => verifyLegacyGovernanceExecution({
       boundary: fixture.boundary,
@@ -496,6 +559,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       classification: fixture.classification,
       executionResults,
       frozenInventory: fixture.preInventory,
+      currentInventory,
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
@@ -509,6 +573,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       classification: fixture.classification,
       executionResults,
       frozenInventory: fixture.preInventory,
+      currentInventory,
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
@@ -523,6 +588,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       classification: fixture.classification,
       executionResults,
       frozenInventory: fixture.preInventory,
+      currentInventory,
       postInventory,
       readback: {
         ...readback,
@@ -623,10 +689,13 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /CLI 2\.4\.4 binary differs from the frozen dry-run boundary/);
   assert.ok((workflow.match(/4ee53da0adf5b1ab990f065edacff5e9ec60a37ce015e10decf76c65828321b0/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
+  assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);
+  assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-inventory\.json/);
   assert.match(workflow, /--phase qualify/);
   assert.match(workflow, /skill govern-legacy-equivalent/);
   assert.match(workflow, /cache batches of at most ten/);
   assert.match(workflow, /--concurrency 1/);
+  assert.match(workflow, /execute-boundary:[\s\S]{0,160}group: production-skill-score-writes/);
   assert.match(workflow, /legacy-equivalent-boundary-/);
   assert.match(workflow, /legacy-equivalent-execution-/);
   assert.match(workflow, /legacy-equivalent-failed-dry-run-/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -39,6 +39,57 @@ export function canonicalSourceEvidence(value) {
   });
 }
 
+function canonicalPackTopology(inventory) {
+  const packMemberships = [...(inventory?.packMemberships || [])]
+    .sort((left, right) => `${left.skill_id}:${left.pack_id}`.localeCompare(
+      `${right.skill_id}:${right.pack_id}`,
+      'en-US'
+    ));
+  const packs = [...(inventory?.packs || [])]
+    .map((pack) => ({ id: pack.id, slug: pack.slug, published_at: pack.published_at }))
+    .sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US'));
+  return canonicalJson({ packMemberships, packs });
+}
+
+function canonicalPackState(inventory) {
+  const packMemberships = [...(inventory?.packMemberships || [])]
+    .sort((left, right) => `${left.skill_id}:${left.pack_id}`.localeCompare(
+      `${right.skill_id}:${right.pack_id}`,
+      'en-US'
+    ));
+  const packs = [...(inventory?.packs || [])]
+    .sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US'));
+  return canonicalJson({ packMemberships, packs });
+}
+
+function assertPackUpdatedAtDoesNotRegress(beforeInventory, afterInventory, context) {
+  const before = asMap(beforeInventory?.packs || [], 'id', `${context} prior Packs`);
+  const after = asMap(afterInventory?.packs || [], 'id', `${context} current Packs`);
+  if (before.size !== after.size) fail(`${context} Pack topology changed`);
+  const advances = [];
+  for (const [id, prior] of before) {
+    const current = after.get(id);
+    const priorTimestamp = Date.parse(prior?.updated_at);
+    const currentTimestamp = Date.parse(current?.updated_at);
+    if (
+      !current
+      || !Number.isFinite(priorTimestamp)
+      || !Number.isFinite(currentTimestamp)
+      || currentTimestamp < priorTimestamp
+    ) {
+      fail(`${context} Pack updated_at regressed for ${id}`);
+    }
+    if (currentTimestamp > priorTimestamp) {
+      advances.push({
+        packId: id,
+        frozenUpdatedAt: prior.updated_at,
+        currentUpdatedAt: current.updated_at,
+      });
+    }
+  }
+  return advances;
+}
+
 function sha256File(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
@@ -432,12 +483,16 @@ export function verifyLegacyGovernanceBoundary({
   const governableLegacy = asMap(governableLegacyRows(classification), 'slug', 'governable legacy cohort');
   const legacySlugs = new Set(governableLegacy.keys());
   if (
-    canonicalJson(frozenInventory.packMemberships) !== canonicalJson(currentInventory.packMemberships)
-    || canonicalJson(frozenInventory.packs) !== canonicalJson(currentInventory.packs)
+    canonicalPackTopology(frozenInventory) !== canonicalPackTopology(currentInventory)
     || frozenSkills.size !== currentSkills.size
   ) {
     fail('production state changed after the frozen dry-run boundary');
   }
+  const packUpdatedAtAdvances = assertPackUpdatedAtDoesNotRegress(
+    frozenInventory,
+    currentInventory,
+    'production state after the frozen dry-run boundary'
+  );
   let resumableCount = 0;
   for (const selected of plan.selected) {
     const before = frozenSkills.get(selected.slug);
@@ -491,6 +546,7 @@ export function verifyLegacyGovernanceBoundary({
     runId: boundary.runId,
     legacyCount: boundary.legacyCount,
     resumableCount,
+    packUpdatedAtAdvances,
     groups: expectedGroups,
   };
 }
@@ -507,6 +563,7 @@ export function verifyLegacyGovernanceExecution({
   classification,
   executionResults,
   frozenInventory,
+  currentInventory,
   postInventory,
   readback,
   frozenSourceEvidence,
@@ -545,10 +602,18 @@ export function verifyLegacyGovernanceExecution({
   const sourceAuditUnproven = classification.governance.unproven.map((decision) => rawLegacy.get(decision.slug));
 
   if (
-    canonicalJson(frozenInventory.packMemberships) !== canonicalJson(postInventory.packMemberships)
-    || canonicalJson(frozenInventory.packs) !== canonicalJson(postInventory.packs)
+    canonicalPackTopology(frozenInventory) !== canonicalPackTopology(currentInventory)
+    || canonicalPackTopology(frozenInventory) !== canonicalPackTopology(postInventory)
   ) {
-    fail('dependent Pack identity or timestamps changed during governance');
+    fail('dependent Pack topology changed during governance');
+  }
+  assertPackUpdatedAtDoesNotRegress(
+    frozenInventory,
+    currentInventory,
+    'dependent Pack state before governance'
+  );
+  if (canonicalPackState(currentInventory) !== canonicalPackState(postInventory)) {
+    fail('dependent Pack state changed during governance execution');
   }
 
   for (const frozen of classification.cohorts.exact.concat(
@@ -715,6 +780,7 @@ export function main(argv = process.argv.slice(2)) {
       classification: readJson(args.classification),
       executionResults: readJson(args['execution-results']),
       frozenInventory: readJson(args['frozen-inventory']),
+      currentInventory: readJson(args['current-inventory']),
       postInventory: readJson(args['post-inventory']),
       readback: readJson(args.readback),
       frozenSourceEvidence: readJson(args['frozen-source-evidence']),


### PR DESCRIPTION
## Problem

Batch 7 partially governed 28 of 29 Skills, then failed while the scorer retried a closed Supabase socket. A safe resumable retry was permanently rejected because an unrelated concurrent score run advanced a scoped Pack `updated_at` after the frozen boundary.

## Fix

- preserve exact Pack membership, ID, slug, and `published_at` checks
- allow only valid, monotonic Pack `updated_at` advances before execution and record them in preflight evidence
- compare the complete current Pack state with post-execution state so execution-time drift still fails closed
- upload `current-inventory.json` with execution evidence
- serialize governance execute jobs with the existing `production-skill-score-writes` group

## Verification

- `CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs`
- 8/8 tests pass
- `git diff --check`

## Incident evidence

- failed partial execute: 29404042005
- rejected resumable retry: 29404474100
- frozen boundary: 29403882694
- current production: 28 governed in the batch, 27 awaiting score finalization, `stablyai-orchestration` still revision 0
- global broken pointers, projection errors, and bad snapshot hashes remain 0