### PR TITLE
fix(governance): bind previous-report legacy evidence

### DIFF
--- a/.github/workflows/bind-legacy-audit-subjects.yml
+++ b/.github/workflows/bind-legacy-audit-subjects.yml
@@ -7,22 +7,11 @@ on:
         type: choice
         required: true
         options: [dry-run, execute]
-      classification_run_id:
-        description: Successful legacy-governance dry-run containing the frozen classification
-        type: string
-        required: true
       dry_run_id:
         description: Successful binding dry-run ID; execute only
         type: string
         required: false
-      expected_targeted:
-        type: number
-        required: true
-        default: 61
-      expected_drift:
-        type: number
-        required: true
-        default: 24
+        default: ''
 
 permissions:
   actions: read
@@ -42,13 +31,15 @@ jobs:
       - name: Validate immutable operator boundary
         env:
           MODE: ${{ inputs.mode }}
-          SOURCE_RUN: ${{ inputs.classification_run_id }}
           DRY_RUN: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$GITHUB_REF_NAME" = main
-          [[ "$SOURCE_RUN$DRY_RUN" != *[^0-9]* ]]
-          if [ "$MODE" = execute ]; then test -n "$DRY_RUN"; else test -z "$DRY_RUN"; fi
+          test "$GITHUB_REF_NAME" = main || { echo '::error::binding boundaries may only run from main'; exit 1; }
+          if [ "$MODE" = execute ]; then
+            [[ "$DRY_RUN" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric binding dry_run_id'; exit 1; }
+          else
+            test -z "$DRY_RUN" || { echo '::error::dry-run does not accept a source override'; exit 1; }
+          fi
       - id: token
         uses: actions/create-github-app-token@v3
         with:
@@ -67,35 +58,105 @@ jobs:
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = 'cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
-      - name: Download frozen hash-classification boundary
-        env: { GH_TOKEN: '${{ steps.token.outputs.token }}' }
+      - name: Download the three immutable governance source boundaries
+        if: inputs.mode == 'dry-run'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           set -euo pipefail
-          source_run='${{ inputs.mode == 'execute' && inputs.dry_run_id || inputs.classification_run_id }}'
-          mkdir -p "$RUNNER_TEMP/source"
-          gh run download "$source_run" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/source"
-          if [ '${{ inputs.mode }}' = execute ]; then
-            boundary=$(find "$RUNNER_TEMP/source" -type d -name 'legacy-audit-binding-boundary-*' -print -quit)
-          else
-            boundary=$(find "$RUNNER_TEMP/source" -type d -name 'legacy-equivalent-boundary-*' -print -quit)
-          fi
-          test -n "$boundary"
-          cp -R "$boundary" "$RUNNER_TEMP/boundary"
+          manifest=scripts/data/legacy-audit-binding-source-boundaries-v1.json
+          root="$RUNNER_TEMP/source-governance-boundaries"; mkdir -p "$root"
+          jq -c '.sources[]' "$manifest" | while read -r source; do
+            run_id=$(jq -r .runId <<< "$source"); head_sha=$(jq -r .headSha <<< "$source")
+            artifact=$(jq -r .artifactName <<< "$source"); target="$root/$run_id"; mkdir -p "$target"
+            run_json=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId,conclusion,event,headBranch,headSha,workflowName,url)
+            jq -e --arg id "$run_id" --arg headSha "$head_sha" '
+              (.databaseId | tostring) == $id and .conclusion == "success"
+              and .event == "workflow_dispatch" and .headBranch == "main"
+              and .headSha == $headSha and .workflowName == "Govern Legacy-Equivalent Artifacts"
+            ' <<< "$run_json" >/dev/null
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "$artifact" --dir "$target"
+            test "$(sha256sum "$target/SHA256SUMS" | awk '{print $1}')" = "$(jq -r .sha256sumsSha256 <<< "$source")"
+            (cd "$target" && sha256sum --check SHA256SUMS)
+            test "$(sha256sum "$target/classification.json" | awk '{print $1}')" = "$(jq -r .classificationSha256 <<< "$source")"
+            git merge-base --is-ancestor "$head_sha" "$GITHUB_SHA"
+          done
+      - name: Select the exact current raw32 cohort from fixed boundaries
+        if: inputs.mode == 'dry-run'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          manifest=scripts/data/legacy-audit-binding-source-boundaries-v1.json
+          root="$RUNNER_TEMP/source-governance-boundaries"
+          mkdir -p "$RUNNER_TEMP/boundary"
+          node scripts/build-legacy-audit-binding-source-cohort.mjs --phase candidate \
+            --manifest "$manifest" --sources-root "$root" --output "$RUNNER_TEMP/boundary/candidate-scope.json"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/boundary/candidate-scope.json" \
+            --output "$RUNNER_TEMP/candidate-source-evidence.json"
+          node scripts/build-legacy-audit-binding-source-cohort.mjs --phase select \
+            --manifest "$manifest" --sources-root "$root" \
+            --source-evidence "$RUNNER_TEMP/candidate-source-evidence.json" \
+            --classification-output "$RUNNER_TEMP/boundary/classification.json" \
+            --plan-output "$RUNNER_TEMP/boundary/plan.json"
+      - name: Authenticate and download the exact binding dry-run boundary
+        if: inputs.mode == 'execute'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          DRY_RUN: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$DRY_RUN" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName,url)
+          jq -e --arg id "$DRY_RUN" '
+            (.databaseId | tostring) == $id and .conclusion == "success"
+            and .event == "workflow_dispatch" and .headBranch == "main"
+            and .workflowName == "Bind Legacy Audit Subjects"
+          ' <<< "$run_json" >/dev/null
+          mkdir -p "$RUNNER_TEMP/boundary"
+          gh run download "$DRY_RUN" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-audit-binding-boundary-$DRY_RUN" --dir "$RUNNER_TEMP/boundary"
+          (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
+          head_sha=$(jq -r .headSha <<< "$run_json")
+          jq -e --arg runId "$DRY_RUN" --arg repository "$GITHUB_REPOSITORY" --arg headSha "$head_sha" '
+            .schemaVersion == 1 and .status == "binding_dry_run_frozen" and .runId == $runId
+            and .repository == $repository and .workflowCommit == $headSha
+            and .cliVersion == "2.7.0" and .expectedTargeted == 61 and .expectedDrift == 24
+          ' "$RUNNER_TEMP/boundary/binding-boundary.json" >/dev/null
+          cmp scripts/data/legacy-audit-binding-source-boundaries-v1.json "$RUNNER_TEMP/boundary/source-boundaries.json"
+          jq -e --slurpfile manifest "$RUNNER_TEMP/boundary/source-boundaries.json" \
+            '.sourceBoundaries == $manifest[0].sources' \
+            "$RUNNER_TEMP/boundary/binding-boundary.json" >/dev/null
+          node scripts/build-legacy-audit-binding-source-cohort.mjs --phase candidate \
+            --manifest "$RUNNER_TEMP/boundary/source-boundaries.json" \
+            --sources-root "$RUNNER_TEMP/boundary/source-governance-boundaries" \
+            --output "$RUNNER_TEMP/current-candidate-scope.json"
+          cmp "$RUNNER_TEMP/current-candidate-scope.json" "$RUNNER_TEMP/boundary/candidate-scope.json"
+          git merge-base --is-ancestor "$head_sha" "$GITHUB_SHA"
       - name: Freeze or verify exact pre-write evidence
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: |
           set -euo pipefail
-          classification="$RUNNER_TEMP/boundary/hash-classification.json"
+          classification="$RUNNER_TEMP/boundary/classification.json"
           test -f "$classification"
+          jq -e '
+            .schemaVersion == 1
+            and .status == "classified"
+            and .counts.exact == 0
+            and .counts.legacy_algorithm_equivalent == 61
+            and .counts.actual_or_unproven_drift == 24
+          ' "$classification" >/dev/null
           node scripts/fetch-legacy-equivalent-governance-readback.mjs \
             --classification "$classification" --output "$RUNNER_TEMP/source-evidence.json"
           node scripts/build-legacy-audit-binding-plan.mjs \
             --classification "$classification" --source-evidence "$RUNNER_TEMP/source-evidence.json" \
             --repository-root "$GITHUB_WORKSPACE" --output "$RUNNER_TEMP/binding-plan.json" \
-            --expected-targeted '${{ inputs.expected_targeted }}' \
-            --expected-drift '${{ inputs.expected_drift }}'
+            --expected-targeted 61 --expected-drift 24
           node scripts/fetch-artifact-version-inventory.mjs \
             --scope-inventory "$RUNNER_TEMP/boundary/plan.json" \
             --output "$RUNNER_TEMP/binding-inventory.json"
@@ -116,10 +177,14 @@ jobs:
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-        run: >-
-          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit
-          --plan "$RUNNER_TEMP/binding-plan.json" --root "$RUNNER_TEMP/reports"
-          --dry-run --concurrency 1 --result-file "$RUNNER_TEMP/binding-dry-run.json"
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit \
+            --plan "$RUNNER_TEMP/binding-plan.json" --root "$RUNNER_TEMP/reports" \
+            --dry-run --concurrency 1 --result-file "$RUNNER_TEMP/binding-dry-run.json"
+          if [ '${{ inputs.mode }}' = execute ]; then
+            cmp "$RUNNER_TEMP/binding-dry-run.json" "$RUNNER_TEMP/boundary/binding-dry-run.json"
+          fi
       - name: Record binding evidence only
         if: inputs.mode == 'execute'
         env:
@@ -137,7 +202,7 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/fetch-legacy-equivalent-governance-readback.mjs \
-            --classification "$RUNNER_TEMP/boundary/hash-classification.json" \
+            --classification "$RUNNER_TEMP/boundary/classification.json" \
             --output "$RUNNER_TEMP/post-source-evidence.json"
           node scripts/fetch-artifact-version-inventory.mjs \
             --scope-inventory "$RUNNER_TEMP/boundary/plan.json" \
@@ -146,8 +211,8 @@ jobs:
           jq -S 'del(.bindings)' "$RUNNER_TEMP/post-source-evidence.json" > "$RUNNER_TEMP/after-without-bindings.json"
           cmp "$RUNNER_TEMP/before-without-bindings.json" "$RUNNER_TEMP/after-without-bindings.json"
           cmp "$RUNNER_TEMP/binding-inventory.json" "$RUNNER_TEMP/post-binding-inventory.json"
-          test "$(jq '.bindings | length' "$RUNNER_TEMP/post-source-evidence.json")" = '${{ inputs.expected_targeted }}'
-          test "$(jq '[.results[] | select(.status == "created" or .status == "existing")] | length' "$RUNNER_TEMP/binding-execute.json")" = '${{ inputs.expected_targeted }}'
+          test "$(jq '.bindings | length' "$RUNNER_TEMP/post-source-evidence.json")" = 61
+          test "$(jq '[.results[] | select(.status == "created" or .status == "existing")] | length' "$RUNNER_TEMP/binding-execute.json")" = 61
       - name: Freeze dry-run boundary
         if: inputs.mode == 'dry-run'
         run: |
@@ -155,13 +220,33 @@ jobs:
           out="$RUNNER_TEMP/legacy-audit-binding-boundary-$GITHUB_RUN_ID"; mkdir -p "$out"
           cp "$RUNNER_TEMP/binding-plan.json" "$RUNNER_TEMP/source-evidence.json" \
             "$RUNNER_TEMP/binding-inventory.json" "$RUNNER_TEMP/binding-dry-run.json" \
-            "$RUNNER_TEMP/boundary/hash-classification.json" "$RUNNER_TEMP/boundary/plan.json" "$out/"
-      - uses: actions/upload-artifact@v6
-        if: always()
+            "$RUNNER_TEMP/candidate-source-evidence.json" \
+            "$RUNNER_TEMP/boundary/classification.json" "$RUNNER_TEMP/boundary/plan.json" \
+            "$RUNNER_TEMP/boundary/candidate-scope.json" "$out/"
+          cp scripts/data/legacy-audit-binding-source-boundaries-v1.json "$out/source-boundaries.json"
+          cp -R "$RUNNER_TEMP/source-governance-boundaries" "$out/source-governance-boundaries"
+          jq -n --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
+            --arg workflowCommit "$GITHUB_SHA" \
+            --slurpfile sourceManifest scripts/data/legacy-audit-binding-source-boundaries-v1.json \
+            '{schemaVersion:1,status:"binding_dry_run_frozen",runId:$runId,repository:$repository,
+              workflowCommit:$workflowCommit,sourceBoundaries:$sourceManifest[0].sources,cliVersion:"2.7.0",
+              cliSha256:"cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7",
+              expectedTargeted:61,expectedDrift:24}' > "$out/binding-boundary.json"
+          (cd "$out" && find . -type f ! -path './SHA256SUMS' -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+      - name: Upload exact binding dry-run boundary
+        if: success() && inputs.mode == 'dry-run'
+        uses: actions/upload-artifact@v6
         with:
-          name: legacy-audit-binding-${{ inputs.mode }}-${{ github.run_id }}
+          name: legacy-audit-binding-boundary-${{ github.run_id }}
+          path: ${{ runner.temp }}/legacy-audit-binding-boundary-${{ github.run_id }}/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Upload binding execution evidence
+        if: always() && inputs.mode == 'execute'
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-audit-binding-execution-${{ github.run_id }}
           path: |
-            ${{ runner.temp }}/legacy-audit-binding-boundary-*
             ${{ runner.temp }}/binding-*.json
             ${{ runner.temp }}/post-source-evidence.json
             ${{ runner.temp }}/post-binding-inventory.json

--- a/scripts/build-legacy-audit-binding-source-cohort.mjs
+++ b/scripts/build-legacy-audit-binding-source-cohort.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const RAW_AUDIT_HASH_RE = /^[0-9a-f]{32}$/;
+
+function fail(message) { throw new Error(message); }
+function readJson(path) { return JSON.parse(readFileSync(path, 'utf8')); }
+function sha256(path) { return createHash('sha256').update(readFileSync(path)).digest('hex'); }
+function uniqueMap(rows, key, label) {
+  const result = new Map();
+  for (const row of rows || []) {
+    const value = row?.[key];
+    if (typeof value !== 'string' || !value || result.has(value)) fail(`${label} has duplicate or invalid ${key}`);
+    result.set(value, row);
+  }
+  return result;
+}
+
+export function loadLegacyAuditBindingSources({ manifest, sourcesRoot }) {
+  if (
+    manifest?.schemaVersion !== 1
+    || manifest?.status !== 'frozen'
+    || manifest?.expected?.legacy_algorithm_equivalent !== 61
+    || manifest?.expected?.actual_or_unproven_drift !== 24
+    || manifest?.expected?.total !== 85
+    || !Array.isArray(manifest?.sources)
+    || manifest.sources.length !== 3
+  ) fail('source-boundary manifest contract is invalid');
+  const runIds = new Set();
+  const allRows = [];
+  const sources = [];
+  const slugs = new Set();
+  const skillIds = new Set();
+  const auditIds = new Set();
+  for (const source of manifest.sources) {
+    if (
+      !/^[1-9][0-9]*$/.test(source?.runId || '')
+      || runIds.has(source.runId)
+      || !COMMIT_RE.test(source?.headSha || '')
+      || source?.artifactName !== `legacy-equivalent-boundary-${source.runId}`
+      || !SHA256_RE.test(source?.sha256sumsSha256 || '')
+      || !SHA256_RE.test(source?.classificationSha256 || '')
+      || !Number.isSafeInteger(source?.expectedLegacy)
+      || !Number.isSafeInteger(source?.expectedDrift)
+    ) fail('source-boundary manifest entry is invalid');
+    runIds.add(source.runId);
+    const root = resolve(sourcesRoot, source.runId);
+    const sumsPath = join(root, 'SHA256SUMS');
+    const classificationPath = join(root, 'classification.json');
+    const boundary = readJson(join(root, 'boundary.json'));
+    if (
+      sha256(sumsPath) !== source.sha256sumsSha256
+      || sha256(classificationPath) !== source.classificationSha256
+      || String(boundary?.runId) !== source.runId
+      || boundary?.workflowCommit !== source.headSha
+    ) fail(`source boundary identity mismatch for run ${source.runId}`);
+    const classification = readJson(classificationPath);
+    if (classification?.schemaVersion !== 1 || classification?.status !== 'classified') {
+      fail(`classification contract is invalid for run ${source.runId}`);
+    }
+    const cohorts = {
+      legacy_algorithm_equivalent: classification?.cohorts?.legacy_algorithm_equivalent,
+      actual_or_unproven_drift: classification?.cohorts?.actual_or_unproven_drift,
+    };
+    for (const [classificationName, rows] of Object.entries(cohorts)) {
+      if (!Array.isArray(rows)) fail(`source ${source.runId} lacks ${classificationName}`);
+      for (const row of rows) {
+        if (
+          !row?.slug || !row?.id || !row?.publicEligibilityAuditId
+          || slugs.has(row.slug) || skillIds.has(row.id) || auditIds.has(row.publicEligibilityAuditId)
+        ) fail(`source boundaries overlap or lack identity at ${row?.slug || '<missing>'}`);
+        slugs.add(row.slug); skillIds.add(row.id); auditIds.add(row.publicEligibilityAuditId);
+        allRows.push({ source, classificationName, row });
+      }
+    }
+    sources.push({ source, root, classification });
+  }
+  return { sources, allRows };
+}
+
+export function buildLegacyAuditBindingCandidateScope(input) {
+  const loaded = loadLegacyAuditBindingSources(input);
+  const rows = loaded.allRows.map(({ row }) => row).sort((a, b) => a.slug.localeCompare(b.slug));
+  return {
+    schemaVersion: 1,
+    status: 'classified',
+    counts: { exact: 0, legacy_algorithm_equivalent: rows.length, actual_or_unproven_drift: 0 },
+    cohorts: { exact: [], legacy_algorithm_equivalent: rows, actual_or_unproven_drift: [] },
+  };
+}
+
+export function selectLegacyAuditBindingSourceCohort({ manifest, sourcesRoot, sourceEvidence }) {
+  const loaded = loadLegacyAuditBindingSources({ manifest, sourcesRoot });
+  if (sourceEvidence?.schemaVersion !== 1 || sourceEvidence?.status !== 'source_evidence_fetched') {
+    fail('candidate source evidence is incomplete');
+  }
+  const skills = uniqueMap(sourceEvidence.skills, 'id', 'candidate Skills');
+  const audits = uniqueMap(sourceEvidence.audits, 'id', 'candidate audits');
+  if (skills.size !== loaded.allRows.length || audits.size !== loaded.allRows.length) {
+    fail('candidate source evidence does not cover all fixed boundaries');
+  }
+  const selected = { exact: [], legacy_algorithm_equivalent: [], actual_or_unproven_drift: [] };
+  const countsByRun = new Map(manifest.sources.map((source) => [source.runId, { legacy: 0, drift: 0 }]));
+  for (const { source, classificationName, row } of loaded.allRows) {
+    const skill = skills.get(row.id);
+    const audit = audits.get(row.publicEligibilityAuditId);
+    if (
+      !skill || skill.slug !== row.slug
+      || !audit || audit.skill_id !== row.id
+    ) {
+      fail(`candidate source identity mismatch for ${row.slug}`);
+    }
+    if (!RAW_AUDIT_HASH_RE.test(audit.content_hash || '')) continue;
+    if (skill.public_eligibility_audit_id !== row.publicEligibilityAuditId) {
+      fail(`current raw32 audit pointer changed for ${row.slug}`);
+    }
+    selected[classificationName].push(row);
+    const counter = countsByRun.get(source.runId);
+    if (classificationName === 'legacy_algorithm_equivalent') counter.legacy += 1;
+    else counter.drift += 1;
+  }
+  for (const source of manifest.sources) {
+    const actual = countsByRun.get(source.runId);
+    if (actual.legacy !== source.expectedLegacy || actual.drift !== source.expectedDrift) {
+      fail(`raw32 cohort count changed for source run ${source.runId}`);
+    }
+  }
+  for (const rows of Object.values(selected)) rows.sort((a, b) => a.slug.localeCompare(b.slug));
+  if (
+    selected.legacy_algorithm_equivalent.length !== manifest.expected.legacy_algorithm_equivalent
+    || selected.actual_or_unproven_drift.length !== manifest.expected.actual_or_unproven_drift
+  ) fail('merged raw32 cohort is not the frozen 61/24 split');
+  const classification = {
+    schemaVersion: 1,
+    status: 'classified',
+    counts: {
+      exact: 0,
+      legacy_algorithm_equivalent: selected.legacy_algorithm_equivalent.length,
+      actual_or_unproven_drift: selected.actual_or_unproven_drift.length,
+    },
+    cohorts: selected,
+  };
+  const planRows = [...selected.legacy_algorithm_equivalent, ...selected.actual_or_unproven_drift]
+    .map(({ evidence: _evidence, ...row }) => row)
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+  return {
+    classification,
+    plan: { schemaVersion: 1, status: 'legacy_audit_binding_scope', selectedCount: 85, selected: planRows },
+  };
+}
+
+function main() {
+  const { values } = parseArgs({ options: {
+    phase: { type: 'string' }, manifest: { type: 'string' }, 'sources-root': { type: 'string' },
+    'source-evidence': { type: 'string' }, output: { type: 'string' },
+    'classification-output': { type: 'string' }, 'plan-output': { type: 'string' },
+  }, strict: true });
+  const manifest = readJson(resolve(values.manifest));
+  const sourcesRoot = resolve(values['sources-root']);
+  if (values.phase === 'candidate') {
+    const result = buildLegacyAuditBindingCandidateScope({ manifest, sourcesRoot });
+    writeFileSync(resolve(values.output), `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx' });
+  } else if (values.phase === 'select') {
+    const result = selectLegacyAuditBindingSourceCohort({
+      manifest, sourcesRoot, sourceEvidence: readJson(resolve(values['source-evidence'])),
+    });
+    writeFileSync(resolve(values['classification-output']), `${JSON.stringify(result.classification, null, 2)}\n`, { flag: 'wx' });
+    writeFileSync(resolve(values['plan-output']), `${JSON.stringify(result.plan, null, 2)}\n`, { flag: 'wx' });
+  } else fail('phase must be candidate or select');
+}
+
+if (process.argv[1]?.endsWith('build-legacy-audit-binding-source-cohort.mjs')) {
+  try { main(); } catch (error) { process.stderr.write(`${error.message}\n`); process.exitCode = 1; }
+}

--- a/scripts/data/legacy-audit-binding-source-boundaries-v1.json
+++ b/scripts/data/legacy-audit-binding-source-boundaries-v1.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "status": "frozen",
+  "expected": {
+    "legacy_algorithm_equivalent": 61,
+    "actual_or_unproven_drift": 24,
+    "total": 85
+  },
+  "sources": [
+    {
+      "runId": "29391353646",
+      "headSha": "8a134852cbb4e5180f075af59ae4189df46b490d",
+      "artifactName": "legacy-equivalent-boundary-29391353646",
+      "sha256sumsSha256": "dbf64f396110327093d7e1dfbc9b3cef36aaef20c9c396451e415c61339bf42a",
+      "classificationSha256": "fbc52726aad4ffbb7646e9eef4cb07c0d36d3d7b394b4c5d8bf6ecf3a33367cf",
+      "expectedLegacy": 0,
+      "expectedDrift": 12
+    },
+    {
+      "runId": "29394223576",
+      "headSha": "498b565d4942ff146aeae8bfa3f69e2d4c17d834",
+      "artifactName": "legacy-equivalent-boundary-29394223576",
+      "sha256sumsSha256": "e7709e736949405fcf97d60672a7760cee50421ac1996c160d2ce8ae94a69a57",
+      "classificationSha256": "5fd6a2acd687c4a243a6857e06831b0814bb486b66e4864c2d9ded5d869137b2",
+      "expectedLegacy": 1,
+      "expectedDrift": 0
+    },
+    {
+      "runId": "29402463151",
+      "headSha": "9be504197f72dcd71e6a0d789fd984274a268461",
+      "artifactName": "legacy-equivalent-boundary-29402463151",
+      "sha256sumsSha256": "4f861cb6c48ca4c6c97e637b2a2089215c93c8b39e81ae2dfb508b67bc60cae0",
+      "classificationSha256": "b77f94af0f4400ade13f8cc3bde678f9602ec736f738003eb143f76a7d77f665",
+      "expectedLegacy": 60,
+      "expectedDrift": 12
+    }
+  ]
+}

--- a/scripts/fetch-legacy-equivalent-governance-readback.mjs
+++ b/scripts/fetch-legacy-equivalent-governance-readback.mjs
@@ -137,7 +137,7 @@ export async function fetchLegacyGovernanceSourceEvidence({
   const [skills, audits, bindings] = await Promise.all([
     request(
       'skills',
-      'id,slug,name,description,author_name,supported_tools,file_structure',
+      'id,slug,name,description,author_name,supported_tools,file_structure,public_eligibility_audit_id',
       'id',
       skillIds
     ),

--- a/scripts/tests/artifact-version-backfill.test.mjs
+++ b/scripts/tests/artifact-version-backfill.test.mjs
@@ -12,6 +12,7 @@ import {
   verifyArtifactVersionExecution,
 } from '../verify-artifact-version-classification.mjs';
 import { verifyArtifactVersionReadback } from '../verify-artifact-version-backfill.mjs';
+import { qualifyLegacyGovernanceClassification } from '../verify-legacy-equivalent-governance.mjs';
 
 const HASH_A = 'a'.repeat(64);
 const HASH_B = 'b'.repeat(64);
@@ -78,9 +79,10 @@ function inventoryRow({
   };
 }
 
-function hashRepair(before, classification) {
+function hashRepair(before, classification, legacyTreeEvidence = 'plain') {
   const exact = classification === 'exact';
   const legacyEquivalent = classification === 'legacy_algorithm_equivalent';
+  const previousReportEquivalent = legacyEquivalent && legacyTreeEvidence === 'previous-report';
   return {
     requested: true,
     applied: false,
@@ -105,21 +107,30 @@ function hashRepair(before, classification) {
     reportTreeHashScheme: exact
       ? 'canonical_entries_v1'
       : legacyEquivalent
-        ? 'legacy_path_sha256_merkle_v1'
+        ? previousReportEquivalent
+          ? 'legacy_path_sha256_merkle_previous_report_v1'
+          : 'legacy_path_sha256_merkle_v1'
         : 'unproven',
     packagedTreeHash: exact ? before.treeHash : HASH_D,
     packagedTreeHashScheme: 'canonical_entries_v1',
     legacyCalculatedContentHash: legacyEquivalent ? before.contentHash : HASH_D,
     legacyCalculatedContentHashScheme: 'skill_md_strip_version_trim_v1',
-    legacyCalculatedTreeHash: legacyEquivalent ? before.treeHash : HASH_C,
+    legacyCalculatedTreeHash: legacyEquivalent && !previousReportEquivalent ? before.treeHash : HASH_C,
     legacyCalculatedTreeHashScheme: 'legacy_path_sha256_merkle_v1',
+    previousReportSha256: previousReportEquivalent ? HASH_D : null,
+    previousReportInputRelation: previousReportEquivalent
+      ? 'canonical_install_plus_previous_generated_report'
+      : null,
+    legacyPreviousReportCalculatedTreeHash: previousReportEquivalent ? before.treeHash : null,
+    legacyPreviousReportCalculatedTreeHashScheme:
+      'legacy_path_sha256_merkle_previous_report_v1',
     observationTimeSource: exact ? 'report_generated_at' : 'backfill_execution_time',
     observedAt: exact ? '2026-01-01T00:00:00.000Z' : '2026-07-15T00:00:00.000Z',
   };
 }
 
-function dryRunResult(before, classification) {
-  const repair = hashRepair(before, classification);
+function dryRunResult(before, classification, legacyTreeEvidence = 'plain') {
+  const repair = hashRepair(before, classification, legacyTreeEvidence);
   return {
     slug: before.slug,
     skillId: before.id,
@@ -152,11 +163,15 @@ function dryRunResult(before, classification) {
   };
 }
 
-function groupWrappers(plan, classificationBySlug) {
+function groupWrappers(plan, classificationBySlug, legacyTreeEvidenceBySlug = {}) {
   return plan.batches.flatMap((batch) => batch.groups.map((group) => {
     const results = group.slugs.map((slug) => {
       const before = plan.selected.find((row) => row.slug === slug);
-      return dryRunResult(before, classificationBySlug[slug]);
+      return dryRunResult(
+        before,
+        classificationBySlug[slug],
+        legacyTreeEvidenceBySlug[slug]
+      );
     });
     return {
       batchIndex: batch.index,
@@ -384,7 +399,7 @@ test('classifies every planned row and derives an exact-only execution cohort', 
       alpha: 'exact',
       beta: 'legacy_algorithm_equivalent',
       charlie: 'actual_or_unproven_drift',
-    }),
+    }, { beta: 'previous-report' }),
   });
   assert.deepEqual(classification.counts, {
     exact: 1,
@@ -393,6 +408,187 @@ test('classifies every planned row and derives an exact-only execution cohort', 
   });
   assert.deepEqual(classification.exactBatches[0].slugs, ['alpha']);
   assert.equal(classification.remainingCohorts.total, 2);
+});
+
+test('strictly proves previous-report legacy evidence without weakening plain legacy or drift', () => {
+  const before = {
+    id: SKILL_ID,
+    slug: 'alpha',
+    path: 'skills/a/one',
+    marketplaceCommit: 'a'.repeat(40),
+    contentHash: HASH_A,
+    treeHash: HASH_B,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+    publicEligibilityAuditId: AUDIT_ID,
+    publishedAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-07-14T16:50:53.000Z',
+  };
+  const plan = {
+    selected: [before],
+    batches: [{ index: 1, groups: [{
+      marketplaceCommit: before.marketplaceCommit,
+      count: 1,
+      slugs: [before.slug],
+      paths: [before.path],
+    }] }],
+  };
+  const previousReportWrappers = () => groupWrappers(
+    plan,
+    { alpha: 'legacy_algorithm_equivalent' },
+    { alpha: 'previous-report' }
+  );
+
+  const proven = classifyArtifactVersionResults({
+    plan,
+    groupResults: previousReportWrappers(),
+  });
+  assert.equal(proven.counts.legacy_algorithm_equivalent, 1);
+
+  for (const [field, value] of [
+    ['previousReportSha256', 'not-a-sha256'],
+    ['previousReportInputRelation', 'wrong-input-relation'],
+    ['legacyPreviousReportCalculatedTreeHash', HASH_C],
+    ['legacyPreviousReportCalculatedTreeHashScheme', 'wrong-tree-scheme'],
+  ]) {
+    const wrappers = previousReportWrappers();
+    wrappers[0].result.results[0].artifact.hashRepair[field] = value;
+    assert.throws(
+      () => classifyArtifactVersionResults({ plan, groupResults: wrappers }),
+      /Previous-report legacy evidence is incomplete|Hash classification is not independently proven/,
+      field
+    );
+  }
+
+  const plain = classifyArtifactVersionResults({
+    plan,
+    groupResults: groupWrappers(plan, { alpha: 'legacy_algorithm_equivalent' }),
+  });
+  assert.equal(plain.counts.legacy_algorithm_equivalent, 1);
+
+  const ambiguousPreviousReport = previousReportWrappers();
+  const ambiguousRepair = ambiguousPreviousReport[0].result.results[0].artifact.hashRepair;
+  ambiguousRepair.legacyCalculatedTreeHash = ambiguousRepair.reportTreeHash;
+  assert.throws(
+    () => classifyArtifactVersionResults({ plan, groupResults: ambiguousPreviousReport }),
+    /not independently proven/
+  );
+
+  ambiguousRepair.reportTreeHashScheme = 'legacy_path_sha256_merkle_v1';
+  const normalizedPlain = classifyArtifactVersionResults({
+    plan,
+    groupResults: ambiguousPreviousReport,
+  });
+  assert.equal(normalizedPlain.counts.legacy_algorithm_equivalent, 1);
+
+  const prePreviousReportCliPlain = groupWrappers(
+    plan,
+    { alpha: 'legacy_algorithm_equivalent' }
+  );
+  const oldRepair = prePreviousReportCliPlain[0].result.results[0].artifact.hashRepair;
+  delete oldRepair.previousReportSha256;
+  delete oldRepair.previousReportInputRelation;
+  delete oldRepair.legacyPreviousReportCalculatedTreeHash;
+  delete oldRepair.legacyPreviousReportCalculatedTreeHashScheme;
+  const oldPlain = classifyArtifactVersionResults({
+    plan,
+    groupResults: prePreviousReportCliPlain,
+  });
+  assert.equal(oldPlain.counts.legacy_algorithm_equivalent, 1);
+
+  const disguisedDrift = groupWrappers(plan, { alpha: 'actual_or_unproven_drift' });
+  const repair = disguisedDrift[0].result.results[0].artifact.hashRepair;
+  repair.previousReportSha256 = HASH_D;
+  repair.previousReportInputRelation = 'canonical_install_plus_previous_generated_report';
+  repair.legacyCalculatedContentHash = repair.reportContentHash;
+  repair.legacyPreviousReportCalculatedTreeHash = repair.reportTreeHash;
+  assert.throws(
+    () => classifyArtifactVersionResults({ plan, groupResults: disguisedDrift }),
+    /not independently proven/
+  );
+});
+
+test('qualifies all 472 Batch 7 previous-report rows through v2 evidence, not raw-digest binding', () => {
+  const commit = 'a'.repeat(40);
+  const selected = Array.from({ length: 472 }, (_, index) => ({
+    id: uuidFor(1000 + index),
+    slug: `batch7-v2-${String(index).padStart(3, '0')}`,
+    path: `skills/batch7/v2-${String(index).padStart(3, '0')}`,
+    marketplaceCommit: commit,
+    contentHash: HASH_A,
+    treeHash: HASH_B,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+    publicEligibilityAuditId: uuidFor(2000 + index),
+    publishedAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-07-14T16:50:53.000Z',
+  }));
+  const plan = {
+    selected,
+    batches: [{ index: 1, groups: [{
+      marketplaceCommit: commit,
+      count: selected.length,
+      slugs: selected.map((row) => row.slug),
+      paths: selected.map((row) => row.path),
+    }] }],
+  };
+  const classifications = Object.fromEntries(
+    selected.map((row) => [row.slug, 'legacy_algorithm_equivalent'])
+  );
+  const previousReportEvidence = Object.fromEntries(
+    selected.map((row) => [row.slug, 'previous-report'])
+  );
+  const classification = classifyArtifactVersionResults({
+    plan,
+    groupResults: groupWrappers(plan, classifications, previousReportEvidence),
+  });
+  assert.equal(classification.counts.legacy_algorithm_equivalent, 472);
+
+  const sourceEvidence = {
+    schemaVersion: 1,
+    status: 'source_evidence_fetched',
+    skillIds: selected.map((row) => row.id).sort(),
+    skills: selected.map((row) => ({ id: row.id, slug: row.slug })),
+    audits: selected.map((row, index) => ({
+      id: row.publicEligibilityAuditId,
+      skill_id: row.id,
+      version: 1,
+      content_hash: `v2:${row.marketplaceCommit}:${row.contentHash}:${row.treeHash}:${String(index).padStart(32, '0')}`,
+      audit_payload_hash: null,
+      subject_marketplace_commit_sha: null,
+      subject_content_hash: null,
+      subject_tree_hash: null,
+      subject_plugin_path: null,
+      derived_from_audit_id: null,
+      derivation_kind: null,
+    })),
+    bindings: [],
+  };
+  const qualified = qualifyLegacyGovernanceClassification({
+    classification,
+    sourceEvidence,
+  });
+  assert.equal(qualified.governance.hashEquivalentCount, 472);
+  assert.equal(qualified.governance.eligibleCount, 472);
+  assert.equal(qualified.governance.unprovenCount, 0);
+  assert.equal(qualified.governance.eligible.every((row) => row.reason === 'eligible_v2'), true);
+
+  const rawDigestWithoutBinding = structuredClone(sourceEvidence);
+  rawDigestWithoutBinding.audits[0].content_hash = 'f'.repeat(32);
+  const rawQualified = qualifyLegacyGovernanceClassification({
+    classification,
+    sourceEvidence: rawDigestWithoutBinding,
+  });
+  assert.equal(rawQualified.governance.eligibleCount, 471);
+  assert.equal(rawQualified.governance.unprovenCount, 1);
+  assert.equal(
+    rawQualified.governance.unproven[0].reason,
+    'source_audit_binding_unproven_legacy_digest'
+  );
 });
 
 test('classification rejects operational failures or incomplete evidence', () => {

--- a/scripts/tests/legacy-audit-binding-cohorts.test.mjs
+++ b/scripts/tests/legacy-audit-binding-cohorts.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
 import { buildLegacyAuditBindingPlan } from '../build-legacy-audit-binding-plan.mjs';
 import { planLegacyAuditBindingCohorts } from '../plan-legacy-audit-binding-cohorts.mjs';
+import {
+  buildLegacyAuditBindingCandidateScope,
+  selectLegacyAuditBindingSourceCohort,
+} from '../build-legacy-audit-binding-source-cohort.mjs';
 
 function row(prefix, index) {
   return {
@@ -89,6 +94,85 @@ test('fails closed on missing, duplicate, or cross-cohort evidence', () => {
   assert.throws(() => planLegacyAuditBindingCohorts(mismatch), /frozen binding identity mismatch/);
 });
 
+test('merges only the frozen 61/24 raw32 cohort from three immutable source boundaries', () => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'legacy-binding-sources-'));
+  try {
+    const distributions = [[0, 12], [1, 0], [60, 12]];
+    const sources = [];
+    const sourceEvidence = {
+      schemaVersion: 1, status: 'source_evidence_fetched', skillIds: [],
+      skills: [], audits: [], bindings: [],
+    };
+    let index = 0;
+    for (let sourceIndex = 0; sourceIndex < distributions.length; sourceIndex += 1) {
+      const runId = String(1000 + sourceIndex);
+      const root = resolve(directory, runId); mkdirSync(root, { recursive: true });
+      const [legacyCount, driftCount] = distributions[sourceIndex];
+      const makeRows = (count, prefix) => Array.from({ length: count }, () => {
+        const current = index++;
+        const item = {
+          id: `skill-${current}`, slug: `${prefix}-${current}`,
+          publicEligibilityAuditId: `audit-${current}`,
+        };
+        sourceEvidence.skillIds.push(item.id);
+        sourceEvidence.skills.push({
+          id: item.id, slug: item.slug,
+          public_eligibility_audit_id: item.publicEligibilityAuditId,
+        });
+        sourceEvidence.audits.push({
+          id: item.publicEligibilityAuditId, skill_id: item.id, content_hash: 'a'.repeat(32),
+        });
+        return item;
+      });
+      const classification = {
+        schemaVersion: 1, status: 'classified', cohorts: {
+          exact: [], legacy_algorithm_equivalent: makeRows(legacyCount, 'legacy'),
+          actual_or_unproven_drift: makeRows(driftCount, 'drift'),
+        },
+      };
+      const headSha = String(sourceIndex + 1).repeat(40);
+      writeFileSync(resolve(root, 'classification.json'), JSON.stringify(classification));
+      writeFileSync(resolve(root, 'boundary.json'), JSON.stringify({ runId, workflowCommit: headSha }));
+      writeFileSync(resolve(root, 'SHA256SUMS'), 'fixture sums\n');
+      const digest = (path) => createHash('sha256').update(readFileSync(path)).digest('hex');
+      sources.push({
+        runId, headSha, artifactName: `legacy-equivalent-boundary-${runId}`,
+        sha256sumsSha256: digest(resolve(root, 'SHA256SUMS')),
+        classificationSha256: digest(resolve(root, 'classification.json')),
+        expectedLegacy: legacyCount, expectedDrift: driftCount,
+      });
+    }
+    sourceEvidence.skillIds.sort();
+    const manifest = {
+      schemaVersion: 1, status: 'frozen',
+      expected: { legacy_algorithm_equivalent: 61, actual_or_unproven_drift: 24, total: 85 },
+      sources,
+    };
+    const candidate = buildLegacyAuditBindingCandidateScope({ manifest, sourcesRoot: directory });
+    assert.equal(candidate.counts.legacy_algorithm_equivalent, 85);
+    const selected = selectLegacyAuditBindingSourceCohort({ manifest, sourcesRoot: directory, sourceEvidence });
+    assert.deepEqual(selected.classification.counts, {
+      exact: 0, legacy_algorithm_equivalent: 61, actual_or_unproven_drift: 24,
+    });
+    assert.equal(selected.plan.selectedCount, 85);
+
+    const changed = structuredClone(sourceEvidence);
+    changed.audits[0].content_hash = `v2:${'1'.repeat(40)}:${'2'.repeat(64)}:${'3'.repeat(64)}:${'4'.repeat(32)}`;
+    assert.throws(
+      () => selectLegacyAuditBindingSourceCohort({ manifest, sourcesRoot: directory, sourceEvidence: changed }),
+      /raw32 cohort count changed/
+    );
+    const pointerDrift = structuredClone(sourceEvidence);
+    pointerDrift.skills[0].public_eligibility_audit_id = 'new-audit-pointer';
+    assert.throws(
+      () => selectLegacyAuditBindingSourceCohort({ manifest, sourcesRoot: directory, sourceEvidence: pointerDrift }),
+      /current raw32 audit pointer changed/
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('binding workflow is two-phase, pinned, score/artifact preserving, and cache inert', () => {
   const workflow = readFileSync(resolve(
     import.meta.dirname,
@@ -101,8 +185,53 @@ test('binding workflow is two-phase, pinned, score/artifact preserving, and cach
   assert.match(workflow, /--dry-run --concurrency 1/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/binding-inventory\.json" "\$RUNNER_TEMP\/post-binding-inventory\.json"/);
   assert.doesNotMatch(workflow, /cache\/invalidate|warm-cache|invalidateApi/);
-  assert.match(workflow, /expected_targeted:[\s\S]*default: 61/);
-  assert.match(workflow, /expected_drift:[\s\S]*default: 24/);
+  assert.doesNotMatch(workflow, /expected_targeted:|expected_drift:/);
+  assert.match(workflow, /--expected-targeted 61 --expected-drift 24/);
+  assert.match(workflow, /\.expectedTargeted == 61/);
+  assert.match(workflow, /\.expectedDrift == 24/);
+  assert.match(workflow, /boundary\/classification\.json/);
+  assert.doesNotMatch(workflow, /boundary\/hash-classification\.json/);
+  assert.match(workflow, /\.counts\.legacy_algorithm_equivalent == 61/);
+  assert.match(workflow, /\.counts\.actual_or_unproven_drift == 24/);
+  assert.match(workflow, /legacy-audit-binding-boundary-/);
+});
+
+test('binding workflow authenticates and byte-freezes governance and binding run boundaries', () => {
+  const workflow = readFileSync(resolve(
+    import.meta.dirname,
+    '../../.github/workflows/bind-legacy-audit-subjects.yml'
+  ), 'utf8');
+  assert.match(workflow, /--json databaseId,conclusion,event,headBranch,headSha,workflowName,url/);
+  assert.match(workflow, /\.conclusion == "success"/);
+  assert.match(workflow, /\.event == "workflow_dispatch"/);
+  assert.match(workflow, /\.headBranch == "main"/);
+  assert.match(workflow, /\.workflowName == "Govern Legacy-Equivalent Artifacts"/);
+  assert.match(workflow, /\.workflowName == "Bind Legacy Audit Subjects"/);
+  assert.match(workflow, /--name "\$artifact" --dir "\$target"/);
+  assert.match(workflow, /--name "legacy-audit-binding-boundary-\$DRY_RUN"/);
+  assert.ok((workflow.match(/sha256sum --check SHA256SUMS/g) || []).length >= 2);
+  assert.match(workflow, /\.headSha == \$headSha/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$head_sha" "\$GITHUB_SHA"/);
+  assert.match(workflow, /source-governance-boundaries/);
+  assert.match(workflow, /legacy-audit-binding-source-boundaries-v1\.json/);
+  assert.match(workflow, /cmp "\$RUNNER_TEMP\/binding-dry-run\.json" "\$RUNNER_TEMP\/boundary\/binding-dry-run\.json"/);
+  assert.match(workflow, /status:"binding_dry_run_frozen"/);
+  assert.match(workflow, /name: legacy-audit-binding-boundary-\$\{\{ github\.run_id \}\}/);
+  const downloads = workflow.match(/gh run download[\s\S]{0,180}/g) || [];
+  assert.equal(downloads.length, 2);
+  assert.match(downloads[0], /--name "\$artifact"/);
+  assert.match(downloads[1], /--name "legacy-audit-binding-boundary-\$DRY_RUN"/);
+
+  const manifest = JSON.parse(readFileSync(resolve(
+    import.meta.dirname,
+    '../data/legacy-audit-binding-source-boundaries-v1.json'
+  ), 'utf8'));
+  assert.deepEqual(manifest.sources.map((source) => source.runId), [
+    '29391353646', '29394223576', '29402463151',
+  ]);
+  assert.deepEqual(manifest.sources.map((source) => [source.expectedLegacy, source.expectedDrift]), [
+    [0, 12], [1, 0], [60, 12],
+  ]);
 });
 
 test('builds the executable plan from the frozen pointer and exact Git blob', () => {

--- a/scripts/verify-artifact-version-classification.mjs
+++ b/scripts/verify-artifact-version-classification.mjs
@@ -6,6 +6,11 @@ import { pathToFileURL } from 'node:url';
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_TREE_HASH_SCHEME = 'legacy_path_sha256_merkle_v1';
+const LEGACY_PREVIOUS_REPORT_TREE_HASH_SCHEME =
+  'legacy_path_sha256_merkle_previous_report_v1';
+const LEGACY_PREVIOUS_REPORT_INPUT_RELATION =
+  'canonical_install_plus_previous_generated_report';
 const CLASSIFICATIONS = [
   'exact',
   'legacy_algorithm_equivalent',
@@ -148,16 +153,40 @@ function validateHashEvidence(artifact, before, expectedClassification) {
   const contentMismatch = repair.reportContentHash !== repair.packagedContentHash;
   const treeMismatch = repair.reportTreeHash !== repair.packagedTreeHash;
   const canonicalMatch = !contentMismatch && !treeMismatch;
-  const legacyMatch =
+  const plainLegacyMatch =
     repair.reportContentHash === repair.legacyCalculatedContentHash
     && repair.reportTreeHash === repair.legacyCalculatedTreeHash;
+  const previousReportEvidenceAbsent =
+    repair.previousReportSha256 == null
+    && repair.previousReportInputRelation == null
+    && repair.legacyPreviousReportCalculatedTreeHash == null;
+  const previousReportEvidenceComplete =
+    SHA256_RE.test(String(repair.previousReportSha256 ?? ''))
+    && repair.previousReportInputRelation === LEGACY_PREVIOUS_REPORT_INPUT_RELATION
+    && SHA256_RE.test(String(repair.legacyPreviousReportCalculatedTreeHash ?? ''));
+  if (
+    (!previousReportEvidenceAbsent && !previousReportEvidenceComplete)
+    || (previousReportEvidenceComplete
+      && repair.legacyPreviousReportCalculatedTreeHashScheme
+        !== LEGACY_PREVIOUS_REPORT_TREE_HASH_SCHEME)
+    || (previousReportEvidenceAbsent
+      && repair.legacyPreviousReportCalculatedTreeHashScheme != null
+      && repair.legacyPreviousReportCalculatedTreeHashScheme
+        !== LEGACY_PREVIOUS_REPORT_TREE_HASH_SCHEME)
+  ) {
+    fail(`Previous-report legacy evidence is incomplete for ${before.slug}`);
+  }
+  const previousReportLegacyMatch =
+    previousReportEvidenceComplete
+    && repair.reportContentHash === repair.legacyCalculatedContentHash
+    && repair.reportTreeHash === repair.legacyPreviousReportCalculatedTreeHash;
   if (
     repair.contentHashMismatch !== contentMismatch
     || repair.treeHashMismatch !== treeMismatch
     || repair.packagedContentHashScheme !== 'skill_md_raw_bytes_v1'
     || repair.packagedTreeHashScheme !== 'canonical_entries_v1'
     || repair.legacyCalculatedContentHashScheme !== 'skill_md_strip_version_trim_v1'
-    || repair.legacyCalculatedTreeHashScheme !== 'legacy_path_sha256_merkle_v1'
+    || repair.legacyCalculatedTreeHashScheme !== LEGACY_TREE_HASH_SCHEME
   ) {
     fail(`Hash algorithm evidence is internally inconsistent for ${before.slug}`);
   }
@@ -172,14 +201,20 @@ function validateHashEvidence(artifact, before, expectedClassification) {
     legacy_algorithm_equivalent: {
       reason: 'report_matches_complete_legacy_scheme_but_audit_rebinding_is_required',
       contentScheme: 'skill_md_strip_version_trim_v1',
-      treeScheme: 'legacy_path_sha256_merkle_v1',
-      matches: !canonicalMatch && legacyMatch,
+      treeScheme: repair.reportTreeHashScheme,
+      matches: !canonicalMatch && (
+        repair.reportTreeHashScheme === LEGACY_TREE_HASH_SCHEME
+          ? plainLegacyMatch
+          : repair.reportTreeHashScheme === LEGACY_PREVIOUS_REPORT_TREE_HASH_SCHEME
+            ? previousReportLegacyMatch && !plainLegacyMatch
+            : false
+      ),
     },
     actual_or_unproven_drift: {
       reason: 'report_hashes_do_not_match_one_complete_known_scheme',
       contentScheme: 'unproven',
       treeScheme: 'unproven',
-      matches: !canonicalMatch && !legacyMatch,
+      matches: !canonicalMatch && !plainLegacyMatch && !previousReportLegacyMatch,
     },
   }[expectedClassification];
   if (


### PR DESCRIPTION
## Summary

- teach the classifier to strictly verify previous-report legacy tree evidence without weakening plain legacy or drift
- replay the failed Batch 7 evidence as 472 proven legacy-equivalent v2 audits
- replace the unusable single-run raw32 binding input with three immutable signed source boundaries
- derive the exact current `61 bindable / 24 drift` cohort from 1,500 frozen candidates
- authenticate source and binding runs, artifact names, head SHAs, SHA256SUMS, ancestry, and byte-frozen execute inputs

## Safety

- previous-report and plain legacy schemes are mutually exclusive
- operator cannot override source runs, source digests, or 61/24 counts
- v2 audits from Batch 7 cannot enter the raw32 binding lane
- execute can consume only one successful binding dry-run and recomputes all current CAS evidence before writes
- this PR dispatches no production workflow

## Validation

- `CI=true node --test scripts/tests/artifact-version-backfill.test.mjs scripts/tests/legacy-audit-binding-cohorts.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs` (27/27)
- workflow YAML safe-load passed
- Node syntax checks passed
- `git diff --check`
- real failed Run 29413723448 replay: 472 legacy-equivalent, 0 drift
- real production read-only merge: 1,500 candidates, current raw32 85/85, exact 61/24
