### PR TITLE
feat(governance): recover exact report-origin cohort

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -27,7 +27,7 @@ env:
   ORIGIN_CLI_VERSION: '2.6.0'
   # Production is intentionally impossible until the released linux-x64 binary
   # has been audited and this placeholder is replaced by its exact SHA-256.
-  ORIGIN_CLI_SHA256: 'TODO_REPLACE_WITH_AUDITED_LINUX_X64_SHA256'
+  ORIGIN_CLI_SHA256: 'ae2d7caf57ea7849ad39b0518d640ee2a0c51f1eee3f4eb2b9797c1abb0bd4cc'
   ORIGIN_COHORT: scripts/data/legacy-report-origin-cohort-v1.json
   ORIGIN_COHORT_SHA256: d00f9af499ab9da6df52d0de76bac9021ffbf0401bfff85ad4ac26331c2a38af
 

--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -1,0 +1,337 @@
+name: Govern Legacy Report-Origin 70
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Freeze a no-write boundary, or execute one successful boundary'
+        type: choice
+        required: true
+        default: dry-run
+        options: [dry-run, execute]
+      dry_run_id:
+        description: 'Successful dry-run run ID; execute only'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+env:
+  ORIGIN_CLI_VERSION: '2.6.0'
+  # Production is intentionally impossible until the released linux-x64 binary
+  # has been audited and this placeholder is replaced by its exact SHA-256.
+  ORIGIN_CLI_SHA256: 'TODO_REPLACE_WITH_AUDITED_LINUX_X64_SHA256'
+  ORIGIN_COHORT: scripts/data/legacy-report-origin-cohort-v1.json
+  ORIGIN_COHORT_SHA256: d00f9af499ab9da6df52d0de76bac9021ffbf0401bfff85ad4ac26331c2a38af
+
+jobs:
+  freeze-boundary:
+    if: inputs.mode == 'dry-run'
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Validate immutable runtime and exact cohort
+        env:
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          [ -z "$DRY_RUN_ID" ] || { echo '::error::dry_run_id is execute-only'; exit 1; }
+          for path in "$ORIGIN_COHORT" \
+            scripts/build-legacy-report-origin-boundary.mjs \
+            scripts/materialize-legacy-report-origin-evidence.mjs \
+            scripts/verify-legacy-report-origin-boundary.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
+          done
+          test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
+          jq -e '.schemaVersion == 2 and .selectedCount == 70 and (.rows | length) == 70 and (.sourceBoundaries | length) == 7' "$ORIGIN_COHORT" >/dev/null
+          [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo '::error::CLI 2.6.0 audit digest is still a non-production placeholder'; exit 1;
+          }
+
+      - name: Download and verify seven frozen drift classifications
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/source-boundaries"
+          while IFS= read -r boundary; do
+            run_id=$(jq -r .runId <<< "$boundary")
+            expected=$(jq -r .classificationSha256 <<< "$boundary")
+            run_json=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId,conclusion,event,headBranch,workflowName)
+            jq -e --argjson id "$run_id" '
+              .databaseId == $id and .conclusion == "success" and
+              .event == "workflow_dispatch" and .headBranch == "main" and
+              .workflowName == "Govern Legacy-Equivalent Artifacts"
+            ' <<< "$run_json" >/dev/null || { echo "::error::invalid source boundary $run_id"; exit 1; }
+            target="$RUNNER_TEMP/source-boundaries/$run_id"
+            mkdir -p "$target"
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --name "legacy-equivalent-boundary-$run_id" --dir "$target"
+            (cd "$target" && sha256sum --check SHA256SUMS)
+            test "$(sha256sum "$target/classification.json" | awk '{print $1}')" = "$expected" || {
+              echo "::error::classification $run_id differs from checked-in cohort"; exit 1;
+            }
+          done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
+
+      - name: Build exact 70-row drift classification and plan
+        run: |
+          set -euo pipefail
+          node scripts/build-legacy-report-origin-boundary.mjs \
+            --cohort "$ORIGIN_COHORT" \
+            --boundaries-root "$RUNNER_TEMP/source-boundaries" \
+            --classification-output "$RUNNER_TEMP/classification.json" \
+            --plan-output "$RUNNER_TEMP/plan.json"
+
+      - name: Re-prove all report-origin evidence from Git
+        run: |
+          set -euo pipefail
+          node scripts/materialize-legacy-report-origin-evidence.mjs \
+            --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
+            --expected-count 70 --origin-root "$RUNNER_TEMP/origin" \
+            --previous-report-root "$RUNNER_TEMP/previous" \
+            --manifest "$RUNNER_TEMP/origin-lineage.json"
+
+      - name: Materialize exact current source trees
+        run: |
+          set -euo pipefail
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            root="$RUNNER_TEMP/current/$commit"
+            mkdir -p "$root"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/plan.json")
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact unpublished-gated CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.6.0'
+          minimum-version: '2.6.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify audited CLI binary identity
+        run: |
+          set -euo pipefail
+          test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
+
+      - name: Run exact 70-row administrator dry-run
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/dry-run-groups"
+          : > "$RUNNER_TEMP/dry-run-results.jsonl"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            slugs=$(jq -r '.slugs | join(",")' <<< "$group")
+            result="$RUNNER_TEMP/dry-run-groups/$commit.json"
+            "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+              --classification "$RUNNER_TEMP/classification.json" \
+              --legacy-origin-lineage "$RUNNER_TEMP/origin-lineage.json" \
+              --legacy-origin-root "$RUNNER_TEMP/origin" \
+              --legacy-previous-report-root "$RUNNER_TEMP/previous" \
+              --root "$RUNNER_TEMP/current/$commit" --slugs "$slugs" \
+              --dry-run --concurrency 1 --result-file "$result"
+            jq -n -c --arg commit "$commit" --slurpfile result "$result" \
+              '{marketplaceCommit:$commit,result:$result[0]}' >> "$RUNNER_TEMP/dry-run-results.jsonl"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/plan.json")
+          jq -s . "$RUNNER_TEMP/dry-run-results.jsonl" > "$RUNNER_TEMP/dry-run-results.json"
+
+      - name: Freeze exact cohort, manifest, classification, and dry-run boundary
+        run: |
+          set -euo pipefail
+          boundary="$RUNNER_TEMP/origin-boundary"
+          mkdir -p "$boundary"
+          cp "$ORIGIN_COHORT" "$boundary/cohort.json"
+          cp "$RUNNER_TEMP/plan.json" "$boundary/plan.json"
+          cp "$RUNNER_TEMP/classification.json" "$boundary/classification.json"
+          cp "$RUNNER_TEMP/origin-lineage.json" "$boundary/origin-lineage.json"
+          cp "$RUNNER_TEMP/dry-run-results.json" "$boundary/dry-run-results.json"
+          node scripts/verify-legacy-report-origin-boundary.mjs --phase freeze \
+            --cohort "$boundary/cohort.json" --plan "$boundary/plan.json" \
+            --classification "$boundary/classification.json" \
+            --manifest "$boundary/origin-lineage.json" \
+            --dry-run-results "$boundary/dry-run-results.json" \
+            --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
+            --workflow-commit "$GITHUB_SHA" --cli-version "$ORIGIN_CLI_VERSION" \
+            --cli-sha256 "$ORIGIN_CLI_SHA256" --output "$boundary/boundary.json"
+          (cd "$boundary" && sha256sum cohort.json plan.json classification.json \
+            origin-lineage.json dry-run-results.json boundary.json > SHA256SUMS)
+
+      - name: Upload immutable report-origin boundary
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-report-origin-70-boundary-${{ github.run_id }}
+          path: ${{ runner.temp }}/origin-boundary/
+          if-no-files-found: error
+          retention-days: 30
+
+  execute-boundary:
+    if: inputs.mode == 'execute'
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Validate execute gate and production pin
+        env:
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires dry_run_id'; exit 1; }
+          [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo '::error::CLI audit digest placeholder blocks production'; exit 1;
+          }
+
+      - name: Download exact successful dry-run boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$DRY_RUN_ID" '
+            .databaseId == $id and .conclusion == "success" and
+            .event == "workflow_dispatch" and .headBranch == "main" and
+            .workflowName == "Govern Legacy Report-Origin 70"
+          ' <<< "$run_json" >/dev/null || { echo '::error::dry_run_id is not a successful origin dry-run'; exit 1; }
+          mkdir -p "$RUNNER_TEMP/boundary"
+          gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-report-origin-70-boundary-$DRY_RUN_ID" --dir "$RUNNER_TEMP/boundary"
+          (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
+          test "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" = "$(jq -r .headSha <<< "$run_json")"
+          git merge-base --is-ancestor "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" "$GITHUB_SHA"
+
+      - name: Recompute Git evidence and byte-match the frozen manifest
+        run: |
+          set -euo pipefail
+          test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
+          node scripts/materialize-legacy-report-origin-evidence.mjs \
+            --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
+            --expected-count 70 --origin-root "$RUNNER_TEMP/origin" \
+            --previous-report-root "$RUNNER_TEMP/previous" \
+            --manifest "$RUNNER_TEMP/current-origin-lineage.json"
+          cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
+            echo '::error::report-origin Git evidence differs from frozen boundary'; exit 1;
+          }
+          node scripts/verify-legacy-report-origin-boundary.mjs --phase execute-preflight \
+            --boundary "$RUNNER_TEMP/boundary/boundary.json" \
+            --expected-run-id '${{ inputs.dry_run_id }}' \
+            --cohort "$RUNNER_TEMP/boundary/cohort.json" --plan "$RUNNER_TEMP/boundary/plan.json" \
+            --classification "$RUNNER_TEMP/boundary/classification.json" \
+            --manifest "$RUNNER_TEMP/boundary/origin-lineage.json" \
+            --dry-run-results "$RUNNER_TEMP/boundary/dry-run-results.json"
+
+      - name: Materialize only the frozen current source trees
+        run: |
+          set -euo pipefail
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            root="$RUNNER_TEMP/current/$commit"
+            mkdir -p "$root"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact audited CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.6.0'
+          minimum-version: '2.6.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify frozen CLI binary identity
+        run: |
+          set -euo pipefail
+          expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
+
+      - name: Execute only the frozen 70 rows
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SKILLSTORE_SITE_URL: https://skillstore.io
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/execution-groups"
+          : > "$RUNNER_TEMP/execution-results.jsonl"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            slugs=$(jq -r '.slugs | join(",")' <<< "$group")
+            result="$RUNNER_TEMP/execution-groups/$commit.json"
+            "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+              --classification "$RUNNER_TEMP/boundary/classification.json" \
+              --legacy-origin-lineage "$RUNNER_TEMP/current-origin-lineage.json" \
+              --legacy-origin-root "$RUNNER_TEMP/origin" \
+              --legacy-previous-report-root "$RUNNER_TEMP/previous" \
+              --root "$RUNNER_TEMP/current/$commit" --slugs "$slugs" \
+              --concurrency 1 --result-file "$result"
+            jq -n -c --arg commit "$commit" --slurpfile result "$result" \
+              '{marketplaceCommit:$commit,result:$result[0]}' >> "$RUNNER_TEMP/execution-results.jsonl"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
+          jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
+          jq -e '[.[].result.results[]] as $rows |
+            ($rows | length) == 70 and ($rows | map(.slug) | unique | length) == 70 and
+            ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
+            "$RUNNER_TEMP/execution-results.json" >/dev/null
+
+      - name: Upload execution evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-report-origin-70-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/boundary/
+            ${{ runner.temp }}/current-origin-lineage.json
+            ${{ runner.temp }}/execution-results.json
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/build-legacy-report-origin-boundary.mjs
+++ b/scripts/build-legacy-report-origin-boundary.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function canonicalIdentity(row) {
+  return {
+    slug: row.slug,
+    skillId: row.skillId,
+    classificationRunId: row.classificationRunId,
+    path: row.path,
+    currentMarketplaceCommit: row.currentMarketplaceCommit,
+  };
+}
+
+function validateCohort(cohort) {
+  if (
+    !cohort
+    || cohort.schemaVersion !== 2
+    || cohort.status !== 'frozen_report_origin_cohort'
+    || cohort.repository !== 'aiskillstore/marketplace'
+    || cohort.selectedCount !== 70
+    || !Array.isArray(cohort.rows)
+    || cohort.rows.length !== 70
+    || !Array.isArray(cohort.sourceBoundaries)
+    || cohort.sourceBoundaries.length !== 7
+  ) fail('report-origin cohort must freeze exactly 70 rows and seven source boundaries');
+  const boundaries = new Map();
+  for (const boundary of cohort.sourceBoundaries) {
+    if (
+      !boundary
+      || !/^\d+$/.test(boundary.runId || '')
+      || !SHA256_RE.test(boundary.classificationSha256 || '')
+      || boundaries.has(boundary.runId)
+    ) fail('invalid or duplicate source classification boundary');
+    boundaries.set(boundary.runId, boundary.classificationSha256);
+  }
+  const slugs = new Set();
+  const ids = new Set();
+  const paths = new Set();
+  for (const row of cohort.rows) {
+    if (
+      JSON.stringify(Object.keys(row || {})) !== JSON.stringify([
+        'slug', 'skillId', 'classificationRunId', 'path', 'currentMarketplaceCommit',
+      ])
+      || typeof row.slug !== 'string'
+      || !row.slug
+      || !UUID_RE.test(row.skillId || '')
+      || !boundaries.has(row.classificationRunId)
+      || typeof row.path !== 'string'
+      || !/^skills\/[^/]+\/[^/]+$/.test(row.path)
+      || !COMMIT_RE.test(row.currentMarketplaceCommit || '')
+      || slugs.has(row.slug)
+      || ids.has(row.skillId)
+      || paths.has(row.path)
+    ) fail(`invalid or duplicate frozen identity: ${row?.slug || '<missing>'}`);
+    slugs.add(row.slug);
+    ids.add(row.skillId);
+    paths.add(row.path);
+  }
+  return boundaries;
+}
+
+export function buildLegacyReportOriginBoundary({ cohort, boundariesRoot }) {
+  const expectedBoundaries = validateCohort(cohort);
+  const classifications = new Map();
+  for (const [runId, expectedSha256] of expectedBoundaries) {
+    const path = join(resolve(boundariesRoot), runId, 'classification.json');
+    const bytes = readFileSync(path);
+    if (sha256(bytes) !== expectedSha256) {
+      fail(`classification ${runId} differs from the frozen SHA-256`);
+    }
+    const document = JSON.parse(bytes.toString('utf8'));
+    if (
+      document?.schemaVersion !== 1
+      || document?.status !== 'classified'
+      || !Array.isArray(document?.cohorts?.actual_or_unproven_drift)
+    ) fail(`classification ${runId} is not a complete frozen classification`);
+    classifications.set(runId, document);
+  }
+
+  const selected = [];
+  for (const identity of cohort.rows) {
+    const document = classifications.get(identity.classificationRunId);
+    const matches = document.cohorts.actual_or_unproven_drift.filter((row) => (
+      row?.slug === identity.slug
+    ));
+    if (matches.length !== 1) {
+      fail(`${identity.slug} is not exactly once in its frozen drift classification`);
+    }
+    const row = matches[0];
+    if (
+      row.id !== identity.skillId
+      || row.path !== identity.path
+      || row.marketplaceCommit !== identity.currentMarketplaceCommit
+    ) fail(`${identity.slug} classification identity differs from the frozen cohort`);
+    selected.push(row);
+  }
+
+  const identities = cohort.rows.map(canonicalIdentity)
+    .sort((left, right) => Buffer.compare(Buffer.from(left.slug), Buffer.from(right.slug)));
+  const identitySha256 = sha256(JSON.stringify(identities));
+  const groupsByCommit = new Map();
+  for (const identity of identities) {
+    let group = groupsByCommit.get(identity.currentMarketplaceCommit);
+    if (!group) {
+      group = { marketplaceCommit: identity.currentMarketplaceCommit, identities: [] };
+      groupsByCommit.set(identity.currentMarketplaceCommit, group);
+    }
+    group.identities.push(identity);
+  }
+  const groups = [...groupsByCommit.values()]
+    .sort((left, right) => left.marketplaceCommit.localeCompare(right.marketplaceCommit))
+    .map((group) => ({
+      marketplaceCommit: group.marketplaceCommit,
+      count: group.identities.length,
+      slugs: group.identities.map((row) => row.slug),
+      paths: group.identities.map((row) => row.path),
+    }));
+
+  return {
+    classification: {
+      schemaVersion: 1,
+      status: 'classified',
+      classifiedCount: 70,
+      counts: { exact: 0, legacy_algorithm_equivalent: 0, actual_or_unproven_drift: 70 },
+      cohorts: { exact: [], legacy_algorithm_equivalent: [], actual_or_unproven_drift: selected },
+    },
+    plan: {
+      schemaVersion: 1,
+      status: 'frozen_report_origin_plan',
+      selectedCount: 70,
+      identitySha256,
+      sourceBoundaries: cohort.sourceBoundaries,
+      identities,
+      groups,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null || value.startsWith('--')) fail(`invalid argument: ${key}`);
+    const name = key.slice(2);
+    if (Object.hasOwn(values, name)) fail(`duplicate argument: ${key}`);
+    values[name] = value;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  for (const name of ['cohort', 'boundaries-root', 'classification-output', 'plan-output']) {
+    if (!args[name]) fail(`--${name} is required`);
+  }
+  const output = buildLegacyReportOriginBoundary({
+    cohort: JSON.parse(readFileSync(resolve(args.cohort), 'utf8')),
+    boundariesRoot: args['boundaries-root'],
+  });
+  writeFileSync(resolve(args['classification-output']), `${JSON.stringify(output.classification, null, 2)}\n`, { flag: 'wx' });
+  writeFileSync(resolve(args['plan-output']), `${JSON.stringify(output.plan, null, 2)}\n`, { flag: 'wx' });
+  process.stdout.write(`${JSON.stringify({ status: output.plan.status, selectedCount: 70 })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try { main(); } catch (error) {
+    process.stderr.write(`report-origin boundary build failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/data/legacy-report-origin-cohort-v1.json
+++ b/scripts/data/legacy-report-origin-cohort-v1.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 2,
+  "status": "frozen_report_origin_cohort",
+  "repository": "aiskillstore/marketplace",
+  "selectedCount": 70,
+  "sourceBoundaries": [
+    {
+      "runId": "29391353646",
+      "classificationSha256": "fbc52726aad4ffbb7646e9eef4cb07c0d36d3d7b394b4c5d8bf6ecf3a33367cf"
+    },
+    {
+      "runId": "29391998167",
+      "classificationSha256": "f26842b5596caf8214cec91cedbdd70a4eaeff535ecf48f776dee20c3c6a64ad"
+    },
+    {
+      "runId": "29392177791",
+      "classificationSha256": "a8c4235a607396bde82af2bf31bbd54fd659d330b07ea8ae0d027452e276a41b"
+    },
+    {
+      "runId": "29394223576",
+      "classificationSha256": "5fd6a2acd687c4a243a6857e06831b0814bb486b66e4864c2d9ded5d869137b2"
+    },
+    {
+      "runId": "29402463151",
+      "classificationSha256": "b77f94af0f4400ade13f8cc3bde678f9602ec736f738003eb143f76a7d77f665"
+    },
+    {
+      "runId": "29403013907",
+      "classificationSha256": "1324584ef97640aab569969e99999dcaf99a6f3926dc9246d1c08aaf63f5cb7c"
+    },
+    {
+      "runId": "29403882694",
+      "classificationSha256": "2a1f384d5d6139a7d6f77d9f02e60e61133cce59fddc171bdc6f066ab2cee836"
+    }
+  ],
+  "rows": [
+    {
+      "slug": "270aldo-ngx-hybrid-sales",
+      "skillId": "807d2bdd-31e9-41f7-9852-b9837ab60574",
+      "classificationRunId": "29391353646",
+      "path": "skills/270aldo/ngx-hybrid-sales",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "5minfutures-architecture-reference",
+      "skillId": "f3651605-d74c-4aa0-8183-61352eb6bc73",
+      "classificationRunId": "29391353646",
+      "path": "skills/5minfutures/architecture-reference",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "5minfutures-coding-standards",
+      "skillId": "4899a218-b0b1-45a6-bea9-6e311303791b",
+      "classificationRunId": "29391353646",
+      "path": "skills/5minfutures/coding-standards",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "5minfutures-migration-tracker",
+      "skillId": "10a8ee7b-8a2d-48fb-8e28-fc1b023750c9",
+      "classificationRunId": "29391353646",
+      "path": "skills/5minfutures/migration-tracker",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "5minfutures-portfolio-context",
+      "skillId": "ee1f9cbd-408d-463f-842f-54749b5283ad",
+      "classificationRunId": "29391353646",
+      "path": "skills/5minfutures/portfolio-context",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-assessment-builder",
+      "skillId": "ec79fd63-6934-4b7a-a872-50b3d1fcf794",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/assessment-builder",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-code-example-generator",
+      "skillId": "8b07a00b-d160-4314-80cb-d596478dff12",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/code-example-generator",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-concept-scaffolding",
+      "skillId": "66d91baf-f4cd-44e8-a54d-416a6ed19d78",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/concept-scaffolding",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-exercise-designer",
+      "skillId": "bcbead38-b80e-41db-9a84-c0751a55b980",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/exercise-designer",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-technical-clarity",
+      "skillId": "f38f488d-2506-4e14-96a3-b55e2581c478",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/technical-clarity",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "92bilal26-visual-asset-workflow",
+      "skillId": "97728fbf-07a1-4be4-bf7d-9cedced1e2af",
+      "classificationRunId": "29391353646",
+      "path": "skills/92bilal26/visual-asset-workflow",
+      "currentMarketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000"
+    },
+    {
+      "slug": "browser-act-google-image-api-skill",
+      "skillId": "b275cbaa-d52c-4b84-a4d7-df5ebb940f92",
+      "classificationRunId": "29391998167",
+      "path": "skills/browser-act/google-image-api-skill",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "browser-act-youtube-channel-api-skill",
+      "skillId": "318955ee-481b-4e8e-9f52-cda6a92975dc",
+      "classificationRunId": "29391998167",
+      "path": "skills/browser-act/youtube-channel-api-skill",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "chachamaru127-ci",
+      "skillId": "4848040c-9036-48be-bf96-b7c71d666198",
+      "classificationRunId": "29391998167",
+      "path": "skills/chachamaru127/ci",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "chachamaru127-maintenance",
+      "skillId": "aeffebce-98e8-4cb7-ac16-cec8d888d402",
+      "classificationRunId": "29391998167",
+      "path": "skills/chachamaru127/maintenance",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "chachamaru127-memory",
+      "skillId": "9d432747-e93c-4281-9f9a-e3df5d16e877",
+      "classificationRunId": "29391998167",
+      "path": "skills/chachamaru127/memory",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-css-colors",
+      "skillId": "677e8ec5-469c-4f23-b093-600b86d1ec7b",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/css-colors",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-database-operations",
+      "skillId": "8e8184ea-25fb-4062-89b2-14085a9e52e9",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/database-operations",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-frontend-aesthetics",
+      "skillId": "621008dd-db95-47bc-8c16-deb5428ba543",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/frontend-aesthetics",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-making-commits",
+      "skillId": "18c9dbe9-545b-427f-8101-a2b92afc6356",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/making-commits",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-typography",
+      "skillId": "bad3b1a0-73c2-4ecd-905c-90d4a31ab142",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/typography",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-writing-tests",
+      "skillId": "15030479-23b9-47c4-9e42-3d0b311b5119",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/writing-tests",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "daviddworetzky-code-review",
+      "skillId": "b932f86b-ccf4-44c8-9ae1-b2a38a5bb341",
+      "classificationRunId": "29392177791",
+      "path": "skills/daviddworetzky/code-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "daviddworetzky-skill-creator",
+      "skillId": "f0a9bbdc-08ca-4579-bbdb-26bdb313b515",
+      "classificationRunId": "29392177791",
+      "path": "skills/daviddworetzky/skill-creator",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-adaptyv",
+      "skillId": "494a8b34-df29-44fd-9c40-053394f1e2f3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/adaptyv",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-algorithmic-art",
+      "skillId": "fafe9202-69ae-4d4f-b5e1-fbd7b86bc3d2",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/algorithmic-art",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-citation-management",
+      "skillId": "92c0226e-d148-48c5-8eca-016b394dd500",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/citation-management",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-clinpgx-database",
+      "skillId": "b1886565-59a7-4019-aa5d-dfaf02ba7099",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/clinpgx-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-clinvar-database",
+      "skillId": "4b8f9e73-51cd-455e-8f15-dc19a62ec0ad",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/clinvar-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-code-reviewer",
+      "skillId": "1638b454-a9ef-4712-b4a8-d87b580b9415",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/code-reviewer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-create-pr",
+      "skillId": "4e1664eb-2528-4f2a-8baa-69657c66df6c",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/create-pr",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-diffdock",
+      "skillId": "2b7f6468-de3a-4490-beaa-a18f7d98a869",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/diffdock",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-docx",
+      "skillId": "bbdb6fc6-804c-4482-8efb-babd259b67c6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/docx",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-drugbank-database",
+      "skillId": "49f58e40-cd8a-4bac-be05-45ed6360ad84",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/drugbank-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-ena-database",
+      "skillId": "f5c2420a-0973-4ea4-ab70-0cdb183e49d7",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/ena-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-ensembl-database",
+      "skillId": "66b91cb0-7489-44c7-8023-990ae6ac0b0a",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/ensembl-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-etetoolkit",
+      "skillId": "1c3f40ff-1e8d-4288-af73-73f6f332cff1",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/etetoolkit",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-executing-marketing-campaigns",
+      "skillId": "c1561bb0-13a4-4aa3-a9d8-5a3098a2f267",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/executing-marketing-campaigns",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-exploratory-data-analysis",
+      "skillId": "21992c59-481f-48e2-b430-81fd0f2f9504",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/exploratory-data-analysis",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gene-database",
+      "skillId": "ea8f8f42-0492-412c-8019-6b99a4239568",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gene-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-geniml",
+      "skillId": "b7c8f272-a123-4dfb-b42d-2937e933f403",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/geniml",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-geo-database",
+      "skillId": "d2b4cb06-a64b-48fd-9c14-9973a0530c7e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/geo-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gget",
+      "skillId": "44020571-226e-4584-8e91-c9b3a7c8d1e9",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gget",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gwas-database",
+      "skillId": "20c5e440-99ef-4042-a397-3bc6ebc68d06",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gwas-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-hypothesis-generation",
+      "skillId": "88a9aae4-a673-4209-a1b6-a473392b739e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/hypothesis-generation",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-literature-review",
+      "skillId": "2f6ad830-9495-4452-a646-0f28326e53b3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/literature-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-matplotlib",
+      "skillId": "a4eb9717-8509-4e7c-b47b-a74512e52d13",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/matplotlib",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-neurokit2",
+      "skillId": "2ab5248f-719a-46d3-8fde-54678dcbcfbf",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/neurokit2",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-opentargets-database",
+      "skillId": "d4bde71d-82d1-41a2-92ee-f6122ef3c814",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/opentargets-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-paper-2-web",
+      "skillId": "9acb87b9-258e-4e39-8e6f-81fc33552779",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/paper-2-web",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-pdf-processing-pro",
+      "skillId": "d3a0e807-8da9-4827-8963-e0d62d6806f7",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/pdf-processing-pro",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-peer-review",
+      "skillId": "5a01a7b5-c8e8-4fca-908e-f8633ac9edd6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/peer-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-pptx",
+      "skillId": "e70ad74d-85cc-410d-b502-30b100b9702a",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/pptx",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-reactome-database",
+      "skillId": "42c1c9a6-c444-437a-bf2d-a4e325b2ba52",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/reactome-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-regulatory-affairs-head",
+      "skillId": "b7a53147-9571-4855-ba28-169cd4922f97",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/regulatory-affairs-head",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-scholar-evaluation",
+      "skillId": "19df73c4-9ded-4a80-bb06-47f1a854e9a5",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/scholar-evaluation",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-scientific-visualization",
+      "skillId": "c7a5e0fc-7724-49a4-8736-2d224174f55e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/scientific-visualization",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-architect",
+      "skillId": "c82884aa-73fb-47ae-91b9-e1e0a415b07f",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-architect",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-backend",
+      "skillId": "7b7e2c70-e800-42b1-bdf8-2c6ea5836ce4",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-backend",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-devops",
+      "skillId": "c64122a1-6fca-4b27-93f0-d9f46324c5a3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-devops",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-frontend",
+      "skillId": "8ed9c078-d4da-4bb3-9af7-7c191b8f2acc",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-frontend",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-fullstack",
+      "skillId": "3f9a3c25-09da-4ac1-93d0-0c55c18164f6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-fullstack",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-ml-engineer",
+      "skillId": "c106af2d-1fd8-4aa7-b400-a45be2fd3831",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-ml-engineer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-prompt-engineer",
+      "skillId": "6a1756c7-13b3-4415-bf78-2d8d05b67cd2",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-prompt-engineer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-qa",
+      "skillId": "721cc65f-0480-405e-b9f0-441f6536b754",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-qa",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-secops",
+      "skillId": "4ee19016-fb4e-4b9a-a09b-4c6f86f10de4",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-secops",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-security",
+      "skillId": "07fb3555-b493-4902-b40e-162ab52f6c26",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-security",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-seo-optimizer",
+      "skillId": "d7599570-7ae5-4996-b989-3a10fda02e3c",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/seo-optimizer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-shap",
+      "skillId": "002db7ad-7f2d-4750-a9e3-07a86f72a8c8",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/shap",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "dmitrypogrebnoy-generating-rbs",
+      "skillId": "6e6dc5b9-7093-421e-b9ff-d10d0e89b622",
+      "classificationRunId": "29392177791",
+      "path": "skills/dmitrypogrebnoy/generating-rbs",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    }
+  ]
+}

--- a/scripts/materialize-legacy-report-origin-evidence.mjs
+++ b/scripts/materialize-legacy-report-origin-evidence.mjs
@@ -1,0 +1,678 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const OBJECT_ID_RE = /^[0-9a-f]{40,64}$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const MAX_GIT_OUTPUT = 256 * 1024 * 1024;
+const TREE_HASH_SCHEME = 'legacy_path_sha256_merkle_previous_report_v1';
+const INPUT_RELATION = 'canonical_install_plus_previous_generated_report';
+const SOURCE_SET_SCHEME = 'canonical_source_set_v1';
+const SOURCE_SET_RELATION =
+  'current_non_report_source_equals_report_origin_non_report_source_v1';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function git(repositoryRoot, args, encoding = 'utf8') {
+  try {
+    return execFileSync('git', ['-C', repositoryRoot, ...args], {
+      encoding,
+      maxBuffer: MAX_GIT_OUTPUT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message;
+    fail(`Git evidence read failed (${args.join(' ')}): ${detail}`);
+  }
+}
+
+function safeSkillPath(value) {
+  if (typeof value !== 'string' || value !== value.trim()) {
+    fail('cohort contains a non-canonical Skill path');
+  }
+  const segments = value.split('/');
+  if (
+    !value.startsWith('skills/')
+    || value.startsWith('/')
+    || value.includes('\\')
+    || /[\u0000-\u001f\u007f,?#]/.test(value)
+    || segments.length !== 3
+    || segments.some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    fail(`cohort contains an unsafe Skill path: ${value || '<empty>'}`);
+  }
+  return value;
+}
+
+function safeRelativePath(value, skillPath) {
+  if (
+    typeof value !== 'string'
+    || !value
+    || value.startsWith('/')
+    || value.includes('\\')
+    || /[\u0000-\u001f\u007f]/.test(value)
+    || value.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    fail(`unsafe Git source path under ${skillPath}: ${value || '<empty>'}`);
+  }
+  return value;
+}
+
+function exactCommit(repositoryRoot, value, label) {
+  if (typeof value !== 'string' || !COMMIT_RE.test(value)) {
+    fail(`${label} is not an exact 40-character commit: ${value ?? '<missing>'}`);
+  }
+  const resolved = git(repositoryRoot, ['rev-parse', '--verify', `${value}^{commit}`]).trim();
+  if (resolved !== value) fail(`${label} did not resolve exactly: ${value}`);
+  return value;
+}
+
+function firstParent(repositoryRoot, commit) {
+  const fields = git(repositoryRoot, ['rev-list', '--parents', '-n', '1', commit]).trim().split(' ');
+  if (fields[0] !== commit || fields.length < 2 || fields.some((field) => !COMMIT_RE.test(field))) {
+    fail(`commit has no valid first parent: ${commit}`);
+  }
+  return fields[1];
+}
+
+function parseTreeRecord(record, expectedPath, label) {
+  const tab = record.indexOf('\t');
+  const metadata = tab === -1 ? [] : record.slice(0, tab).split(' ');
+  const treePath = tab === -1 ? '' : record.slice(tab + 1);
+  const [mode, type, objectId] = metadata;
+  if (
+    treePath !== expectedPath
+    || type !== 'blob'
+    || !['100644', '100755'].includes(mode)
+    || !OBJECT_ID_RE.test(objectId || '')
+  ) {
+    fail(`${label} is not an ordinary Git file: ${expectedPath}`);
+  }
+  return { mode, objectId };
+}
+
+function readTreeFile(repositoryRoot, commit, path, label, blobCache) {
+  const output = git(repositoryRoot, [
+    'ls-tree',
+    '-z',
+    '--full-tree',
+    commit,
+    '--',
+    path,
+  ], 'buffer');
+  const records = output.toString('utf8').split('\0').filter(Boolean);
+  if (records.length !== 1) {
+    fail(`${label} must resolve to exactly one Git file: ${commit}:${path}`);
+  }
+  const { mode, objectId } = parseTreeRecord(records[0], path, label);
+  let bytes = blobCache.get(objectId);
+  if (!bytes) {
+    bytes = git(repositoryRoot, ['cat-file', 'blob', objectId], 'buffer');
+    blobCache.set(objectId, bytes);
+  }
+  return { mode, gitBlob: objectId, sha256: sha256(bytes), bytes };
+}
+
+function findReportOrigin(repositoryRoot, currentCommit, reportPath) {
+  const commits = git(repositoryRoot, [
+    'log',
+    '--first-parent',
+    '--format=%H',
+    currentCommit,
+    '--',
+    reportPath,
+  ]).trim().split('\n').filter(Boolean);
+  if (commits.length === 0 || commits.some((commit) => !COMMIT_RE.test(commit))) {
+    fail(`current report has no valid first-parent origin: ${currentCommit}:${reportPath}`);
+  }
+  return commits[0];
+}
+
+function readSourceSet(repositoryRoot, commit, skillPath, blobCache) {
+  const prefix = `${skillPath}/`;
+  const reportPath = `${skillPath}/skill-report.json`;
+  const output = git(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--full-tree',
+    commit,
+    '--',
+    `${skillPath}/`,
+  ], 'buffer');
+  const records = output.toString('utf8').split('\0').filter(Boolean);
+  const entries = [];
+  const seen = new Set();
+  for (const record of records) {
+    const tab = record.indexOf('\t');
+    const treePath = tab === -1 ? '' : record.slice(tab + 1);
+    if (!treePath.startsWith(prefix)) fail(`Git returned a source path outside ${skillPath}`);
+    if (treePath === reportPath) continue;
+    const { mode, objectId } = parseTreeRecord(record, treePath, 'non-report source');
+    const path = safeRelativePath(treePath.slice(prefix.length), skillPath);
+    if (seen.has(path)) fail(`duplicate non-report source path under ${skillPath}: ${path}`);
+    seen.add(path);
+    let bytes = blobCache.get(objectId);
+    if (!bytes) {
+      bytes = git(repositoryRoot, ['cat-file', 'blob', objectId], 'buffer');
+      blobCache.set(objectId, bytes);
+    }
+    entries.push({ path, mode, gitBlob: objectId, sha256: sha256(bytes) });
+  }
+  // This evidence is a new cross-platform contract. Unlike the historical
+  // tree walker below, it must not depend on the runner's ICU/default locale.
+  entries.sort((left, right) => Buffer.compare(
+    Buffer.from(left.path, 'utf8'),
+    Buffer.from(right.path, 'utf8'),
+  ));
+  if (entries.length === 0 || !entries.some((entry) => entry.path === 'SKILL.md')) {
+    fail(`non-report source at ${commit}:${skillPath} has no ordinary SKILL.md`);
+  }
+  const canonicalJson = JSON.stringify(entries);
+  return {
+    sha256: sha256(canonicalJson),
+    entryCount: entries.length,
+    entries,
+    canonicalJson,
+  };
+}
+
+function buildLegacyDfsInput(sourceEntries, previousReportSha256, skillPath) {
+  const root = { type: 'directory', children: new Map() };
+  const inputs = sourceEntries.map((entry) => ({ path: entry.path, sha256: entry.sha256 }));
+  inputs.push({ path: 'skill-report.json', sha256: previousReportSha256 });
+
+  for (const input of inputs) {
+    const parts = input.path.split('/');
+    let directory = root;
+    for (let index = 0; index < parts.length; index++) {
+      const name = parts[index];
+      const isFile = index === parts.length - 1;
+      const existing = directory.children.get(name);
+      if (isFile) {
+        if (existing) fail(`legacy DFS input has a path collision under ${skillPath}: ${input.path}`);
+        directory.children.set(name, { type: 'file', sha256: input.sha256 });
+      } else {
+        if (existing?.type === 'file') {
+          fail(`legacy DFS input has a file/directory collision under ${skillPath}: ${input.path}`);
+        }
+        if (!existing) {
+          directory.children.set(name, { type: 'directory', children: new Map() });
+        }
+        directory = directory.children.get(name);
+      }
+    }
+  }
+
+  const entries = [];
+  function walk(directory, prefix = '') {
+    const children = [...directory.children.entries()]
+      .sort(([left], [right]) => left.localeCompare(right));
+    for (const [name, child] of children) {
+      const path = prefix ? `${prefix}/${name}` : name;
+      if (child.type === 'directory') walk(child, path);
+      else entries.push(`${path}:${child.sha256}`);
+    }
+  }
+  walk(root);
+  const serialized = entries.length === 0 ? 'empty' : entries.join('\n');
+  return { entries, serializedSha256: sha256(serialized), treeHash: sha256(serialized) };
+}
+
+function normalizeLegacySkillMdContent(content) {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatterMatch) return content.trim();
+  const body = content.slice(frontmatterMatch[0].length);
+  const normalizedFrontmatter = frontmatterMatch[1]
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('version:'))
+    .join('\n');
+  return `---\n${normalizedFrontmatter}\n---${body}`.trim();
+}
+
+function contentRelation(reportContentHash, skillBytes) {
+  if (sha256(skillBytes) === reportContentHash) return 'canonical';
+  const legacy = sha256(normalizeLegacySkillMdContent(skillBytes.toString('utf8')));
+  if (legacy === reportContentHash) return 'legacy_strip_version_trim';
+  return 'unknown';
+}
+
+function requireString(value, label, pattern) {
+  if (typeof value !== 'string' || !pattern.test(value)) fail(`${label} is invalid`);
+  return value;
+}
+
+function assertExpected(actual, expected, label) {
+  if (actual !== expected) fail(`${label} differs from the frozen lineage cohort`);
+}
+
+function validateCohort(cohort, expectedCount, repositoryRoot) {
+  const frozenIdentityOnly = cohort?.schemaVersion === 2
+    && cohort?.status === 'frozen_report_origin_cohort';
+  const sourceBoundaries = frozenIdentityOnly && Array.isArray(cohort?.sourceBoundaries)
+    ? new Map(cohort.sourceBoundaries.map((boundary) => [
+        boundary?.runId,
+        boundary?.classificationSha256,
+      ]))
+    : null;
+  if (
+    !cohort
+    || (!frozenIdentityOnly && (
+      cohort.schemaVersion !== 1 || cohort.status !== 'lineage_recovered'
+    ))
+    || cohort.repository !== 'aiskillstore/marketplace'
+    || !Array.isArray(cohort.rows)
+    || !Number.isSafeInteger(frozenIdentityOnly ? cohort.selectedCount : cohort.count)
+    || (frozenIdentityOnly ? cohort.selectedCount : cohort.count) !== cohort.rows.length
+    || cohort.rows.length !== expectedCount
+    || (frozenIdentityOnly && (
+      JSON.stringify(Object.keys(cohort)) !== JSON.stringify([
+        'schemaVersion', 'status', 'repository', 'selectedCount', 'sourceBoundaries', 'rows',
+      ])
+      || sourceBoundaries?.size !== cohort.sourceBoundaries.length
+      || cohort.sourceBoundaries.length < 1
+      || cohort.sourceBoundaries.some((boundary) => (
+        !isFinite(Number(boundary?.runId))
+        || !/^\d+$/.test(boundary?.runId || '')
+        || !SHA256_RE.test(boundary?.classificationSha256 || '')
+        || JSON.stringify(Object.keys(boundary || {}))
+          !== JSON.stringify(['runId', 'classificationSha256'])
+      ))
+    ))
+    || (!frozenIdentityOnly && (
+      cohort.method?.reportOrigin !== 'last first-parent commit changing the same-path skill-report.json'
+      || cohort.method?.treeHashScheme !== TREE_HASH_SCHEME
+      || cohort.method?.inputRelation !== INPUT_RELATION
+      || cohort.method?.sourceSetIdentity
+        !== 'canonical JSON of sorted non-report path, mode, git blob, sha256 entries'
+    ))
+  ) {
+    fail('lineage cohort does not match the frozen report-origin contract');
+  }
+
+  const slugs = new Set();
+  const paths = new Set();
+  for (const row of cohort.rows) {
+    const slug = row?.slug;
+    const path = safeSkillPath(row?.path);
+    if (
+      typeof slug !== 'string'
+      || !slug
+      || slug !== slug.trim()
+      || /[\u0000-\u001f\u007f,\s]/.test(slug)
+      || slugs.has(slug)
+    ) {
+      fail(`cohort contains an invalid or duplicate slug: ${slug ?? '<missing>'}`);
+    }
+    if (paths.has(path)) fail(`cohort contains a duplicate Skill path: ${path}`);
+    slugs.add(slug);
+    paths.add(path);
+    requireString(row.skillId, `${slug} skill ID`, UUID_RE);
+    requireString(row.classificationRunId, `${slug} classification run ID`, /^\d+$/);
+    if (frozenIdentityOnly && !sourceBoundaries.has(row.classificationRunId)) {
+      fail(`${slug} classification run is not in the frozen source boundaries`);
+    }
+    const currentCommit = frozenIdentityOnly ? row.currentMarketplaceCommit : row.marketplaceCommit;
+    exactCommit(repositoryRoot, currentCommit, `${slug} Marketplace commit`);
+    if (frozenIdentityOnly) {
+      const expectedKeys = [
+        'slug', 'skillId', 'classificationRunId', 'path', 'currentMarketplaceCommit',
+      ];
+      if (JSON.stringify(Object.keys(row)) !== JSON.stringify(expectedKeys)) {
+        fail(`${slug} frozen cohort identity has unexpected fields`);
+      }
+      continue;
+    }
+    for (const [label, value] of [
+      ['current report SHA-256', row.currentReportSha256],
+      ['previous report SHA-256', row.previousReportSha256],
+      ['report content hash', row.reportContentHash],
+      ['report tree hash', row.reportTreeHash],
+      ['origin calculated tree hash', row.originCalculatedTreeHash],
+      ['origin tree input SHA-256', row.originTreeInputSha256],
+      ['current source-set SHA-256', row.sourceSetEquality?.currentSha256],
+      ['origin source-set SHA-256', row.sourceSetEquality?.originSha256],
+    ]) requireString(value, `${slug} ${label}`, SHA256_RE);
+    requireString(row.currentReportGitBlob, `${slug} current report Git blob`, OBJECT_ID_RE);
+    requireString(row.previousReportGitBlob, `${slug} previous report Git blob`, OBJECT_ID_RE);
+    requireString(row.reportOriginCommit, `${slug} report-origin commit`, COMMIT_RE);
+    requireString(row.reportOriginParent, `${slug} report-origin parent`, COMMIT_RE);
+    if (
+      row.treeHashScheme !== TREE_HASH_SCHEME
+      || row.inputRelation !== INPUT_RELATION
+      || row.lineageClassification !== 'legacy_previous_report_tree_equivalent'
+      || row.governanceEligibleByLineage !== true
+      || row.sourceSetEquality?.equal !== true
+      || !Number.isSafeInteger(row.sourceSetEquality.currentEntryCount)
+      || row.sourceSetEquality.currentEntryCount < 1
+      || row.sourceSetEquality.currentEntryCount !== row.sourceSetEquality.originEntryCount
+      || !Number.isSafeInteger(row.originTreeEntryCount)
+      || row.originTreeEntryCount !== row.sourceSetEquality.originEntryCount + 1
+      || !['canonical', 'legacy_strip_version_trim'].includes(row.currentContentRelation)
+      || !['canonical', 'legacy_strip_version_trim'].includes(row.originContentRelation)
+    ) {
+      fail(`${slug} is not independently eligible for report-origin governance`);
+    }
+  }
+  return { frozenIdentityOnly };
+}
+
+function safeOutputPath(outputRoot, currentCommit, repositoryPath) {
+  const relative = `${currentCommit}/${repositoryPath}`;
+  const target = resolve(outputRoot, ...relative.split('/'));
+  if (!target.startsWith(`${outputRoot}${sep}`)) fail(`refusing output path outside root: ${relative}`);
+  return { relative, target };
+}
+
+function assertUnusedOutput(originRoot, previousReportRoot, manifestPath) {
+  if (existsSync(manifestPath)) fail(`manifest output already exists: ${manifestPath}`);
+  for (const [label, outputRoot] of [
+    ['origin source', originRoot],
+    ['previous-report', previousReportRoot],
+  ]) {
+    if (existsSync(outputRoot) && readdirSync(outputRoot).length > 0) {
+      fail(`${label} output root is not empty: ${outputRoot}`);
+    }
+  }
+}
+
+export function materializeLegacyReportOriginEvidence({
+  repositoryRoot,
+  cohort,
+  expectedCount,
+  originRoot,
+  previousReportRoot,
+  manifestPath,
+}) {
+  const root = resolve(repositoryRoot);
+  const originDestination = resolve(originRoot);
+  const previousReportDestination = resolve(previousReportRoot);
+  const manifest = resolve(manifestPath);
+  if (!Number.isSafeInteger(expectedCount) || expectedCount < 1) fail('expected count must be positive');
+  const unsafeRoot = [originDestination, previousReportDestination].some((destination) => (
+    destination === resolve('/')
+    || manifest === destination
+    || manifest.startsWith(`${destination}${sep}`)
+  ));
+  if (
+    unsafeRoot
+    || originDestination === previousReportDestination
+    || originDestination.startsWith(`${previousReportDestination}${sep}`)
+    || previousReportDestination.startsWith(`${originDestination}${sep}`)
+  ) {
+    fail('origin, previous-report, and manifest outputs must be separate safe paths');
+  }
+  assertUnusedOutput(originDestination, previousReportDestination, manifest);
+  const { frozenIdentityOnly } = validateCohort(cohort, expectedCount, root);
+
+  // Read, recompute, and validate the entire cohort before creating any output.
+  const blobCache = new Map();
+  const pending = [];
+  for (const row of cohort.rows) {
+    const currentCommit = frozenIdentityOnly ? row.currentMarketplaceCommit : row.marketplaceCommit;
+    const skillPath = row.path;
+    const reportPath = `${skillPath}/skill-report.json`;
+    const currentReport = readTreeFile(root, currentCommit, reportPath, 'current report', blobCache);
+    const reportOriginCommit = findReportOrigin(root, currentCommit, reportPath);
+    const reportOriginParent = firstParent(root, reportOriginCommit);
+    const originReport = readTreeFile(
+      root,
+      reportOriginCommit,
+      reportPath,
+      'report at its first-parent origin',
+      blobCache,
+    );
+    const previousReport = readTreeFile(
+      root,
+      reportOriginParent,
+      reportPath,
+      'previous report at report-origin first parent',
+      blobCache,
+    );
+    if (
+      currentReport.gitBlob !== originReport.gitBlob
+      || currentReport.sha256 !== originReport.sha256
+      || !currentReport.bytes.equals(originReport.bytes)
+    ) {
+      fail(`${row.slug} current report bytes do not equal the report-origin subject`);
+    }
+
+    let report;
+    try {
+      report = JSON.parse(currentReport.bytes.toString('utf8'));
+    } catch (error) {
+      fail(`${row.slug} current report is not valid JSON: ${error.message}`);
+    }
+    const reportContentHash = requireString(
+      report?.meta?.content_hash,
+      `${row.slug} current report content hash`,
+      SHA256_RE,
+    );
+    const reportTreeHash = requireString(
+      report?.meta?.tree_hash,
+      `${row.slug} current report tree hash`,
+      SHA256_RE,
+    );
+    if (report?.meta?.slug !== row.slug) fail(`${row.slug} current report slug differs from cohort`);
+
+    const currentSourceSet = readSourceSet(root, currentCommit, skillPath, blobCache);
+    const originSourceSet = readSourceSet(root, reportOriginCommit, skillPath, blobCache);
+    if (currentSourceSet.canonicalJson !== originSourceSet.canonicalJson) {
+      fail(`${row.slug} non-report source changed after the report-origin subject`);
+    }
+    const currentSkill = currentSourceSet.entries.find((entry) => entry.path === 'SKILL.md');
+    const originSkill = originSourceSet.entries.find((entry) => entry.path === 'SKILL.md');
+    const currentContentRelation = contentRelation(
+      reportContentHash,
+      blobCache.get(currentSkill.gitBlob),
+    );
+    const originContentRelation = contentRelation(
+      reportContentHash,
+      blobCache.get(originSkill.gitBlob),
+    );
+    if (currentContentRelation === 'unknown' || originContentRelation === 'unknown') {
+      fail(`${row.slug} report content hash is not reproducible from equal source bytes`);
+    }
+
+    const legacyTree = buildLegacyDfsInput(
+      originSourceSet.entries,
+      previousReport.sha256,
+      skillPath,
+    );
+    if (legacyTree.treeHash !== reportTreeHash) {
+      fail(`${row.slug} report tree hash is not reproducible from report-origin evidence`);
+    }
+
+    const expected = frozenIdentityOnly ? [] : [
+      [currentReport.gitBlob, row.currentReportGitBlob, 'current report Git blob'],
+      [currentReport.sha256, row.currentReportSha256, 'current report SHA-256'],
+      [previousReport.gitBlob, row.previousReportGitBlob, 'previous report Git blob'],
+      [previousReport.sha256, row.previousReportSha256, 'previous report SHA-256'],
+      [reportOriginCommit, row.reportOriginCommit, 'report-origin commit'],
+      [reportOriginParent, row.reportOriginParent, 'report-origin first parent'],
+      [reportContentHash, row.reportContentHash, 'report content hash'],
+      [reportTreeHash, row.reportTreeHash, 'report tree hash'],
+      [legacyTree.treeHash, row.originCalculatedTreeHash, 'origin calculated tree hash'],
+      [legacyTree.serializedSha256, row.originTreeInputSha256, 'origin tree input SHA-256'],
+      [legacyTree.entries.length, row.originTreeEntryCount, 'origin tree entry count'],
+      [currentSourceSet.entryCount, row.sourceSetEquality.currentEntryCount, 'current source count'],
+      [originSourceSet.entryCount, row.sourceSetEquality.originEntryCount, 'origin source count'],
+      [currentContentRelation, row.currentContentRelation, 'current content relation'],
+      [originContentRelation, row.originContentRelation, 'origin content relation'],
+    ];
+    for (const [actual, frozen, label] of expected) {
+      assertExpected(actual, frozen, `${row.slug} ${label}`);
+    }
+
+    const previousReportOutput = safeOutputPath(
+      previousReportDestination,
+      currentCommit,
+      `${skillPath}/skill-report.json`,
+    );
+    const originFiles = originSourceSet.entries.map((source) => {
+      const output = safeOutputPath(
+        originDestination,
+        currentCommit,
+        `${skillPath}/${source.path}`,
+      );
+      return {
+        ...source,
+        relativePath: output.relative,
+        outputPath: output.target,
+        bytes: blobCache.get(source.gitBlob),
+      };
+    });
+    pending.push({
+      slug: row.slug,
+      skillId: row.skillId,
+      classificationRunId: row.classificationRunId,
+      path: skillPath,
+      currentMarketplaceCommit: currentCommit,
+      currentReport: {
+        gitBlob: currentReport.gitBlob,
+        sha256: currentReport.sha256,
+        contentHash: reportContentHash,
+        contentRelation: currentContentRelation,
+        treeHash: reportTreeHash,
+      },
+      originCommit: reportOriginCommit,
+      originParent: reportOriginParent,
+      originReport: {
+        gitBlob: originReport.gitBlob,
+        sha256: originReport.sha256,
+        contentRelation: originContentRelation,
+      },
+      previousReport: {
+        gitBlob: previousReport.gitBlob,
+        sha256: previousReport.sha256,
+        relativePath: previousReportOutput.relative,
+      },
+      sourceSetEvidence: {
+        scheme: SOURCE_SET_SCHEME,
+        relation: SOURCE_SET_RELATION,
+        equal: true,
+        current: {
+          sha256: currentSourceSet.sha256,
+          entryCount: currentSourceSet.entryCount,
+          entries: currentSourceSet.entries,
+        },
+        origin: {
+          sha256: originSourceSet.sha256,
+          entryCount: originSourceSet.entryCount,
+          entries: originSourceSet.entries,
+        },
+      },
+      legacyTreeEvidence: {
+        treeHashScheme: TREE_HASH_SCHEME,
+        inputRelation: INPUT_RELATION,
+        entryCount: legacyTree.entries.length,
+        entries: legacyTree.entries,
+        inputSha256: legacyTree.serializedSha256,
+        calculatedTreeHash: legacyTree.treeHash,
+        matchesCurrentReport: true,
+      },
+      governanceEligible: true,
+      previousReportBytes: previousReport.bytes,
+      previousReportOutputPath: previousReportOutput.target,
+      originFiles,
+    });
+  }
+  pending.sort((left, right) => left.path.localeCompare(right.path));
+
+  mkdirSync(originDestination, { recursive: true });
+  mkdirSync(previousReportDestination, { recursive: true });
+  for (const entry of pending) {
+    for (const source of entry.originFiles) {
+      mkdirSync(dirname(source.outputPath), { recursive: true });
+      writeFileSync(source.outputPath, source.bytes, {
+        flag: 'wx',
+        mode: source.mode === '100755' ? 0o700 : 0o600,
+      });
+    }
+    mkdirSync(dirname(entry.previousReportOutputPath), { recursive: true });
+    writeFileSync(entry.previousReportOutputPath, entry.previousReportBytes, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+  }
+  const output = {
+    schemaVersion: 1,
+    status: 'legacy_report_origin_evidence_materialized',
+    selectedCount: pending.length,
+    treeHashScheme: TREE_HASH_SCHEME,
+    inputRelation: INPUT_RELATION,
+    sourceSetScheme: SOURCE_SET_SCHEME,
+    sourceSetRelation: SOURCE_SET_RELATION,
+    entries: pending.map(({
+      previousReportBytes: _bytes,
+      previousReportOutputPath: _previousPath,
+      originFiles,
+      ...entry
+    }) => ({
+      ...entry,
+      originFiles: originFiles.map(({ bytes: _fileBytes, outputPath: _filePath, ...source }) => source),
+    })),
+  };
+  mkdirSync(dirname(manifest), { recursive: true });
+  writeFileSync(manifest, `${JSON.stringify(output, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+  return output;
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null || value.startsWith('--')) {
+      fail(`invalid argument: ${key || '<missing>'}`);
+    }
+    const name = key.slice(2);
+    if (Object.hasOwn(values, name)) fail(`duplicate argument: ${key}`);
+    values[name] = value;
+  }
+  return values;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  for (const name of ['cohort', 'expected-count', 'origin-root', 'previous-report-root', 'manifest']) {
+    if (!args[name]) fail(`--${name} is required`);
+  }
+  if (!/^\d+$/.test(args['expected-count'])) fail('--expected-count must be a positive integer');
+  const output = materializeLegacyReportOriginEvidence({
+    repositoryRoot: args['repository-root'] || process.cwd(),
+    cohort: JSON.parse(readFileSync(resolve(args.cohort), 'utf8')),
+    expectedCount: Number(args['expected-count']),
+    originRoot: args['origin-root'],
+    previousReportRoot: args['previous-report-root'],
+    manifestPath: args.manifest,
+  });
+  process.stdout.write(`${JSON.stringify({ status: output.status, selectedCount: output.selectedCount })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`legacy report-origin evidence materialization failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -102,7 +102,7 @@ test('builds and verifies only the exact 70 identities from seven hash-bound cla
   }
 });
 
-test('workflow freezes and replays Git evidence and remains production-disabled at TODO digest', () => {
+test('workflow freezes and replays Git evidence with the audited CLI digest', () => {
   const workflow = readFileSync(resolve(
     import.meta.dirname,
     '../../.github/workflows/govern-legacy-report-origin-70.yml'
@@ -114,7 +114,7 @@ test('workflow freezes and replays Git evidence and remains production-disabled 
   assert.equal(cohort.selectedCount, 70);
   assert.equal(cohort.rows.length, 70);
   assert.equal(cohort.sourceBoundaries.length, 7);
-  assert.match(workflow, /ORIGIN_CLI_SHA256: 'TODO_REPLACE_WITH_AUDITED_LINUX_X64_SHA256'/);
+  assert.match(workflow, /ORIGIN_CLI_SHA256: 'ae2d7caf57ea7849ad39b0518d640ee2a0c51f1eee3f4eb2b9797c1abb0bd4cc'/);
   assert.match(workflow, /\[\[ "\$ORIGIN_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin 70"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { buildLegacyReportOriginBoundary } from '../build-legacy-report-origin-boundary.mjs';
+import { verifyLegacyReportOriginDocuments } from '../verify-legacy-report-origin-boundary.mjs';
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'origin-boundary-'));
+  const rows = Array.from({ length: 70 }, (_, index) => ({
+    slug: `owner-skill-${String(index).padStart(2, '0')}`,
+    skillId: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    classificationRunId: String(1000 + (index % 7)),
+    path: `skills/owner/skill-${String(index).padStart(2, '0')}`,
+    currentMarketplaceCommit: 'a'.repeat(40),
+  }));
+  const sourceBoundaries = [];
+  for (let index = 0; index < 7; index++) {
+    const runId = String(1000 + index);
+    const selected = rows.filter((row) => row.classificationRunId === runId).map((row) => ({
+      id: row.skillId,
+      slug: row.slug,
+      path: row.path,
+      marketplaceCommit: row.currentMarketplaceCommit,
+    }));
+    const document = {
+      schemaVersion: 1,
+      status: 'classified',
+      cohorts: { actual_or_unproven_drift: selected },
+    };
+    const bytes = `${JSON.stringify(document, null, 2)}\n`;
+    const directory = join(root, runId);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, 'classification.json'), bytes);
+    sourceBoundaries.push({ runId, classificationSha256: sha256(bytes) });
+  }
+  return {
+    root,
+    cohort: {
+      schemaVersion: 2,
+      status: 'frozen_report_origin_cohort',
+      repository: 'aiskillstore/marketplace',
+      selectedCount: 70,
+      sourceBoundaries,
+      rows,
+    },
+  };
+}
+
+test('builds and verifies only the exact 70 identities from seven hash-bound classifications', () => {
+  const item = fixture();
+  try {
+    const built = buildLegacyReportOriginBoundary({ cohort: item.cohort, boundariesRoot: item.root });
+    const manifest = {
+      status: 'legacy_report_origin_evidence_materialized',
+      selectedCount: 70,
+      entries: item.cohort.rows,
+    };
+    const dryRunResults = [{
+      result: {
+        results: item.cohort.rows.map((row) => ({
+          slug: row.slug,
+          mode: 'dry-run',
+          artifactVersionId: null,
+          artifactRevision: null,
+          derivedAuditId: null,
+        })),
+      },
+    }];
+    assert.doesNotThrow(() => verifyLegacyReportOriginDocuments({
+      cohort: item.cohort,
+      plan: built.plan,
+      classification: built.classification,
+      manifest,
+      dryRunResults,
+    }));
+
+    const outside = structuredClone(manifest);
+    outside.selectedCount = 71;
+    outside.entries.push({ ...outside.entries[0], slug: 'outside-row' });
+    assert.throws(() => verifyLegacyReportOriginDocuments({
+      cohort: item.cohort,
+      plan: built.plan,
+      classification: built.classification,
+      manifest: outside,
+      dryRunResults,
+    }), /exactly the frozen 70-row cohort/);
+
+    writeFileSync(join(item.root, '1000', 'classification.json'), '{"drift":true}\n');
+    assert.throws(() => buildLegacyReportOriginBoundary({
+      cohort: item.cohort,
+      boundariesRoot: item.root,
+    }), /differs from the frozen SHA-256/);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test('workflow freezes and replays Git evidence and remains production-disabled at TODO digest', () => {
+  const workflow = readFileSync(resolve(
+    import.meta.dirname,
+    '../../.github/workflows/govern-legacy-report-origin-70.yml'
+  ), 'utf8');
+  const cohort = JSON.parse(readFileSync(resolve(
+    import.meta.dirname,
+    '../data/legacy-report-origin-cohort-v1.json'
+  ), 'utf8'));
+  assert.equal(cohort.selectedCount, 70);
+  assert.equal(cohort.rows.length, 70);
+  assert.equal(cohort.sourceBoundaries.length, 7);
+  assert.match(workflow, /ORIGIN_CLI_SHA256: 'TODO_REPLACE_WITH_AUDITED_LINUX_X64_SHA256'/);
+  assert.match(workflow, /\[\[ "\$ORIGIN_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
+  assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin 70"/);
+  assert.match(workflow, /sha256sum --check SHA256SUMS/);
+  assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
+  assert.match(workflow, /--expected-count 70/);
+  assert.equal((workflow.match(/--legacy-origin-lineage/g) || []).length, 2);
+  assert.equal((workflow.match(/--legacy-origin-root/g) || []).length, 2);
+  assert.equal((workflow.match(/--legacy-previous-report-root/g) || []).length, 2);
+});

--- a/scripts/tests/materialize-legacy-report-origin-evidence.test.mjs
+++ b/scripts/tests/materialize-legacy-report-origin-evidence.test.mjs
@@ -1,0 +1,371 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { materializeLegacyReportOriginEvidence } from '../materialize-legacy-report-origin-evidence.mjs';
+
+const SKILL_ID = '11111111-1111-4111-8111-111111111111';
+const SKILL_PATH = 'skills/owner/demo';
+const SLUG = 'owner-demo';
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function git(repositoryRoot, args, encoding = 'utf8') {
+  return execFileSync('git', args, { cwd: repositoryRoot, encoding }).trim();
+}
+
+function write(repositoryRoot, relativePath, contents, mode = null) {
+  const path = join(repositoryRoot, relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  if (mode != null) chmodSync(path, mode);
+}
+
+function commit(repositoryRoot, message) {
+  git(repositoryRoot, ['add', '.']);
+  git(repositoryRoot, ['commit', '-m', message]);
+  return git(repositoryRoot, ['rev-parse', 'HEAD']);
+}
+
+function gitFile(repositoryRoot, commitSha, repositoryPath) {
+  const line = git(repositoryRoot, ['ls-tree', '--full-tree', commitSha, '--', repositoryPath]);
+  const match = line.match(/^(100644|100755) blob ([0-9a-f]{40,64})\t(.+)$/);
+  assert.ok(match, `expected ordinary Git file: ${repositoryPath}`);
+  assert.equal(match[3], repositoryPath);
+  const bytes = execFileSync('git', ['cat-file', 'blob', match[2]], {
+    cwd: repositoryRoot,
+    encoding: 'buffer',
+  });
+  return { mode: match[1], gitBlob: match[2], sha256: sha256(bytes), bytes };
+}
+
+function sourceSet(repositoryRoot, commitSha) {
+  const output = execFileSync('git', [
+    'ls-tree', '-r', '-z', '--full-tree', commitSha, '--', `${SKILL_PATH}/`,
+  ], { cwd: repositoryRoot, encoding: 'buffer' });
+  const prefix = `${SKILL_PATH}/`;
+  const entries = output.toString('utf8').split('\0').filter(Boolean).map((record) => {
+    const [metadata, repositoryPath] = record.split('\t');
+    const [mode, type, gitBlob] = metadata.split(' ');
+    assert.equal(type, 'blob');
+    const bytes = execFileSync('git', ['cat-file', 'blob', gitBlob], {
+      cwd: repositoryRoot,
+      encoding: 'buffer',
+    });
+    return {
+      path: repositoryPath.slice(prefix.length),
+      mode,
+      gitBlob,
+      sha256: sha256(bytes),
+    };
+  }).filter((entry) => entry.path !== 'skill-report.json');
+  entries.sort((left, right) => Buffer.compare(
+    Buffer.from(left.path, 'utf8'),
+    Buffer.from(right.path, 'utf8'),
+  ));
+  return { entries, sha256: sha256(JSON.stringify(entries)) };
+}
+
+function legacyTreeHash(sourceEntries, previousReportSha256) {
+  const root = new Map();
+  for (const input of sourceEntries
+    .map((entry) => ({ path: entry.path, sha256: entry.sha256 }))
+    .concat({ path: 'skill-report.json', sha256: previousReportSha256 })) {
+    const parts = input.path.split('/');
+    let directory = root;
+    for (let index = 0; index < parts.length; index++) {
+      const name = parts[index];
+      if (index === parts.length - 1) directory.set(name, { sha256: input.sha256 });
+      else {
+        if (!directory.has(name)) directory.set(name, { children: new Map() });
+        directory = directory.get(name).children;
+      }
+    }
+  }
+  const entries = [];
+  function walk(directory, prefix = '') {
+    for (const [name, child] of [...directory].sort(([left], [right]) => left.localeCompare(right))) {
+      const path = prefix ? `${prefix}/${name}` : name;
+      if (child.children) walk(child.children, path);
+      else entries.push(`${path}:${child.sha256}`);
+    }
+  }
+  walk(root);
+  return { entries, treeHash: sha256(entries.join('\n')) };
+}
+
+function makeRepository({ wrongTree = false } = {}) {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'legacy-report-origin-'));
+  git(repositoryRoot, ['init', '--initial-branch=main']);
+  git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+  git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+  git(repositoryRoot, ['config', 'commit.gpgSign', 'false']);
+
+  write(repositoryRoot, `${SKILL_PATH}/SKILL.md`, '# Demo\n');
+  write(repositoryRoot, `${SKILL_PATH}/scripts/tool.sh`, '#!/bin/sh\necho demo\n', 0o755);
+  const previousReportBytes = Buffer.from('{"revision":1}\n');
+  write(repositoryRoot, `${SKILL_PATH}/skill-report.json`, previousReportBytes);
+  const originParent = commit(repositoryRoot, 'previous report');
+
+  const parentSource = sourceSet(repositoryRoot, originParent);
+  const legacyTree = legacyTreeHash(parentSource.entries, sha256(previousReportBytes));
+  const reportTreeHash = wrongTree ? 'f'.repeat(64) : legacyTree.treeHash;
+  const report = {
+    schema_version: '1.0.0',
+    meta: {
+      slug: SLUG,
+      content_hash: sha256('# Demo\n'),
+      tree_hash: reportTreeHash,
+    },
+  };
+  write(repositoryRoot, `${SKILL_PATH}/skill-report.json`, `${JSON.stringify(report)}\n`);
+  const originCommit = commit(repositoryRoot, 'audit report origin');
+  write(repositoryRoot, 'unrelated.txt', 'does not change the Skill\n');
+  const currentCommit = commit(repositoryRoot, 'later unrelated commit');
+
+  const currentReport = gitFile(repositoryRoot, currentCommit, `${SKILL_PATH}/skill-report.json`);
+  const previousReport = gitFile(repositoryRoot, originParent, `${SKILL_PATH}/skill-report.json`);
+  const currentSource = sourceSet(repositoryRoot, currentCommit);
+  const originSource = sourceSet(repositoryRoot, originCommit);
+  const row = {
+    slug: SLUG,
+    skillId: SKILL_ID,
+    classificationRunId: '123456789',
+    path: SKILL_PATH,
+    marketplaceCommit: currentCommit,
+    reportOriginCommit: originCommit,
+    reportOriginParent: originParent,
+    currentReportGitBlob: currentReport.gitBlob,
+    currentReportSha256: currentReport.sha256,
+    previousReportGitBlob: previousReport.gitBlob,
+    previousReportSha256: previousReport.sha256,
+    reportContentHash: report.meta.content_hash,
+    reportTreeHash,
+    originCalculatedTreeHash: reportTreeHash,
+    originTreeInputSha256: reportTreeHash,
+    originTreeEntryCount: legacyTree.entries.length,
+    treeHashScheme: 'legacy_path_sha256_merkle_previous_report_v1',
+    inputRelation: 'canonical_install_plus_previous_generated_report',
+    originContentRelation: 'canonical',
+    currentContentRelation: 'canonical',
+    sourceSetEquality: {
+      equal: true,
+      currentSha256: currentSource.sha256,
+      originSha256: originSource.sha256,
+      currentEntryCount: currentSource.entries.length,
+      originEntryCount: originSource.entries.length,
+    },
+    lineageClassification: 'legacy_previous_report_tree_equivalent',
+    governanceEligibleByLineage: true,
+  };
+  return { repositoryRoot, originParent, originCommit, currentCommit, row, previousReportBytes };
+}
+
+function cohortFor(row) {
+  return {
+    schemaVersion: 1,
+    repository: 'aiskillstore/marketplace',
+    status: 'lineage_recovered',
+    count: 1,
+    method: {
+      reportOrigin: 'last first-parent commit changing the same-path skill-report.json',
+      treeHashScheme: 'legacy_path_sha256_merkle_previous_report_v1',
+      inputRelation: 'canonical_install_plus_previous_generated_report',
+      sourceSetIdentity: 'canonical JSON of sorted non-report path, mode, git blob, sha256 entries',
+    },
+    rows: [row],
+  };
+}
+
+function outputs(repositoryRoot, suffix = '') {
+  return {
+    originRoot: join(repositoryRoot, `origin-output${suffix}`),
+    previousReportRoot: join(repositoryRoot, `previous-output${suffix}`),
+    manifestPath: join(repositoryRoot, `manifest${suffix}.json`),
+  };
+}
+
+test('materializes exact origin sources and previous report with complete deterministic evidence', () => {
+  const fixture = makeRepository();
+  try {
+    // The old temporary audit digest is selection evidence, not the new
+    // canonical_source_set_v1 authority. Independent Git recomputation wins.
+    fixture.row.sourceSetEquality.currentSha256 = 'a'.repeat(64);
+    fixture.row.sourceSetEquality.originSha256 = 'b'.repeat(64);
+    const paths = outputs(fixture.repositoryRoot);
+    const manifest = materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...paths,
+    });
+
+    assert.equal(manifest.status, 'legacy_report_origin_evidence_materialized');
+    assert.equal(manifest.selectedCount, 1);
+    assert.equal(manifest.sourceSetScheme, 'canonical_source_set_v1');
+    const entry = manifest.entries[0];
+    assert.equal(entry.originCommit, fixture.originCommit);
+    assert.equal(entry.originParent, fixture.originParent);
+    assert.equal(entry.sourceSetEvidence.equal, true);
+    assert.equal(
+      entry.sourceSetEvidence.current.sha256,
+      entry.sourceSetEvidence.origin.sha256,
+    );
+    assert.deepEqual(
+      entry.sourceSetEvidence.current.entries,
+      entry.sourceSetEvidence.origin.entries,
+    );
+    assert.equal(entry.legacyTreeEvidence.matchesCurrentReport, true);
+    assert.deepEqual(
+      readFileSync(join(paths.previousReportRoot, entry.previousReport.relativePath)),
+      fixture.previousReportBytes,
+    );
+    const executable = entry.originFiles.find((file) => file.path.endsWith('scripts/tool.sh'));
+    assert.ok(executable);
+    assert.equal(executable.mode, '100755');
+    assert.ok(statSync(join(paths.originRoot, executable.relativePath)).mode & 0o100);
+    assert.deepEqual(JSON.parse(readFileSync(paths.manifestPath, 'utf8')), manifest);
+
+    const second = outputs(fixture.repositoryRoot, '-second');
+    const repeated = materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...second,
+    });
+    assert.deepEqual(repeated, manifest);
+    assert.deepEqual(readFileSync(second.manifestPath), readFileSync(paths.manifestPath));
+  } finally {
+    rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('rebuilds evidence from a minimal checked-in identity cohort', () => {
+  const fixture = makeRepository();
+  try {
+    const paths = outputs(fixture.repositoryRoot, '-identity');
+    const cohort = {
+      schemaVersion: 2,
+      status: 'frozen_report_origin_cohort',
+      repository: 'aiskillstore/marketplace',
+      selectedCount: 1,
+      sourceBoundaries: [{
+        runId: fixture.row.classificationRunId,
+        classificationSha256: 'a'.repeat(64),
+      }],
+      rows: [{
+        slug: fixture.row.slug,
+        skillId: fixture.row.skillId,
+        classificationRunId: fixture.row.classificationRunId,
+        path: fixture.row.path,
+        currentMarketplaceCommit: fixture.row.marketplaceCommit,
+      }],
+    };
+    const manifest = materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort,
+      expectedCount: 1,
+      ...paths,
+    });
+    assert.equal(manifest.entries[0].originCommit, fixture.originCommit);
+    assert.equal(manifest.entries[0].originParent, fixture.originParent);
+    assert.equal(manifest.entries[0].classificationRunId, fixture.row.classificationRunId);
+  } finally {
+    rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails closed without partial outputs when source changed after the report origin', () => {
+  const fixture = makeRepository();
+  try {
+    write(fixture.repositoryRoot, `${SKILL_PATH}/SKILL.md`, '# Changed after report\n');
+    fixture.row.marketplaceCommit = commit(fixture.repositoryRoot, 'source changed');
+    const paths = outputs(fixture.repositoryRoot);
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...paths,
+    }), /non-report source changed after the report-origin subject/);
+    assert.equal(existsSync(paths.originRoot), false);
+    assert.equal(existsSync(paths.previousReportRoot), false);
+    assert.equal(existsSync(paths.manifestPath), false);
+  } finally {
+    rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails closed without outputs when the legacy DFS tree cannot reproduce the report', () => {
+  const fixture = makeRepository({ wrongTree: true });
+  try {
+    const paths = outputs(fixture.repositoryRoot);
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...paths,
+    }), /report tree hash is not reproducible from report-origin evidence/);
+    assert.equal(existsSync(paths.originRoot), false);
+    assert.equal(existsSync(paths.previousReportRoot), false);
+    assert.equal(existsSync(paths.manifestPath), false);
+  } finally {
+    rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('rejects unproven cohorts, frozen identity drift, unsafe output overlap, and overwrites', () => {
+  const fixture = makeRepository();
+  try {
+    const invalidStatus = cohortFor(fixture.row);
+    invalidStatus.status = 'lineage_unproven';
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: invalidStatus,
+      expectedCount: 1,
+      ...outputs(fixture.repositoryRoot),
+    }), /does not match the frozen report-origin contract/);
+
+    const drifted = structuredClone(fixture.row);
+    drifted.reportOriginCommit = fixture.originParent;
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(drifted),
+      expectedCount: 1,
+      ...outputs(fixture.repositoryRoot),
+    }), /report-origin commit differs from the frozen lineage cohort/);
+
+    const overlapping = outputs(fixture.repositoryRoot, '-overlap');
+    overlapping.previousReportRoot = join(overlapping.originRoot, 'previous');
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...overlapping,
+    }), /must be separate safe paths/);
+
+    const occupied = outputs(fixture.repositoryRoot, '-occupied');
+    write(occupied.originRoot, 'sentinel', 'keep\n');
+    assert.throws(() => materializeLegacyReportOriginEvidence({
+      repositoryRoot: fixture.repositoryRoot,
+      cohort: cohortFor(fixture.row),
+      expectedCount: 1,
+      ...occupied,
+    }), /origin source output root is not empty/);
+  } finally {
+    rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-legacy-report-origin-boundary.mjs
+++ b/scripts/verify-legacy-report-origin-boundary.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+
+function fail(message) { throw new Error(message); }
+function sha256(bytes) { return createHash('sha256').update(bytes).digest('hex'); }
+function bytes(path) { return readFileSync(resolve(path)); }
+function json(path) { return JSON.parse(bytes(path).toString('utf8')); }
+
+function identity(row) {
+  return {
+    slug: row.slug,
+    skillId: row.skillId,
+    classificationRunId: row.classificationRunId,
+    path: row.path,
+    currentMarketplaceCommit: row.currentMarketplaceCommit,
+  };
+}
+
+function canonicalIdentities(rows) {
+  return rows.map(identity)
+    .sort((left, right) => Buffer.compare(Buffer.from(left.slug), Buffer.from(right.slug)));
+}
+
+export function verifyLegacyReportOriginDocuments({ cohort, plan, classification, manifest, dryRunResults }) {
+  if (
+    cohort?.schemaVersion !== 2
+    || cohort?.status !== 'frozen_report_origin_cohort'
+    || cohort?.selectedCount !== 70
+    || cohort?.rows?.length !== 70
+    || plan?.status !== 'frozen_report_origin_plan'
+    || plan?.selectedCount !== 70
+    || manifest?.status !== 'legacy_report_origin_evidence_materialized'
+    || manifest?.selectedCount !== 70
+    || classification?.status !== 'classified'
+    || classification?.classifiedCount !== 70
+    || classification?.counts?.exact !== 0
+    || classification?.counts?.legacy_algorithm_equivalent !== 0
+    || classification?.counts?.actual_or_unproven_drift !== 70
+    || classification?.cohorts?.actual_or_unproven_drift?.length !== 70
+    || !Array.isArray(dryRunResults)
+  ) fail('report-origin boundary must cover exactly the frozen 70-row cohort');
+
+  const expected = canonicalIdentities(cohort.rows);
+  const fromPlan = canonicalIdentities(plan.identities || []);
+  const fromManifest = canonicalIdentities(manifest.entries || []);
+  const classificationRuns = new Map(cohort.rows.map((row) => [row.slug, row.classificationRunId]));
+  const fromClassification = canonicalIdentities(
+    classification.cohorts.actual_or_unproven_drift.map((row) => ({
+      slug: row.slug,
+      skillId: row.id,
+      classificationRunId: classificationRuns.get(row.slug),
+      path: row.path,
+      currentMarketplaceCommit: row.marketplaceCommit,
+    }))
+  );
+  const identityJson = JSON.stringify(expected);
+  if (
+    JSON.stringify(fromPlan) !== identityJson
+    || JSON.stringify(fromManifest) !== identityJson
+    || JSON.stringify(fromClassification) !== identityJson
+    || plan.identitySha256 !== sha256(identityJson)
+    || JSON.stringify(plan.sourceBoundaries) !== JSON.stringify(cohort.sourceBoundaries)
+  ) fail('cohort, classification, plan, and origin manifest identities differ');
+
+  const dryRows = dryRunResults.flatMap((group) => group?.result?.results || []);
+  const drySlugs = dryRows.map((row) => row?.slug).sort();
+  const expectedSlugs = expected.map((row) => row.slug).sort();
+  if (
+    dryRows.length !== 70
+    || JSON.stringify(drySlugs) !== JSON.stringify(expectedSlugs)
+    || dryRows.some((row) => (
+      row?.mode !== 'dry-run'
+      || row?.artifactVersionId !== null
+      || row?.artifactRevision !== null
+      || row?.derivedAuditId !== null
+    ))
+  ) fail('administrator dry-run does not cover exactly 70 no-write results');
+  return { identitySha256: plan.identitySha256 };
+}
+
+export function freezeLegacyReportOriginBoundary(input) {
+  const verified = verifyLegacyReportOriginDocuments(input);
+  if (
+    !/^\d+$/.test(input.runId || '')
+    || input.repository !== 'aiskillstore/marketplace'
+    || !COMMIT_RE.test(input.workflowCommit || '')
+    || input.cliVersion !== '2.6.0'
+    || !SHA256_RE.test(input.cliSha256 || '')
+  ) fail('invalid frozen execution identity');
+  return {
+    schemaVersion: 1,
+    status: 'frozen',
+    workflow: 'govern-legacy-report-origin-70',
+    runId: input.runId,
+    repository: input.repository,
+    workflowCommit: input.workflowCommit,
+    cliVersion: input.cliVersion,
+    cliSha256: input.cliSha256,
+    selectedCount: 70,
+    identitySha256: verified.identitySha256,
+    cohortSha256: input.cohortSha256,
+    planSha256: input.planSha256,
+    classificationSha256: input.classificationSha256,
+    manifestSha256: input.manifestSha256,
+    dryRunResultsSha256: input.dryRunResultsSha256,
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null || value.startsWith('--')) fail(`invalid argument: ${key}`);
+    const name = key.slice(2);
+    if (Object.hasOwn(values, name)) fail(`duplicate argument: ${key}`);
+    values[name] = value;
+  }
+  return values;
+}
+
+function fileInputs(args) {
+  return {
+    cohort: json(args.cohort),
+    plan: json(args.plan),
+    classification: json(args.classification),
+    manifest: json(args.manifest),
+    dryRunResults: json(args['dry-run-results']),
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  for (const name of ['phase', 'cohort', 'plan', 'classification', 'manifest', 'dry-run-results']) {
+    if (!args[name]) fail(`--${name} is required`);
+  }
+  const documents = fileInputs(args);
+  if (args.phase === 'freeze') {
+    for (const name of ['run-id', 'repository', 'workflow-commit', 'cli-version', 'cli-sha256', 'output']) {
+      if (!args[name]) fail(`--${name} is required`);
+    }
+    const output = freezeLegacyReportOriginBoundary({
+      ...documents,
+      runId: args['run-id'],
+      repository: args.repository,
+      workflowCommit: args['workflow-commit'],
+      cliVersion: args['cli-version'],
+      cliSha256: args['cli-sha256'],
+      cohortSha256: sha256(bytes(args.cohort)),
+      planSha256: sha256(bytes(args.plan)),
+      classificationSha256: sha256(bytes(args.classification)),
+      manifestSha256: sha256(bytes(args.manifest)),
+      dryRunResultsSha256: sha256(bytes(args['dry-run-results'])),
+    });
+    writeFileSync(resolve(args.output), `${JSON.stringify(output, null, 2)}\n`, { flag: 'wx' });
+    return output;
+  }
+  if (args.phase === 'execute-preflight') {
+    if (!args.boundary || !args['expected-run-id']) fail('--boundary and --expected-run-id are required');
+    const boundary = json(args.boundary);
+    const verified = verifyLegacyReportOriginDocuments(documents);
+    const digests = {
+      cohortSha256: sha256(bytes(args.cohort)),
+      planSha256: sha256(bytes(args.plan)),
+      classificationSha256: sha256(bytes(args.classification)),
+      manifestSha256: sha256(bytes(args.manifest)),
+      dryRunResultsSha256: sha256(bytes(args['dry-run-results'])),
+    };
+    if (
+      boundary?.status !== 'frozen'
+      || boundary?.workflow !== 'govern-legacy-report-origin-70'
+      || boundary?.runId !== args['expected-run-id']
+      || boundary?.selectedCount !== 70
+      || boundary?.identitySha256 !== verified.identitySha256
+      || Object.entries(digests).some(([key, value]) => boundary[key] !== value)
+    ) fail('execute inputs differ from the successful frozen boundary');
+    return { status: 'verified', selectedCount: 70 };
+  }
+  fail(`unsupported phase: ${args.phase}`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.stdout.write(`${JSON.stringify(main())}\n`);
+  } catch (error) {
+    process.stderr.write(`report-origin boundary verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add a dedicated two-phase workflow for the exact 70 report-origin legacy artifacts
- check in the identity cohort bound to seven original classification runs and SHAs
- rematerialize origin/current/previous-report Git evidence and require byte-identical freeze/execute manifests
- pin Skillstore CLI 2.6.0 and its audited Linux x64 SHA-256

## Safety

- only the checked-in 70 identities can enter the lane
- dry-run and execute both verify the CLI digest
- execute consumes the frozen boundary and fails closed on any evidence drift
- this PR does not run production governance by itself

## Validation

- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs scripts/tests/materialize-legacy-report-origin-evidence.test.mjs` (7/7)
- `git diff --check`
- cohort manifest SHA-256: `0ce310b82260d882811305cbb69db50d4e0771ad617ac387056db0315d1d5313`
- CLI 2.6.0 Linux x64 SHA-256: `ae2d7caf57ea7849ad39b0518d640ee2a0c51f1eee3f4eb2b9797c1abb0bd4cc`
