### PR TITLE
feat(governance): bind 32hex legacy audits

### DIFF
--- a/.github/workflows/bind-legacy-audit-subjects.yml
+++ b/.github/workflows/bind-legacy-audit-subjects.yml
@@ -1,0 +1,168 @@
+name: Bind Legacy Audit Subjects
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        required: true
+        options: [dry-run, execute]
+      classification_run_id:
+        description: Successful legacy-governance dry-run containing the frozen classification
+        type: string
+        required: true
+      dry_run_id:
+        description: Successful binding dry-run ID; execute only
+        type: string
+        required: false
+      expected_targeted:
+        type: number
+        required: true
+        default: 61
+      expected_drift:
+        type: number
+        required: true
+        default: 24
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+jobs:
+  bind:
+    runs-on: self-hosted
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 0, clean: true }
+      - name: Validate immutable operator boundary
+        env:
+          MODE: ${{ inputs.mode }}
+          SOURCE_RUN: ${{ inputs.classification_run_id }}
+          DRY_RUN: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          [[ "$SOURCE_RUN$DRY_RUN" != *[^0-9]* ]]
+          if [ "$MODE" = execute ]; then test -n "$DRY_RUN"; else test -z "$DRY_RUN"; fi
+      - id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+      - name: Download pinned binding CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.token.outputs.token }}
+          version: '2.7.0'
+          minimum-version: '2.7.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+      - name: Verify pinned Linux binary
+        run: |
+          set -euo pipefail
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          test "$actual" = '__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
+      - name: Download frozen hash-classification boundary
+        env: { GH_TOKEN: '${{ steps.token.outputs.token }}' }
+        run: |
+          set -euo pipefail
+          source_run='${{ inputs.mode == 'execute' && inputs.dry_run_id || inputs.classification_run_id }}'
+          mkdir -p "$RUNNER_TEMP/source"
+          gh run download "$source_run" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/source"
+          if [ '${{ inputs.mode }}' = execute ]; then
+            boundary=$(find "$RUNNER_TEMP/source" -type d -name 'legacy-audit-binding-boundary-*' -print -quit)
+          else
+            boundary=$(find "$RUNNER_TEMP/source" -type d -name 'legacy-equivalent-boundary-*' -print -quit)
+          fi
+          test -n "$boundary"
+          cp -R "$boundary" "$RUNNER_TEMP/boundary"
+      - name: Freeze or verify exact pre-write evidence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          classification="$RUNNER_TEMP/boundary/hash-classification.json"
+          test -f "$classification"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$classification" --output "$RUNNER_TEMP/source-evidence.json"
+          node scripts/build-legacy-audit-binding-plan.mjs \
+            --classification "$classification" --source-evidence "$RUNNER_TEMP/source-evidence.json" \
+            --repository-root "$GITHUB_WORKSPACE" --output "$RUNNER_TEMP/binding-plan.json" \
+            --expected-targeted '${{ inputs.expected_targeted }}' \
+            --expected-drift '${{ inputs.expected_drift }}'
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/boundary/plan.json" \
+            --output "$RUNNER_TEMP/binding-inventory.json"
+          if [ '${{ inputs.mode }}' = execute ]; then
+            cmp "$RUNNER_TEMP/binding-plan.json" "$RUNNER_TEMP/boundary/binding-plan.json"
+            cmp "$RUNNER_TEMP/source-evidence.json" "$RUNNER_TEMP/boundary/source-evidence.json"
+            cmp "$RUNNER_TEMP/binding-inventory.json" "$RUNNER_TEMP/boundary/binding-inventory.json"
+          fi
+      - name: Materialize exact pinned reports
+        run: |
+          set -euo pipefail
+          jq -c '.entries[]' "$RUNNER_TEMP/binding-plan.json" | while read -r row; do
+            commit=$(jq -r .marketplaceCommit <<<"$row"); path=$(jq -r .pluginPath <<<"$row")
+            mkdir -p "$RUNNER_TEMP/reports/$path"
+            git show "$commit:$path/skill-report.json" > "$RUNNER_TEMP/reports/$path/skill-report.json"
+          done
+      - name: Recompute all report payloads without writes
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: >-
+          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit
+          --plan "$RUNNER_TEMP/binding-plan.json" --root "$RUNNER_TEMP/reports"
+          --dry-run --concurrency 1 --result-file "$RUNNER_TEMP/binding-dry-run.json"
+      - name: Record binding evidence only
+        if: inputs.mode == 'execute'
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: >-
+          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit
+          --plan "$RUNNER_TEMP/binding-plan.json" --root "$RUNNER_TEMP/reports"
+          --concurrency 1 --result-file "$RUNNER_TEMP/binding-execute.json"
+      - name: Re-read source and assert only append-only bindings changed
+        if: inputs.mode == 'execute'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/boundary/hash-classification.json" \
+            --output "$RUNNER_TEMP/post-source-evidence.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/boundary/plan.json" \
+            --output "$RUNNER_TEMP/post-binding-inventory.json"
+          jq -S 'del(.bindings)' "$RUNNER_TEMP/source-evidence.json" > "$RUNNER_TEMP/before-without-bindings.json"
+          jq -S 'del(.bindings)' "$RUNNER_TEMP/post-source-evidence.json" > "$RUNNER_TEMP/after-without-bindings.json"
+          cmp "$RUNNER_TEMP/before-without-bindings.json" "$RUNNER_TEMP/after-without-bindings.json"
+          cmp "$RUNNER_TEMP/binding-inventory.json" "$RUNNER_TEMP/post-binding-inventory.json"
+          test "$(jq '.bindings | length' "$RUNNER_TEMP/post-source-evidence.json")" = '${{ inputs.expected_targeted }}'
+          test "$(jq '[.results[] | select(.status == "created" or .status == "existing")] | length' "$RUNNER_TEMP/binding-execute.json")" = '${{ inputs.expected_targeted }}'
+      - name: Freeze dry-run boundary
+        if: inputs.mode == 'dry-run'
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/legacy-audit-binding-boundary-$GITHUB_RUN_ID"; mkdir -p "$out"
+          cp "$RUNNER_TEMP/binding-plan.json" "$RUNNER_TEMP/source-evidence.json" \
+            "$RUNNER_TEMP/binding-inventory.json" "$RUNNER_TEMP/binding-dry-run.json" \
+            "$RUNNER_TEMP/boundary/hash-classification.json" "$RUNNER_TEMP/boundary/plan.json" "$out/"
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: legacy-audit-binding-${{ inputs.mode }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/legacy-audit-binding-boundary-*
+            ${{ runner.temp }}/binding-*.json
+            ${{ runner.temp }}/post-source-evidence.json
+            ${{ runner.temp }}/post-binding-inventory.json
+          if-no-files-found: error

--- a/.github/workflows/bind-legacy-audit-subjects.yml
+++ b/.github/workflows/bind-legacy-audit-subjects.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          test "$actual" = '__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
+          test "$actual" = 'cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
       - name: Download frozen hash-classification boundary
         env: { GH_TOKEN: '${{ steps.token.outputs.token }}' }
         run: |

--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version'
         type: string
         required: true
-        default: '2.5.0'
+        default: '2.7.0'
       batch_size:
         description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
         type: number
@@ -86,7 +86,7 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.5.0' || { echo '::error::workflow is pinned to skillstore-cli 2.5.0'; exit 1; }
+          test "$CLI_VERSION" = '2.7.0' || { echo '::error::workflow is pinned to skillstore-cli 2.7.0'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
           [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
             echo '::error::batch_size must be between 1 and 500'; exit 1;
@@ -145,17 +145,17 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.5.0'
-          minimum-version: '2.5.0'
+          version: '2.7.0'
+          minimum-version: '2.7.0'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Verify audited CLI 2.5.0 binary identity
+      - name: Verify audited binding-aware CLI binary identity
         run: |
           set -euo pipefail
-          expected='e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e'
+          expected='__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
-            echo '::error::CLI 2.5.0 binary does not match the audited linux-x64 digest'; exit 1;
+            echo '::error::binding-aware CLI binary does not match the audited linux-x64 digest'; exit 1;
           }
 
       - name: Materialize frozen first-parent report evidence
@@ -294,7 +294,7 @@ jobs:
             --source-evidence "$boundary/source-evidence.json" \
             --previous-report-manifest "$boundary/legacy-previous-report-manifest.json" \
             --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
-            --workflow-commit "$GITHUB_SHA" --cli-version '2.5.0' \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.7.0' \
             --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --output "$boundary/boundary.json"
           (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json legacy-previous-report-manifest.json boundary.json > SHA256SUMS)
@@ -315,7 +315,7 @@ jobs:
           {
             echo '## Legacy-equivalent frozen boundary'
             echo "- Run ID: \`$GITHUB_RUN_ID\`"
-            echo "- CLI: \`2.5.0\`"
+            echo "- CLI: \`2.7.0\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
             echo "- Hash-equivalent: \`$(jq -r .governance.hashEquivalentCount "$RUNNER_TEMP/classification.json")\`; governable: \`$(jq -r .governance.eligibleCount "$RUNNER_TEMP/classification.json")\`; source-audit unproven: \`$(jq -r .governance.unprovenCount "$RUNNER_TEMP/classification.json")\`"
@@ -373,7 +373,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git sparse-checkout disable
           git reset --hard HEAD
-          test "$CLI_VERSION" = '2.5.0' || { echo '::error::workflow is pinned to skillstore-cli 2.5.0'; exit 1; }
+          test "$CLI_VERSION" = '2.7.0' || { echo '::error::workflow is pinned to skillstore-cli 2.7.0'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
           [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
@@ -456,22 +456,22 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.5.0
+      - name: Download exact audited binding-aware CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.5.0'
-          minimum-version: '2.5.0'
+          version: '2.7.0'
+          minimum-version: '2.7.0'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e'
+          audited='__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {
-            echo '::error::CLI 2.5.0 binary differs from the frozen dry-run boundary'; exit 1;
+            echo '::error::binding-aware CLI binary differs from the frozen dry-run boundary'; exit 1;
           }
 
       - name: Materialize only frozen legacy groups
@@ -583,7 +583,7 @@ jobs:
           {
             echo '## Legacy-equivalent execution verified'
             echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
-            echo '- CLI: `2.5.0`'
+            echo '- CLI: `2.7.0`'
             echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
             echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
             echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'

--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Verify audited binding-aware CLI binary identity
         run: |
           set -euo pipefail
-          expected='__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
+          expected='cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
             echo '::error::binding-aware CLI binary does not match the audited linux-x64 digest'; exit 1;
@@ -467,7 +467,7 @@ jobs:
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='__LEGACY_AUDIT_BINDING_LINUX_SHA256__'
+          audited='cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {

--- a/scripts/build-legacy-audit-binding-plan.mjs
+++ b/scripts/build-legacy-audit-binding-plan.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const HASH32 = /^[0-9a-f]{32}$/;
+function fail(message) { throw new Error(message); }
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`;
+  return JSON.stringify(value);
+}
+function map(rows, key, label) {
+  const result = new Map();
+  for (const row of rows || []) {
+    if (!row?.[key] || result.has(row[key])) fail(`${label} identity is invalid`);
+    result.set(row[key], row);
+  }
+  return result;
+}
+
+export function buildLegacyAuditBindingPlan({ classification, sourceEvidence, repositoryRoot }) {
+  if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
+    fail('classification is not frozen');
+  }
+  const legacy = classification?.cohorts?.legacy_algorithm_equivalent || [];
+  const drift = classification?.cohorts?.actual_or_unproven_drift || [];
+  const skills = map(sourceEvidence?.skills, 'id', 'source Skills');
+  const audits = map(sourceEvidence?.audits, 'id', 'source audits');
+  const entries = [];
+  for (const row of legacy) {
+    const skill = skills.get(row.id);
+    const audit = audits.get(row.publicEligibilityAuditId);
+    if (!skill || skill.slug !== row.slug || !audit || audit.skill_id !== row.id
+      || audit.id !== row.publicEligibilityAuditId || !HASH32.test(audit.content_hash || '')) {
+      continue;
+    }
+    const objectSpec = `${row.marketplaceCommit}:${row.path}/skill-report.json`;
+    const raw = execFileSync('git', ['-C', repositoryRoot, 'show', objectSpec]);
+    const report = JSON.parse(raw.toString('utf8'));
+    if (report?.meta?.slug !== row.slug || report?.meta?.content_hash !== row.contentHash
+      || report?.meta?.tree_hash !== row.treeHash || !report?.security_audit) {
+      fail(`pinned report identity mismatch for ${row.slug}`);
+    }
+    entries.push({
+      skillId: row.id, slug: row.slug, pluginPath: row.path,
+      marketplaceCommit: row.marketplaceCommit, skillContentHash: row.contentHash,
+      treeHash: row.treeHash, sourceAuditId: audit.id,
+      sourceAuditVersion: audit.version, sourceAuditPayloadHash: audit.content_hash,
+      reportBlobSha256: createHash('sha256').update(raw).digest('hex'),
+    });
+  }
+  entries.sort((a, b) => a.slug.localeCompare(b.slug, 'en-US'));
+  const identity = { schemaVersion: 1, entries };
+  return {
+    ...identity,
+    planSha256: createHash('sha256').update(canonical(identity)).digest('hex'),
+    driftQuarantine: drift.map((row) => ({
+      slug: row.slug, skillId: row.id, sourceAuditId: row.publicEligibilityAuditId,
+      artifactGovernanceAllowed: false,
+    })).sort((a, b) => a.slug.localeCompare(b.slug, 'en-US')),
+  };
+}
+
+if (process.argv[1]?.endsWith('build-legacy-audit-binding-plan.mjs')) {
+  try {
+    const { values } = parseArgs({ options: {
+      classification: { type: 'string' }, 'source-evidence': { type: 'string' },
+      'repository-root': { type: 'string' }, output: { type: 'string' },
+      'expected-targeted': { type: 'string' }, 'expected-drift': { type: 'string' },
+    } });
+    const result = buildLegacyAuditBindingPlan({
+      classification: JSON.parse(readFileSync(resolve(values.classification), 'utf8')),
+      sourceEvidence: JSON.parse(readFileSync(resolve(values['source-evidence']), 'utf8')),
+      repositoryRoot: resolve(values['repository-root']),
+    });
+    if (values['expected-targeted'] && result.entries.length !== Number(values['expected-targeted']))
+      fail('targeted binding count mismatch');
+    if (values['expected-drift'] && result.driftQuarantine.length !== Number(values['expected-drift']))
+      fail('drift quarantine count mismatch');
+    writeFileSync(resolve(values.output), `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx' });
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`); process.exitCode = 1;
+  }
+}

--- a/scripts/fetch-legacy-equivalent-governance-readback.mjs
+++ b/scripts/fetch-legacy-equivalent-governance-readback.mjs
@@ -134,7 +134,7 @@ export async function fetchLegacyGovernanceSourceEvidence({
     values,
     fetchImpl,
   });
-  const [skills, audits] = await Promise.all([
+  const [skills, audits, bindings] = await Promise.all([
     request(
       'skills',
       'id,slug,name,description,author_name,supported_tools,file_structure',
@@ -142,6 +142,7 @@ export async function fetchLegacyGovernanceSourceEvidence({
       skillIds
     ),
     request('skill_security_audit', '*', 'id', auditIds),
+    request('legacy_audit_subject_bindings', '*', 'source_audit_id', auditIds),
   ]);
   if (skills.length !== legacy.length || audits.length !== legacy.length) {
     fail('source evidence readback is incomplete');
@@ -152,6 +153,7 @@ export async function fetchLegacyGovernanceSourceEvidence({
     skillIds,
     skills: sortRowsById(skills),
     audits: sortRowsById(audits),
+    bindings: sortRowsById(bindings),
   };
 }
 

--- a/scripts/plan-legacy-audit-binding-cohorts.mjs
+++ b/scripts/plan-legacy-audit-binding-cohorts.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function asUniqueMap(rows, label) {
+  if (!Array.isArray(rows)) fail(`${label} must be an array`);
+  const result = new Map();
+  for (const row of rows) {
+    if (!row || typeof row.slug !== 'string' || !row.slug || result.has(row.slug)) {
+      fail(`${label} must contain unique non-empty slugs`);
+    }
+    result.set(row.slug, row);
+  }
+  return result;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+    ).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function planLegacyAuditBindingCohorts({
+  classification,
+  bindingEvidence,
+  expectedTargetedCount,
+  expectedDriftCount,
+}) {
+  if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
+    fail('hash classification is not frozen');
+  }
+  if (bindingEvidence?.schemaVersion !== 1 || bindingEvidence?.status !== 'verified') {
+    fail('legacy audit binding evidence is not frozen');
+  }
+  const hashEquivalent = asUniqueMap(
+    classification?.cohorts?.legacy_algorithm_equivalent,
+    'hash-equivalent cohort'
+  );
+  const drift = asUniqueMap(
+    classification?.cohorts?.actual_or_unproven_drift,
+    'drift cohort'
+  );
+  for (const slug of hashEquivalent.keys()) {
+    if (drift.has(slug)) fail(`classification cohorts overlap for ${slug}`);
+  }
+
+  const evidence = asUniqueMap(bindingEvidence.entries, 'binding evidence');
+  const bindingScope = new Set([...hashEquivalent.keys(), ...drift.keys()]);
+  if (evidence.size !== bindingScope.size) {
+    fail('binding evidence does not cover the hash-equivalent and drift cohorts exactly once');
+  }
+  for (const slug of evidence.keys()) {
+    if (!bindingScope.has(slug)) fail(`binding evidence contains an out-of-scope slug: ${slug}`);
+  }
+
+  const targeted = [];
+  const unprovenHashEquivalent = [];
+  for (const [slug, row] of hashEquivalent) {
+    const proof = evidence.get(slug);
+    if (
+      proof.skillId !== row.id
+      || proof.sourceAuditId !== row.publicEligibilityAuditId
+    ) fail(`frozen binding identity mismatch for ${slug}`);
+    const decision = {
+      slug,
+      skillId: row.id,
+      sourceAuditId: row.publicEligibilityAuditId,
+      bindingVerified: proof.decision === 'verified',
+      artifactGovernanceAllowed: proof.decision === 'verified',
+      reason: proof.reason,
+      planEntry: proof.planEntry,
+    };
+    (decision.bindingVerified ? targeted : unprovenHashEquivalent).push(decision);
+  }
+
+  const driftQuarantine = [];
+  for (const [slug, row] of drift) {
+    const proof = evidence.get(slug);
+    if (
+      proof.skillId !== row.id
+      || proof.sourceAuditId !== row.publicEligibilityAuditId
+    ) fail(`frozen drift binding identity mismatch for ${slug}`);
+    driftQuarantine.push({
+      slug,
+      skillId: row.id,
+      sourceAuditId: row.publicEligibilityAuditId,
+      bindingVerified: proof.decision === 'verified',
+      artifactGovernanceAllowed: false,
+      reason: 'artifact_hash_drift_quarantined',
+    });
+  }
+  targeted.sort((a, b) => a.slug.localeCompare(b.slug));
+  unprovenHashEquivalent.sort((a, b) => a.slug.localeCompare(b.slug));
+  driftQuarantine.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  if (
+    expectedTargetedCount !== undefined
+    && targeted.length !== expectedTargetedCount
+  ) fail(`targeted binding count mismatch: expected ${expectedTargetedCount}, got ${targeted.length}`);
+  if (
+    expectedDriftCount !== undefined
+    && driftQuarantine.length !== expectedDriftCount
+  ) fail(`drift quarantine count mismatch: expected ${expectedDriftCount}, got ${driftQuarantine.length}`);
+
+  const plan = {
+    schemaVersion: 1,
+    status: 'legacy_audit_binding_cohorts_planned',
+    counts: {
+      hashEquivalent: hashEquivalent.size,
+      targeted: targeted.length,
+      unprovenHashEquivalent: unprovenHashEquivalent.length,
+      driftQuarantined: driftQuarantine.length,
+    },
+    targeted,
+    unprovenHashEquivalent,
+    driftQuarantine,
+  };
+  const bindingPlanIdentity = {
+    schemaVersion: 1,
+    entries: targeted.map((row) => {
+      if (!row.planEntry || row.planEntry.slug !== row.slug) {
+        fail(`verified binding evidence lacks an exact plan entry for ${row.slug}`);
+      }
+      return row.planEntry;
+    }),
+  };
+  const bindingPlan = {
+    ...bindingPlanIdentity,
+    planSha256: createHash('sha256').update(canonicalJson(bindingPlanIdentity)).digest('hex'),
+  };
+  return {
+    planSha256: createHash('sha256').update(canonicalJson(plan)).digest('hex'),
+    plan,
+    bindingPlan,
+  };
+}
+
+function parseCount(value, name) {
+  if (value === undefined) return undefined;
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) fail(`${name} must be a non-negative integer`);
+  return Number(value);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      classification: { type: 'string' },
+      evidence: { type: 'string' },
+      output: { type: 'string' },
+      'expected-targeted': { type: 'string' },
+      'expected-drift': { type: 'string' },
+    },
+    strict: true,
+  });
+  if (!values.classification || !values.evidence || !values.output) {
+    fail('--classification, --evidence, and --output are required');
+  }
+  const result = planLegacyAuditBindingCohorts({
+    classification: JSON.parse(readFileSync(values.classification, 'utf8')),
+    bindingEvidence: JSON.parse(readFileSync(values.evidence, 'utf8')),
+    expectedTargetedCount: parseCount(values['expected-targeted'], '--expected-targeted'),
+    expectedDriftCount: parseCount(values['expected-drift'], '--expected-drift'),
+  });
+  writeFileSync(values.output, `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx' });
+  process.stdout.write(`${JSON.stringify(result.plan.counts)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/legacy-audit-binding-cohorts.test.mjs
+++ b/scripts/tests/legacy-audit-binding-cohorts.test.mjs
@@ -96,7 +96,7 @@ test('binding workflow is two-phase, pinned, score/artifact preserving, and cach
   ), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute\]/);
   assert.match(workflow, /version: '2\.7\.0'/);
-  assert.match(workflow, /__LEGACY_AUDIT_BINDING_LINUX_SHA256__/);
+  assert.match(workflow, /cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7/);
   assert.match(workflow, /skill bind-legacy-audit/);
   assert.match(workflow, /--dry-run --concurrency 1/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/binding-inventory\.json" "\$RUNNER_TEMP\/post-binding-inventory\.json"/);

--- a/scripts/tests/legacy-audit-binding-cohorts.test.mjs
+++ b/scripts/tests/legacy-audit-binding-cohorts.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { buildLegacyAuditBindingPlan } from '../build-legacy-audit-binding-plan.mjs';
+import { planLegacyAuditBindingCohorts } from '../plan-legacy-audit-binding-cohorts.mjs';
+
+function row(prefix, index) {
+  return {
+    id: `${prefix}-skill-${index}`,
+    slug: `${prefix}-${String(index).padStart(3, '0')}`,
+    publicEligibilityAuditId: `${prefix}-audit-${index}`,
+  };
+}
+
+function fixtures() {
+  const legacy = Array.from({ length: 61 }, (_, index) => row('legacy', index));
+  const drift = Array.from({ length: 24 }, (_, index) => row('drift', index));
+  const entries = legacy.concat(drift).map((item) => ({
+    slug: item.slug,
+    skillId: item.id,
+    sourceAuditId: item.publicEligibilityAuditId,
+    decision: 'verified',
+    reason: 'pinned_report_payload_matches',
+    planEntry: {
+      skillId: item.id,
+      slug: item.slug,
+      pluginPath: `skills/history/${item.slug}`,
+      marketplaceCommit: 'a'.repeat(40),
+      skillContentHash: 'b'.repeat(64),
+      treeHash: 'c'.repeat(64),
+      sourceAuditId: item.publicEligibilityAuditId,
+      sourceAuditVersion: 1,
+      sourceAuditPayloadHash: 'd'.repeat(32),
+      reportBlobSha256: 'e'.repeat(64),
+    },
+  }));
+  return {
+    classification: {
+      schemaVersion: 1,
+      status: 'classified',
+      cohorts: {
+        legacy_algorithm_equivalent: legacy,
+        actual_or_unproven_drift: drift,
+      },
+    },
+    bindingEvidence: { schemaVersion: 1, status: 'verified', entries },
+  };
+}
+
+test('targets 61 hash-equivalent rows and quarantines all 24 drift rows after binding proof', () => {
+  const fixture = fixtures();
+  const result = planLegacyAuditBindingCohorts({
+    ...fixture,
+    expectedTargetedCount: 61,
+    expectedDriftCount: 24,
+  });
+  assert.deepEqual(result.plan.counts, {
+    hashEquivalent: 61,
+    targeted: 61,
+    unprovenHashEquivalent: 0,
+    driftQuarantined: 24,
+  });
+  assert.equal(result.plan.targeted.every((row) => row.artifactGovernanceAllowed), true);
+  assert.equal(result.bindingPlan.entries.length, 61);
+  assert.equal(result.plan.driftQuarantine.every((row) =>
+    row.bindingVerified && !row.artifactGovernanceAllowed
+  ), true);
+  const targetedSlugs = new Set(result.plan.targeted.map((row) => row.slug));
+  assert.equal(
+    result.plan.driftQuarantine.some((row) => targetedSlugs.has(row.slug)),
+    false
+  );
+});
+
+test('fails closed on missing, duplicate, or cross-cohort evidence', () => {
+  const fixture = fixtures();
+  fixture.bindingEvidence.entries.pop();
+  assert.throws(() => planLegacyAuditBindingCohorts(fixture), /cover.*exactly once/);
+
+  const duplicate = fixtures();
+  duplicate.bindingEvidence.entries[84] = duplicate.bindingEvidence.entries[0];
+  assert.throws(() => planLegacyAuditBindingCohorts(duplicate), /unique non-empty slugs/);
+
+  const mismatch = fixtures();
+  mismatch.bindingEvidence.entries[0].sourceAuditId = 'latest-audit-not-frozen-pointer';
+  assert.throws(() => planLegacyAuditBindingCohorts(mismatch), /frozen binding identity mismatch/);
+});
+
+test('binding workflow is two-phase, pinned, score/artifact preserving, and cache inert', () => {
+  const workflow = readFileSync(resolve(
+    import.meta.dirname,
+    '../../.github/workflows/bind-legacy-audit-subjects.yml'
+  ), 'utf8');
+  assert.match(workflow, /options: \[dry-run, execute\]/);
+  assert.match(workflow, /version: '2\.7\.0'/);
+  assert.match(workflow, /__LEGACY_AUDIT_BINDING_LINUX_SHA256__/);
+  assert.match(workflow, /skill bind-legacy-audit/);
+  assert.match(workflow, /--dry-run --concurrency 1/);
+  assert.match(workflow, /cmp "\$RUNNER_TEMP\/binding-inventory\.json" "\$RUNNER_TEMP\/post-binding-inventory\.json"/);
+  assert.doesNotMatch(workflow, /cache\/invalidate|warm-cache|invalidateApi/);
+  assert.match(workflow, /expected_targeted:[\s\S]*default: 61/);
+  assert.match(workflow, /expected_drift:[\s\S]*default: 24/);
+});
+
+test('builds the executable plan from the frozen pointer and exact Git blob', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'legacy-binding-plan-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: directory });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: directory });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: directory });
+    const path = 'skills/history/legacy-000';
+    mkdirSync(resolve(directory, path), { recursive: true });
+    const report = { meta: { slug: 'legacy-000', content_hash: 'b'.repeat(64), tree_hash: 'c'.repeat(64) }, security_audit: { risk_level: 'low' } };
+    writeFileSync(resolve(directory, path, 'skill-report.json'), JSON.stringify(report));
+    execFileSync('git', ['add', '.'], { cwd: directory });
+    execFileSync('git', ['commit', '-qm', 'fixture'], { cwd: directory });
+    const commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: directory, encoding: 'utf8' }).trim();
+    const classification = {
+      schemaVersion: 1, status: 'classified',
+      cohorts: {
+        legacy_algorithm_equivalent: [{ id: 'skill-1', slug: 'legacy-000', path, marketplaceCommit: commit, contentHash: 'b'.repeat(64), treeHash: 'c'.repeat(64), publicEligibilityAuditId: 'audit-1' }],
+        actual_or_unproven_drift: [{ id: 'skill-2', slug: 'drift-000', publicEligibilityAuditId: 'audit-2' }],
+      },
+    };
+    const sourceEvidence = {
+      skills: [{ id: 'skill-1', slug: 'legacy-000' }],
+      audits: [{ id: 'audit-1', skill_id: 'skill-1', version: 3, content_hash: 'd'.repeat(32) }],
+    };
+    const plan = buildLegacyAuditBindingPlan({ classification, sourceEvidence, repositoryRoot: directory });
+    assert.equal(plan.entries.length, 1);
+    assert.equal(plan.entries[0].sourceAuditId, 'audit-1');
+    assert.equal(plan.driftQuarantine[0].artifactGovernanceAllowed, false);
+    assert.match(plan.planSha256, /^[0-9a-f]{64}$/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -229,7 +229,7 @@ function createBoundaryFixture() {
       runId: '12345',
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
-      cliVersion: '2.5.0',
+      cliVersion: '2.7.0',
       cliSha256: '9'.repeat(64),
     },
   });
@@ -257,6 +257,26 @@ test('qualifies only exact v2/v3 source bindings and preserves hash classificati
     sourceEvidence: v3Evidence,
   });
   assert.equal(v3Qualified.governance.eligible[0].reason, 'eligible_v3');
+
+  const legacyEvidence = structuredClone(base.sourceEvidence);
+  legacyEvidence.audits[0].content_hash = payloadHash;
+  legacyEvidence.bindings = [{
+    id: 'binding-1',
+    skill_id: base.row.id,
+    source_audit_id: SOURCE_AUDIT_ID,
+    source_audit_version: legacyEvidence.audits[0].version,
+    source_audit_payload_hash: payloadHash,
+    subject_marketplace_commit_sha: COMMIT,
+    subject_content_hash: LEGACY_CONTENT,
+    subject_tree_hash: LEGACY_TREE,
+    subject_plugin_path: base.row.path,
+    report_object_spec: `${COMMIT}:${base.row.path}/skill-report.json`,
+  }];
+  const legacyQualified = qualifyLegacyGovernanceClassification({
+    classification: base.hashClassification,
+    sourceEvidence: legacyEvidence,
+  });
+  assert.equal(legacyQualified.governance.eligible[0].reason, 'eligible_legacy_binding_v1');
 
   const cases = [
     {
@@ -749,8 +769,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.5\.0'/);
-  assert.match(workflow, /test "\$CLI_VERSION" = '2\.5\.0'/);
+  assert.match(workflow, /default: '2\.7\.0'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.7\.0'/);
   assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
   assert.match(workflow, /batch_size must be between 1 and 500/);
   assert.match(workflow, /dry_run_id/);
@@ -760,8 +780,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /boundaries may only be created from main/);
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
-  assert.match(workflow, /CLI 2\.5\.0 binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/e6110fa711ac570d4c4fa03bf03b57e5857ddc158a54a891500f72eb2023441e/g) || []).length >= 2);
+  assert.match(workflow, /binding-aware CLI binary differs from the frozen dry-run boundary/);
+  assert.ok((workflow.match(/__LEGACY_AUDIT_BINDING_LINUX_SHA256__/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-inventory\.json/);

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -781,7 +781,7 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /binding-aware CLI binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/__LEGACY_AUDIT_BINDING_LINUX_SHA256__/g) || []).length >= 2);
+  assert.ok((workflow.match(/cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-inventory\.json/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const CLI_VERSION = '2.5.0';
+const CLI_VERSION = '2.7.0';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
@@ -36,6 +36,7 @@ export function canonicalSourceEvidence(value) {
     ...value,
     skills: [...(value?.skills || [])].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US')),
     audits: [...(value?.audits || [])].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US')),
+    bindings: [...(value?.bindings || [])].sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US')),
   });
 }
 
@@ -130,7 +131,7 @@ function decodePluginPath(value) {
   return path;
 }
 
-function qualifySourceAudit(audit, row) {
+function qualifySourceAudit(audit, row, legacyBinding) {
   if (
     audit.skill_id !== row.id
     || audit.derived_from_audit_id != null
@@ -142,6 +143,23 @@ function qualifySourceAudit(audit, row) {
     return { eligible: false, reason: 'source_audit_identity_unproven' };
   }
   if (AUDIT_PAYLOAD_HASH_RE.test(audit.content_hash)) {
+    if (
+      legacyBinding
+      && legacyBinding.skill_id === row.id
+      && legacyBinding.source_audit_id === audit.id
+      && legacyBinding.source_audit_version === audit.version
+      && legacyBinding.source_audit_payload_hash === audit.content_hash
+      && legacyBinding.subject_marketplace_commit_sha === row.marketplaceCommit
+      && legacyBinding.subject_content_hash === row.contentHash
+      && legacyBinding.subject_tree_hash === row.treeHash
+      && legacyBinding.subject_plugin_path === row.path
+      && legacyBinding.report_object_spec === `${row.marketplaceCommit}:${row.path}/skill-report.json`
+      && audit.audit_payload_hash === null
+      && audit.subject_marketplace_commit_sha === null
+      && audit.subject_content_hash === null
+      && audit.subject_tree_hash === null
+      && audit.subject_plugin_path === null
+    ) return { eligible: true, reason: 'eligible_legacy_binding_v1' };
     return { eligible: false, reason: 'source_audit_binding_unproven_legacy_digest' };
   }
 
@@ -219,6 +237,7 @@ export function qualifyLegacyGovernanceClassification({ classification, sourceEv
   const legacy = asMap(classification?.cohorts?.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
   const skills = asMap(sourceEvidence.skills, 'id', 'source evidence Skills');
   const audits = asMap(sourceEvidence.audits, 'id', 'source evidence audits');
+  const bindings = asMap(sourceEvidence.bindings || [], 'source_audit_id', 'source evidence bindings');
   if (
     skills.size !== legacy.size
     || audits.size !== legacy.size
@@ -235,7 +254,7 @@ export function qualifyLegacyGovernanceClassification({ classification, sourceEv
     if (!skill || skill.slug !== row.slug || !audit || audit.id !== row.publicEligibilityAuditId) {
       fail(`source evidence identity mismatch for ${row.slug}`);
     }
-    const decision = qualifySourceAudit(audit, row);
+    const decision = qualifySourceAudit(audit, row, bindings.get(audit.id));
     const frozen = {
       slug: row.slug,
       skillId: row.id,


### PR DESCRIPTION
## Summary

- add an exact append-only binding lane for 61 hash-equivalent legacy 32hex audits
- keep all 24 drift rows permanently ineligible for artifact governance
- add binding-aware two-phase artifact governance using CLI 2.7.0
- pin the audited Linux x64 CLI digest in binding, dry-run, and execute paths

## Safety

- never mutates the historical audit row
- binding workflow only records evidence; it does not change artifacts, scores, Packs, or caches
- governance consumes only exact binding evidence and remains CAS/response-loss safe
- all three production paths verify the same CLI digest
- this PR does not dispatch production workflows

## Validation

- `CI=true node --test scripts/tests/legacy-audit-binding-cohorts.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs` (13/13, after rebase)
- `git diff --check`
- CLI 2.7.0 Linux x64 SHA-256: `cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7`
