### PR TITLE
feat(governance): add fresh audit recovery lane

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -1,0 +1,489 @@
+name: Govern Fresh Canonical Audits
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Freeze a no-write fresh-audit boundary, or execute one frozen boundary'
+        type: choice
+        required: true
+        default: dry-run
+        options: [dry-run, execute]
+      cohort_path:
+        description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
+        type: string
+        required: false
+        default: 'governance/fresh-canonical-audit/remaining-lineage.json'
+      start_after:
+        description: 'Exact prior batch end slug; dry-run only'
+        type: string
+        required: false
+        default: ''
+      previous_boundary_run_id:
+        description: 'Immediately preceding successful fresh dry-run boundary; production inventory must prove it was executed'
+        type: string
+        required: false
+        default: ''
+      previous_execute_run_id:
+        description: 'Successful execute run for previous_boundary_run_id; required when start_after is set'
+        type: string
+        required: false
+        default: ''
+      batch_size:
+        description: 'Fresh audits per frozen batch (1-10)'
+        type: number
+        required: true
+        default: 10
+      model:
+        description: 'Fresh audit model override'
+        type: string
+        required: false
+        default: ''
+      dry_run_id:
+        description: 'Successful dry-run workflow run ID; execute only'
+        type: string
+        required: false
+        default: ''
+      cli_version:
+        description: 'Exact audited CLI version'
+        type: string
+        required: true
+        default: '2.8.0'
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+jobs:
+  freeze-boundary:
+    if: inputs.mode == 'dry-run'
+    runs-on: self-hosted
+    timeout-minutes: 360
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Validate dry-run inputs and governance runtime
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+          COHORT_PATH: ${{ inputs.cohort_path }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+          PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
+          PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
+        run: |
+          set -euo pipefail
+          test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
+          test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
+          if test -n "$START_AFTER"; then
+            [[ "$PREVIOUS_BOUNDARY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::cursor continuation requires numeric previous_boundary_run_id'; exit 1; }
+            [[ "$PREVIOUS_EXECUTE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::cursor continuation requires numeric previous_execute_run_id'; exit 1; }
+          else
+            test -z "$PREVIOUS_BOUNDARY_RUN_ID" || { echo '::error::initial batch cannot consume previous_boundary_run_id'; exit 1; }
+            test -z "$PREVIOUS_EXECUTE_RUN_ID" || { echo '::error::initial batch cannot consume previous_execute_run_id'; exit 1; }
+          fi
+          test -f "$COHORT_PATH" || { echo '::error::lineage-unproven cohort is missing'; exit 1; }
+          test -f scripts/prepare-fresh-canonical-audit-batch.mjs
+          test -f .github/actions/download-skillstore-cli/action.yml
+
+      - name: Authenticate the immediately preceding boundary chain
+        if: inputs.start_after != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
+          PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$PREVIOUS_BOUNDARY_RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$PREVIOUS_BOUNDARY_RUN_ID" '.databaseId==$id and .conclusion=="success" and .event=="workflow_dispatch" and .headBranch=="main" and .workflowName=="Govern Fresh Canonical Audits"' <<< "$run_json" >/dev/null
+          mkdir -p "$RUNNER_TEMP/previous-boundary"
+          gh run download "$PREVIOUS_BOUNDARY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-boundary-$PREVIOUS_BOUNDARY_RUN_ID" \
+            --dir "$RUNNER_TEMP/previous-boundary"
+          (cd "$RUNNER_TEMP/previous-boundary" && sha256sum --check SHA256SUMS)
+          test "$(jq -r .lastSelected "$RUNNER_TEMP/previous-boundary/metadata.json")" = "$START_AFTER"
+          test "$(jq -r .lastSelected "$RUNNER_TEMP/previous-boundary/selected-cohort.json")" = "$START_AFTER"
+          jq -n --slurpfile metadata "$RUNNER_TEMP/previous-boundary/metadata.json" \
+            --slurpfile selection "$RUNNER_TEMP/previous-boundary/selected-cohort.json" \
+            '{metadata:$metadata[0],selection:$selection[0]}' > "$RUNNER_TEMP/previous-boundary-chain-base.json"
+
+          execute_json=$(gh run view "$PREVIOUS_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$PREVIOUS_EXECUTE_RUN_ID" '.databaseId==$id and .conclusion=="success" and .event=="workflow_dispatch" and .headBranch=="main" and .workflowName=="Govern Fresh Canonical Audits"' <<< "$execute_json" >/dev/null
+          mkdir -p "$RUNNER_TEMP/previous-execution"
+          gh run download "$PREVIOUS_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-execution-$PREVIOUS_EXECUTE_RUN_ID" \
+            --dir "$RUNNER_TEMP/previous-execution"
+          (cd "$RUNNER_TEMP/previous-execution/boundary" && sha256sum --check SHA256SUMS)
+          cmp "$RUNNER_TEMP/previous-boundary/SHA256SUMS" \
+            "$RUNNER_TEMP/previous-execution/boundary/SHA256SUMS"
+          (cd "$RUNNER_TEMP/previous-execution/execution-proof" && sha256sum --check SHA256SUMS)
+          proof="$RUNNER_TEMP/previous-execution/execution-proof/proof.json"
+          jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
+            --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
+            --arg executeHeadSha "$(jq -r .headSha <<< "$execute_json")" \
+            '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
+            "$proof" >/dev/null
+          test "$(jq -r .cohortSha256 "$proof")" = "$(jq -r .cohortSha256 "$RUNNER_TEMP/previous-boundary/metadata.json")"
+          test "$(jq -r .executedCount "$proof")" = "$(jq -r .count "$RUNNER_TEMP/previous-boundary/selected-cohort.json")"
+          test "$(jq -r .executionResultsSha256 "$proof")" = "$(sha256sum "$RUNNER_TEMP/previous-execution/execution-results.json" | awk '{print $1}')"
+          test "$(jq -r .postInventorySha256 "$proof")" = "$(sha256sum "$RUNNER_TEMP/previous-execution/post-inventory.json" | awk '{print $1}')"
+          jq -e --slurpfile selected "$RUNNER_TEMP/previous-boundary/selected-cohort.json" '
+            [$selected[0].rows[].skillId] as $ids |
+            [.rows[] | select(.id as $id | $ids | index($id))] as $rows |
+            ($rows|length)==($ids|length) and all($rows[]; .artifact_revision>=1 and (.current_artifact_version_id|type)=="string")
+          ' "$RUNNER_TEMP/previous-execution/post-inventory.json" >/dev/null
+          jq -n --slurpfile chain "$RUNNER_TEMP/previous-boundary-chain-base.json" \
+            --slurpfile proof "$proof" \
+            '$chain[0] + {executionProof:$proof[0]}' > "$RUNNER_TEMP/previous-boundary-chain.json"
+
+      - name: Fetch exact production cursor inventory
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-artifact-version-inventory.mjs --skills-only \
+            --output "$RUNNER_TEMP/pre-inventory.json"
+
+      - name: Select one bounded cohort from immutable lineage evidence
+        id: plan
+        env:
+          COHORT_PATH: ${{ inputs.cohort_path }}
+          START_AFTER: ${{ inputs.start_after }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+        run: |
+          set -euo pipefail
+          continuation_args=()
+          test -z "$START_AFTER" || continuation_args=(--previous-boundary "$RUNNER_TEMP/previous-boundary-chain.json")
+          node scripts/prepare-fresh-canonical-audit-batch.mjs \
+            --repository-root "$GITHUB_WORKSPACE" --cohort "$COHORT_PATH" \
+            --start-after "$START_AFTER" --batch-size "$BATCH_SIZE" \
+            --production-inventory "$RUNNER_TEMP/pre-inventory.json" \
+            "${continuation_args[@]}" \
+            --output "$RUNNER_TEMP/selected-cohort.json"
+          echo "count=$(jq -r .count "$RUNNER_TEMP/selected-cohort.json")" >> "$GITHUB_OUTPUT"
+          echo "last_selected=$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" >> "$GITHUB_OUTPUT"
+          echo "remaining=$(jq -r .remaining "$RUNNER_TEMP/selected-cohort.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Materialize only frozen commit-addressed paths
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/materialized"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            target="$root/$commit"
+            mkdir -p "$target"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$target"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/selected-cohort.json")
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact fresh-governance CLI 2.8.0
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.8.0'
+          minimum-version: '2.8.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Hard-block until the released Linux binary digest is audited
+        run: |
+          set -euo pipefail
+          audited='TODO_RELEASE_CLI_2_8_0_SHA256'
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO before any run'; exit 1; }
+          test "$actual" = "$audited" || { echo '::error::CLI 2.8.0 digest mismatch'; exit 1; }
+
+      - name: Run genuinely fresh audits against each frozen commit
+        env:
+          SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+          MODEL: ${{ inputs.model }}
+        run: |
+          set -euo pipefail
+          run_nonce=$(node -e "process.stdout.write(require('node:crypto').randomUUID())")
+          run_started_at=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)
+          mkdir -p "$RUNNER_TEMP/fresh-audit-manifests"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            slugs=$(jq -r '.slugs | join(",")' <<< "$group")
+            count=$(jq -r .count <<< "$group")
+            model_args=()
+            test -z "$MODEL" || model_args=(--model "$MODEL")
+            "$GITHUB_WORKSPACE/skillstore-cli" skill audit \
+              "$RUNNER_TEMP/materialized/$commit/skills" --slugs "$slugs" \
+              --checkpoint-file "$RUNNER_TEMP/audit-$commit.checkpoint.json" \
+              --correlation-id "$GITHUB_RUN_ID-$commit" \
+              --fresh-run-manifest-file "$RUNNER_TEMP/fresh-audit-manifests/$commit.json" \
+              --fresh-run-nonce "$run_nonce" --fresh-run-id "$GITHUB_RUN_ID" \
+              --fresh-run-started-at "$run_started_at" --fresh-selected-count "$count" \
+              "${model_args[@]}"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/selected-cohort.json")
+          jq -s --arg nonce "$run_nonce" --arg runId "$GITHUB_RUN_ID" --arg startedAt "$run_started_at" '
+            if length == 0 or any(.runNonce != $nonce or .runId != $runId or .startedAt != $startedAt or .status != "fresh_audit_run_complete") then error("fresh audit group manifest mismatch") else {
+              schemaVersion:1,status:"fresh_audit_run_complete",runNonce:$nonce,runId:$runId,startedAt:$startedAt,
+              selectedCount:(map(.selectedCount)|add),selectedSlugs:(map(.selectedSlugs[])|sort),completed:(map(.completed[])|sort_by(.slug))
+            } end' "$RUNNER_TEMP"/fresh-audit-manifests/*.json > "$RUNNER_TEMP/fresh-audit-run.json"
+          test "$(jq -r .selectedCount "$RUNNER_TEMP/fresh-audit-run.json")" = "$(jq -r .count "$RUNNER_TEMP/selected-cohort.json")"
+          diff -u <(jq -S '.selectedSlugs' "$RUNNER_TEMP/fresh-audit-run.json") \
+            <(jq -S '[.rows[].slug] | sort' "$RUNNER_TEMP/selected-cohort.json")
+
+      - name: Freeze production CAS and fresh v3 audit evidence without writes
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/skillstore-cli" skill govern-fresh-canonical-audit \
+            --cohort "$RUNNER_TEMP/selected-cohort.json" \
+            --audit-run-manifest "$RUNNER_TEMP/fresh-audit-run.json" \
+            --root "$RUNNER_TEMP/materialized" --dry-run \
+            --result-file "$RUNNER_TEMP/fresh-boundary.json"
+
+      - name: Freeze exact audited reports and execution boundary
+        env:
+          COHORT_PATH: ${{ inputs.cohort_path }}
+        run: |
+          set -euo pipefail
+          boundary="$RUNNER_TEMP/fresh-canonical-boundary"
+          mkdir -p "$boundary/reports" "$boundary/runtime/.github/workflows" \
+            "$boundary/runtime/.github/actions/download-skillstore-cli" "$boundary/runtime/scripts"
+          cp "$RUNNER_TEMP/selected-cohort.json" "$boundary/selected-cohort.json"
+          cp "$RUNNER_TEMP/fresh-boundary.json" "$boundary/fresh-boundary.json"
+          cp "$RUNNER_TEMP/fresh-audit-run.json" "$boundary/fresh-audit-run.json"
+          cp "$RUNNER_TEMP/pre-inventory.json" "$boundary/pre-inventory.json"
+          cp .github/workflows/govern-fresh-canonical-audits.yml \
+            "$boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
+          cp .github/actions/download-skillstore-cli/action.yml \
+            "$boundary/runtime/.github/actions/download-skillstore-cli/action.yml"
+          cp scripts/prepare-fresh-canonical-audit-batch.mjs \
+            "$boundary/runtime/scripts/prepare-fresh-canonical-audit-batch.mjs"
+          while IFS=$'\t' read -r commit path; do
+            source="$RUNNER_TEMP/materialized/$commit/$path/skill-report.json"
+            target="$boundary/reports/$commit/$path/skill-report.json"
+            mkdir -p "$(dirname "$target")"
+            cp "$source" "$target"
+          done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
+          jq -n \
+            --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.0' \
+            --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
+            --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
+            --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
+            --arg previousBoundaryRunId '${{ inputs.previous_boundary_run_id }}' \
+            --arg previousExecuteRunId '${{ inputs.previous_execute_run_id }}' \
+            --arg cohortSha256 "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" \
+            --arg preInventorySha256 "$(sha256sum "$RUNNER_TEMP/pre-inventory.json" | awk '{print $1}')" \
+            '{schemaVersion:1,status:"fresh_canonical_audit_frozen",runId:$runId,repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,cliSha256:$cliSha256,cohortPath:$cohortPath,cohortSha256:$cohortSha256,startAfter:$startAfter,lastSelected:$lastSelected,previousBoundaryRunId:$previousBoundaryRunId,previousExecuteRunId:$previousExecuteRunId,preInventorySha256:$preInventorySha256}' \
+            > "$boundary/metadata.json"
+          (cd "$boundary" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+
+      - name: Upload strict fresh-audit boundary
+        uses: actions/upload-artifact@v6
+        with:
+          name: fresh-canonical-audit-boundary-${{ github.run_id }}
+          path: ${{ runner.temp }}/fresh-canonical-boundary/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish no-write boundary summary
+        run: |
+          {
+            echo '## Fresh canonical audit boundary'
+            echo "- Selected: \`${{ steps.plan.outputs.count }}\` (maximum 10)"
+            echo "- Last selected: \`${{ steps.plan.outputs.last_selected }}\`"
+            echo "- Remaining: \`${{ steps.plan.outputs.remaining }}\`"
+            echo '- Every report is a new v3 audit over an exact historical commit/path; no production write occurred.'
+            echo "- Execute with \`dry_run_id=$GITHUB_RUN_ID\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  execute-boundary:
+    if: inputs.mode == 'execute'
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
+    runs-on: self-hosted
+    timeout-minutes: 180
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Validate execute inputs
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
+          test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
+          [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
+          test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
+
+      - name: Download and authenticate the successful frozen boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$DRY_RUN_ID" '.databaseId==$id and .conclusion=="success" and .event=="workflow_dispatch" and .headBranch=="main" and .workflowName=="Govern Fresh Canonical Audits"' <<< "$run_json" >/dev/null
+          mkdir -p "$RUNNER_TEMP/boundary"
+          gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-boundary-$DRY_RUN_ID" --dir "$RUNNER_TEMP/boundary"
+          (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
+          test "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/metadata.json")" = "$(jq -r .headSha <<< "$run_json")"
+          git merge-base --is-ancestor "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/metadata.json")" "$GITHUB_SHA"
+          cmp .github/workflows/govern-fresh-canonical-audits.yml \
+            "$RUNNER_TEMP/boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
+          cmp .github/actions/download-skillstore-cli/action.yml \
+            "$RUNNER_TEMP/boundary/runtime/.github/actions/download-skillstore-cli/action.yml"
+          cmp scripts/prepare-fresh-canonical-audit-batch.mjs \
+            "$RUNNER_TEMP/boundary/runtime/scripts/prepare-fresh-canonical-audit-batch.mjs"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact audited CLI 2.8.0
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.8.0'
+          minimum-version: '2.8.0'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify frozen CLI identity
+        run: |
+          set -euo pipefail
+          audited='TODO_RELEASE_CLI_2_8_0_SHA256'
+          expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
+          actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO'; exit 1; }
+          test "$expected" = "$audited" && test "$actual" = "$audited"
+
+      - name: Rematerialize exact source and overlay only frozen fresh reports
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/materialized"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            target="$root/$commit"
+            mkdir -p "$target"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$target"
+          done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/selected-cohort.json")
+          while IFS=$'\t' read -r commit path; do
+            cp "$RUNNER_TEMP/boundary/reports/$commit/$path/skill-report.json" \
+              "$root/$commit/$path/skill-report.json"
+          done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$RUNNER_TEMP/boundary/selected-cohort.json")
+
+      - name: Execute resumable compound governance, score, and cache closure
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SKILLSTORE_SITE_URL: https://skillstore.io
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/skillstore-cli" skill govern-fresh-canonical-audit \
+            --boundary "$RUNNER_TEMP/boundary/fresh-boundary.json" \
+            --root "$RUNNER_TEMP/materialized" \
+            --result-file "$RUNNER_TEMP/execution-results.json"
+
+      - name: Fetch exact post-execution artifact and Pack evidence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          jq '{schemaVersion:1,scopedSkillIds:[.rows[].skillId],rows:.rows}' \
+            "$RUNNER_TEMP/boundary/selected-cohort.json" > "$RUNNER_TEMP/scope.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$RUNNER_TEMP/scope.json" --output "$RUNNER_TEMP/post-inventory.json"
+          test "$(jq -r '[.artifacts[] | select(.artifact_revision==1)] | length' "$RUNNER_TEMP/post-inventory.json")" \
+            = "$(jq -r .count "$RUNNER_TEMP/boundary/selected-cohort.json")"
+          test "$(jq --slurpfile scope "$RUNNER_TEMP/scope.json" -r '[.rows[] as $row | select(($scope[0].scopedSkillIds | index($row.id)) != null) | select($row.artifact_revision==1 and $row.current_artifact_version_id!=null)] | length' "$RUNNER_TEMP/post-inventory.json")" \
+            = "$(jq -r .count "$RUNNER_TEMP/boundary/selected-cohort.json")"
+
+      - name: Checkout current Skillstore production smoke harness
+        uses: actions/checkout@v5
+        with:
+          repository: aiskillstore/skillstore
+          token: ${{ steps.app-token.outputs.token }}
+          path: skillstore-smoke
+
+      - name: Verify every P0/P1 download, install, NPX, Pack, and MCP channel
+        env:
+          SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0.1.9,skillstore@latest
+          SMOKE_EXPECTED_PUBLIC_CLI_VERSION: 0.1.9
+          SMOKE_EXPECTED_SIGNING_KEY_ID: EP0Myk7rTk_J0RdG1fvpkP
+          SMOKE_EXPECTED_SIGNING_PUBLIC_KEY_X: 2tbC6eNY4T9sx4Pvuo_NwHlXGyWWz95WAtHyHUTqzs8
+          SMOKE_EXPECT_INTERACTION_RECOVERY: true
+        run: >-
+          node skillstore-smoke/scripts/smoke/production-smoke.mjs
+          --base-url https://skillstore.io
+          --attempts 3
+          --retry-ms 3000
+
+      - name: Seal successful execute closure for the next cursor
+        run: |
+          set -euo pipefail
+          expected=$(jq -r .count "$RUNNER_TEMP/boundary/selected-cohort.json")
+          test "$(jq length "$RUNNER_TEMP/execution-results.json")" = "$expected"
+          proof="$RUNNER_TEMP/execution-proof"
+          mkdir -p "$proof"
+          jq -n \
+            --arg executeRunId "$GITHUB_RUN_ID" --arg dryRunId '${{ inputs.dry_run_id }}' \
+            --arg workflowCommit "$GITHUB_SHA" \
+            --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/boundary/selected-cohort.json")" \
+            --arg cohortSha256 "$(jq -r .cohortSha256 "$RUNNER_TEMP/boundary/metadata.json")" \
+            --arg executionResultsSha256 "$(sha256sum "$RUNNER_TEMP/execution-results.json" | awk '{print $1}')" \
+            --arg postInventorySha256 "$(sha256sum "$RUNNER_TEMP/post-inventory.json" | awk '{print $1}')" \
+            --argjson executedCount "$expected" \
+            '{schemaVersion:1,status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
+            > "$proof/proof.json"
+          (cd "$proof" && sha256sum proof.json > SHA256SUMS)
+
+      - name: Upload execution and smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: fresh-canonical-audit-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/boundary/
+            ${{ runner.temp }}/execution-results.json
+            ${{ runner.temp }}/post-inventory.json
+            ${{ runner.temp }}/execution-proof/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish verified execution summary
+        run: |
+          {
+            echo '## Fresh canonical audit execution verified'
+            echo "- Frozen boundary: \`${{ inputs.dry_run_id }}\`"
+            echo "- Executed: \`$(jq length "$RUNNER_TEMP/execution-results.json")\`"
+            echo '- Canonical r1, independent v3 source audits, fresh scores, cache/Pack closure, and all production P0/P1 install channels passed.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='TODO_RELEASE_CLI_2_8_0_SHA256'
+          audited='ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO before any run'; exit 1; }
           test "$actual" = "$audited" || { echo '::error::CLI 2.8.0 digest mismatch'; exit 1; }
@@ -377,7 +377,7 @@ jobs:
       - name: Verify frozen CLI identity
         run: |
           set -euo pipefail
-          audited='TODO_RELEASE_CLI_2_8_0_SHA256'
+          audited='ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO'; exit 1; }

--- a/governance/fresh-canonical-audit/remaining-lineage.json
+++ b/governance/fresh-canonical-audit/remaining-lineage.json
@@ -1,0 +1,1533 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-15T10:07:46.861Z",
+  "repository": "aiskillstore/marketplace",
+  "status": "lineage_unproven",
+  "count": 106,
+  "counts": {
+    "same_source_tree_unproven": 24,
+    "source_changed_after_report_subject": 82
+  },
+  "sourceBoundaries": [
+    {
+      "runId": "29391353646",
+      "classificationSha256": "fbc52726aad4ffbb7646e9eef4cb07c0d36d3d7b394b4c5d8bf6ecf3a33367cf"
+    },
+    {
+      "runId": "29391998167",
+      "classificationSha256": "f26842b5596caf8214cec91cedbdd70a4eaeff535ecf48f776dee20c3c6a64ad"
+    },
+    {
+      "runId": "29392177791",
+      "classificationSha256": "a8c4235a607396bde82af2bf31bbd54fd659d330b07ea8ae0d027452e276a41b"
+    },
+    {
+      "runId": "29394223576",
+      "classificationSha256": "5fd6a2acd687c4a243a6857e06831b0814bb486b66e4864c2d9ded5d869137b2"
+    },
+    {
+      "runId": "29402463151",
+      "classificationSha256": "b77f94af0f4400ade13f8cc3bde678f9602ec736f738003eb143f76a7d77f665"
+    },
+    {
+      "runId": "29403013907",
+      "classificationSha256": "1324584ef97640aab569969e99999dcaf99a6f3926dc9246d1c08aaf63f5cb7c"
+    },
+    {
+      "runId": "29403882694",
+      "classificationSha256": "2a1f384d5d6139a7d6f77d9f02e60e61133cce59fddc171bdc6f066ab2cee836"
+    }
+  ],
+  "method": {
+    "reportOrigin": "last first-parent commit changing the same-path skill-report.json",
+    "treeHashScheme": "legacy_path_sha256_merkle_previous_report_v1",
+    "inputRelation": "canonical_install_plus_previous_generated_report",
+    "sourceSetIdentity": "canonical JSON of sorted non-report path, mode, git blob, sha256 entries"
+  },
+  "rows": [
+    {
+      "slug": "101-skills-agent-browser",
+      "skillId": "282fe060-c545-45ed-8acf-6701dc05e1bc",
+      "path": "skills/101-skills/agent-browser",
+      "marketplaceCommit": "d71c7417a35d5c2624161bd2fe8de8a41a362128",
+      "reportContentHash": "433ed471ceca49f696ba72856894860594a5dccbcac82da61797ae7a3a3ebfef",
+      "reportTreeHash": "9217592db0c540dbb41db26b2a752f111a2b3008d156a9cfe4edc7f56b71639d",
+      "canonicalArtifact": {
+        "contentHash": "433ed471ceca49f696ba72856894860594a5dccbcac82da61797ae7a3a3ebfef",
+        "treeHash": "efb3a5c2872f1f029609b8b1b25768a3862f787750acdbbc6626ac4a262e5cae"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "2025emma-twscrape",
+      "skillId": "d965034f-be4c-4b07-8fe8-74a3c68fa6f8",
+      "path": "skills/2025emma/twscrape",
+      "marketplaceCommit": "e9e4712298ed071d92417a41714be123eb8364fa",
+      "reportContentHash": "bc5c2914477268281acaf94f2bd0618624199b07fbefd156c07e1a5a04def0f5",
+      "reportTreeHash": "05b7352b22ac59ac91638586adc501d1cbf7610d115a380cda7007706944e740",
+      "canonicalArtifact": {
+        "contentHash": "50cfe9c06c3acfefb9a82b674cf6b494fd8126cff67e58e79dea0514f2553e72",
+        "treeHash": "02dddc02ebcaac5aee5064c4e93bde1e5d8563c47e27689ea5fc6f87f1e207af"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "89jobrien-git-commit-helper",
+      "skillId": "bff3cd0d-6ea9-443a-8950-c615a6326f42",
+      "path": "skills/89jobrien/git-commit-helper",
+      "marketplaceCommit": "c4037264bbd363c572662d6154a3ab28f5ca4f53",
+      "reportContentHash": "eaa786e8c12c85e7f4a7fe449cdde208dc0e02f725c0c3985f2c5d483a3b5325",
+      "reportTreeHash": "396b5767ce5259f5d5b1e7784c157d48d27c64d1534e282f542edbffe493e1e5",
+      "canonicalArtifact": {
+        "contentHash": "c5e1458d8bc0dac922f6632a4ab28f612f6c27cc374b4f34330087f7fc1fef87",
+        "treeHash": "959607e7ab6b03458bd5ebf67280bfe395787caaa925421fe3d589223e22d5ed"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "89jobrien-pdf-processing",
+      "skillId": "0507e276-3182-4887-84fa-523f86e13b4a",
+      "path": "skills/89jobrien/pdf-processing",
+      "marketplaceCommit": "c4037264bbd363c572662d6154a3ab28f5ca4f53",
+      "reportContentHash": "1309a756ddbbb03331c2b63969d9a74960cb2a691d41f59142b89d3f84e8bf90",
+      "reportTreeHash": "1df5762f93e18e1855dd2ab9ff9a81a5f11d149361f4b587a944e2927a634ffc",
+      "canonicalArtifact": {
+        "contentHash": "b36b71cdea4cc738307f7a9bfec6b7d100adb45f1cf13e0c0243113ec7abf86d",
+        "treeHash": "db97aceff2487d7cca540aea60c8221e1e7f7419df2ff98ec15c4967aa315ac4"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "aaronabuusama-prompting",
+      "skillId": "6a2d8575-be3d-4765-83e4-00bbc7dbc98a",
+      "path": "skills/aaronabuusama/prompting",
+      "marketplaceCommit": "2e36836131679643f7a49e4cfff588d67adc404b",
+      "reportContentHash": "ceaa98f4ff0ee951fc4410de8a7832fb841a8c1a7d4bbae8bf2efbb5fae9b950",
+      "reportTreeHash": "9e91af3665c8d7e864e0489bff34ce5bf2b8514e7f9f9c559f21d7ec616d8150",
+      "canonicalArtifact": {
+        "contentHash": "ceaa98f4ff0ee951fc4410de8a7832fb841a8c1a7d4bbae8bf2efbb5fae9b950",
+        "treeHash": "f0bff9d6be56d4e1be4749a0377f01c2f9bcab76eacdf3c220606ee47cea4bbd"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "aaronabuusama-smc-harness",
+      "skillId": "5e1d6516-9f13-4b25-bcc5-996837a1bd5c",
+      "path": "skills/aaronabuusama/smc-harness",
+      "marketplaceCommit": "2e36836131679643f7a49e4cfff588d67adc404b",
+      "reportContentHash": "8a871efe4e95efc79edfccf2da3c2dc3a0998927e704711883cf87647f8c3460",
+      "reportTreeHash": "3865ab0fffd43af7d068ea39ad0b61c711a5a173c3859dbef941b2534a8333a8",
+      "canonicalArtifact": {
+        "contentHash": "8a871efe4e95efc79edfccf2da3c2dc3a0998927e704711883cf87647f8c3460",
+        "treeHash": "ff204ebed83412aa20322e61e104c1a3a4143f66195c007b3788b3e76cc05051"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdul-haseeb360-api-jwt-authenticator",
+      "skillId": "90dc73bb-e8f1-48f1-95ee-e3547dcd5aa0",
+      "path": "skills/abdul-haseeb360/api-jwt-authenticator",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "b0257ce489bf09a63547acc588bd08d7329ca2e8ef03b6d6d18b9781c62876d8",
+      "reportTreeHash": "df737903692f4a5bf98d5ad65b5008fb645ac3d3bbc68d28797d77d0bace94f4",
+      "canonicalArtifact": {
+        "contentHash": "11f93dbe6a616b145cb3ff127ac2f3c7098ba39e22d66aba0275bcdf7556fbdf",
+        "treeHash": "295db5d9a04b4298de6106b8411870088592e8698d363521c67aa235c6f5ef8d"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdul-haseeb360-crud-with-spec-kit",
+      "skillId": "ad24069b-ad81-41c6-a0dc-fd65ed05bf52",
+      "path": "skills/abdul-haseeb360/crud-with-spec-kit",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "9d3c34d268b22c55d1d3f44b1bd63be56205e1f2ef834306f8f3a2fb38a29a34",
+      "reportTreeHash": "57f5fddd9c656636c9c30e8cbce1562f6001b90f2e77214e2a4062ff09543f20",
+      "canonicalArtifact": {
+        "contentHash": "07f12106c12a903bea6b5dee5d5e505cb3dce01e3c2d180d918e36a23107a211",
+        "treeHash": "4df4771bcb23949fafa81d9013622403621031de113367353003755f0097ceab"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdul-haseeb360-frontend-api-client-with-jwt",
+      "skillId": "e48c18f2-a06e-43e0-b438-385bb5dbf7bd",
+      "path": "skills/abdul-haseeb360/frontend-api-client-with-jwt",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "529e3794656c250b7304710ba9451184b5dd7f54efaff9614d8e94cc750bf154",
+      "reportTreeHash": "95fd73b582c5f23582d12993e5f754c55d1fdbc1bfb6bf57b51ab3f7a001d73e",
+      "canonicalArtifact": {
+        "contentHash": "68efc3b7b7e7c39ec31503f5efb2f969a517c5a38fb0342be3748bcadb3a5112",
+        "treeHash": "4258cb4c58b7061519773fe339e9578d0cc20afc40b17b1085a20f486492ea8d"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdul-haseeb360-next-js-better-auth-integration",
+      "skillId": "ed6e0d2e-98cb-4396-9748-b79f81a3023a",
+      "path": "skills/abdul-haseeb360/next-js-better-auth-integration",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "02567aa45b927401022f34fa2d5b87aeedf395d4fa0ba7a0d75d663207daed45",
+      "reportTreeHash": "87ba4dd7021b41f1f413a5b1265afb517ad0c5f70b580e297bc8d72db2960b54",
+      "canonicalArtifact": {
+        "contentHash": "89adf1372568572aaf547889ae8d22b0cbd7d7f207a3beb6befe972f5081a08b",
+        "treeHash": "3f5d62346bab3b94581ced71fd8448f2b9e18acc3e8bad098308c48bfe07e041"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdul-haseeb360-spec-kit-claude-code-workflow",
+      "skillId": "95669e7d-2f03-47d0-aafd-1f0b54d09ca8",
+      "path": "skills/abdul-haseeb360/spec-kit-claude-code-workflow",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "b4ebde0dece4a7121e283f3c0888436d58f3f27423ce571df660889a63d76f3b",
+      "reportTreeHash": "f9054709574de9a1e7b3f41b8cfa5f320164cccef081d01e8deca17e3d28f7a6",
+      "canonicalArtifact": {
+        "contentHash": "9c0c309aecfdde5d213aa9e5d8dc912479cb3797ec1dd4e772d06cb5e99698c4",
+        "treeHash": "de103a8d167a41bea9e3c61e5dd359bc1626548a8511c75d0d1a27e2be7d4350"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-authentication-logic",
+      "skillId": "45bf8d7d-d35d-4be1-985b-b59e360e13ed",
+      "path": "skills/abdulsamad94/authentication-logic",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "25ea73ec22a3929625cd173092d45655e456dbfd9a501c94189c5c8118a41bae",
+      "reportTreeHash": "f4079034c7d6d3c7595f3897a21d2a26c9abbf1f4885165afa702cdd7a9732ac",
+      "canonicalArtifact": {
+        "contentHash": "ac21517a3a598032230796ff5b6de069f61e97952d83ec5ede564d99afc37690",
+        "treeHash": "acf62e2d2ce925e184f8bc9e06001d6de44ec789dc9d580655e6dfca89bfa5b2"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-backend-fastapi",
+      "skillId": "6a8c35b4-86f3-4de3-9b37-f1683100b1b8",
+      "path": "skills/abdulsamad94/backend-fastapi",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "7284f8a621da4861cff2bef69813355a23cb0bae7e84d2adc4866f20839808f0",
+      "reportTreeHash": "4b15374903b26d522f24089f8596ddd6c920301700d43bdf6381d0fc91e754bb",
+      "canonicalArtifact": {
+        "contentHash": "7a3b26c3a1f12c57cee0d3f17e57da4280d0bb9b8b2fbd5e82f449325dfae3ed",
+        "treeHash": "ddba62fb086cab9754b2846984523a9e03d24e0161e4230a6ce04cfd3c6d851d"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-chapter-analyzer",
+      "skillId": "ed2fe8fa-c938-4d90-a9df-1a86b9e5b514",
+      "path": "skills/abdulsamad94/chapter-analyzer",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "db57284592bdb6201b2079cc57322816f45ccabb60ab1226856d3ebb8ef9b0f0",
+      "reportTreeHash": "89e6a06274404273c1da49588fe01257e8a60a2fced09093447f5f2bff415721",
+      "canonicalArtifact": {
+        "contentHash": "a446e9a0c0947e4d4df4bd50a52a8a626fdf4e18e623feb7f67c617e96d5c320",
+        "treeHash": "bac3d1521be5cdbb567e902f97bcc6ed2e8a97ba16fb0d0e9407dc1d6a864f9c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-chatbot-implementation",
+      "skillId": "3c78a0bd-279c-4223-8e5c-ff880baed348",
+      "path": "skills/abdulsamad94/chatbot-implementation",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "1eae79ec8710fe0e5ab2c4ca40b191b1e685ba6e91db498f243be76c008f546b",
+      "reportTreeHash": "66d43b1ea9b19da8be13b2b86542eea29f6e92c6f7d4a1b1b7eb2734028615e5",
+      "canonicalArtifact": {
+        "contentHash": "37f165b120226c7c58d2b90751f39bc48b0f0c400072a91831b7daa17a8b3e83",
+        "treeHash": "342997ad65c70629366bd0d6a0e12ec2af9c3ad17b46264f52e3e0c0cd45f4eb"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-deployment-build",
+      "skillId": "48a37774-2717-4f07-97ef-a22bedc8a154",
+      "path": "skills/abdulsamad94/deployment-build",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "73708a8d4888c2305e18629c05d5fc21e573ef779d6b45dd380528b9c74d3db8",
+      "reportTreeHash": "8b086d574a664a1facc861c97b96c1fc6c4e9043f8af0d2e3693eaa9b28d36ea",
+      "canonicalArtifact": {
+        "contentHash": "c8de8b63385aad087fab990105a1f6333cf77e28161dc22b9c755273c6e9c2f7",
+        "treeHash": "8505fdd0a2a8bf5e667e6bd5751845ec0966666d6c499e5e400b81eb96dd7a00"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-devops-quality",
+      "skillId": "8fe835c2-dd73-4448-994e-ab8d0762ce3d",
+      "path": "skills/abdulsamad94/devops-quality",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "7102224528c76b50b55217185d2235a06bc123bc9edd5a4d1c1b085fd1301a84",
+      "reportTreeHash": "cf5d1dc29f751b9591249ea4e41ff875e4b3f93a3be5c3526a0499c8cfce6be4",
+      "canonicalArtifact": {
+        "contentHash": "9a6f32ab5d1b4f2ad7ccab9abe40d874ac99afb2d4e4ab926da27c34152674ba",
+        "treeHash": "f89320a6d93c0513dd19fb1569b0e5ca644ce73e0c350b70951ab6db84a0b997"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-docusaurus-advanced",
+      "skillId": "b6094c96-2eeb-4d59-8da5-7b82561b1b9d",
+      "path": "skills/abdulsamad94/docusaurus-advanced",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "4a2c82e4cda60fbd7b1b2e7869b7843abd6f4e02c032aecc1064266cb0d01251",
+      "reportTreeHash": "9c989095f1d98f71d05b722e8d7b164d75b3eb3060cd5e9f40578a73f65a3e99",
+      "canonicalArtifact": {
+        "contentHash": "7a354b4abfb1fd3308d4e045e818e7cb1fee86c72006894fad84ce866246636f",
+        "treeHash": "f3c090b8777274f33798fd03f9e1149548f0eea4cb95b43ea5bd40290ec9a1cf"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-next-js-patterns",
+      "skillId": "2d189b3c-1467-4714-ae89-999ac21e8b74",
+      "path": "skills/abdulsamad94/next-js-patterns",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "00d872112f0a5607508b640537e4a79e8a4ac55c85af40441f8e062b81f38b50",
+      "reportTreeHash": "71d5e5e0ed8d41fe9d3625af0381d2efe11948c42906302b8a20b3ef069baa51",
+      "canonicalArtifact": {
+        "contentHash": "1b265ebe35aaedbb362ef578e4759327b649f573e1dfd98647ae41f57e250356",
+        "treeHash": "8fa161afddc1100e8b75acde5cda6d498b5588a1a7e8387f61aa10c9405b62e1"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-project-architecture",
+      "skillId": "92aaf3b5-318b-4308-a05e-c5d1d46f53ad",
+      "path": "skills/abdulsamad94/project-architecture",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "eac95897a1ee49b6d7ec126667cab7455006542de7ad9611264cbf8da534780c",
+      "reportTreeHash": "060f2dea2973cb055d86fc51e287efead9da25edb07aa7bf6f3295526f2e06eb",
+      "canonicalArtifact": {
+        "contentHash": "8860dd2f041d6c3e78b84a1db5f66204e4675d0106f1524334a223650603b410",
+        "treeHash": "cf39b9df0c81ea3355936477a531f07458639c0bceb2029a1dda8470d1f38312"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-rag-pipeline",
+      "skillId": "9cd0d5b3-bf60-451b-8621-1985c4fe0625",
+      "path": "skills/abdulsamad94/rag-pipeline",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "50ad6c04be029eb8a7879c34ce08c4a301b0c62e55c20d3db204bbfd1d996196",
+      "reportTreeHash": "58aba2efa35cfafd0caa1cfb0f6b2aef570c5daa6b76e96fa4e444b2c0b3dbd2",
+      "canonicalArtifact": {
+        "contentHash": "f7dc70ef14db8e99127f7f084cbd298e80c9aa1741c46a64c02c6941eab9d1cd",
+        "treeHash": "53b088d85fd149a3826a2210ec919af881ff84a82a69ae8a6a99073075ac676b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-robotics-subject-expert",
+      "skillId": "d3995911-27fa-4460-be68-04651a43b894",
+      "path": "skills/abdulsamad94/robotics-subject-expert",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "be8ab45d55661ed08d161f083809c0362a0e95d9f16a7d679ce99268bd76135e",
+      "reportTreeHash": "52374fd5ad1a408a0e365b2b42ee5325afd3cc5f526731bf8fc8076236f04e4f",
+      "canonicalArtifact": {
+        "contentHash": "abe6f2713490aa2da9aa0570ba2b5240f7bdb45d70a42564fb870212e4c69c47",
+        "treeHash": "027d9ad486006e4338b92b1a113818bdbc3d50390a63ae2182415adc6eb24e73"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "abdulsamad94-ui-design-system",
+      "skillId": "65d9bb7d-7a4d-4943-8f8e-176f00b78695",
+      "path": "skills/abdulsamad94/ui-design-system",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "115d27a551cf0c7dd023fe993b7f76a2f751783cd1e9329d6f2e2388098715b2",
+      "reportTreeHash": "1bf5e7e89edb16911657efcaf7545d589e17ec78d9761dd567e47ff3484d459f",
+      "canonicalArtifact": {
+        "contentHash": "7934fc29df7fe7a651acb4a829340c0eb710c2fdc54e32d598d5fb51247926be",
+        "treeHash": "dfa3996a35b188d9fa47e3ffee9b734f4d129b5c631a62038e8ca06eab673636"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "adamfehse-cookmode-v2-source-of-truth",
+      "skillId": "c86ff855-34b1-4424-abd5-76df154a8f3c",
+      "path": "skills/adamfehse/cookmode-v2-source-of-truth",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "3a1738e20e9d13c464e02e4ae952a1d5903ac1de1ddaf0f117c3e7f47214cf0f",
+      "reportTreeHash": "626d87394af5b771e3d70c5aff03caab3ebbae30ed785fe0a25b4602c617aba3",
+      "canonicalArtifact": {
+        "contentHash": "c2c56fa469df8998c35f853646aae4ee87d7fac2c700bc0d62004b22a401ee45",
+        "treeHash": "1965c8e7980764eb12665e2377fb2b950e88504a49093d5e442d8563797c4bc4"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "adamfehse-database-manager",
+      "skillId": "98b79416-bb39-496e-a6a6-ab8307b39d10",
+      "path": "skills/adamfehse/database-manager",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "db8cf722c3e26ba06a44809302ba5ada67c0c192f9ffb85086c2eec75e0804bf",
+      "reportTreeHash": "d9f75229089023d1ac9f49927a6f2daa3d8c0754a8ad293091188f6e37221e7a",
+      "canonicalArtifact": {
+        "contentHash": "a3e24f0ba80d46a5e2f5d30e8e0dedddd5d55c13fb62414b047dc20bbf3aba46",
+        "treeHash": "e940943ef24e0803050aade940511b34b3b2483a001e74ce4eaa871fd9addb83"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "adamfehse-recipe-manager",
+      "skillId": "229f0bca-e149-4ac8-8334-0b65821a720e",
+      "path": "skills/adamfehse/recipe-manager",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "d38da859306de5e12af4da2baaf24c4c7fdab07fc372af7c0d3a9822ffb4d220",
+      "reportTreeHash": "dcac4ee215ec9e5c08e84d290be387b9940ef616ed486ccbcf3125e98175b010",
+      "canonicalArtifact": {
+        "contentHash": "6cd5b8dc040eff3ca168e8618ad36519f2adf1373709cef5000b292129a435f3",
+        "treeHash": "9e3be7fc22d72e10d0d19eab5c0b193e01601f57e189b67680b7728bcd6fd9cd"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "agent-development",
+      "skillId": "67ab7a89-65ca-422a-81b7-f156f215cc1f",
+      "path": "skills/agent-development",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "ff3324078bbeef3e214157391795360e148892e9c6735f1fc049f397aa939c80",
+      "reportTreeHash": "46f5a837147a4df577f70eda9001cd4ac97b676e01ec51af736b5f09da7504ea",
+      "canonicalArtifact": {
+        "contentHash": "035ab8d539500108041ec3ea2222fa7e79a78c5592f0eb7051335fcb7c514d31",
+        "treeHash": "497a0b25b113dffd131c29c9e9f69fe0d76def5e01f30bf01f41844ceadb464c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "andresnaza-roadmap-planning-expert",
+      "skillId": "fd429f1e-b96d-4e56-a70b-91fcda71c371",
+      "path": "skills/andresnaza/roadmap-planning-expert",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "4c6e978d28a8363d0cdc14062f25cfdcaad15f7259a9a06cacfd0102d3d5b767",
+      "reportTreeHash": "83f485cfa4a76577b2aa297f0dd006f6140b5e01032257c4707425de37a86d96",
+      "canonicalArtifact": {
+        "contentHash": "bc97ee7a6f33f421969764bbcda2f2a15cb2174254ab806cbe33b0f1fcfe5181",
+        "treeHash": "6e262b168135316567ab5ce06c049735dd7942f5d9e999b798905d0aeef9cd72"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-agent-development",
+      "skillId": "e2f4b4ed-b4b9-4b9f-a454-c0ef9bac03b5",
+      "path": "skills/anthropics/agent-development",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "ff3324078bbeef3e214157391795360e148892e9c6735f1fc049f397aa939c80",
+      "reportTreeHash": "46f5a837147a4df577f70eda9001cd4ac97b676e01ec51af736b5f09da7504ea",
+      "canonicalArtifact": {
+        "contentHash": "035ab8d539500108041ec3ea2222fa7e79a78c5592f0eb7051335fcb7c514d31",
+        "treeHash": "497a0b25b113dffd131c29c9e9f69fe0d76def5e01f30bf01f41844ceadb464c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-command-development",
+      "skillId": "c9f9f963-fe84-4760-b2f8-5e71b9b83e0c",
+      "path": "skills/anthropics/command-development",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "cf4372aa8f5e86ef0b587aa3703b4af9b22996e0dc7fd0ea6ffae49770136a2a",
+      "reportTreeHash": "4792ce181cbc9d8168b4118e1e49748aab0195c8bddb3f45271f807af0386f4d",
+      "canonicalArtifact": {
+        "contentHash": "34a5b317562e909cf259222cc2f097a957f6d6a95f7f70fed705f74c527c2116",
+        "treeHash": "0bbddf32c86415d3c718464ad5f757aa23f1724e5ef3c99ea4671085af9b327b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-hook-development",
+      "skillId": "b2a3e746-2053-4e75-a08c-af85f5421621",
+      "path": "skills/anthropics/hook-development",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "d14528f389cae485ac50583a22be326485c83fc9c8ef7ce700213e1583cf8fbe",
+      "reportTreeHash": "6cdfd2cf000fd9630044091c0f0a9f16e79043578a4cb6c91b435752e505ffef",
+      "canonicalArtifact": {
+        "contentHash": "f47e2d42f6360294216a859ae0c30b93caafdd2b2e5ffc007489ba4ca447fa5c",
+        "treeHash": "5fcbad83becd6841b35f0932f480c8ee79f0c54dd276d5f4ccd242cde6c2f01c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-mcp-integration",
+      "skillId": "9c40a6bf-b302-4f65-b6ad-1c9290bfde3b",
+      "path": "skills/anthropics/mcp-integration",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "1cbfb6b1cf98f48a7c6938e113869a229cd5a59037712072fe11f21a47c6df0e",
+      "reportTreeHash": "4928f25a252bc9a3d86d76f11677dc6bdd05a25cff8ee4b7210879a1c5e2a8b8",
+      "canonicalArtifact": {
+        "contentHash": "2bcc3b5e93924d7632218f494890f6e6f75a9248138bc97070bc62aea942dd49",
+        "treeHash": "42d95b79203bee6c7f0174c22ea647a2ddd7f745efe839ac5e16d312031f44e9"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-plugin-settings",
+      "skillId": "c7517dc4-afe8-44ad-9a3e-8a272f9acfd3",
+      "path": "skills/anthropics/plugin-settings",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "868f07d0ea1e846111b5ebbef89930f8c82f5138d18b887d4a51d6ef48a69268",
+      "reportTreeHash": "5d4689a97a80c3e34a0a6f081c73182b063bcc855c78536b39320e6087cd0b39",
+      "canonicalArtifact": {
+        "contentHash": "028b955244b937ebc1a5c268a12776b8ceae4cbfb60928fbca927227f4c8851d",
+        "treeHash": "ac19ad2b78b6af4bda29182389174267dc2fcfe89c88203f3f415756db3f7d1b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-plugin-structure",
+      "skillId": "5401e37d-535a-428b-a40b-516d572805e7",
+      "path": "skills/anthropics/plugin-structure",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "ee28fd41535313e9ffb2fd04393cc70e6e7e1d7ea143097a2c3b856e8be98132",
+      "reportTreeHash": "7b83f6139df87ef90c6b9f549021cf9497bd815f1734f0c492f14eb87abf4df3",
+      "canonicalArtifact": {
+        "contentHash": "a2dbc1e5502aacb360d0ca74732cdd7be4f6a12a49edf4f2ade4134fbc026247",
+        "treeHash": "231fcbfe446be2298c009729d2799a2d84acb6bd1bca30a46a8a43bb4aa3acb3"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "anthropics-writing-hookify-rules",
+      "skillId": "eca00f57-9ba6-4937-b287-6b07d358b9a4",
+      "path": "skills/anthropics/writing-hookify-rules",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "cf7a6a0b92092f44c6532bd9af7189748a9c3b4d044005418230b08cc99ac55c",
+      "reportTreeHash": "fcc9476370307733b8d587432deb847809aefea6dc45f2dccf50c861c856ad62",
+      "canonicalArtifact": {
+        "contentHash": "2994b5d3152243b1a1cbf8358e9d7c18f290f31a23920647f31053c3efdf990d",
+        "treeHash": "c8f8fed4693eac590f0829f2297bd34d57d509852bf15cca24eacfd8b24a0ce9"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ariegoldkin-evidence-verification",
+      "skillId": "e9ab303f-b775-40ff-8018-6091d51b7979",
+      "path": "skills/ariegoldkin/evidence-verification",
+      "marketplaceCommit": "804a852bf1af3832fb01d8e3d44df7817e65e365",
+      "reportContentHash": "4e4df997523118d69f068d6c0940c4db755e9c20debe7491647037762d46caf2",
+      "reportTreeHash": "805b87bce27feae9b65a21541fad00c32735292beb839e5bfe6eb037f02e7d84",
+      "canonicalArtifact": {
+        "contentHash": "d2e58ea72a5c59e63dc7a8ac9355291cb2d3dd9a1ca93cac11cab0000a28d277",
+        "treeHash": "7e5e6948c498a40f1fd20d0ad85c85303cfc193458611e64799277c34fae9dc4"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ariegoldkin-observability-monitoring",
+      "skillId": "406cc0ed-afb0-4caf-9998-f87338d287fa",
+      "path": "skills/ariegoldkin/observability-monitoring",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "0f21f74dae56a870ab2b4ca9213af5df2c14a4d7b7a9b029933456b9ee26906c",
+      "reportTreeHash": "04763e93b64743cde37c29eef3ea88b78d474ac6e43669d7a972a79d843a5867",
+      "canonicalArtifact": {
+        "contentHash": "8d2ee93e2f986a517d1fbf47db7c45b66f4c60e219990876b8cad70326959886",
+        "treeHash": "3c16fe7c6aef419ee3fa99ecaa45373cc9bca86de271d71980a81bf7d3c21009"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ariegoldkin-performance-optimization",
+      "skillId": "2c8a16c3-1647-4922-b61e-1a9fb71d46e9",
+      "path": "skills/ariegoldkin/performance-optimization",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "2edaad1efc50b9872a5aaf16180feee05d7b6bded968effdc37958a718d3955c",
+      "reportTreeHash": "435865b30c0cf6667559fc28112c541b727efa024c9ddd74009ac6e7aa8408e8",
+      "canonicalArtifact": {
+        "contentHash": "a744291bf8c54d18d8f55f089a6218498f66434a26626197190aa38021a62e58",
+        "treeHash": "713ace5a65a58f88f7ab2d455dfd0fe500386317abdf5712f75bb748a2db9c5a"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "attendantlion8-provider-management",
+      "skillId": "880fa831-21a2-466d-953e-a66ef79ff714",
+      "path": "skills/attendantlion8/provider-management",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "ccc71997892a7094e10158f01a19306284b7fbd554116d90296745b85290b8e9",
+      "reportTreeHash": "3f630385ccd760ea0d222737a53affa8acb452a222bf83fb9f3161899a7c2b44",
+      "canonicalArtifact": {
+        "contentHash": "b96d3c8fbbd966e519e2ddfa0bab74f94882431672a7292199d5b26e3724cf87",
+        "treeHash": "9e9ee963333a766aeed6a07f6129fedb7df2d71b22d1225ae2d8e550794cb3ee"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bayramannakov-claude-reflect",
+      "skillId": "6cef6ab0-4951-4e99-801c-a3e81dc0578d",
+      "path": "skills/bayramannakov/claude-reflect",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "7d035c84ea96ba9808bc9731533e1bafdbbdf113317ef151ead458d18242067b",
+      "reportTreeHash": "c1c005b1e493712aa2af162cd32990ced39a56e98f9e733d094a4088191d23bd",
+      "canonicalArtifact": {
+        "contentHash": "7d035c84ea96ba9808bc9731533e1bafdbbdf113317ef151ead458d18242067b",
+        "treeHash": "86e6fac3dec9f16db3e5a6537e605c095a28f6203160124c5cd4fd0ba32221b6"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "benderfendor-skill-creator",
+      "skillId": "7c25fcf6-2913-494e-886e-4f6fbd275a07",
+      "path": "skills/benderfendor/skill-creator",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "852334e060db04731f4915f389d8ee5098a2eaf1e15ab458334bf9fc0c90629a",
+      "reportTreeHash": "b89806a07bcd299ce2359dc53ddf03fae97b3f960bc452688665b52c94251d0c",
+      "canonicalArtifact": {
+        "contentHash": "718d28aa45edf2504c88e64a525c2770f428cb370abfc18ef28a3038db5c1b55",
+        "treeHash": "29a7192e7d58afff0cb4a93494fe491f889481f12be0193443262d60bf5a1c8d"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bikach-security-guardian",
+      "skillId": "8d004b81-a1ed-4e7f-9f4b-9721d58a72da",
+      "path": "skills/bikach/security-guardian",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "0cf1007a6ffeb36d569a8ecc93e0ab05074dca695504ea14af327fd2819eaf21",
+      "reportTreeHash": "3bfc7e21846490d96e7eec8cd21e33c4db0a49523824fdfeb30b66ce33d5a2c8",
+      "canonicalArtifact": {
+        "contentHash": "0cf1007a6ffeb36d569a8ecc93e0ab05074dca695504ea14af327fd2819eaf21",
+        "treeHash": "ab33b27c602d59b76df9d54c5cf780923841f8a11b70540b54e849c25b19e82d"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bltgv-microsoft-graph-api",
+      "skillId": "9704cc54-77ec-4f8a-bc5d-511bb26ad1de",
+      "path": "skills/bltgv/microsoft-graph-api",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "0b443989bf126f14047bb33ad6201830bcc479c8123ed9ef44dbacc3eda6690c",
+      "reportTreeHash": "1ea5bbbabd8337bd361bb0441ec71e89e907b38ea27bf809f4a31a95e0113f4c",
+      "canonicalArtifact": {
+        "contentHash": "bf7ab9c9ec4116894e71044efa0b2922e31e5fc70e0042c910c9c73bf450f306",
+        "treeHash": "e8d8aa2365bdad9471acdf2cd9870b79bc488295d0ca4e5aa9f8cc741a7d82e0"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bltgv-notion-api",
+      "skillId": "e7d01bdf-4118-418c-8869-49b3a90097e4",
+      "path": "skills/bltgv/notion-api",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "d5ea8ac718c0cac49f46f917fc67fa764ca93c095f6fdece7141e084c455f0b2",
+      "reportTreeHash": "72741e3640d5f9bcab8e864f7e08f7edc3906b7756931c3398e6170f1d74279b",
+      "canonicalArtifact": {
+        "contentHash": "9806e602fcb9524124b24f845c145cce4de8304feb96838a6c640484cb81479a",
+        "treeHash": "4e55b75bafa13b558340a34253564a8c6bbe909af87eb2eac391519deab90288"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bookiosk-ddd-check",
+      "skillId": "1f536335-b67f-4dc5-9359-a4ba24b457c5",
+      "path": "skills/bookiosk/ddd-check",
+      "marketplaceCommit": "c47a0d6818048b11e035c26cf0a679adb938020c",
+      "reportContentHash": "6bacf904f8ea99f88d4eee282af9b889f6d2c2163ae6f6fb1c51099f2495deb1",
+      "reportTreeHash": "39c78e9d2f6c0de97c8f0431751dfca815db9f14c9df81f1fca6e4abcfbbf4fa",
+      "canonicalArtifact": {
+        "contentHash": "5997b06e360f400fd4ba2399de8afd43d0bd9aebc901d537f91ac057c7b4f3e9",
+        "treeHash": "992b9e17fa5d8279b034e5ab9130da7863cc85c583dc821a32d36c883c186b8f"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bossjones-fastapi-development",
+      "skillId": "db74bda4-6d0f-4c89-848c-37263c4e5e67",
+      "path": "skills/bossjones/fastapi-development",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "842428f5cea03cd4eb34ce1193a878b4371b291cc7bddf4d0d11ed1d368698a3",
+      "reportTreeHash": "02614e54e7d02868591dee4d0137371c6c9458a9f170daead3741ead094db024",
+      "canonicalArtifact": {
+        "contentHash": "f689d73a64b581a8a1ee57f3e61b072f6a3d69203cd9693323dbb4dbab603ce5",
+        "treeHash": "5e634361b2d8edf99590870a4a2e70dcd490a73979f3200aeaadb789f379cc6d"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bossjones-sqlalchemy-2-0",
+      "skillId": "e852f5b1-8e19-473d-b201-52cf2e6c91f8",
+      "path": "skills/bossjones/sqlalchemy-2-0",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "4e35d17b368edab2fd4185cdff122d71d129b7da712a71dd8c70a1721ca9106b",
+      "reportTreeHash": "025eb7897efc545aa9b82693a01ecca6f4b52f2ce9494d3409a25c925812a4c1",
+      "canonicalArtifact": {
+        "contentHash": "f6e6aff68b7d66987d33dcb4d2b3cc831ce0e95190f71b221f1eb51f3218e5e7",
+        "treeHash": "c5c7695155cf8accb05c12a5447a70bedbfbe46c75089c6f33ee0783bbed663b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bytedance-create-node",
+      "skillId": "fccf46a9-7ac9-4aba-9992-1f36f5b55c34",
+      "path": "skills/bytedance/create-node",
+      "marketplaceCommit": "67e6747f5b57a33ea8c62a0043d8f2ef310189ab",
+      "reportContentHash": "54cdff81a4c4b8d63bc4eef020c01c6cd22b0348664f916edcf73421d52da4f0",
+      "reportTreeHash": "755d6058b36eba786dad9f77971964473e806164e1e693a3eab73ce1fff8d71b",
+      "canonicalArtifact": {
+        "contentHash": "0ddf74b1f29f40c95762e374892bfc7d79f41e4c27b0084cdf303e2694f51318",
+        "treeHash": "bd65df08be1d99102f216ecc53c29f19df814cac967b0dc96e89e1bee1b5f7ea"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "bytedance-material-component-dev",
+      "skillId": "60daa9ec-1425-49cc-b9de-466bdb7390c4",
+      "path": "skills/bytedance/material-component-dev",
+      "marketplaceCommit": "67e6747f5b57a33ea8c62a0043d8f2ef310189ab",
+      "reportContentHash": "2c7d30fd5c55393784f92f19faf7399fabcad029a18b98f40f2d07b0a7ef632e",
+      "reportTreeHash": "45f1dc8d8300d2b5182f564c9efd9875a198874b8606316e7f40dc9ec79c70f2",
+      "canonicalArtifact": {
+        "contentHash": "c9b88922b7ec5c8aeedbd3a7182ad4dfbc6d675b969d130aa74d049c02c9c8e1",
+        "treeHash": "50d0f83cf7d58c48d24396b3c0f6666e9d0b295103dcbf26e39deee681e51be2"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "calel33-next-js-16-launchpad",
+      "skillId": "1ba28191-062f-45e2-a8ba-4d38bbb36ee5",
+      "path": "skills/calel33/next-js-16-launchpad",
+      "marketplaceCommit": "67e6747f5b57a33ea8c62a0043d8f2ef310189ab",
+      "reportContentHash": "3df88a25324bf64d7e07c38e089816cb3b196851c643873141db6ce275266524",
+      "reportTreeHash": "e75f795c66a75701eb14faa33786694edaef90e74296807253aa3789827d9b5d",
+      "canonicalArtifact": {
+        "contentHash": "0b508f5c931671765326380d17ad746c7b504bd53dafea02536d7a55f96b0b79",
+        "treeHash": "c0469f64ae18ca207f87896009580197ca95552988b3932a205cf82ce420eada"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "calel33-tailwind-css-v4-mastery",
+      "skillId": "8205fa15-d54a-4ac9-b202-41dd5c8ae40b",
+      "path": "skills/calel33/tailwind-css-v4-mastery",
+      "marketplaceCommit": "67e6747f5b57a33ea8c62a0043d8f2ef310189ab",
+      "reportContentHash": "2a0724bd25d2718c9b45f74d65398ae355bcdbc31ca0e56ef2d91d1f383826e4",
+      "reportTreeHash": "5df1aac71722d88c0410b9bf9784224b1bc0347796fca15be8b3905493b17734",
+      "canonicalArtifact": {
+        "contentHash": "b60207ab78125f0f106b127b7ac05f4f21141b5f9a0316f925908b175d018c7a",
+        "treeHash": "bd506d1fa3c1a050755dc0244ac455bcd49e011db75e7de1b57b0982548e6f18"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "cam10001110101-pptx",
+      "skillId": "b293f865-7a7b-4a0d-b6e6-8f86b89b437a",
+      "path": "skills/cam10001110101/pptx",
+      "marketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5",
+      "reportContentHash": "336864cfb0878052defd1b014acde767ba2aeed96a9fd8e28b5bb2b462807007",
+      "reportTreeHash": "400aab2f7cb79c0fb3947e0d0ede2163bb0f1c7f0507b7fb55b3512ffc031e9b",
+      "canonicalArtifact": {
+        "contentHash": "336864cfb0878052defd1b014acde767ba2aeed96a9fd8e28b5bb2b462807007",
+        "treeHash": "ee665396b309bfa8033cd64e67eefaa3219da3d570dac4d5cc06f2c0b0b150cb"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "captaincrouton89-writing-hookify-rules",
+      "skillId": "9f50225d-d662-4fd4-bf0f-7c5d7e813c75",
+      "path": "skills/captaincrouton89/writing-hookify-rules",
+      "marketplaceCommit": "67e6747f5b57a33ea8c62a0043d8f2ef310189ab",
+      "reportContentHash": "0ef8ad1f2e2aeb2b0477ad1f0eefced416413f5da704c550673819df7a50ded2",
+      "reportTreeHash": "3cf3ea3799441f85ad70bee71f159b8022f6f65330cca2ca016c53defa617283",
+      "canonicalArtifact": {
+        "contentHash": "6be1c324ca51afe08f450abee2c0e3df1d90b1ae3ee87a4c5cf6cdd685b15895",
+        "treeHash": "3f43f0430d02032d7f742cef59ccf10562cd5a07366e69592a1ce1f1db3e37be"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "command-development",
+      "skillId": "c21ac180-2390-41b6-a9a6-2747367975f4",
+      "path": "skills/command-development",
+      "marketplaceCommit": "1b5b6c4962b2ad5a7a34603cab2685bbbd1b61ef",
+      "reportContentHash": "cf4372aa8f5e86ef0b587aa3703b4af9b22996e0dc7fd0ea6ffae49770136a2a",
+      "reportTreeHash": "4792ce181cbc9d8168b4118e1e49748aab0195c8bddb3f45271f807af0386f4d",
+      "canonicalArtifact": {
+        "contentHash": "34a5b317562e909cf259222cc2f097a957f6d6a95f7f70fed705f74c527c2116",
+        "treeHash": "0bbddf32c86415d3c718464ad5f757aa23f1724e5ef3c99ea4671085af9b327b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-mapreduce",
+      "skillId": "7c47b5e1-3242-4eb7-ba9d-c8dcc5867756",
+      "path": "skills/consiliency/mapreduce",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "ec24c6a59c1ceeb954e87c3b037b94f5962307066f90f398585c356a2bdc1a16",
+      "reportTreeHash": "a480cf93bdf369b4130bedc84b2f306b02552ba78b3d94d89fd810476c2ec71d",
+      "canonicalArtifact": {
+        "contentHash": "4225760e96ac3811f867102822f3e28ee134bbd368bfe04be560b0b8124fd37c",
+        "treeHash": "5ed8a584f45b24cfeb19a81d4561936552602785d7499d3a0c065402f147d421"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-orchestration",
+      "skillId": "801df8ab-7ad8-4414-a2db-10592ee07b76",
+      "path": "skills/consiliency/orchestration",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "a34576e340fe287a92d6c8fb1212466d450757b8673fd5c49c42a93559b64754",
+      "reportTreeHash": "a8ee8f9d4ecf18a63596f14c085261a69fd16a36badadb922d59a4a3c9289ab3",
+      "canonicalArtifact": {
+        "contentHash": "a34576e340fe287a92d6c8fb1212466d450757b8673fd5c49c42a93559b64754",
+        "treeHash": "945ca73ec7b96181006c2b9947c8a15f6dbc5b39162c87b05fdda8378cb19733"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-orchestration-native-invoke",
+      "skillId": "9a6ee269-63e9-4b53-8035-ca26a4137cff",
+      "path": "skills/consiliency/orchestration-native-invoke",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "6ea53c6398a31846e882abd16132cde9eaef3f40a2a1d88ba27f0e0ecc08d6aa",
+      "reportTreeHash": "e88e3a4ae6586072865cb6484439cadc2a070905d6f971a3eb82167809dba804",
+      "canonicalArtifact": {
+        "contentHash": "0aca49ac80547b642757b771e2cb2cb49e0caab6a2a4a2f11fa28951466f3be4",
+        "treeHash": "633cb4ef5540cffcf9201024f7d8dafb91bc8a6a14b9e424c6ee54c7b8852530"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-spawn",
+      "skillId": "7b5c6c58-4519-4e98-8e03-7438f6ac9175",
+      "path": "skills/consiliency/spawn",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "6e33576dcdea5824d6a486f854a089549fe3520627d0bae4d0f41a48220d4175",
+      "reportTreeHash": "3d5635a1ebec37f622c6ad26ba47027cc5935d316778be71793cf077378ca999",
+      "canonicalArtifact": {
+        "contentHash": "6e33576dcdea5824d6a486f854a089549fe3520627d0bae4d0f41a48220d4175",
+        "treeHash": "a92bcb1c88fe565c8883adb9bf6c07b1bc13ca512914608e5abd34f6470511fd"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-spawn-terminal",
+      "skillId": "ebe76636-4583-491c-acf0-37060974d329",
+      "path": "skills/consiliency/spawn-terminal",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "2844360500f74f4c300708981f3f37e16699d8c4b264f6912acbfa231bc7d11d",
+      "reportTreeHash": "c9b923aec6e9134b32a7ee6459c92d8844ca3d00f7150985b66132e2d4f3d65c",
+      "canonicalArtifact": {
+        "contentHash": "74bf91a9bc3d366670d838e91ff99693b26df3e732108a253f6be23f79d14712",
+        "treeHash": "1fbe407c2fc07702fdf9c903bf83e63f48e1db312c6ff02d24f1a1a352cea9e1"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "consiliency-stack-analyzer",
+      "skillId": "d72aad3b-13aa-44eb-a0a8-1419637cd4a5",
+      "path": "skills/consiliency/stack-analyzer",
+      "marketplaceCommit": "635f69fb8d2f4e6330ba47a4e5a0fb239c04d110",
+      "reportContentHash": "bde7ed2e93547a370475c4af5f1d2b9d9239cd131f37617d01e2455d343d4b30",
+      "reportTreeHash": "5c629d8e67d166fee8d82b5d3e280ec9bd8526ae8a35d3419aff46ab589c29f4",
+      "canonicalArtifact": {
+        "contentHash": "bde7ed2e93547a370475c4af5f1d2b9d9239cd131f37617d01e2455d343d4b30",
+        "treeHash": "cfe6120bf8110b1e4b5846c499520b8f28c835515134840bf7ae8adbcca993a5"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "dailydotdev-daily-dev",
+      "skillId": "f73ed042-0040-4643-bc3b-67784a5c94ea",
+      "path": "skills/dailydotdev/daily-dev",
+      "marketplaceCommit": "536932510ff0a3e976ac88662d9e038a7faa088b",
+      "reportContentHash": "6688587fc517433ff79cdc9e464a2543a2ced8278006922945b72f9e2a687da6",
+      "reportTreeHash": "606311914801708a9ed11edf89152badae7dc42e4083936d9f6f9c6aef906b34",
+      "canonicalArtifact": {
+        "contentHash": "515b589df25a3d32632b127a2134b68851236731b25650ff9edd2ddaadc08cb9",
+        "treeHash": "5276982e8ec075c808d222221f991559d788940fcced924353859e0d71041a42"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-accessibility-auditor",
+      "skillId": "7461d1e3-5e8c-4e69-8aea-1b4961d8e7ea",
+      "path": "skills/davila7/accessibility-auditor",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "400a9a2aa92ca67c0a098e18cfa3e142db6e5d84ac9781646cd6fbf7a95a013e",
+      "reportTreeHash": "3ed23bfbe5995eabd50f9c37f0425a2d9a8057336d79edb6a868b9e41af9665b",
+      "canonicalArtifact": {
+        "contentHash": "ed95f4d35a934619f4086957776134fdef60f4393c8ea744aa0f6ec4054e47f4",
+        "treeHash": "9891f304a717f428e0a53276d6dc3c63c1d8f118be13f944025f30ab19d7932e"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-agent-development",
+      "skillId": "71075898-7938-4248-8d7f-a8a1c92f512f",
+      "path": "skills/davila7/agent-development",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "ff3324078bbeef3e214157391795360e148892e9c6735f1fc049f397aa939c80",
+      "reportTreeHash": "46f5a837147a4df577f70eda9001cd4ac97b676e01ec51af736b5f09da7504ea",
+      "canonicalArtifact": {
+        "contentHash": "035ab8d539500108041ec3ea2222fa7e79a78c5592f0eb7051335fcb7c514d31",
+        "treeHash": "497a0b25b113dffd131c29c9e9f69fe0d76def5e01f30bf01f41844ceadb464c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-api-integration-specialist",
+      "skillId": "48fc6d1a-5fb5-45ba-b2ae-84249abd552f",
+      "path": "skills/davila7/api-integration-specialist",
+      "marketplaceCommit": "671851766a45c702993ad67d773d60fd34e6c09d",
+      "reportContentHash": "b6ae66805cf63e1bd7eabee6acdaf32ecfdb43c94596656ad52a68a6da526062",
+      "reportTreeHash": "cb6b72a4415762e8089d428d383caefcc8f9296bfb917c6fe482bd6640f056ae",
+      "canonicalArtifact": {
+        "contentHash": "f68458304e084c185956f7d82ef23fbc5f0d86904eeb2c5fb64edf32fc230984",
+        "treeHash": "a478121fdec3c87a5712ee80c82aa4485290475e675d1a323da4e75219ea9dad"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-command-development",
+      "skillId": "a8bb0288-ce25-403a-89c1-50fecae7b5f5",
+      "path": "skills/davila7/command-development",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "cf4372aa8f5e86ef0b587aa3703b4af9b22996e0dc7fd0ea6ffae49770136a2a",
+      "reportTreeHash": "4792ce181cbc9d8168b4118e1e49748aab0195c8bddb3f45271f807af0386f4d",
+      "canonicalArtifact": {
+        "contentHash": "34a5b317562e909cf259222cc2f097a957f6d6a95f7f70fed705f74c527c2116",
+        "treeHash": "0bbddf32c86415d3c718464ad5f757aa23f1724e5ef3c99ea4671085af9b327b"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-data-privacy-compliance",
+      "skillId": "c05193ee-2d97-449e-87c9-4b8fa65a80e9",
+      "path": "skills/davila7/data-privacy-compliance",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "296ba56e91988a457e4706fcd1e2cd6c2d37f2c98d17d88a37d0c522f675e7ec",
+      "reportTreeHash": "2bf4a1f47ff393071876c181966f94a8ec1a5d46f51547bd27ef27789e91bb8b",
+      "canonicalArtifact": {
+        "contentHash": "8dcc659db76ec99d605242530736a435606a5eeb43faf78e56cecdb3feb36bba",
+        "treeHash": "ce85c185d5f2231c298c77b38836b368cc5294587ad28b5a432b18d4a68aff89"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-email-composer",
+      "skillId": "d5520d28-4b28-4d5b-9b60-bef871b0f4e3",
+      "path": "skills/davila7/email-composer",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "fee7df66bbb4f9edc8d50bf2e0f5302ba3ab6330de8356ba2a9c712c10504eee",
+      "reportTreeHash": "8d3ce33e55801f55571b2cd37bad0a9196b6c8d63223223840d95b387ea49ace",
+      "canonicalArtifact": {
+        "contentHash": "41ef0b0906ea45a8802bbc5f81b9b12a90a64d4d6fd304618216b2562eefba60",
+        "treeHash": "6f7c3684315bcfdeccd33f4041a36fa2f54b26a5030d0ec5dc9b7c6c139d501c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-error-resolver",
+      "skillId": "2b818e7e-af80-4846-926b-b9ff18bc6dfd",
+      "path": "skills/davila7/error-resolver",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "5864ed0414f31a138a5d41dc7b50f3acd31c5adc0cfc911c434f2f6605fb0d7a",
+      "reportTreeHash": "4438088c7530241d6f361e4d624b1c4cf4906a31e39f21377fbe02525046cf18",
+      "canonicalArtifact": {
+        "contentHash": "bf4b3a7f476bf793cf317ed790398d9c8a7c63ada5cf635c96a22471fdf6ab46",
+        "treeHash": "d38049d1ce7b80b3a47266b77583d9eac9bbc7aa02ce1a50811570a4e5915cb5"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-excel-analysis",
+      "skillId": "17c94000-de24-4e65-bc6d-77919188a63d",
+      "path": "skills/davila7/excel-analysis",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "fb681b860b4d3bc20938cfbe490ebdc39d679d1634f1a6c12727bd4ab7ac91d0",
+      "reportTreeHash": "92eb75d14017b797e4d27eaf42c8cd8edbf6dff573a7da1af0992d7490d8fd15",
+      "canonicalArtifact": {
+        "contentHash": "7c90ac714941c49a0e0b28f49e47bf233b49b7517113ea32381e0a2df6a5e7c3",
+        "treeHash": "2708b4b580efc08fbadfe833ff4a3b0fa7212a20f9ae17b07073ba2642a40178"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-git-commit-helper",
+      "skillId": "d8ce3ab9-11bd-4133-b174-ded0359811c1",
+      "path": "skills/davila7/git-commit-helper",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "6dbef2aecbb3680f8fcb41e5c2a39b8905b42b29818b6feedab72621e728e850",
+      "reportTreeHash": "0dce51349e545f072747d8b5a53d90224460f17fca49c7f31b73ee58ee5aa3c5",
+      "canonicalArtifact": {
+        "contentHash": "30eeef683207e13e41c5f534b1e767c412f27a9c63ea8c630264a4c43ec182c5",
+        "treeHash": "c9249bb9138f94af8c41fe999c44f2a83da4fc056b46f032f08d969c642b31db"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-hook-development",
+      "skillId": "04decdd3-a73b-465b-8c00-e7c51a889648",
+      "path": "skills/davila7/hook-development",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "d14528f389cae485ac50583a22be326485c83fc9c8ef7ce700213e1583cf8fbe",
+      "reportTreeHash": "6cdfd2cf000fd9630044091c0f0a9f16e79043578a4cb6c91b435752e505ffef",
+      "canonicalArtifact": {
+        "contentHash": "f47e2d42f6360294216a859ae0c30b93caafdd2b2e5ffc007489ba4ca447fa5c",
+        "treeHash": "5fcbad83becd6841b35f0932f480c8ee79f0c54dd276d5f4ccd242cde6c2f01c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-mcp-integration",
+      "skillId": "d815d871-a4ce-4629-a412-c7b44ade6fe3",
+      "path": "skills/davila7/mcp-integration",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "1cbfb6b1cf98f48a7c6938e113869a229cd5a59037712072fe11f21a47c6df0e",
+      "reportTreeHash": "4928f25a252bc9a3d86d76f11677dc6bdd05a25cff8ee4b7210879a1c5e2a8b8",
+      "canonicalArtifact": {
+        "contentHash": "2bcc3b5e93924d7632218f494890f6e6f75a9248138bc97070bc62aea942dd49",
+        "treeHash": "42d95b79203bee6c7f0174c22ea647a2ddd7f745efe839ac5e16d312031f44e9"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-plugin-settings",
+      "skillId": "ec803259-5bde-4417-aacb-44d4c0a31801",
+      "path": "skills/davila7/plugin-settings",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "03edd6f2bbf2499468e9ee8cfb75b34b4fbe04dd43b9133d94920db71459306d",
+      "reportTreeHash": "1e2829fb0d958d79c9ce1b8f5e043da0e1e00a51f9dfbc3fdde8b500d6ceb847",
+      "canonicalArtifact": {
+        "contentHash": "0c3a372dee363a740a3879a5265062a880a050dc354d40e1e13731dd4a05fe2f",
+        "treeHash": "808c04ff25ab886a0a608d5954ea27ae1096865e9839ab8912e3fbaf14b8b4c7"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-plugin-structure",
+      "skillId": "ab053ccc-ba23-4b06-99e5-f4e917002a24",
+      "path": "skills/davila7/plugin-structure",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "ee28fd41535313e9ffb2fd04393cc70e6e7e1d7ea143097a2c3b856e8be98132",
+      "reportTreeHash": "7b83f6139df87ef90c6b9f549021cf9497bd815f1734f0c492f14eb87abf4df3",
+      "canonicalArtifact": {
+        "contentHash": "a2dbc1e5502aacb360d0ca74732cdd7be4f6a12a49edf4f2ade4134fbc026247",
+        "treeHash": "231fcbfe446be2298c009729d2799a2d84acb6bd1bca30a46a8a43bb4aa3acb3"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "davila7-writing-hookify-rules",
+      "skillId": "183ad404-d381-47ec-b12a-e3ff472340ea",
+      "path": "skills/davila7/writing-hookify-rules",
+      "marketplaceCommit": "536932510ff0a3e976ac88662d9e038a7faa088b",
+      "reportContentHash": "cf7a6a0b92092f44c6532bd9af7189748a9c3b4d044005418230b08cc99ac55c",
+      "reportTreeHash": "fcc9476370307733b8d587432deb847809aefea6dc45f2dccf50c861c856ad62",
+      "canonicalArtifact": {
+        "contentHash": "2994b5d3152243b1a1cbf8358e9d7c18f290f31a23920647f31053c3efdf990d",
+        "treeHash": "c8f8fed4693eac590f0829f2297bd34d57d509852bf15cca24eacfd8b24a0ce9"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "firecrawl-firecrawl-monitor",
+      "skillId": "46b04c75-9fad-4b7a-8455-e81e97835d16",
+      "path": "skills/firecrawl/firecrawl-monitor",
+      "marketplaceCommit": "b425f5e2e895b936f199f466467223d3613dfe98",
+      "reportContentHash": "a1137f2690dc601f0dc9a7aca14bb42db14634ec7015c6a51fadde190c1e3284",
+      "reportTreeHash": "2babf6c7a91e5c83131c68219e4cdcfe6d812c53fc64721d3d2f83e9f0e85d86",
+      "canonicalArtifact": {
+        "contentHash": "e5f7fd4194cef1e3cd06a58a1f6e90cf098f700c2a8ec7cf515d56c793943217",
+        "treeHash": "b6f39690ba3cd04eff5202f9730158317d34465592284d66d0f3583479d49a82"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "gobeyondyang-business-conflict-analyzer",
+      "skillId": "be7a7c59-fd91-42fb-b2fa-d338eee34f46",
+      "path": "skills/gobeyondyang/business-conflict-analyzer",
+      "marketplaceCommit": "536932510ff0a3e976ac88662d9e038a7faa088b",
+      "reportContentHash": "b4443eb7c4c48ba0552d759033d0f398a78fdf992326b044e06df9bbdd4c60d7",
+      "reportTreeHash": "a91fa92a88bd77a7a154d7b293a30f5506d98ee7c78a6debb655142c7f25f7e0",
+      "canonicalArtifact": {
+        "contentHash": "48645e1c36070837a6cabee28068ffd3afcb92cecef59b3e47ea65bd324d56c1",
+        "treeHash": "f7e2f7d43ffb100993ce6eff1781a859dd5397a57d7d57afa6c96a3da07733b3"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "heygen-com-embedded-captions",
+      "skillId": "d5208802-4e53-4694-84bd-1586794360d0",
+      "path": "skills/heygen-com/embedded-captions",
+      "marketplaceCommit": "536932510ff0a3e976ac88662d9e038a7faa088b",
+      "reportContentHash": "e4c58462cfd2405782d04f56923ac1313ead0ea9bea812689c100be59c88be9b",
+      "reportTreeHash": "ec1b378ae3e306d1bcd6122481e82761cd43ca520653aa0e2ac4d903826b5f5a",
+      "canonicalArtifact": {
+        "contentHash": "3f370eed3fbd88444a4151ba886b8d69ed34293d1205a90ca7f89395beff4be8",
+        "treeHash": "0c0c6587fd5b317031e94f0711ccfbc573d7ef138b4d934502776dd01b9c3651"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "heygen-com-remotion-to-hyperframes",
+      "skillId": "238a1a51-c9aa-4f90-acd3-0ef5e0894038",
+      "path": "skills/heygen-com/remotion-to-hyperframes",
+      "marketplaceCommit": "b9e5ae9c7a884b8b0bc6894c293164039a0aa79d",
+      "reportContentHash": "d57e2f399415daf64312b2a52a19a5bfd4987febaa888b23074cceff4eca149c",
+      "reportTreeHash": "04d0b700aa37c87f0c7af2bc7dde9ca429ff29c4d91912dec3c61f3dcb27f507",
+      "canonicalArtifact": {
+        "contentHash": "d57e2f399415daf64312b2a52a19a5bfd4987febaa888b23074cceff4eca149c",
+        "treeHash": "85e7350f0666930a4fbeec0da8902267f19a80bdf64db533ea90378cd3c3a019"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "hook-development",
+      "skillId": "8dd5b187-964d-419a-bb8a-dadf11b81d1d",
+      "path": "skills/hook-development",
+      "marketplaceCommit": "6e2dddf587274c5f8c929a916ca092529545819b",
+      "reportContentHash": "d14528f389cae485ac50583a22be326485c83fc9c8ef7ce700213e1583cf8fbe",
+      "reportTreeHash": "6cdfd2cf000fd9630044091c0f0a9f16e79043578a4cb6c91b435752e505ffef",
+      "canonicalArtifact": {
+        "contentHash": "f47e2d42f6360294216a859ae0c30b93caafdd2b2e5ffc007489ba4ca447fa5c",
+        "treeHash": "5fcbad83becd6841b35f0932f480c8ee79f0c54dd276d5f4ccd242cde6c2f01c"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-0g-compute",
+      "skillId": "320502ef-920e-487b-8c6b-2de59932edad",
+      "path": "skills/internet-court/0g-compute",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "0c79af96bdb378df7c3c6b691324667f4f05edfc9cb8f4499e526b88d53a38ab",
+      "reportTreeHash": "736720f2bf0acf07eb2de6186ec8f2d825f3285eb950f68efc82ec098eb2284c",
+      "canonicalArtifact": {
+        "contentHash": "5af544f552f1bba017f20311dd09fef6a7d244cd6ed05574cc30f158449ea176",
+        "treeHash": "7fa805a7f512490aaf4b3fd3b966315cc377e977b26f97a9853b2874fccea1cd"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-humanode-agentlink",
+      "skillId": "15f60807-ae43-47c7-8300-342409dac79b",
+      "path": "skills/internet-court/humanode-agentlink",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "fb062c73e3de47238b60a033f8cd2dcd877979449f37133a00b2526e5fa4ec85",
+      "reportTreeHash": "7d730949d443209d7a0958f373db60c21c24710a33b22c3da0a9d4a09f9e0aa8",
+      "canonicalArtifact": {
+        "contentHash": "209b60b19eae16ac3666a573e3b30d94c2c1ed21a6c271e87f6f2cda6efbcf10",
+        "treeHash": "b964578bad067a4d4a06ac89cd69e24ab8f9dc14e8b2e45d5a7a3e1baea29479"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-internet-court",
+      "skillId": "0a0bdc0b-0ca2-4752-8a9a-9280c250248d",
+      "path": "skills/internet-court/internet-court",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "39d8de82cb5e2708f36603a1e7f80859f55cea0fd188be30124381468e0ced38",
+      "reportTreeHash": "ca3b9066bcf1a5d0abeb82886f0ae6a2f1ed25b1459eb0e4668613e8ff492d0e",
+      "canonicalArtifact": {
+        "contentHash": "b3bbd91c0da8933660828dc9fc57c7c558662a81bd6f099b34e84c47fc6b995a",
+        "treeHash": "370a15e0720f135e57402e9fbddc3af4723c6f041cc94d225f4e1b42b995ec96"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-kleros-curate",
+      "skillId": "4a0f3fda-2084-438c-8c5a-99a3a9b4f315",
+      "path": "skills/internet-court/kleros-curate",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "55f5bbb094a5c0a1fdbc0098a588df9e7b89be1b35baf8c839007faa72f5b770",
+      "reportTreeHash": "58b0c8bccd1ece120980147f8fec3c2d71a8905328e5edb0e7b813f5f849f357",
+      "canonicalArtifact": {
+        "contentHash": "df7ca692f4572fabd830cb654a312a15b481220b4d68e8bba1981073883be8b0",
+        "treeHash": "37d52d68e9adabdeb6e226e41090ad46e67e1582357c32d5ff942dd13fcf2c74"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-kleros-ipfs-upload",
+      "skillId": "574e8308-6076-42a6-8ffb-da15e0fe3394",
+      "path": "skills/internet-court/kleros-ipfs-upload",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "b12143796ea6e659873ac5430ce33506cdb7046b312709dfb3daefab754f9981",
+      "reportTreeHash": "4bfce9cd17d62faf75375a3e162e94b7772700e835f9f221b21ec406f62118a1",
+      "canonicalArtifact": {
+        "contentHash": "ffbe871570e5225c4eb0c3587a3db3e3e5ce4fec32645fb10213c09883a8625e",
+        "treeHash": "9ac461a6d62dd477d1314d0708af584ee496702ebdabc5b3c6823bc47fe26c10"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-lifi",
+      "skillId": "218466d9-7bb5-4a94-a996-444eb4460c90",
+      "path": "skills/internet-court/lifi",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "e2106ec7e8f323136688032d696364492400eaa117bf606712e46fd99c0eec89",
+      "reportTreeHash": "fe00056560cacb9c8244ade85023ab34a8c3ae935ee6e900b6b2f1a955eb0b8b",
+      "canonicalArtifact": {
+        "contentHash": "a2cf3b286003c5108e8d81cc59338757a5999186d3891a603474b37fb88f7661",
+        "treeHash": "4df857f43e3d737da87173238ecf0f683d21bc7bc6c5d267117e79f275566604"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-lifi-stablecoin-swap",
+      "skillId": "cdbcec48-cad1-40a4-83cc-3d571f986b08",
+      "path": "skills/internet-court/lifi-stablecoin-swap",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f50d2a606e27f557711e606d820e727954b87dde5f2b6fb79ba41dad689afcf1",
+      "reportTreeHash": "5bf8e549ed34c85bbcc4ba240af284d90b30beaf11424f4d6cd778d9e30e93d2",
+      "canonicalArtifact": {
+        "contentHash": "25d340c22329fddc39da2578ba0bd5d58929a3e8340c5c16b13e3a0d4b606bdb",
+        "treeHash": "59596a6f998fbcd62bb0834487cf4fdc445da8247713384124cd0383495921f2"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-okx-guide",
+      "skillId": "f715c206-e11a-4889-8699-2466ad5aa43d",
+      "path": "skills/internet-court/okx-guide",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "83ccf1b2f77efae63fe76edc7969274ac17c9fc2e7c44f88bae95b9ece33b272",
+      "reportTreeHash": "75a7b13f2c29f6e51bbfaa369e24173177e7f82bcb735a80a93a8a27e2f21bf4",
+      "canonicalArtifact": {
+        "contentHash": "787338f26e6732e31c153f302988c77aa5864c78d2a014de63db05531798ceba",
+        "treeHash": "9a448339ed13355a5c4c725cc2a05149e326a1e91da555387d5e9b1ed9d56686"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-privy",
+      "skillId": "6a34e143-821d-4296-9de2-0d09fb5768df",
+      "path": "skills/internet-court/privy",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "96e0f50925cac814158f2615218bb081fbab510a17d52b4f7f4c949d81044d01",
+      "reportTreeHash": "13f63f47f0a894a89ec48ecd25e4a39ef2a231ab4dcb000e4874e8938fecfc86",
+      "canonicalArtifact": {
+        "contentHash": "6587b37ea9008d6a80526f2e94299d27481251b62a2447af493bc6cbe79bebb7",
+        "treeHash": "ce5e1ecb4bf4e9f28dd00ed61c2b6ee855b33fd73a4a8a06a817d9e9b99b7efa"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-trustless-agents",
+      "skillId": "e196a311-6fe0-4d08-936a-3a5321d65eb5",
+      "path": "skills/internet-court/trustless-agents",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "d04c9378ab437df78e0e8af216255ed7e35ca12c9de31698fe0c5016ac519c6a",
+      "reportTreeHash": "41802c0454f869a791bc4e9bd7d46bcbecd86dc0107bdc2fe6f5ab0504b28033",
+      "canonicalArtifact": {
+        "contentHash": "67844391320ffe7614217a4ac0323f0e0bff0aa1dacdeb2cb0059c5c12a865dc",
+        "treeHash": "012dc8f1994a6c4775ffe684a67dd2dcdd935d28f70c0f237daa437af8fc2bf9"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-web3-data",
+      "skillId": "a927a14d-369d-4cd3-97e4-59426cfc362c",
+      "path": "skills/internet-court/web3-data",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "60c7ab19ba9f5d3b2c58894c7085d6546e2cd3045644c4edb0c20a481e16dfb5",
+      "reportTreeHash": "a774e0fdba2bf82431545e24a878236f09908c03654b8ac0f2077886e18b5301",
+      "canonicalArtifact": {
+        "contentHash": "98eadfb1b4dbbcd56bd92dbff9021820378b94cdf28ca34ba9ff4b733f602c91",
+        "treeHash": "2946e0fc8ba405a89fbe225bbab2dafeb616b942b8891288501a5046fbe60e88"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "internet-court-x402",
+      "skillId": "6651aa7f-996b-43d4-af41-e54240361c58",
+      "path": "skills/internet-court/x402",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "83b4762a44fa5b226e2e6e9d67e7465f3a7ece0f7109a0dd406a63170233858e",
+      "reportTreeHash": "5ab85517ee7bf2202c778c24cc6ae91f2261a2ffb7133e605ef44109f5903b66",
+      "canonicalArtifact": {
+        "contentHash": "b2bf1e7ba3a3efe747929a11d6078986bb46974bd50ac203045555a98165815b",
+        "treeHash": "3fa9bb11ad27998a811645f2efc138a5ba5c20e4569d6a237816eb844c827f1a"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "mcp-integration",
+      "skillId": "8b6de746-21ac-4a09-ab23-935c502dff3b",
+      "path": "skills/mcp-integration",
+      "marketplaceCommit": "426dcacce0b57cb18ace616fd241b7c665d58f37",
+      "reportContentHash": "1cbfb6b1cf98f48a7c6938e113869a229cd5a59037712072fe11f21a47c6df0e",
+      "reportTreeHash": "4928f25a252bc9a3d86d76f11677dc6bdd05a25cff8ee4b7210879a1c5e2a8b8",
+      "canonicalArtifact": {
+        "contentHash": "2bcc3b5e93924d7632218f494890f6e6f75a9248138bc97070bc62aea942dd49",
+        "treeHash": "42d95b79203bee6c7f0174c22ea647a2ddd7f745efe839ac5e16d312031f44e9"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "microsoft-microsoft-foundry",
+      "skillId": "f8197c83-b95b-4348-9453-846415c35280",
+      "path": "skills/microsoft/microsoft-foundry",
+      "marketplaceCommit": "1200d2f84325e4a40a4c6cc230f3864179fd6940",
+      "reportContentHash": "16721068b5f11e409c2cc586477004a6696df2623aa5507db3d5d693117e60da",
+      "reportTreeHash": "d5047a5aecac59de45af46f1e1ef78377cc82e932498780cbe3b4582d6d0cf22",
+      "canonicalArtifact": {
+        "contentHash": "16721068b5f11e409c2cc586477004a6696df2623aa5507db3d5d693117e60da",
+        "treeHash": "7fe2ce83bf57ad86cedba75be323f25f48d26419a781ce2f14fc029ef6839a41"
+      },
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "plugin-settings",
+      "skillId": "74995c17-d42a-45df-ae82-22c75f383d66",
+      "path": "skills/plugin-settings",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "03edd6f2bbf2499468e9ee8cfb75b34b4fbe04dd43b9133d94920db71459306d",
+      "reportTreeHash": "1e2829fb0d958d79c9ce1b8f5e043da0e1e00a51f9dfbc3fdde8b500d6ceb847",
+      "canonicalArtifact": {
+        "contentHash": "0c3a372dee363a740a3879a5265062a880a050dc354d40e1e13731dd4a05fe2f",
+        "treeHash": "808c04ff25ab886a0a608d5954ea27ae1096865e9839ab8912e3fbaf14b8b4c7"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "plugin-structure",
+      "skillId": "e8f27301-2113-4843-bc32-576f8e6b35c5",
+      "path": "skills/plugin-structure",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "ee28fd41535313e9ffb2fd04393cc70e6e7e1d7ea143097a2c3b856e8be98132",
+      "reportTreeHash": "7b83f6139df87ef90c6b9f549021cf9497bd815f1734f0c492f14eb87abf4df3",
+      "canonicalArtifact": {
+        "contentHash": "a2dbc1e5502aacb360d0ca74732cdd7be4f6a12a49edf4f2ade4134fbc026247",
+        "treeHash": "231fcbfe446be2298c009729d2799a2d84acb6bd1bca30a46a8a43bb4aa3acb3"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-agentdb-advanced-features",
+      "skillId": "58917b83-5269-4e4b-9f06-d24a5b60122e",
+      "path": "skills/ruvnet/agentdb-advanced-features",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "e5524686b1e900b8c890c665747752cf5df5732dc1e217f9cf3514fc5e89efd3",
+      "reportTreeHash": "c8fed603c413f93cd53b303f806afe74dbfc511329ed858e121cb3ab8a7d207a",
+      "canonicalArtifact": {
+        "contentHash": "6f45f3231fc0bcbbdcfc5a2c0783355d585d65b48ce2f87a10fadc34c23d5d63",
+        "treeHash": "46c563c8112e772ae61782a717bc0ee1fbb1f438b6c5d51e070c779e1498ec47"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-agentdb-learning-plugins",
+      "skillId": "8cdc1914-2421-4638-b45c-4b7afbd96bf3",
+      "path": "skills/ruvnet/agentdb-learning-plugins",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "5e52ac69d8804930e420302fff517cfba81a0ff0b8f54ba77fb366f412998232",
+      "reportTreeHash": "0c8ec755442204c98c69725479a28b82a4ff37828a026276dc81614f466816c2",
+      "canonicalArtifact": {
+        "contentHash": "8e35205e668d4c6f25847771190d49435c4b94d58da6412a9f3d210565e493ef",
+        "treeHash": "2ac370685dbabf9483665383672bcfc650356de39cd8f7a6ce21d7f0e34e4116"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-agentdb-memory-patterns",
+      "skillId": "15def53c-fa72-471f-afb7-0352a29ce884",
+      "path": "skills/ruvnet/agentdb-memory-patterns",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "516a5357177cc65909277b639af151b393388e5f5eaaa3fc9d29cff6526b0cf7",
+      "reportTreeHash": "621404614cd3f2bc93ff4878296fa1b26288a81ae90a1e9e176f1c55ea161494",
+      "canonicalArtifact": {
+        "contentHash": "a56a01a5175ff08c63b110e4f9fa2d5f9dd8a8032fd4c08da0393803c6a63029",
+        "treeHash": "330a2f3325d4d4a65300209fd322df80f2fa0dd9417b4832b5b7c9b436b37a62"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-agentdb-vector-search",
+      "skillId": "c8034d77-14e1-4370-a546-8002c384a186",
+      "path": "skills/ruvnet/agentdb-vector-search",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "beecdac71c19e0ed3506737d5cb8704e6ceeb7dfa6052b425607cda0c548a5af",
+      "reportTreeHash": "8151cc0ab3c616dfe2754b856d6bf5c05c1da5bb5e49a3d539647ff09aa03d6f",
+      "canonicalArtifact": {
+        "contentHash": "db04df1f7099b4f7a242b7587f80a99785cad987d1d08b7dc46833e842b971ff",
+        "treeHash": "600a88e5a7fd7efce246843d4743c9e491ed9b0a24290784ec0b0c0efcb52fff"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-hooks-automation",
+      "skillId": "d2b774c8-da92-4188-916e-59c056b5d8bb",
+      "path": "skills/ruvnet/hooks-automation",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "748868e06e46fd98c2c219d9e2cc05bcd4109d86c768c2e819c150e1c45020bd",
+      "reportTreeHash": "55d30d6d2e39245b12c3b8825958ce0fef7c9e9232a87b50482815545cf89180",
+      "canonicalArtifact": {
+        "contentHash": "f6103044860be3934a8b2ab83dbfb03e4c79993b0039d794647abdba9b0fb29c",
+        "treeHash": "4c703c0cfdbbae2496d93f147c97c3f58792ab06423e3e192eda0e595ec30e60"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-pair-programming",
+      "skillId": "f0ac74f0-2cfc-45e3-8de7-22708888b78d",
+      "path": "skills/ruvnet/pair-programming",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "32ef344d86f63817fefbadc949ecafee891fc91ab1de97c21031e7540bb61108",
+      "reportTreeHash": "700fce4b7c5c7d83443798d410cffbcb56da456543fd0ad2786e3189e34236b0",
+      "canonicalArtifact": {
+        "contentHash": "be5c9c30facd0e53240956c769d9d5d070bd9d13e26fb4353788cc1460dfd11c",
+        "treeHash": "d9f19e20fef660f490158928f4dca79e7be5bbb4b30d1e45978534450b4f4373"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-reasoningbank-intelligence",
+      "skillId": "993a4067-ce8c-4c09-ba11-a51b2812a231",
+      "path": "skills/ruvnet/reasoningbank-intelligence",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "b62b18984d12dd918bd9b74740eefcbff2c203e09956c01021389882923192d4",
+      "reportTreeHash": "dc5602758451c652a9ddccb8cb475d4bdd07db8205ddb1f2706692056dff2912",
+      "canonicalArtifact": {
+        "contentHash": "e6c0088c8cf9b4f951c92088cd6bf8e486f12c44e8f947421f535c7b320a80e9",
+        "treeHash": "5b17b6297c4d3a4164652280f737c4b8fdd5df439e3701b0efb86c074e1a2038"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-reasoningbank-with-agentdb",
+      "skillId": "809f4a27-771f-4653-aa2f-69d2d84ce4a7",
+      "path": "skills/ruvnet/reasoningbank-with-agentdb",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "d60a616ad0bbe90ce3907ea1047731ca45fb33704f4359a22f6723022b9ea255",
+      "reportTreeHash": "59c9ee33889422a4c571a110ea14d2085bec61be6b7b1df94a2ba8281393e5d2",
+      "canonicalArtifact": {
+        "contentHash": "341125d812777c98fc4a3f9df2c185a17b16ce5320e616cb9a6fce652ffd76b4",
+        "treeHash": "f487bbce4c9fe6c30c6697579ccc75388e1938b88a86b0bd202a6b8cf2e68c2f"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-skill-builder",
+      "skillId": "a1df1adf-7d66-48d2-b3bd-43d87038e1f7",
+      "path": "skills/ruvnet/skill-builder",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "3ebb2c70e4d816c24ce7ac03c762b0bba1afaa34505e3aaa3c04f65ed8270297",
+      "reportTreeHash": "ecf6a97051dc5217f42e79cb256cde4c86478a4ea39b0054b1c5ee7edd3fee47",
+      "canonicalArtifact": {
+        "contentHash": "976919c7748b12288dd7210f7049c73fa199c8e8477b392dfadd7f94f3cbef9a",
+        "treeHash": "a1208b0d777fa47a8b671cbe7f7504077b197bf553e0250eb53e5bd5f79e5f84"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    },
+    {
+      "slug": "ruvnet-verification-quality-assurance",
+      "skillId": "20794ed4-0af6-4356-8268-5f5d7934bef0",
+      "path": "skills/ruvnet/verification-quality-assurance",
+      "marketplaceCommit": "dbe0e719813583400773166a0621f8a9b8185c72",
+      "reportContentHash": "bdc3acb006caead9f6222fef3bb0d5c14ed0c286fb575fe9888d55c6af40dc19",
+      "reportTreeHash": "91a06f1eaca31eb67db83faf4ebf17a8a842e0d542114c3e79fd022eb564594b",
+      "canonicalArtifact": {
+        "contentHash": "d1f6a8d087f73896b75b188b968a6fa7dee5ea608c2e9f877ae800e184a87b29",
+        "treeHash": "778636dc9039e67791ca30af71b3639754a0e127ef5a1cdb80fd35b33f45de23"
+      },
+      "remainingReason": "source_changed_after_report_subject",
+      "governanceEligibleByLineage": false
+    }
+  ]
+}

--- a/scripts/prepare-fresh-canonical-audit-batch.mjs
+++ b/scripts/prepare-fresh-canonical-audit-batch.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAX_BATCH_SIZE = 10;
+
+function fail(message) { throw new Error(message); }
+function git(root, args) {
+  try {
+    return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    fail(`Git evidence failed (${args.join(' ')}): ${error.stderr?.trim() || error.message}`);
+  }
+}
+
+export function prepareFreshCanonicalAuditBatch({
+  repositoryRoot,
+  cohort,
+  startAfter = null,
+  batchSize = 10,
+  productionInventory,
+  previousBoundary = null,
+  cohortSha256 = null,
+}) {
+  if (cohort?.schemaVersion !== 1 || cohort?.status !== 'lineage_unproven'
+    || !Array.isArray(cohort.rows) || cohort.count !== cohort.rows.length) fail('Invalid lineage-unproven cohort');
+  const size = Number(batchSize);
+  if (!Number.isSafeInteger(size) || size < 1 || size > MAX_BATCH_SIZE) fail(`batch-size must be 1-${MAX_BATCH_SIZE}`);
+  const seen = new Set();
+  const rows = cohort.rows.map((row) => {
+    if (typeof row?.slug !== 'string' || !row.slug || seen.has(row.slug)
+      || !UUID_RE.test(row.skillId || '') || !COMMIT_RE.test(row.marketplaceCommit || '')
+      || !SHA256_RE.test(row.reportContentHash || '') || !SHA256_RE.test(row.reportTreeHash || '')
+      || !SHA256_RE.test(row.canonicalArtifact?.contentHash || '')
+      || !SHA256_RE.test(row.canonicalArtifact?.treeHash || '')
+      || row.governanceEligibleByLineage !== false
+      || !['same_source_tree_unproven', 'source_changed_after_report_subject'].includes(row.remainingReason)
+      || typeof row.path !== 'string' || !row.path.startsWith('skills/')
+      || row.path.includes('\\') || row.path.split('/').some((part) => !part || part === '.' || part === '..')) {
+      fail(`Invalid fresh-audit cohort row: ${row?.slug || '<unknown>'}`);
+    }
+    seen.add(row.slug);
+    return row;
+  }).sort((left, right) => left.slug.localeCompare(right.slug, 'en', { sensitivity: 'variant' }));
+  const cursor = startAfter || null;
+  const cursorIndex = cursor ? rows.findIndex((row) => row.slug === cursor) : -1;
+  if (cursor && cursorIndex < 0) fail(`start-after is not in the cohort: ${cursor}`);
+  if (!productionInventory || !Array.isArray(productionInventory.rows)) {
+    fail('Exact production inventory is required for cursor continuity');
+  }
+  if (!cursor && previousBoundary !== null) fail('Initial batch cannot consume a previous boundary');
+  if (cursor) {
+    const metadata = previousBoundary?.metadata;
+    const selection = previousBoundary?.selection;
+    const execution = previousBoundary?.executionProof;
+    if (metadata?.status !== 'fresh_canonical_audit_frozen'
+      || metadata.lastSelected !== cursor || selection?.lastSelected !== cursor
+      || selection?.status !== 'lineage_unproven'
+      || typeof metadata.runId !== 'string' || !metadata.runId
+      || !cohortSha256 || metadata.cohortSha256 !== cohortSha256
+      || execution?.status !== 'fresh_canonical_audit_execution_complete'
+      || execution.dryRunId !== metadata.runId
+      || execution.lastSelected !== cursor || execution.cohortSha256 !== cohortSha256
+      || typeof execution.executeRunId !== 'string' || !execution.executeRunId
+      || execution.scoreFinalized !== true || execution.timestampFinalized !== true
+      || execution.cacheClosureCompleted !== true || execution.packClosureCompleted !== true
+      || execution.productionSmokeCompleted !== true) {
+      fail('Cursor is not chained to a successfully closed previous execution');
+    }
+    const productionById = new Map(productionInventory.rows.map((row) => [row.id, row]));
+    for (const row of rows.slice(0, cursorIndex + 1)) {
+      const production = productionById.get(row.skillId);
+      if (production?.slug !== row.slug || !Number.isSafeInteger(production.artifact_revision)
+        || production.artifact_revision < 1
+        || typeof production.current_artifact_version_id !== 'string'
+        || !production.current_artifact_version_id) {
+        fail(`Cursor prefix is not fully governed in production: ${row.slug}`);
+      }
+    }
+  }
+  const selected = rows.slice(cursorIndex + 1, cursorIndex + 1 + size);
+  for (const row of selected) {
+    git(repositoryRoot, ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/SKILL.md`]);
+    git(repositoryRoot, ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/skill-report.json`]);
+  }
+  const grouped = new Map();
+  for (const row of selected) {
+    if (!grouped.has(row.marketplaceCommit)) grouped.set(row.marketplaceCommit, []);
+    grouped.get(row.marketplaceCommit).push(row);
+  }
+  const groups = [...grouped.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([marketplaceCommit, group]) => ({
+      marketplaceCommit,
+      count: group.length,
+      paths: group.map((row) => row.path),
+      slugs: group.map((row) => row.slug),
+    }));
+  return {
+    schemaVersion: 1,
+    status: 'lineage_unproven',
+    count: selected.length,
+    counts: {
+      same_source_tree_unproven: selected.filter((row) => row.remainingReason === 'same_source_tree_unproven').length,
+      source_changed_after_report_subject: selected.filter((row) => row.remainingReason === 'source_changed_after_report_subject').length,
+    },
+    rows: selected,
+    groups,
+    sourceCount: rows.length,
+    startAfter: cursor,
+    lastSelected: selected.at(-1)?.slug ?? null,
+    remaining: rows.length - (cursorIndex + 1 + selected.length),
+  };
+}
+
+function args(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) result[argv[index]?.replace(/^--/, '')] = argv[index + 1];
+  return result;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = args(argv);
+  if (!options.cohort || !options.output || !options['production-inventory']) {
+    fail('--cohort, --production-inventory, and --output are required');
+  }
+  const cohortBytes = readFileSync(resolve(options.cohort));
+  const result = prepareFreshCanonicalAuditBatch({
+    repositoryRoot: resolve(options['repository-root'] || process.cwd()),
+    cohort: JSON.parse(cohortBytes.toString('utf8')),
+    startAfter: options['start-after'] || null,
+    batchSize: options['batch-size'] || 10,
+    productionInventory: JSON.parse(readFileSync(resolve(options['production-inventory']), 'utf8')),
+    previousBoundary: options['previous-boundary']
+      ? JSON.parse(readFileSync(resolve(options['previous-boundary']), 'utf8'))
+      : null,
+    cohortSha256: createHash('sha256').update(cohortBytes).digest('hex'),
+  });
+  if (result.count === 0) fail('No remaining rows after the requested cursor');
+  writeFileSync(resolve(options.output), `${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ count: result.count, lastSelected: result.lastSelected, remaining: result.remaining })}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try { main(); } catch (error) { process.stderr.write(`fresh audit batch preparation failed: ${error.message}\n`); process.exitCode = 1; }
+}

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -101,8 +101,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute\]/);
   assert.match(workflow, /default: '2\.8\.0'/);
-  assert.match(workflow, /TODO_RELEASE_CLI_2_8_0_SHA256/);
-  assert.match(workflow, /replace CLI 2\.8\.0 digest TODO/);
+  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 2);
+  assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /fresh-run-manifest-file/);
   assert.match(workflow, /fresh-audit-run\.json/);

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { prepareFreshCanonicalAuditBatch } from '../prepare-fresh-canonical-audit-batch.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'fresh-audit-plan-'));
+  execFileSync('git', ['init', '-q', root]);
+  execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+  mkdirSync(join(root, 'skills', 'owner', 'skill'), { recursive: true });
+  writeFileSync(join(root, 'skills', 'owner', 'skill', 'SKILL.md'), '---\nname: skill\n---\n');
+  writeFileSync(join(root, 'skills', 'owner', 'skill', 'skill-report.json'), '{}\n');
+  execFileSync('git', ['-C', root, 'add', '.']);
+  execFileSync('git', ['-C', root, 'commit', '-qm', 'fixture']);
+  const commit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const row = {
+    slug: 'owner-skill', skillId: '11111111-1111-4111-8111-111111111111',
+    path: 'skills/owner/skill', marketplaceCommit: commit,
+    reportContentHash: 'a'.repeat(64), reportTreeHash: 'b'.repeat(64),
+    canonicalArtifact: { contentHash: 'c'.repeat(64), treeHash: 'd'.repeat(64) },
+    remainingReason: 'source_changed_after_report_subject', governanceEligibleByLineage: false,
+  };
+  return { root, row };
+}
+
+function inventory(row, revision = 0) {
+  return {
+    rows: [{
+      id: row.skillId,
+      slug: row.slug,
+      artifact_revision: revision,
+      current_artifact_version_id: revision > 0 ? 'artifact-version-id' : null,
+    }],
+  };
+}
+
+test('prepares a bounded commit-addressed fresh audit batch', () => {
+  const { root, row } = fixture();
+  const result = prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root,
+    cohort: { schemaVersion: 1, status: 'lineage_unproven', count: 1, rows: [row] },
+    batchSize: 1,
+    productionInventory: inventory(row),
+  });
+  assert.equal(result.count, 1);
+  assert.equal(result.groups[0].marketplaceCommit, row.marketplaceCommit);
+  assert.equal(result.remaining, 0);
+});
+
+test('rejects a lineage-governable row from the fresh audit lane', () => {
+  const { root, row } = fixture();
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root,
+    cohort: { schemaVersion: 1, status: 'lineage_unproven', count: 1, rows: [{ ...row, governanceEligibleByLineage: true }] },
+    batchSize: 1,
+    productionInventory: inventory(row),
+  }), /Invalid fresh-audit cohort row/);
+});
+
+test('cursor requires both the immediately preceding boundary and a fully governed production prefix', () => {
+  const { root, row } = fixture();
+  const cohortSha256 = 'f'.repeat(64);
+  const cohort = { schemaVersion: 1, status: 'lineage_unproven', count: 1, rows: [row] };
+  const previousBoundary = {
+    metadata: {
+      status: 'fresh_canonical_audit_frozen', runId: '123', lastSelected: row.slug,
+      cohortSha256,
+    },
+    selection: { status: 'lineage_unproven', lastSelected: row.slug },
+    executionProof: {
+      status: 'fresh_canonical_audit_execution_complete', executeRunId: '456',
+      dryRunId: '123', lastSelected: row.slug, cohortSha256,
+      scoreFinalized: true, timestampFinalized: true, cacheClosureCompleted: true,
+      packClosureCompleted: true, productionSmokeCompleted: true,
+    },
+  };
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 0), previousBoundary, cohortSha256,
+  }), /Cursor prefix is not fully governed/);
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1), previousBoundary: null, cohortSha256,
+  }), /successfully closed previous execution/);
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1),
+    previousBoundary: {
+      ...previousBoundary,
+      executionProof: { ...previousBoundary.executionProof, productionSmokeCompleted: false },
+    },
+    cohortSha256,
+  }), /successfully closed previous execution/);
+});
+
+test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
+  const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
+  assert.match(workflow, /options: \[dry-run, execute\]/);
+  assert.match(workflow, /default: '2\.8\.0'/);
+  assert.match(workflow, /TODO_RELEASE_CLI_2_8_0_SHA256/);
+  assert.match(workflow, /replace CLI 2\.8\.0 digest TODO/);
+  assert.match(workflow, /skill audit/);
+  assert.match(workflow, /fresh-run-manifest-file/);
+  assert.match(workflow, /fresh-audit-run\.json/);
+  assert.match(workflow, /previous_boundary_run_id/);
+  assert.match(workflow, /previous_execute_run_id/);
+  assert.match(workflow, /fresh_canonical_audit_execution_complete/);
+  assert.match(workflow, /productionSmokeCompleted:true/);
+  assert.match(workflow, /pre-inventory\.json/);
+  assert.match(workflow, /skill govern-fresh-canonical-audit/);
+  assert.match(workflow, /production-skill-score-writes/);
+  assert.match(workflow, /CACHE_INVALIDATE_SECRET/);
+  assert.match(workflow, /expected.*Pack|post-execution artifact and Pack evidence/i);
+  assert.match(workflow, /SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0\.1\.9,skillstore@latest/);
+  assert.match(workflow, /production-smoke\.mjs/);
+  assert.match(workflow, /MCP channel/);
+});


### PR DESCRIPTION
## Summary

- add the exact checked-in 106-row fresh canonical audit cohort
- process at most 10 Skills per dry-run boundary
- require new per-slug fresh audit run manifests and independent v3 audit evidence
- bind continuation to both the immediately previous dry-run and its fully successful execute Run
- pin Skillstore CLI 2.8.0 and its audited Linux x64 digest

## Safety

- source-changed and same-source-unproven rows receive fresh audits; lineage-governable rows are rejected
- partial/time-limited/legacy report reuse cannot enter governance
- cursor prefix must be artifact-governed in current production inventory
- previous execute proof must confirm score, timestamp, cache, Pack, post-inventory, and full production smoke closure
- failed execute runs cannot advance the cursor even if their RPC writes already committed
- this PR does not dispatch production governance

## Validation

- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs` (4/4 after rebase)
- workflow YAML safe-load passed
- `git diff --check`
- CLI 2.8.0 Linux x64 SHA-256: `ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a`

## Review history

Independent P0/P1 review found and this branch fixes stale report reuse, skipped-prefix cursor advancement, and advancement after partial execute closure. Final independent review found no remaining P0/P1.
