### PR TITLE
feat(governance): prove previous-report lineage

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version'
         type: string
         required: true
-        default: '2.4.4'
+        default: '2.5.0'
       batch_size:
         description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
         type: number
@@ -69,6 +69,7 @@ jobs:
             .github/actions/download-skillstore-cli/action.yml \
             scripts/fetch-artifact-version-inventory.mjs \
             scripts/plan-artifact-version-backfill.mjs \
+            scripts/materialize-legacy-previous-reports.mjs \
             scripts/verify-artifact-version-classification.mjs \
             scripts/fetch-legacy-equivalent-governance-readback.mjs \
             scripts/verify-legacy-equivalent-governance.mjs; do
@@ -85,7 +86,7 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.4.4' || { echo '::error::workflow is pinned to skillstore-cli 2.4.4'; exit 1; }
+          test "$CLI_VERSION" = '2.5.0' || { echo '::error::workflow is pinned to skillstore-cli 2.5.0'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
           [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
             echo '::error::batch_size must be between 1 and 500'; exit 1;
@@ -144,18 +145,26 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.4'
-          minimum-version: '2.4.4'
+          version: '2.5.0'
+          minimum-version: '2.5.0'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Verify audited CLI 2.4.4 binary identity
+      - name: Verify audited CLI 2.5.0 binary identity
         run: |
           set -euo pipefail
-          expected='4ee53da0adf5b1ab990f065edacff5e9ec60a37ce015e10decf76c65828321b0'
+          expected='e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
-            echo '::error::CLI 2.4.4 binary does not match the audited linux-x64 digest'; exit 1;
+            echo '::error::CLI 2.5.0 binary does not match the audited linux-x64 digest'; exit 1;
           }
+
+      - name: Materialize frozen first-parent report evidence
+        run: >-
+          node scripts/materialize-legacy-previous-reports.mjs
+          --repository-root "$GITHUB_WORKSPACE"
+          --plan "$RUNNER_TEMP/plan.json"
+          --output-root "$RUNNER_TEMP/legacy-previous-reports"
+          --manifest "$RUNNER_TEMP/legacy-previous-report-manifest.json"
 
       - name: Materialize pinned snapshots
         run: |
@@ -191,6 +200,7 @@ jobs:
               set +e
               (cd "$RUNNER_TEMP/materialized/batch-$index/$commit" && "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
                 --slugs "$slug_paths" --artifact-only --legacy-only --repair-stale-report-hashes \
+                --legacy-previous-report-root "$RUNNER_TEMP/legacy-previous-reports/batch-$index/$commit" \
                 --dry-run --concurrency 5 --marketplace-commit "$commit" --output json) > "$raw"
               exit_code=$?
               set -e
@@ -244,6 +254,7 @@ jobs:
             "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
               --classification "$RUNNER_TEMP/classification.json" \
               --root "$RUNNER_TEMP/materialized/batch-$index/$commit" \
+              --legacy-previous-report-root "$RUNNER_TEMP/legacy-previous-reports/batch-$index/$commit" \
               --slugs "$slugs" --dry-run --concurrency 1 --result-file "$result"
             jq -n -c --argjson batchIndex "$index" --arg marketplaceCommit "$commit" \
               --argjson selectedCount "$count" --argjson slugs "$(jq -c .slugs <<< "$group")" \
@@ -276,15 +287,17 @@ jobs:
           cp "$RUNNER_TEMP/pre-inventory.json" "$boundary/pre-inventory.json"
           cp "$RUNNER_TEMP/governance-dry-run.json" "$boundary/governance-dry-run.json"
           cp "$RUNNER_TEMP/source-evidence.json" "$boundary/source-evidence.json"
+          cp "$RUNNER_TEMP/legacy-previous-report-manifest.json" "$boundary/legacy-previous-report-manifest.json"
           node scripts/verify-legacy-equivalent-governance.mjs --phase freeze \
             --plan "$boundary/plan.json" --classification "$boundary/classification.json" \
             --pre-inventory "$boundary/pre-inventory.json" --dry-run-results "$boundary/governance-dry-run.json" \
             --source-evidence "$boundary/source-evidence.json" \
+            --previous-report-manifest "$boundary/legacy-previous-report-manifest.json" \
             --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
-            --workflow-commit "$GITHUB_SHA" --cli-version '2.4.4' \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.5.0' \
             --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --output "$boundary/boundary.json"
-          (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json boundary.json > SHA256SUMS)
+          (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json legacy-previous-report-manifest.json boundary.json > SHA256SUMS)
 
       - name: Upload strict frozen-boundary evidence
         if: success()
@@ -302,7 +315,7 @@ jobs:
           {
             echo '## Legacy-equivalent frozen boundary'
             echo "- Run ID: \`$GITHUB_RUN_ID\`"
-            echo "- CLI: \`2.4.4\`"
+            echo "- CLI: \`2.5.0\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
             echo "- Hash-equivalent: \`$(jq -r .governance.hashEquivalentCount "$RUNNER_TEMP/classification.json")\`; governable: \`$(jq -r .governance.eligibleCount "$RUNNER_TEMP/classification.json")\`; source-audit unproven: \`$(jq -r .governance.unprovenCount "$RUNNER_TEMP/classification.json")\`"
@@ -316,7 +329,7 @@ jobs:
           set -euo pipefail
           boundary="$RUNNER_TEMP/legacy-boundary"
           mkdir -p "$boundary"
-          for item in plan hash-classification classification pre-inventory governance-dry-run source-evidence source-evidence-after classification-results legacy-groups; do
+          for item in plan hash-classification classification pre-inventory governance-dry-run source-evidence source-evidence-after classification-results legacy-groups legacy-previous-report-manifest; do
             source="$RUNNER_TEMP/$item.json"
             [ ! -f "$source" ] || cp "$source" "$boundary/$item.json"
           done
@@ -360,12 +373,13 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git sparse-checkout disable
           git reset --hard HEAD
-          test "$CLI_VERSION" = '2.4.4' || { echo '::error::workflow is pinned to skillstore-cli 2.4.4'; exit 1; }
+          test "$CLI_VERSION" = '2.5.0' || { echo '::error::workflow is pinned to skillstore-cli 2.5.0'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
           [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
           for path in scripts/fetch-artifact-version-inventory.mjs \
             scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            scripts/materialize-legacy-previous-reports.mjs \
             scripts/verify-legacy-equivalent-governance.mjs; do
             test -f "$path" || { echo "::error file=$path::Missing governance runtime"; exit 1; }
           done
@@ -393,6 +407,20 @@ jobs:
             echo '::error::boundary workflow commit is not an ancestor of this main execution'; exit 1;
           }
 
+      - name: Recompute and match frozen first-parent report evidence
+        run: |
+          set -euo pipefail
+          node scripts/materialize-legacy-previous-reports.mjs \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --plan "$RUNNER_TEMP/boundary/plan.json" \
+            --output-root "$RUNNER_TEMP/current-legacy-previous-reports" \
+            --manifest "$RUNNER_TEMP/current-legacy-previous-report-manifest.json"
+          cmp \
+            "$RUNNER_TEMP/boundary/legacy-previous-report-manifest.json" \
+            "$RUNNER_TEMP/current-legacy-previous-report-manifest.json" || {
+              echo '::error::first-parent report evidence differs from the frozen boundary'; exit 1;
+            }
+
       - name: Refetch current scoped production state
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -416,6 +444,7 @@ jobs:
             --current-inventory "$RUNNER_TEMP/current-inventory.json" \
             --frozen-source-evidence "$RUNNER_TEMP/boundary/source-evidence.json" \
             --current-source-evidence "$RUNNER_TEMP/current-source-evidence.json" \
+            --previous-report-manifest "$RUNNER_TEMP/boundary/legacy-previous-report-manifest.json" \
             --dry-run-results "$RUNNER_TEMP/boundary/governance-dry-run.json" \
             --expected-run-id '${{ inputs.dry_run_id }}' --output "$RUNNER_TEMP/execution-preflight.json"
 
@@ -427,22 +456,22 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.4.4
+      - name: Download exact audited CLI 2.5.0
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.4.4'
-          minimum-version: '2.4.4'
+          version: '2.5.0'
+          minimum-version: '2.5.0'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='4ee53da0adf5b1ab990f065edacff5e9ec60a37ce015e10decf76c65828321b0'
+          audited='e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {
-            echo '::error::CLI 2.4.4 binary differs from the frozen dry-run boundary'; exit 1;
+            echo '::error::CLI 2.5.0 binary differs from the frozen dry-run boundary'; exit 1;
           }
 
       - name: Materialize only frozen legacy groups
@@ -476,6 +505,7 @@ jobs:
             "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
               --classification "$RUNNER_TEMP/boundary/classification.json" \
               --root "$RUNNER_TEMP/materialized/batch-$index/$commit" \
+              --legacy-previous-report-root "$RUNNER_TEMP/current-legacy-previous-reports/batch-$index/$commit" \
               --slugs "$slugs" --concurrency 1 --result-file "$result"
             jq -n -c --argjson batchIndex "$index" --arg marketplaceCommit "$commit" \
               --argjson selectedCount "$count" --argjson slugs "$(jq -c .slugs <<< "$group")" \
@@ -538,6 +568,7 @@ jobs:
             ${{ runner.temp }}/execution-preflight.json
             ${{ runner.temp }}/current-inventory.json
             ${{ runner.temp }}/current-source-evidence.json
+            ${{ runner.temp }}/current-legacy-previous-report-manifest.json
             ${{ runner.temp }}/execution-results.json
             ${{ runner.temp }}/post-inventory.json
             ${{ runner.temp }}/governance-readback.json
@@ -552,7 +583,7 @@ jobs:
           {
             echo '## Legacy-equivalent execution verified'
             echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
-            echo '- CLI: `2.4.4`'
+            echo '- CLI: `2.5.0`'
             echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
             echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
             echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'

--- a/scripts/materialize-legacy-previous-reports.mjs
+++ b/scripts/materialize-legacy-previous-reports.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function git(repositoryRoot, args, encoding = 'utf8') {
+  try {
+    return execFileSync('git', ['-C', repositoryRoot, ...args], {
+      encoding,
+      maxBuffer: MAX_GIT_OUTPUT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message;
+    fail(`Git evidence read failed (${args.join(' ')}): ${detail}`);
+  }
+}
+
+function safeSkillPath(value) {
+  if (typeof value !== 'string' || value !== value.trim()) {
+    fail('plan contains a non-canonical Skill path');
+  }
+  const segments = value.split('/');
+  if (
+    !value.startsWith('skills/')
+    || value.startsWith('/')
+    || value.includes('\\')
+    || /[\u0000-\u001f\u007f,?#]/.test(value)
+    || segments.some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    fail(`plan contains an unsafe Skill path: ${value || '<empty>'}`);
+  }
+  return value;
+}
+
+function exactCommit(repositoryRoot, value) {
+  if (typeof value !== 'string' || !COMMIT_RE.test(value)) {
+    fail(`plan contains an invalid exact commit: ${value ?? '<missing>'}`);
+  }
+  const resolved = git(repositoryRoot, ['rev-parse', '--verify', `${value}^{commit}`]).trim();
+  if (resolved !== value) fail(`commit did not resolve exactly: ${value}`);
+  return value;
+}
+
+function firstParent(repositoryRoot, commit) {
+  const fields = git(repositoryRoot, ['rev-list', '--parents', '-n', '1', commit]).trim().split(' ');
+  if (fields[0] !== commit || fields.length < 2 || fields.some((field) => !COMMIT_RE.test(field))) {
+    fail(`commit has no valid first parent: ${commit}`);
+  }
+  return fields[1];
+}
+
+function readPreviousReport(repositoryRoot, parentCommit, skillPath) {
+  const reportPath = `${skillPath}/skill-report.json`;
+  const output = git(repositoryRoot, [
+    'ls-tree',
+    '-z',
+    '--full-tree',
+    parentCommit,
+    '--',
+    reportPath,
+  ], 'buffer');
+  if (output.length === 0) return null;
+
+  const records = output.toString('utf8').split('\0').filter(Boolean);
+  if (records.length !== 1) fail(`ambiguous previous report tree entry: ${parentCommit}:${reportPath}`);
+  const tab = records[0].indexOf('\t');
+  const metadata = tab === -1 ? [] : records[0].slice(0, tab).split(' ');
+  const treePath = tab === -1 ? '' : records[0].slice(tab + 1);
+  const [mode, type, objectId] = metadata;
+  if (
+    treePath !== reportPath
+    || type !== 'blob'
+    || !/^100[0-7]{3}$/.test(mode || '')
+    || !/^[0-9a-f]{40,64}$/.test(objectId || '')
+  ) {
+    fail(`previous report is not an ordinary Git file: ${parentCommit}:${reportPath}`);
+  }
+  return git(repositoryRoot, ['cat-file', 'blob', objectId], 'buffer');
+}
+
+function assertUnusedOutput(outputRoot, manifestPath) {
+  if (existsSync(manifestPath)) fail(`manifest output already exists: ${manifestPath}`);
+  if (existsSync(outputRoot) && readdirSync(outputRoot).length > 0) {
+    fail(`previous-report output root is not empty: ${outputRoot}`);
+  }
+}
+
+function safeOutputPath(outputRoot, batchIndex, commit, skillPath) {
+  const relative = `batch-${batchIndex}/${commit}/${skillPath}/skill-report.json`;
+  const target = resolve(outputRoot, ...relative.split('/'));
+  if (!target.startsWith(`${outputRoot}${sep}`)) fail(`refusing output path outside root: ${relative}`);
+  return target;
+}
+
+function validatePlan(plan, repositoryRoot) {
+  if (
+    !plan
+    || !Array.isArray(plan.selected)
+    || !Array.isArray(plan.batches)
+    || !Number.isSafeInteger(plan.selectedCount)
+    || plan.selectedCount < 0
+    || plan.selectedCount !== plan.selected.length
+  ) {
+    fail('plan does not contain one complete selected cohort');
+  }
+
+  const selectedByPath = new Map();
+  const selectedSlugs = new Set();
+  for (const row of plan.selected) {
+    const path = safeSkillPath(row?.path);
+    const commit = exactCommit(repositoryRoot, row?.marketplaceCommit);
+    if (
+      typeof row?.slug !== 'string'
+      || !row.slug
+      || row.slug !== row.slug.trim()
+      || /[\u0000-\u001f\u007f,\s]/.test(row.slug)
+      || selectedSlugs.has(row.slug)
+    ) {
+      fail(`plan contains an invalid or duplicate slug: ${row?.slug ?? '<missing>'}`);
+    }
+    if (selectedByPath.has(path)) fail(`plan contains duplicate Skill path: ${path}`);
+    selectedSlugs.add(row.slug);
+    selectedByPath.set(path, { path, slug: row.slug, currentCommit: commit });
+  }
+
+  const coveredPaths = new Set();
+  const groups = [];
+  const batchIndexes = new Set();
+  const groupKeys = new Set();
+  for (const batch of plan.batches) {
+    if (!Number.isSafeInteger(batch?.index) || batch.index < 1 || batchIndexes.has(batch.index)) {
+      fail(`plan contains an invalid or duplicate batch index: ${batch?.index ?? '<missing>'}`);
+    }
+    batchIndexes.add(batch.index);
+    if (!Array.isArray(batch.groups)) fail(`plan batch ${batch.index} has no groups`);
+    let batchCount = 0;
+    for (const group of batch.groups) {
+      const commit = exactCommit(repositoryRoot, group?.marketplaceCommit);
+      const groupKey = `${batch.index}:${commit}`;
+      if (groupKeys.has(groupKey)) fail(`plan contains duplicate group: ${groupKey}`);
+      groupKeys.add(groupKey);
+      if (!Number.isSafeInteger(group.count) || group.count < 1
+          || !Array.isArray(group.paths) || !Array.isArray(group.slugs) || group.count !== group.paths.length
+          || group.count !== group.slugs.length) {
+        fail(`plan group ${batch.index}/${commit} is incomplete`);
+      }
+      const paths = group.paths.map(safeSkillPath);
+      for (let index = 0; index < paths.length; index++) {
+        const path = paths[index];
+        const selected = selectedByPath.get(path);
+        if (
+          !selected
+          || selected.currentCommit !== commit
+          || selected.slug !== group.slugs[index]
+          || coveredPaths.has(path)
+        ) {
+          fail(`plan group coverage mismatch for ${path}`);
+        }
+        coveredPaths.add(path);
+      }
+      batchCount += group.count;
+      groups.push({ batchIndex: batch.index, currentCommit: commit, paths });
+    }
+    if (batch.count !== batchCount) fail(`plan batch ${batch.index} count does not match its groups`);
+  }
+  if (coveredPaths.size !== selectedByPath.size) fail('plan groups do not cover selected paths exactly once');
+  return groups;
+}
+
+export function materializeLegacyPreviousReports({
+  repositoryRoot,
+  plan,
+  outputRoot,
+  manifestPath,
+}) {
+  const root = resolve(repositoryRoot);
+  const destination = resolve(outputRoot);
+  const manifest = resolve(manifestPath);
+  if (destination === resolve('/') || manifest === destination || manifest.startsWith(`${destination}${sep}`)) {
+    fail('previous-report root and manifest outputs must be separate safe paths');
+  }
+  assertUnusedOutput(destination, manifest);
+  const groups = validatePlan(plan, root);
+
+  // Read and hash the complete cohort before creating any output.
+  const pending = [];
+  for (const group of groups) {
+    const parentCommit = firstParent(root, group.currentCommit);
+    for (const path of group.paths) {
+      const contents = readPreviousReport(root, parentCommit, path);
+      pending.push({
+        batchIndex: group.batchIndex,
+        path,
+        currentCommit: group.currentCommit,
+        parentCommit,
+        present: contents !== null,
+        sha256: contents === null ? null : createHash('sha256').update(contents).digest('hex'),
+        contents,
+      });
+    }
+  }
+  pending.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+
+  mkdirSync(destination, { recursive: true });
+  for (const group of groups) {
+    const groupRoot = resolve(destination, `batch-${group.batchIndex}`, group.currentCommit);
+    if (!groupRoot.startsWith(`${destination}${sep}`)) fail('refusing group output outside root');
+    mkdirSync(groupRoot, { recursive: true });
+  }
+  for (const entry of pending) {
+    if (entry.contents === null) continue;
+    const target = safeOutputPath(
+      destination,
+      entry.batchIndex,
+      entry.currentCommit,
+      entry.path,
+    );
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, entry.contents, { flag: 'wx', mode: 0o600 });
+  }
+  const output = {
+    schemaVersion: 1,
+    status: 'legacy_previous_reports_materialized',
+    selectedCount: pending.length,
+    entries: pending.map(({ contents: _contents, batchIndex: _batchIndex, ...entry }) => entry),
+  };
+  mkdirSync(dirname(manifest), { recursive: true });
+  writeFileSync(manifest, `${JSON.stringify(output, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+  return output;
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null || value.startsWith('--')) {
+      fail(`invalid argument: ${key || '<missing>'}`);
+    }
+    const name = key.slice(2);
+    if (Object.hasOwn(values, name)) fail(`duplicate argument: ${key}`);
+    values[name] = value;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  for (const name of ['plan', 'output-root', 'manifest']) {
+    if (!args[name]) fail(`--${name} is required`);
+  }
+  const output = materializeLegacyPreviousReports({
+    repositoryRoot: args['repository-root'] || process.cwd(),
+    plan: JSON.parse(readFileSync(resolve(args.plan), 'utf8')),
+    outputRoot: args['output-root'],
+    manifestPath: args.manifest,
+  });
+  process.stdout.write(`${JSON.stringify({ status: output.status, selectedCount: output.selectedCount })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`legacy previous-report materialization failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -7,6 +7,7 @@ import {
   canonicalSourceEvidence,
   createLegacyGovernanceBoundary,
   qualifyLegacyGovernanceClassification,
+  validateLegacyPreviousReportManifest,
   verifyLegacyGovernanceBoundary,
   verifyLegacyGovernanceExecution,
 } from '../verify-legacy-equivalent-governance.mjs';
@@ -177,7 +178,29 @@ function fixtures() {
     classification: hashClassification,
     sourceEvidence,
   });
-  return { row, plan, hashClassification, classification, rawSkill, preInventory, dryRunResults, sourceEvidence };
+  const previousReportManifest = {
+    schemaVersion: 1,
+    status: 'legacy_previous_reports_materialized',
+    selectedCount: 1,
+    entries: [{
+      path: row.path,
+      currentCommit: COMMIT,
+      parentCommit: '8'.repeat(40),
+      present: true,
+      sha256: '7'.repeat(64),
+    }],
+  };
+  return {
+    row,
+    plan,
+    hashClassification,
+    classification,
+    rawSkill,
+    preInventory,
+    dryRunResults,
+    sourceEvidence,
+    previousReportManifest,
+  };
 }
 
 function createBoundaryFixture() {
@@ -189,12 +212,14 @@ function createBoundaryFixture() {
     preInventory: join(directory, 'pre-inventory.json'),
     dryRunResults: join(directory, 'dry-run.json'),
     sourceEvidence: join(directory, 'source-evidence.json'),
+    previousReportManifest: join(directory, 'legacy-previous-report-manifest.json'),
   };
   writeFileSync(files.plan, JSON.stringify(values.plan));
   writeFileSync(files.classification, JSON.stringify(values.classification));
   writeFileSync(files.preInventory, JSON.stringify(values.preInventory));
   writeFileSync(files.dryRunResults, JSON.stringify(values.dryRunResults));
   writeFileSync(files.sourceEvidence, JSON.stringify(values.sourceEvidence));
+  writeFileSync(files.previousReportManifest, JSON.stringify(values.previousReportManifest));
   const boundary = createLegacyGovernanceBoundary({
     plan: values.plan,
     classification: values.classification,
@@ -204,7 +229,7 @@ function createBoundaryFixture() {
       runId: '12345',
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
-      cliVersion: '2.4.4',
+      cliVersion: '2.5.0',
       cliSha256: '9'.repeat(64),
     },
   });
@@ -291,11 +316,44 @@ test('aborts instead of classifying incomplete source evidence', () => {
   }), /cover.*exactly once/);
 });
 
+test('validates exact present and absent previous-report manifest evidence', () => {
+  const fixture = fixtures();
+  const absent = structuredClone(fixture.previousReportManifest);
+  absent.entries[0].present = false;
+  absent.entries[0].sha256 = null;
+  assert.doesNotThrow(() => validateLegacyPreviousReportManifest(absent, fixture.plan));
+
+  const cases = [
+    {
+      mutate(manifest) { manifest.entries[0].unexpected = true; },
+      error: /unexpected fields/,
+    },
+    {
+      mutate(manifest) { manifest.entries[0].sha256 = 'bad'; },
+      error: /manifest mismatch/,
+    },
+    {
+      mutate(manifest) { manifest.entries[0].parentCommit = COMMIT; },
+      error: /manifest mismatch/,
+    },
+    {
+      mutate(manifest) { manifest.entries[0] = null; },
+      error: /not an object/,
+    },
+  ];
+  for (const item of cases) {
+    const manifest = structuredClone(fixture.previousReportManifest);
+    item.mutate(manifest);
+    assert.throws(() => validateLegacyPreviousReportManifest(manifest, fixture.plan), item.error);
+  }
+});
+
 test('freezes and verifies one exact dry-run boundary', () => {
   const fixture = createBoundaryFixture();
   try {
     assert.equal(fixture.boundary.status, 'frozen');
     assert.equal(fixture.boundary.legacyCount, 1);
+    assert.match(fixture.boundary.hashes.previousReportManifest, /^[0-9a-f]{64}$/);
     const verified = verifyLegacyGovernanceBoundary({
       boundary: fixture.boundary,
       plan: fixture.plan,
@@ -433,6 +491,22 @@ test('freezes and verifies one exact dry-run boundary', () => {
       paths: fixture.files,
       expectedRunId: '12345',
     }), /source audit changed/);
+
+    writeFileSync(fixture.files.previousReportManifest, JSON.stringify({
+      ...fixture.previousReportManifest,
+      entries: [{ ...fixture.previousReportManifest.entries[0], sha256: '6'.repeat(64) }],
+    }));
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: fixture.preInventory,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: fixture.sourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /previousReportManifest hash mismatch/);
   } finally {
     rmSync(fixture.directory, { recursive: true, force: true });
   }
@@ -675,8 +749,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.4\.4'/);
-  assert.match(workflow, /test "\$CLI_VERSION" = '2\.4\.4'/);
+  assert.match(workflow, /default: '2\.5\.0'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.5\.0'/);
   assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
   assert.match(workflow, /batch_size must be between 1 and 500/);
   assert.match(workflow, /dry_run_id/);
@@ -686,8 +760,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /boundaries may only be created from main/);
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
-  assert.match(workflow, /CLI 2\.4\.4 binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/4ee53da0adf5b1ab990f065edacff5e9ec60a37ce015e10decf76c65828321b0/g) || []).length >= 2);
+  assert.match(workflow, /CLI 2\.5\.0 binary differs from the frozen dry-run boundary/);
+  assert.ok((workflow.match(/e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-inventory\.json/);
@@ -700,6 +774,13 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /legacy-equivalent-execution-/);
   assert.match(workflow, /legacy-equivalent-failed-dry-run-/);
   assert.match(workflow, /Preserve execution status evidence/);
+  assert.match(workflow, /scripts\/materialize-legacy-previous-reports\.mjs/);
+  assert.match(workflow, /--manifest "\$RUNNER_TEMP\/legacy-previous-report-manifest\.json"/);
+  assert.match(workflow, /--manifest "\$RUNNER_TEMP\/current-legacy-previous-report-manifest\.json"/);
+  assert.match(workflow, /cmp \\\n+\s+"\$RUNNER_TEMP\/boundary\/legacy-previous-report-manifest\.json" \\\n+\s+"\$RUNNER_TEMP\/current-legacy-previous-report-manifest\.json"/);
+  assert.match(workflow, /--previous-report-manifest "\$RUNNER_TEMP\/boundary\/legacy-previous-report-manifest\.json"/);
+  assert.match(workflow, /sha256sum plan\.json classification\.json pre-inventory\.json governance-dry-run\.json source-evidence\.json legacy-previous-report-manifest\.json boundary\.json/);
+  assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-legacy-previous-report-manifest\.json/);
   const sourceEvidenceIndex = workflow.indexOf('Fetch complete source audit evidence before governance planning');
   const qualificationIndex = workflow.indexOf('Qualify source-audit bindings and plan only governable groups');
   const governanceDryRunIndex = workflow.indexOf('Run administrator governance dry-run');
@@ -712,6 +793,14 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.equal(syncCalls.length, 1);
   assert.match(syncCalls[0], /--dry-run/);
   assert.match(syncCalls[0], /--repair-stale-report-hashes/);
+  assert.match(syncCalls[0], /--legacy-previous-report-root "\$RUNNER_TEMP\/legacy-previous-reports\/batch-\$index\/\$commit"/);
+  const governanceCalls = workflow.match(/skill govern-legacy-equivalent[\s\S]{0,420}/g) || [];
+  assert.equal(governanceCalls.length, 2);
+  assert.match(governanceCalls[0], /--legacy-previous-report-root "\$RUNNER_TEMP\/legacy-previous-reports\/batch-\$index\/\$commit"/);
+  assert.match(governanceCalls[1], /--legacy-previous-report-root "\$RUNNER_TEMP\/current-legacy-previous-reports\/batch-\$index\/\$commit"/);
+  const recomputeIndex = workflow.indexOf('Recompute and match frozen first-parent report evidence');
+  const executeIndex = workflow.indexOf('Execute frozen legacy cohort serially');
+  assert(recomputeIndex > 0 && recomputeIndex < executeIndex);
   assert.match(ordinaryWorkflow, /\.exactBatches\[\]/);
   assert.match(ordinaryWorkflow, /CLI_VERSION" != "2\.3\.1"/);
 });

--- a/scripts/tests/materialize-legacy-previous-reports.test.mjs
+++ b/scripts/tests/materialize-legacy-previous-reports.test.mjs
@@ -1,0 +1,215 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { materializeLegacyPreviousReports } from '../materialize-legacy-previous-reports.mjs';
+
+function git(repositoryRoot, args) {
+  return execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+}
+
+function write(repositoryRoot, relativePath, contents) {
+  const path = join(repositoryRoot, relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+function commit(repositoryRoot, message) {
+  git(repositoryRoot, ['add', '.']);
+  git(repositoryRoot, ['commit', '-m', message]);
+  return git(repositoryRoot, ['rev-parse', 'HEAD']);
+}
+
+function makeRepository() {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'legacy-previous-reports-'));
+  git(repositoryRoot, ['init', '--initial-branch=main']);
+  git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+  git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+  write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v1\n');
+  write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":1}\n');
+  write(repositoryRoot, 'skills/owner/new/SKILL.md', '# New placeholder\n');
+  const parentCommit = commit(repositoryRoot, 'parent');
+
+  write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v2\n');
+  write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":2}\n');
+  write(repositoryRoot, 'skills/owner/new/skill-report.json', '{"revision":1}\n');
+  const currentCommit = commit(repositoryRoot, 'current');
+  return { repositoryRoot, parentCommit, currentCommit };
+}
+
+function planFor(currentCommit) {
+  const selected = [
+    { slug: 'owner-demo', path: 'skills/owner/demo', marketplaceCommit: currentCommit },
+    { slug: 'owner-new', path: 'skills/owner/new', marketplaceCommit: currentCommit },
+  ];
+  return {
+    schemaVersion: 3,
+    selectedCount: selected.length,
+    selected,
+    batches: [{
+      index: 1,
+      count: selected.length,
+      groups: [{
+        marketplaceCommit: currentCommit,
+        count: selected.length,
+        paths: selected.map((row) => row.path),
+        slugs: selected.map((row) => row.slug),
+      }],
+    }],
+  };
+}
+
+test('materializes first-parent reports and records an exact deterministic absence manifest', () => {
+  const { repositoryRoot, parentCommit, currentCommit } = makeRepository();
+  const outputRoot = join(repositoryRoot, 'output');
+  const manifestPath = join(repositoryRoot, 'manifest.json');
+  try {
+    const manifest = materializeLegacyPreviousReports({
+      repositoryRoot,
+      plan: planFor(currentCommit),
+      outputRoot,
+      manifestPath,
+    });
+    assert.equal(manifest.selectedCount, 2);
+    assert.deepEqual(manifest.entries, [
+      {
+        path: 'skills/owner/demo',
+        currentCommit,
+        parentCommit,
+        present: true,
+        sha256: createHash('sha256').update('{"revision":1}\n').digest('hex'),
+      },
+      {
+        path: 'skills/owner/new',
+        currentCommit,
+        parentCommit,
+        present: false,
+        sha256: null,
+      },
+    ]);
+    assert.equal(
+      readFileSync(join(outputRoot, `batch-1/${currentCommit}/skills/owner/demo/skill-report.json`), 'utf8'),
+      '{"revision":1}\n',
+    );
+    assert.equal(
+      existsSync(join(outputRoot, `batch-1/${currentCommit}/skills/owner/new/skill-report.json`)),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(manifestPath, 'utf8')), manifest);
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('uses a merge commit first parent rather than another parent', () => {
+  const { repositoryRoot } = makeRepository();
+  const outputRoot = join(repositoryRoot, 'output');
+  const manifestPath = join(repositoryRoot, 'manifest.json');
+  try {
+    git(repositoryRoot, ['checkout', '-b', 'side']);
+    write(repositoryRoot, 'side.txt', 'side\n');
+    commit(repositoryRoot, 'side');
+    git(repositoryRoot, ['checkout', 'main']);
+    write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":3}\n');
+    const firstParent = commit(repositoryRoot, 'main parent');
+    git(repositoryRoot, ['merge', '--no-ff', 'side', '-m', 'merge']);
+    const mergeCommit = git(repositoryRoot, ['rev-parse', 'HEAD']);
+    const plan = planFor(mergeCommit);
+    plan.selected = [plan.selected[0]];
+    plan.selectedCount = 1;
+    plan.batches[0].count = 1;
+    plan.batches[0].groups[0].paths = [plan.selected[0].path];
+    plan.batches[0].groups[0].slugs = [plan.selected[0].slug];
+    plan.batches[0].groups[0].count = 1;
+    const manifest = materializeLegacyPreviousReports({ repositoryRoot, plan, outputRoot, manifestPath });
+    assert.equal(manifest.entries[0].parentCommit, firstParent);
+    assert.equal(
+      readFileSync(join(outputRoot, `batch-1/${mergeCommit}/skills/owner/demo/skill-report.json`), 'utf8'),
+      '{"revision":3}\n',
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('rejects unsafe, duplicate, symbolic, uncovered, and root-commit evidence before output', () => {
+  const { repositoryRoot, currentCommit } = makeRepository();
+  try {
+    const cases = [
+      {
+        mutate(plan) { plan.selected[0].path = 'skills/owner/../demo'; plan.batches[0].groups[0].paths[0] = plan.selected[0].path; },
+        error: /unsafe Skill path/,
+      },
+      {
+        mutate(plan) { plan.selected[1].path = plan.selected[0].path; plan.batches[0].groups[0].paths[1] = plan.selected[0].path; },
+        error: /duplicate Skill path/,
+      },
+      {
+        mutate(plan) { plan.selected[0].marketplaceCommit = 'HEAD'; },
+        error: /invalid exact commit/,
+      },
+      {
+        mutate(plan) {
+          plan.batches[0].groups[0].paths.pop();
+          plan.batches[0].groups[0].slugs.pop();
+          plan.batches[0].groups[0].count = 1;
+          plan.batches[0].count = 1;
+        },
+        error: /do not cover selected paths/,
+      },
+    ];
+    for (const [index, item] of cases.entries()) {
+      const plan = planFor(currentCommit);
+      item.mutate(plan);
+      const outputRoot = join(repositoryRoot, `output-${index}`);
+      const manifestPath = join(repositoryRoot, `manifest-${index}.json`);
+      assert.throws(() => materializeLegacyPreviousReports({
+        repositoryRoot, plan, outputRoot, manifestPath,
+      }), item.error);
+      assert.equal(existsSync(outputRoot), false);
+      assert.equal(existsSync(manifestPath), false);
+    }
+
+    const rootCommit = git(repositoryRoot, ['rev-list', '--max-parents=0', 'HEAD']);
+    const rootPlan = planFor(rootCommit);
+    assert.throws(() => materializeLegacyPreviousReports({
+      repositoryRoot,
+      plan: rootPlan,
+      outputRoot: join(repositoryRoot, 'root-output'),
+      manifestPath: join(repositoryRoot, 'root-manifest.json'),
+    }), /no valid first parent/);
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('refuses to overwrite either evidence output', () => {
+  const { repositoryRoot, currentCommit } = makeRepository();
+  try {
+    const plan = planFor(currentCommit);
+    const outputRoot = join(repositoryRoot, 'output');
+    const manifestPath = join(repositoryRoot, 'manifest.json');
+    mkdirSync(outputRoot);
+    write(outputRoot, 'sentinel', 'keep\n');
+    assert.throws(() => materializeLegacyPreviousReports({
+      repositoryRoot, plan, outputRoot, manifestPath,
+    }), /output root is not empty/);
+    rmSync(outputRoot, { recursive: true });
+    writeFileSync(manifestPath, 'keep\n');
+    assert.throws(() => materializeLegacyPreviousReports({
+      repositoryRoot, plan, outputRoot, manifestPath,
+    }), /manifest output already exists/);
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const CLI_VERSION = '2.4.4';
+const CLI_VERSION = '2.5.0';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
@@ -333,6 +333,49 @@ function legacyGroups(plan, classification) {
   return groups;
 }
 
+export function validateLegacyPreviousReportManifest(manifest, plan) {
+  if (
+    manifest?.schemaVersion !== 1
+    || manifest?.status !== 'legacy_previous_reports_materialized'
+    || manifest?.selectedCount !== plan?.selectedCount
+    || !Array.isArray(manifest?.entries)
+    || manifest.entries.length !== plan?.selectedCount
+  ) {
+    fail('previous-report manifest has an invalid summary');
+  }
+  const selected = asMap(plan?.selected, 'path', 'plan previous-report paths');
+  const seen = new Set();
+  let priorPath = null;
+  for (const entry of manifest.entries) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      fail('previous-report manifest entry is not an object');
+    }
+    const keys = Object.keys(entry).sort();
+    if (canonicalJson(keys) !== canonicalJson([
+      'currentCommit', 'parentCommit', 'path', 'present', 'sha256',
+    ])) {
+      fail('previous-report manifest entry has unexpected fields');
+    }
+    const planned = selected.get(entry.path);
+    if (
+      !planned
+      || seen.has(entry.path)
+      || entry.currentCommit !== planned.marketplaceCommit
+      || !COMMIT_RE.test(String(entry.parentCommit || ''))
+      || entry.parentCommit === entry.currentCommit
+      || typeof entry.present !== 'boolean'
+      || (entry.present && !SHA256_RE.test(String(entry.sha256 || '')))
+      || (!entry.present && entry.sha256 !== null)
+      || (priorPath !== null && priorPath >= entry.path)
+    ) {
+      fail(`previous-report manifest mismatch for ${entry?.path ?? '<missing>'}`);
+    }
+    seen.add(entry.path);
+    priorPath = entry.path;
+  }
+  if (seen.size !== selected.size) fail('previous-report manifest does not cover the frozen plan');
+}
+
 function validateAdminWrapper(wrapper, expected, mode, classification) {
   if (
     wrapper?.batchIndex !== expected.batchIndex
@@ -409,6 +452,10 @@ export function createLegacyGovernanceBoundary({
     classification,
     JSON.parse(readFileSync(paths.sourceEvidence, 'utf8'))
   );
+  validateLegacyPreviousReportManifest(
+    JSON.parse(readFileSync(paths.previousReportManifest, 'utf8')),
+    plan,
+  );
   const groups = legacyGroups(plan, classification);
   if (!Array.isArray(dryRunResults) || dryRunResults.length !== groups.length) {
     fail('dry-run result group count does not match the frozen legacy cohort');
@@ -436,6 +483,7 @@ export function createLegacyGovernanceBoundary({
       preInventory: sha256File(paths.preInventory),
       dryRunResults: sha256File(paths.dryRunResults),
       sourceEvidence: sha256File(paths.sourceEvidence),
+      previousReportManifest: sha256File(paths.previousReportManifest),
     },
     groups,
   };
@@ -469,6 +517,10 @@ export function verifyLegacyGovernanceBoundary({
     }
   }
   const expectedGroups = legacyGroups(plan, classification);
+  validateLegacyPreviousReportManifest(
+    JSON.parse(readFileSync(paths.previousReportManifest, 'utf8')),
+    plan,
+  );
   if (canonicalJson(boundary.groups) !== canonicalJson(expectedGroups)) {
     fail('downloaded boundary groups do not match plan/classification');
   }
@@ -746,6 +798,7 @@ export function main(argv = process.argv.slice(2)) {
         preInventory: resolve(args['pre-inventory']),
         dryRunResults: resolve(args['dry-run-results']),
         sourceEvidence: resolve(args['source-evidence']),
+        previousReportManifest: resolve(args['previous-report-manifest']),
       },
       metadata: {
         runId: args['run-id'],
@@ -770,6 +823,7 @@ export function main(argv = process.argv.slice(2)) {
         preInventory: resolve(args['frozen-inventory']),
         dryRunResults: resolve(args['dry-run-results']),
         sourceEvidence: resolve(args['frozen-source-evidence']),
+        previousReportManifest: resolve(args['previous-report-manifest']),
       },
       expectedRunId: args['expected-run-id'],
     });


### PR DESCRIPTION
## Summary

- materialize exact first-parent `skill-report.json` bytes for each frozen Marketplace snapshot
- freeze report presence, parent commit, and SHA-256 in the dry-run boundary and recompute it before execute
- pass the evidence root to Skillstore CLI sync/governance and pin audited CLI 2.5.0 (`e6110fa7…3441e`)
- retain missing reports as explicit absence evidence while failing closed on Git/path/tree errors

## Safety boundary

This workflow only promotes direct first-parent matches. Report-origin lineage that requires an older source commit remains drift and cannot execute. The existing production score mutex is retained.

## Verification

- `CI=true node --test scripts/tests/materialize-legacy-previous-reports.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs` (13/13)
- Node syntax checks for both governance scripts
- workflow YAML syntax parse
- `git diff --check`
- Skillstore CLI 2.5.0 release checksum verified against downloaded Linux asset