### PR TITLE
fix(scores): make score and cache closure fail-closed

### DIFF
--- a/.github/actions/invalidate-cache/action.yml
+++ b/.github/actions/invalidate-cache/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: 'Batch size for API calls'
     required: false
     default: '30'
+  invalidate-artifacts:
+    description: 'Whether immutable ZIP/install artifact keys must also be deleted'
+    required: false
+    default: 'true'
+  invalidate-dependent-packs:
+    description: 'Whether dependent Pack cache closure must also be deleted'
+    required: false
+    default: 'true'
   fail-on-error:
     description: 'Fail the action when one or more cache invalidations fail'
     required: false
@@ -54,6 +62,8 @@ runs:
         SLUGS_STR: ${{ inputs.slugs }}
         SLUGS_FILE: ${{ inputs['slugs-file'] }}
         FAIL_ON_ERROR: ${{ inputs['fail-on-error'] }}
+        INVALIDATE_ARTIFACTS: ${{ inputs['invalidate-artifacts'] }}
+        INVALIDATE_DEPENDENT_PACKS: ${{ inputs['invalidate-dependent-packs'] }}
       run: |
         set -euo pipefail
 
@@ -61,6 +71,14 @@ runs:
           echo "::error::fail-on-error must be true or false"
           exit 1
         fi
+
+        for boolean_name in INVALIDATE_ARTIFACTS INVALIDATE_DEPENDENT_PACKS; do
+          boolean_value="${!boolean_name}"
+          if [ "$boolean_value" != "true" ] && [ "$boolean_value" != "false" ]; then
+            echo "::error::$boolean_name must be true or false"
+            exit 1
+          fi
+        done
 
         case "$CONTENT_TYPE" in
           skills|packs|plugins|releases) ;;
@@ -132,7 +150,15 @@ runs:
           jq -n \
             --arg type "$CONTENT_TYPE" \
             --argjson slugs "$json_array" \
-            '{type: $type, slugs: $slugs}' > "$body_file"
+            --argjson invalidateArtifacts "$INVALIDATE_ARTIFACTS" \
+            --argjson invalidateDependentPacks "$INVALIDATE_DEPENDENT_PACKS" \
+            '{
+              type: $type,
+              slugs: $slugs,
+              invalidateApi: true,
+              invalidateArtifacts: $invalidateArtifacts,
+              invalidateDependentPacks: $invalidateDependentPacks
+            }' > "$body_file"
 
           status=$(curl -sS -o "$response_file" -w "%{http_code}" \
             --connect-timeout 10 \
@@ -147,6 +173,25 @@ runs:
           rm -f "$body_file"
 
           if [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+            if ! jq -e \
+              --arg type "$CONTENT_TYPE" \
+              --argjson requested "$json_array" \
+              --argjson invalidateArtifacts "$INVALIDATE_ARTIFACTS" \
+              --argjson invalidateDependentPacks "$INVALIDATE_DEPENDENT_PACKS" \
+              '.preflight == false
+                and (.type == $type or .requestedType == $type)
+                and ((.slugs | sort) == ($requested | sort))
+                and (.invalidated.total | type == "number")
+                and (.invalidated.api | type == "number")
+                and (.invalidated.artifacts | type == "number")
+                and ($invalidateArtifacts or .invalidated.artifacts == 0)
+                and ($invalidateDependentPacks or ((.closure.dependentPacks.all // []) | length) == 0)' \
+              "$response_file" >/dev/null; then
+              echo "Cache invalidation response violated the requested closure contract" >&2
+              sed -n '1,20p' "$response_file" >&2 || true
+              rm -f "$response_file"
+              return 1
+            fi
             cat "$response_file"
             rm -f "$response_file"
             return 0

--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -32,25 +32,29 @@ on:
         type: boolean
         default: false
       cli_version:
-        description: 'CLI version (default: latest)'
+        description: 'Pinned score CLI version'
         type: string
-        default: 'latest'
+        default: '2.8.0'
       timeout_seconds:
         description: 'Per-skill CLI timeout in seconds (0 disables)'
         type: string
         default: '180'
 
 concurrency:
-  group: recalculate-scores
+  # This workflow-level mutex remains held through score writes, cache
+  # invalidation, and production readback. Every other production score writer
+  # uses the same group.
+  group: production-skill-score-writes
   cancel-in-progress: false
+
+env:
+  SCORE_CLI_VERSION: '2.8.0'
+  SCORE_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
 
 jobs:
   recalculate:
     runs-on: self-hosted
     timeout-minutes: 1440
-    concurrency:
-      group: production-skill-score-writes
-      cancel-in-progress: false
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -73,28 +77,52 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version || 'latest' }}
+          version: ${{ env.SCORE_CLI_VERSION }}
+          minimum-version: ${{ env.SCORE_CLI_VERSION }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Validate requested version and fixed CLI identity
+        env:
+          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.0' }}
+        run: |
+          set -euo pipefail
+          [[ "$INPUT_CLI_VERSION" =~ ^(cli-v)?[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo '::error::cli_version must be a plain semver or cli-v prefixed semver'
+            exit 2
+          }
+          normalized="${INPUT_CLI_VERSION#cli-v}"
+          test "$normalized" = "$SCORE_CLI_VERSION" || {
+            echo "::error::score workflow is pinned to CLI $SCORE_CLI_VERSION"
+            exit 2
+          }
+          test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$SCORE_CLI_SHA256"
 
       - name: Recalculate quality scores
         id: score
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          # Used below for one batched score-cache invalidation after scoring.
-          # The per-slug CLI children intentionally run with this env cleared.
-          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           INPUT_SLUG: ${{ inputs.slug }}
           INPUT_LIMIT: ${{ inputs.limit }}
           INPUT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '180' }}
+          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.0' }}
         run: |
           echo "=== Skill Quality Score Recalculation ==="
           echo "Time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
           echo ""
-          INVALIDATE_SLUGS_FILE=""
+          INPUT_DRY_RUN="${INPUT_DRY_RUN:-false}"
+          [[ "$INPUT_CLI_VERSION" =~ ^(cli-v)?[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          NORMALIZED_CLI_VERSION="${INPUT_CLI_VERSION#cli-v}"
+          test "$NORMALIZED_CLI_VERSION" = "$SCORE_CLI_VERSION"
+          CLOSURE_DIR="$RUNNER_TEMP/score-closure"
+          SUCCESS_SLUGS_FILE="$CLOSURE_DIR/successful-slugs.txt"
+          FAILED_SLUGS_FILE="$CLOSURE_DIR/failed-slugs.txt"
+          mkdir -p "$CLOSURE_DIR"
+          : > "$SUCCESS_SLUGS_FILE"
+          : > "$FAILED_SLUGS_FILE"
 
           configure_tls() {
             if [ ! -s /etc/ssl/certs/ca-certificates.crt ] && command -v apt-get >/dev/null 2>&1; then
@@ -153,8 +181,6 @@ jobs:
             fi
             # Single-skill mode: per-slug wrapper
             WRAPPER_ARGS+=( --slugs "$INPUT_SLUG" )
-            INVALIDATE_SLUGS_FILE="$RUNNER_TEMP/recalculate-invalidate-slugs.txt"
-            printf '%s\n' "$INPUT_SLUG" > "$INVALIDATE_SLUGS_FILE"
             echo "Mode: Single skill ($INPUT_SLUG)"
           elif [ "$SUPPORTS_SLUGS" -eq 1 ]; then
             # Scheduled/default full recalculation must still use the
@@ -203,7 +229,6 @@ jobs:
             SLUGS_FILE="$RUNNER_TEMP/recalculate-slugs.txt"
             printf '%s\n' "${ALL_SLUGS[@]}" > "$SLUGS_FILE"
             WRAPPER_ARGS+=( --slugs-file "$SLUGS_FILE" )
-            INVALIDATE_SLUGS_FILE="$SLUGS_FILE"
             echo "Skills queued: ${#ALL_SLUGS[@]}"
             echo "Slug list file: $SLUGS_FILE"
           else
@@ -222,6 +247,13 @@ jobs:
               echo "Mode: All skills via legacy CLI"
             fi
             WRAPPER_ARGS+=( --recalculate )
+          fi
+
+          if [ "$SUPPORTS_SLUGS" -eq 1 ]; then
+            WRAPPER_ARGS+=(
+              --success-slugs-file "$SUCCESS_SLUGS_FILE"
+              --failed-slugs-file "$FAILED_SLUGS_FILE"
+            )
           fi
 
           if [ "$INPUT_CONCURRENCY" != "5" ]; then
@@ -243,8 +275,8 @@ jobs:
           # and preserve partial-success behavior.
           set +e
           # Full recalculation launches one CLI process per slug. Do not let
-          # each child invalidate cache independently; that turns 5k skills
-          # into 5k network calls. We batch invalidate after scoring succeeds.
+          # each child invalidate cache independently; the exact success set
+          # crosses to the hosted cache-closure job as an artifact.
           CACHE_INVALIDATE_SECRET= bash scripts/recalculate-scores.sh "${WRAPPER_ARGS[@]}" 2>&1 | tee score-output.log
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
@@ -264,100 +296,57 @@ jobs:
           echo "updated=$UPDATED" >> $GITHUB_OUTPUT
           echo "errors=$ERRORS" >> $GITHUB_OUTPUT
           echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-
-          # Treat partial per-slug failures as a successful run only when
-          # at least one slug succeeded. A non-zero wrapper exit means the
-          # run made no successful progress (all/global failure) and must
-          # keep the workflow red.
+          FINAL_EXIT_CODE="$EXIT_CODE"
+          if [ "${ERRORS:-0}" -gt 0 ]; then
+            FINAL_EXIT_CODE=1
+          fi
           SUCCESSFUL=$(( ${PROCESSED:-0} - ${ERRORS:-0} ))
-          if [ "$EXIT_CODE" -ne 0 ]; then
+          SUCCESS_FILE_COUNT=$(sed '/^$/d' "$SUCCESS_SLUGS_FILE" | wc -l | tr -d ' ')
+          FAILED_FILE_COUNT=$(sed '/^$/d' "$FAILED_SLUGS_FILE" | wc -l | tr -d ' ')
+          if [ "$SUCCESS_FILE_COUNT" -ne "$SUCCESSFUL" ] || [ "$FAILED_FILE_COUNT" -ne "${ERRORS:-0}" ]; then
+            echo "::error::Exact score closure count mismatch: successful=$SUCCESSFUL/$SUCCESS_FILE_COUNT failed=${ERRORS:-0}/$FAILED_FILE_COUNT"
+            FINAL_EXIT_CODE=1
+          fi
+          echo "exit_code=$FINAL_EXIT_CODE" >> $GITHUB_OUTPUT
+
+          if [ "$INPUT_DRY_RUN" != "true" ] && [ "$SUCCESS_FILE_COUNT" -gt 0 ]; then
+            node scripts/score-cache-closure.mjs freeze-score-evidence \
+              --slugs-file "$SUCCESS_SLUGS_FILE" \
+              --output "$CLOSURE_DIR/expected-score-evidence.json" \
+              --require-snapshot true
+          fi
+
+          jq -n \
+            --argjson schemaVersion 1 \
+            --arg sourceRunId "$GITHUB_RUN_ID" \
+            --arg workflowCommit "$GITHUB_SHA" \
+            --arg cliVersion "$NORMALIZED_CLI_VERSION" \
+            --argjson processed "${PROCESSED:-0}" \
+            --argjson updated "${UPDATED:-0}" \
+            --argjson errors "${ERRORS:-0}" \
+            --argjson successfulCount "$SUCCESS_FILE_COUNT" \
+            --argjson failedCount "$FAILED_FILE_COUNT" \
+            --argjson dryRun "$INPUT_DRY_RUN" \
+            '{schemaVersion:$schemaVersion,sourceRunId:$sourceRunId,workflowCommit:$workflowCommit,cliVersion:$cliVersion,processed:$processed,updated:$updated,errors:$errors,successfulCount:$successfulCount,failedCount:$failedCount,dryRun:$dryRun}' \
+            > "$CLOSURE_DIR/metadata.json"
+
+          if [ "$FINAL_EXIT_CODE" -ne 0 ]; then
             if [ "${PROCESSED:-0}" -eq 0 ] || [ "$SUCCESSFUL" -le 0 ]; then
               echo "::error::Recalculation failed: no skills were scored successfully."
-              exit "$EXIT_CODE"
+            else
+              echo "::error::Score recalculation has ${ERRORS:-0} terminal failure(s); recovery is required."
             fi
-
-            echo "::warning::Score recalculation finished with $ERRORS error(s) after processing $PROCESSED skill(s); keeping the workflow green because it made progress."
-          elif [ "${ERRORS:-0}" -gt 0 ]; then
-            echo "::warning::Score recalculation finished with $ERRORS error(s) after processing $PROCESSED skill(s)."
+            exit "$FINAL_EXIT_CODE"
           fi
 
-          if [ "$INPUT_DRY_RUN" != "true" ] && [ -n "$INVALIDATE_SLUGS_FILE" ] && [ -s "$INVALIDATE_SLUGS_FILE" ] && [ "$SUCCESSFUL" -gt 0 ]; then
-            echo ""
-            echo "Batch invalidating skill score cache from $INVALIDATE_SLUGS_FILE"
-            INVALIDATE_SLUGS_FILE="$INVALIDATE_SLUGS_FILE" node <<'NODE' || echo "::warning::Batch cache invalidation failed; scores were already written and will be visible after cache refresh."
-          const fs = require('node:fs');
-
-          const file = process.env.INVALIDATE_SLUGS_FILE;
-          const secret = process.env.CACHE_INVALIDATE_SECRET;
-          const site = (process.env.SKILLSTORE_SITE_URL || 'https://skillstore.io').replace(/\/+$/, '');
-          const batchSize = 50;
-          const timeoutMs = 10_000;
-
-          async function postBatch(batch, index) {
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), timeoutMs);
-            try {
-              const res = await fetch(`${site}/api/cache/invalidate`, {
-                method: 'POST',
-                signal: controller.signal,
-                headers: {
-                  Authorization: `Bearer ${secret}`,
-                  'Content-Type': 'application/json',
-                  'User-Agent': 'skillstore-marketplace-workflow',
-                },
-                body: JSON.stringify({
-                  type: 'skills',
-                  slugs: batch,
-                  invalidateApi: true,
-                  invalidateArtifacts: false,
-                }),
-              });
-              const text = await res.text();
-              if (!res.ok) {
-                console.error(`::warning::cache invalidation batch ${index} failed ${res.status}: ${text.slice(0, 300)}`);
-                return false;
-              }
-              console.log(`[cache] invalidated ${batch.length} skills in batch ${index}`);
-              return true;
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              console.error(`::warning::cache invalidation batch ${index} skipped: ${message}`);
-              return false;
-            } finally {
-              clearTimeout(timeout);
-            }
-          }
-
-          (async () => {
-            if (!secret) {
-              console.log('[cache] skipped: CACHE_INVALIDATE_SECRET is not set');
-              return;
-            }
-            const slugs = [...new Set(
-              fs.readFileSync(file, 'utf8')
-                .split(/\r?\n/)
-                .map((slug) => slug.trim())
-                .filter(Boolean)
-            )];
-            if (slugs.length === 0) {
-              console.log('[cache] skipped: no slugs to invalidate');
-              return;
-            }
-
-            let failed = 0;
-            for (let i = 0; i < slugs.length; i += batchSize) {
-              const ok = await postBatch(slugs.slice(i, i + batchSize), Math.floor(i / batchSize) + 1);
-              if (!ok) failed++;
-            }
-            console.log(`[cache] batch invalidation complete: slugs=${slugs.length} failed_batches=${failed}`);
-            if (failed > 0) process.exitCode = 1;
-          })().catch((error) => {
-            console.error(error instanceof Error ? error.stack || error.message : String(error));
-            process.exitCode = 1;
-          });
-          NODE
-          fi
+      - name: Upload exact score closure
+        if: always() && inputs.dry_run != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: score-closure-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-closure
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Cleanup
         if: always()
@@ -374,7 +363,7 @@ jobs:
           EXIT_CODE: ${{ steps.score.outputs.exit_code }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           SLUG: ${{ inputs.slug }}
-          CLI_VERSION: ${{ inputs.cli_version || 'latest' }}
+          CLI_VERSION: ${{ env.SCORE_CLI_VERSION }}
         run: |
           MODE="All skills"
           if [ -n "$SLUG" ]; then
@@ -401,10 +390,10 @@ jobs:
 
           EOF
 
-          if [ "$EXIT_CODE" = "0" ]; then
+          if [ "${EXIT_CODE:-1}" = "0" ]; then
             echo "✅ Score recalculation completed successfully" >> $GITHUB_STEP_SUMMARY
-          elif [ "$PROCESSED" -gt 0 ]; then
-            echo "⚠️ Score recalculation completed with warnings (non-fatal exit code: $EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
+          elif [ "${PROCESSED:-0}" -gt 0 ]; then
+            echo "❌ Score recalculation has terminal failures and requires recovery (exit code: $EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Score recalculation failed before making progress (exit code: $EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
           fi
@@ -416,3 +405,107 @@ jobs:
           - Skills older than 7 days now use actual metrics instead of neutral 50 score
           - Maintainability recency scores refreshed based on update timestamps
           EOF
+
+  cache-closure:
+    name: score cache closure (hosted)
+    needs: recalculate
+    if: always() && inputs.dry_run != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout cache closure runtime
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions/invalidate-cache
+            scripts/score-cache-closure.mjs
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Download exact score closure
+        uses: actions/download-artifact@v5
+        with:
+          name: score-closure-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-closure
+
+      - name: Validate exact successful score set
+        id: closure
+        env:
+          CLOSURE_DIR: ${{ runner.temp }}/score-closure
+        run: |
+          set -euo pipefail
+          metadata="$CLOSURE_DIR/metadata.json"
+          successes="$CLOSURE_DIR/successful-slugs.txt"
+          failures="$CLOSURE_DIR/failed-slugs.txt"
+          expected="$CLOSURE_DIR/expected-score-evidence.json"
+          test -s "$metadata" && test -f "$successes" && test -f "$failures" && test -s "$expected"
+          jq -e --arg runId "$GITHUB_RUN_ID" \
+            '.schemaVersion == 1 and .sourceRunId == $runId and .dryRun == false
+             and (.processed == (.successfulCount + .failedCount))
+             and (.errors == .failedCount) and (.updated == .successfulCount)' \
+            "$metadata" >/dev/null
+          success_count=$(sed '/^$/d' "$successes" | sort -u | wc -l | tr -d ' ')
+          failed_count=$(sed '/^$/d' "$failures" | sort -u | wc -l | tr -d ' ')
+          test "$success_count" -eq "$(jq -r .successfulCount "$metadata")"
+          test "$failed_count" -eq "$(jq -r .failedCount "$metadata")"
+          test "$success_count" -gt 0
+          test "$(jq -r '.scores | length' "$expected")" -eq "$success_count"
+          test "$(jq -r '[.scores[].slug] | unique | length' "$expected")" -eq "$success_count"
+          echo "slug_count=$success_count" >> "$GITHUB_OUTPUT"
+
+      - name: Invalidate only successfully rescored API entries
+        id: invalidate
+        uses: ./.github/actions/invalidate-cache
+        with:
+          type: skills
+          slugs-file: ${{ runner.temp }}/score-closure/successful-slugs.txt
+          site-url: https://skillstore.io
+          secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          batch-size: '30'
+          invalidate-artifacts: 'false'
+          invalidate-dependent-packs: 'false'
+          fail-on-error: 'true'
+
+      - name: Require exact invalidation count
+        env:
+          EXPECTED: ${{ steps.closure.outputs.slug_count }}
+          TOTAL: ${{ steps.invalidate.outputs.total_count }}
+          SUCCEEDED: ${{ steps.invalidate.outputs.success_count }}
+          FAILED: ${{ steps.invalidate.outputs.failed_count }}
+        run: |
+          set -euo pipefail
+          test "$TOTAL" -eq "$EXPECTED"
+          test "$SUCCEEDED" -eq "$EXPECTED"
+          test "$FAILED" -eq 0
+
+      - name: Verify every production API cache readback
+        id: readback
+        run: |
+          node scripts/score-cache-closure.mjs readback \
+            --expected-score-evidence "$RUNNER_TEMP/score-closure/expected-score-evidence.json" \
+            --evidence "$RUNNER_TEMP/score-closure/cache-readback.json" \
+            --site-url https://skillstore.io \
+            --concurrency 8 \
+            --attempts 3 \
+            --timeout-ms 30000
+
+      - name: Upload score cache closure evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: score-cache-closure-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-closure
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Cache closure summary
+        if: always()
+        run: |
+          {
+            echo '## Score cache closure'
+            echo
+            echo "- Scored entries selected: ${{ steps.closure.outputs.slug_count || 'unknown' }}"
+            echo "- Cache invalidation: ${{ steps.invalidate.outcome }}"
+            echo "- Production readback: ${{ steps.readback.outcome }}"
+            echo "- Hosted runner: ${{ runner.name }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/recover-score-cache-closure.yml
+++ b/.github/workflows/recover-score-cache-closure.yml
@@ -1,0 +1,382 @@
+name: Recover Score and Cache Closure
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Recover terminal score failures from one run, or close cache for the current approved catalog'
+        type: choice
+        required: true
+        default: source-run-failures
+        options: [source-run-failures, approved-catalog-cache]
+      source_run_id:
+        description: 'Completed Recalculate Skill Scores run ID (required for source-run-failures)'
+        type: string
+        required: false
+        default: ''
+      expected_failures:
+        description: 'Optional exact terminal-failure count asserted against the source log'
+        type: string
+        required: false
+        default: ''
+      score_concurrency:
+        description: 'Bounded failed-score recovery concurrency (1-2)'
+        type: choice
+        required: true
+        default: '1'
+        options: ['1', '2']
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  # Freeze DB identity, write scores, invalidate, and read back while holding
+  # the same mutex as every other production score writer.
+  group: production-skill-score-writes
+  cancel-in-progress: false
+
+env:
+  RECOVERY_CLI_VERSION: '2.8.0'
+  RECOVERY_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      scope: ${{ steps.plan.outputs.scope }}
+      slug_count: ${{ steps.plan.outputs.slug_count }}
+    steps:
+      - name: Checkout recovery planner
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/score-cache-closure.mjs
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Materialize exact file-backed recovery plan
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_FAILURES: ${{ inputs.expected_failures }}
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SCOPE: ${{ inputs.scope }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          plan="$RUNNER_TEMP/score-cache-recovery-plan"
+          mkdir -p "$plan"
+
+          if [ "$SCOPE" = source-run-failures ]; then
+            [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+              echo '::error::source_run_id must be a positive GitHub Actions run ID'
+              exit 2
+            }
+            run_json=$(gh run view "$SOURCE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId,displayTitle,status,conclusion,headSha,event)
+            jq -e --argjson runId "$SOURCE_RUN_ID" \
+              '.databaseId == $runId and .displayTitle == "Recalculate Skill Scores"
+               and .status == "completed" and (.headSha | test("^[0-9a-f]{40}$"))' \
+              <<< "$run_json" >/dev/null
+            printf '%s\n' "$run_json" > "$plan/source-run.json"
+            gh run view "$SOURCE_RUN_ID" --repo "$GITHUB_REPOSITORY" --log > "$plan/source-run.log"
+            args=(extract-run-log --log "$plan/source-run.log" --output "$plan/requested-slugs.txt")
+            if [ -n "$EXPECTED_FAILURES" ]; then
+              args+=(--expected-failures "$EXPECTED_FAILURES")
+            fi
+            node scripts/score-cache-closure.mjs "${args[@]}"
+          else
+            test "$SCOPE" = approved-catalog-cache
+            test -z "$SOURCE_RUN_ID" || {
+              echo '::error::source_run_id must be empty for approved-catalog-cache'
+              exit 2
+            }
+            node scripts/score-cache-closure.mjs approved-catalog \
+              --output "$plan/requested-slugs.txt"
+            node scripts/score-cache-closure.mjs freeze-score-evidence \
+              --slugs-file "$plan/requested-slugs.txt" \
+              --output "$plan/expected-score-evidence.json" \
+              --require-snapshot false
+          fi
+
+          slug_count=$(sed '/^$/d' "$plan/requested-slugs.txt" | sort -u | wc -l | tr -d ' ')
+          test "$slug_count" -gt 0
+          jq -n --arg scope "$SCOPE" --arg sourceRunId "$SOURCE_RUN_ID" \
+            --argjson slugCount "$slug_count" --arg workflowCommit "$GITHUB_SHA" \
+            '{schemaVersion:1,scope:$scope,sourceRunId:$sourceRunId,slugCount:$slugCount,workflowCommit:$workflowCommit}' \
+            > "$plan/metadata.json"
+          (cd "$plan" && find . -maxdepth 1 -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
+          echo "slug_count=$slug_count" >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact recovery plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: score-cache-recovery-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-plan
+          if-no-files-found: error
+          retention-days: 30
+
+  rescore-failures:
+    needs: plan
+    if: needs.plan.outputs.scope == 'source-run-failures'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1440
+    steps:
+      - name: Checkout bounded score recovery runtime
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions/download-skillstore-cli
+            scripts/recalculate-scores.sh
+            scripts/score-cache-closure.mjs
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Download recovery plan
+        uses: actions/download-artifact@v5
+        with:
+          name: score-cache-recovery-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-plan
+
+      - name: Verify exact plan boundary
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/score-cache-recovery-plan"
+          sha256sum --check SHA256SUMS
+          test "$(sed '/^$/d' requested-slugs.txt | sort -u | wc -l | tr -d ' ')" \
+            -eq "$(jq -r .slugCount metadata.json)"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download fixed score recovery CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          version: ${{ env.RECOVERY_CLI_VERSION }}
+          minimum-version: ${{ env.RECOVERY_CLI_VERSION }}
+          token: ${{ steps.app-token.outputs.token }}
+          cache-dir: ${{ runner.temp }}/skillstore-cli-cache
+
+      - name: Verify fixed CLI identity
+        run: |
+          set -euo pipefail
+          test "$(sha256sum skillstore-cli | awk '{print $1}')" = "$RECOVERY_CLI_SHA256"
+
+      - name: Recalculate every terminal failure with bounded concurrency
+        id: score
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/score-cache-recovery-result"
+          mkdir -p "$result"
+          requested="$RUNNER_TEMP/score-cache-recovery-plan/requested-slugs.txt"
+          node scripts/score-cache-closure.mjs freeze-score-evidence \
+            --slugs-file "$requested" \
+            --output "$result/before-score-evidence.json" \
+            --require-snapshot false
+          RUN_BOUNDARY=$(date -u +'%Y-%m-%dT%H:%M:%S.%3NZ')
+          printf '%s\n' "$RUN_BOUNDARY" > "$result/run-boundary.txt"
+          set +e
+          CACHE_INVALIDATE_SECRET= bash scripts/recalculate-scores.sh \
+            --cli "$GITHUB_WORKSPACE/skillstore-cli" \
+            --slugs-file "$requested" \
+            --success-slugs-file "$result/successful-slugs.txt" \
+            --failed-slugs-file "$result/failed-slugs.txt" \
+            --concurrency "${{ inputs.score_concurrency }}" \
+            --max-attempts 3 \
+            --retry-base-seconds 5 \
+            --timeout-seconds 300 2>&1 | tee "$result/score-output.log"
+          wrapper_exit=${PIPESTATUS[0]}
+          set -e
+          requested_count=$(sed '/^$/d' "$requested" | sort -u | wc -l | tr -d ' ')
+          successful_count=$(sed '/^$/d' "$result/successful-slugs.txt" | sort -u | wc -l | tr -d ' ')
+          failed_count=$(sed '/^$/d' "$result/failed-slugs.txt" | sort -u | wc -l | tr -d ' ')
+          test "$requested_count" -eq "$((successful_count + failed_count))"
+          proven_count=0
+          if [ "$successful_count" -gt 0 ]; then
+            node scripts/score-cache-closure.mjs freeze-score-evidence \
+              --slugs-file "$result/successful-slugs.txt" \
+              --output "$result/expected-score-evidence.json" \
+              --require-snapshot true
+            node scripts/score-cache-closure.mjs verify-score-transitions \
+              --before "$result/before-score-evidence.json" \
+              --after "$result/expected-score-evidence.json" \
+              --run-boundary "$RUN_BOUNDARY" \
+              --output "$result/score-write-evidence.json"
+            proven_count=$(jq -r .provenCount "$result/score-write-evidence.json")
+            test "$proven_count" -eq "$successful_count"
+          fi
+          jq -n --argjson requestedCount "$requested_count" \
+            --argjson successfulCount "$successful_count" --argjson failedCount "$failed_count" \
+            --argjson causallyProvenCount "$proven_count" --arg runBoundary "$RUN_BOUNDARY" \
+            --argjson wrapperExit "$wrapper_exit" --arg cliVersion "$RECOVERY_CLI_VERSION" \
+            --arg cliSha256 "$RECOVERY_CLI_SHA256" \
+            '{schemaVersion:1,requestedCount:$requestedCount,successfulCount:$successfulCount,failedCount:$failedCount,causallyProvenCount:$causallyProvenCount,runBoundary:$runBoundary,wrapperExit:$wrapperExit,cliVersion:$cliVersion,cliSha256:$cliSha256}' \
+            > "$result/metadata.json"
+          (cd "$result" && find . -maxdepth 1 -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          echo "successful_count=$successful_count" >> "$GITHUB_OUTPUT"
+          echo "failed_count=$failed_count" >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact rescore result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: score-cache-recovery-result-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-result
+          if-no-files-found: error
+          retention-days: 30
+
+  close-cache:
+    needs: [plan, rescore-failures]
+    if: always() && needs.plan.result == 'success' && (needs.rescore-failures.result == 'success' || needs.rescore-failures.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout hosted cache closure runtime
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions/invalidate-cache
+            scripts/score-cache-closure.mjs
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Download recovery plan
+        uses: actions/download-artifact@v5
+        with:
+          name: score-cache-recovery-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-plan
+
+      - name: Download rescore result
+        if: needs.plan.outputs.scope == 'source-run-failures'
+        uses: actions/download-artifact@v5
+        with:
+          name: score-cache-recovery-result-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-result
+
+      - name: Select only proven cache closure slugs
+        id: selected
+        env:
+          SCOPE: ${{ needs.plan.outputs.scope }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/score-cache-recovery-plan" && sha256sum --check SHA256SUMS)
+          target="$RUNNER_TEMP/cache-closure-slugs.txt"
+          expected="$RUNNER_TEMP/cache-closure-expected-score-evidence.json"
+          if [ "$SCOPE" = source-run-failures ]; then
+            result="$RUNNER_TEMP/score-cache-recovery-result"
+            (cd "$result" && sha256sum --check SHA256SUMS)
+            jq -e '.successfulCount > 0 and .causallyProvenCount == .successfulCount' "$result/metadata.json" >/dev/null
+            test "$(jq -r '.transitions | length' "$result/score-write-evidence.json")" \
+              -eq "$(jq -r .successfulCount "$result/metadata.json")"
+            cp "$result/successful-slugs.txt" "$target"
+            cp "$result/expected-score-evidence.json" "$expected"
+            echo "remaining_score_failures=$(jq -r .failedCount "$result/metadata.json")" >> "$GITHUB_OUTPUT"
+          else
+            cp "$RUNNER_TEMP/score-cache-recovery-plan/requested-slugs.txt" "$target"
+            cp "$RUNNER_TEMP/score-cache-recovery-plan/expected-score-evidence.json" "$expected"
+            echo 'remaining_score_failures=0' >> "$GITHUB_OUTPUT"
+          fi
+          count=$(sed '/^$/d' "$target" | sort -u | wc -l | tr -d ' ')
+          test "$count" -gt 0
+          test "$(jq -r '.scores | length' "$expected")" -eq "$count"
+          echo "slug_count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Invalidate selected score API entries
+        id: invalidate
+        uses: ./.github/actions/invalidate-cache
+        with:
+          type: skills
+          slugs-file: ${{ runner.temp }}/cache-closure-slugs.txt
+          site-url: https://skillstore.io
+          secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          batch-size: '30'
+          invalidate-artifacts: 'false'
+          invalidate-dependent-packs: 'false'
+          fail-on-error: 'true'
+
+      - name: Require exact invalidation count
+        env:
+          EXPECTED: ${{ steps.selected.outputs.slug_count }}
+          FAILED: ${{ steps.invalidate.outputs.failed_count }}
+          SUCCEEDED: ${{ steps.invalidate.outputs.success_count }}
+          TOTAL: ${{ steps.invalidate.outputs.total_count }}
+        run: |
+          set -euo pipefail
+          test "$TOTAL" -eq "$EXPECTED"
+          test "$SUCCEEDED" -eq "$EXPECTED"
+          test "$FAILED" -eq 0
+
+      - name: Verify every production cache readback
+        id: readback
+        run: |
+          node scripts/score-cache-closure.mjs readback \
+            --expected-score-evidence "$RUNNER_TEMP/cache-closure-expected-score-evidence.json" \
+            --evidence "$RUNNER_TEMP/cache-readback.json" \
+            --site-url https://skillstore.io \
+            --concurrency 8 \
+            --attempts 3 \
+            --timeout-ms 30000
+
+      - name: Write closure evidence
+        if: always()
+        env:
+          REMAINING: ${{ steps.selected.outputs.remaining_score_failures || 'unknown' }}
+          SLUG_COUNT: ${{ steps.selected.outputs.slug_count || 'unknown' }}
+        run: |
+          evidence="$RUNNER_TEMP/score-cache-recovery-evidence"
+          mkdir -p "$evidence"
+          cp "$RUNNER_TEMP/cache-closure-slugs.txt" "$evidence/selected-slugs.txt" 2>/dev/null || true
+          cp "$RUNNER_TEMP/cache-closure-expected-score-evidence.json" "$evidence/expected-score-evidence.json" 2>/dev/null || true
+          cp "$RUNNER_TEMP/cache-readback.json" "$evidence/cache-readback.json" 2>/dev/null || true
+          cp "$RUNNER_TEMP/score-cache-recovery-result/before-score-evidence.json" "$evidence/before-score-evidence.json" 2>/dev/null || true
+          cp "$RUNNER_TEMP/score-cache-recovery-result/run-boundary.txt" "$evidence/run-boundary.txt" 2>/dev/null || true
+          cp "$RUNNER_TEMP/score-cache-recovery-result/score-write-evidence.json" "$evidence/score-write-evidence.json" 2>/dev/null || true
+          jq -n --arg scope "${{ needs.plan.outputs.scope }}" --arg slugCount "$SLUG_COUNT" \
+            --arg remainingScoreFailures "$REMAINING" --arg invalidation "${{ steps.invalidate.outcome }}" \
+            --arg readback "${{ steps.readback.outcome }}" \
+            '{schemaVersion:1,scope:$scope,slugCount:$slugCount,remainingScoreFailures:$remainingScoreFailures,invalidation:$invalidation,readback:$readback}' \
+            > "$evidence/summary.json"
+
+      - name: Upload closure evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: score-cache-recovery-evidence-${{ github.run_id }}
+          path: ${{ runner.temp }}/score-cache-recovery-evidence
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Require complete score and cache recovery
+        env:
+          REMAINING: ${{ steps.selected.outputs.remaining_score_failures }}
+        run: |
+          set -euo pipefail
+          test "$REMAINING" -eq 0 || {
+            echo "::error::$REMAINING score recalculation(s) still failed; cache closure covered only proven successes"
+            exit 1
+          }
+
+      - name: Recovery summary
+        if: always()
+        run: |
+          {
+            echo '## Score and cache recovery'
+            echo
+            echo "- Scope: ${{ needs.plan.outputs.scope }}"
+            echo "- Planned slugs: ${{ needs.plan.outputs.slug_count }}"
+            echo "- Cache-closed slugs: ${{ steps.selected.outputs.slug_count || 'unknown' }}"
+            echo "- Remaining score failures: ${{ steps.selected.outputs.remaining_score_failures || 'unknown' }}"
+            echo "- Invalidation: ${{ steps.invalidate.outcome }}"
+            echo "- Production readback: ${{ steps.readback.outcome }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scrape-skills-sh.yml
+++ b/.github/workflows/scrape-skills-sh.yml
@@ -65,9 +65,12 @@ env:
 
 jobs:
   scrape:
-    name: Scrape, Store Metrics & Rescore
+    name: Scrape & Store Metrics
     runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 360
+    outputs:
+      dry_run: ${{ steps.scrape.outputs.dry_run }}
+      metric_slugs: ${{ steps.scrape.outputs.metric_slugs }}
 
     steps:
       - name: Generate GitHub App Token
@@ -252,57 +255,6 @@ jobs:
             exit "$EXIT_CODE"
           fi
 
-      - name: Recalculate scores for matched metrics
-        id: rescore
-        if: steps.scrape.outputs.dry_run != 'true' && steps.scrape.outputs.metric_slugs != ''
-        env:
-          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
-          RESCORE_METRICS: ${{ inputs.rescore_metrics }}
-          METRIC_SLUGS: ${{ steps.scrape.outputs.metric_slugs }}
-        run: |
-          if [ -z "$RESCORE_METRICS" ]; then
-            RESCORE_METRICS="true"
-          fi
-
-          if [ "$RESCORE_METRICS" != "true" ]; then
-            echo "Rescore disabled by workflow input"
-            echo "processed=0" >> "$GITHUB_OUTPUT"
-            echo "updated=0" >> "$GITHUB_OUTPUT"
-            echo "errors=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          SLUG_FILE="$RUNNER_TEMP/skills-sh-metric-slugs.txt"
-          printf '%s' "$METRIC_SLUGS" | tr ',' '\n' | sed '/^$/d' > "$SLUG_FILE"
-
-          SLUG_COUNT=$(wc -l < "$SLUG_FILE" | tr -d ' ')
-          echo "🎯 Recalculating scores for $SLUG_COUNT skills matched from skills.sh metrics"
-
-          set +e
-          bash scripts/recalculate-scores.sh \
-            --cli "$GITHUB_WORKSPACE/skillstore-cli" \
-            --slugs-file "$SLUG_FILE" \
-            --concurrency 5 \
-            --max-attempts 3 \
-            --retry-base-seconds 5 2>&1 | tee score-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -e
-
-          PROCESSED=$(grep -oP 'Processed:\s*\K\d+' score-output.log | tail -n1 || echo "0")
-          UPDATED=$(grep -oP 'Updated:\s*\K\d+' score-output.log | tail -n1 || echo "0")
-          ERRORS=$(grep -oP 'Errors:\s*\K\d+' score-output.log | tail -n1 || echo "0")
-
-          echo "processed=${PROCESSED:-0}" >> "$GITHUB_OUTPUT"
-          echo "updated=${UPDATED:-0}" >> "$GITHUB_OUTPUT"
-          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
-
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "::error::Metric-driven score recalculation failed"
-            exit "$EXIT_CODE"
-          fi
-
       - name: Summary
         if: always()
         env:
@@ -322,9 +274,6 @@ jobs:
           METRIC_UNMATCHED: ${{ steps.scrape.outputs.metric_unmatched }}
           METRIC_SNAPSHOTS: ${{ steps.scrape.outputs.metric_snapshots }}
           METRIC_DETAIL_FAILURES: ${{ steps.scrape.outputs.metric_detail_failures }}
-          RESCORE_PROCESSED: ${{ steps.rescore.outputs.processed }}
-          RESCORE_UPDATED: ${{ steps.rescore.outputs.updated }}
-          RESCORE_ERRORS: ${{ steps.rescore.outputs.errors }}
           DRY_RUN: ${{ steps.scrape.outputs.dry_run }}
         run: |
           cat << EOF >> $GITHUB_STEP_SUMMARY
@@ -352,9 +301,6 @@ jobs:
           | Metric unmatched | ${METRIC_UNMATCHED:-0} |
           | Metric snapshots inserted | ${METRIC_SNAPSHOTS:-0} |
           | Detail page failures | ${METRIC_DETAIL_FAILURES:-0} |
-          | Scores processed from metrics | ${RESCORE_PROCESSED:-0} |
-          | Scores updated from metrics | ${RESCORE_UPDATED:-0} |
-          | Score errors | ${RESCORE_ERRORS:-0} |
           EOF
 
           if [ "$DRY_RUN" != "true" ]; then
@@ -379,3 +325,93 @@ jobs:
         if: failure()
         run: |
           echo "::error::Skills.sh scrape workflow failed"
+
+  rescore-metrics:
+    name: Rescore matched skills.sh metrics
+    needs: scrape
+    if: needs.scrape.outputs.dry_run != 'true' && needs.scrape.outputs.metric_slugs != '' && (github.event_name == 'schedule' || inputs.rescore_metrics == true)
+    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || 'self-hosted' }}
+    timeout-minutes: 180
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Checkout score runtime
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: |
+            .github/actions/download-skillstore-cli
+            scripts/recalculate-scores.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Download Skillstore CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          version: ${{ env.CLI_VERSION }}
+          token: ${{ steps.app-token.outputs.token }}
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Recalculate scores for matched metrics
+        id: rescore
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          METRIC_SLUGS: ${{ needs.scrape.outputs.metric_slugs }}
+        run: |
+          set -euo pipefail
+          SLUG_FILE="$RUNNER_TEMP/skills-sh-metric-slugs.txt"
+          printf '%s' "$METRIC_SLUGS" | tr ',' '\n' | sed '/^$/d' > "$SLUG_FILE"
+
+          SLUG_COUNT=$(wc -l < "$SLUG_FILE" | tr -d ' ')
+          test "$SLUG_COUNT" -gt 0
+          echo "🎯 Recalculating scores for $SLUG_COUNT skills matched from skills.sh metrics"
+
+          set +e
+          bash scripts/recalculate-scores.sh \
+            --cli "$GITHUB_WORKSPACE/skillstore-cli" \
+            --slugs-file "$SLUG_FILE" \
+            --concurrency 5 \
+            --max-attempts 3 \
+            --retry-base-seconds 5 2>&1 | tee score-output.log
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          PROCESSED=$(grep -oP 'Processed:\s*\K\d+' score-output.log | tail -n1 || echo "0")
+          UPDATED=$(grep -oP 'Updated:\s*\K\d+' score-output.log | tail -n1 || echo "0")
+          ERRORS=$(grep -oP 'Errors:\s*\K\d+' score-output.log | tail -n1 || echo "0")
+
+          echo "processed=${PROCESSED:-0}" >> "$GITHUB_OUTPUT"
+          echo "updated=${UPDATED:-0}" >> "$GITHUB_OUTPUT"
+          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
+
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo "::error::Metric-driven score recalculation failed"
+            exit "$EXIT_CODE"
+          fi
+
+      - name: Rescore summary
+        if: always()
+        run: |
+          {
+            echo '## Skills.sh metric score refresh'
+            echo
+            echo "- Processed: ${{ steps.rescore.outputs.processed || 'unknown' }}"
+            echo "- Updated: ${{ steps.rescore.outputs.updated || 'unknown' }}"
+            echo "- Errors: ${{ steps.rescore.outputs.errors || 'unknown' }}"
+            echo "- Mutex: production-skill-score-writes"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify on score failure
+        if: failure()
+        run: |
+          echo "::error::Skills.sh metric score refresh failed"

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -11,12 +11,17 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
+      - ".github/workflows/scrape-skills-sh.yml"
+      - ".github/workflows/recalculate-scores.yml"
+      - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/actions/invalidate-cache/action.yml"
       - ".github/workflows/test-recalculate-scores.yml"
   push:
     branches: [main]
@@ -28,12 +33,17 @@ on:
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
       - "scripts/recalculate-scores.sh"
+      - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
       - ".github/workflows/sync-to-supabase.yml"
+      - ".github/workflows/scrape-skills-sh.yml"
+      - ".github/workflows/recalculate-scores.yml"
+      - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/actions/invalidate-cache/action.yml"
   workflow_dispatch:
 
 permissions:
@@ -72,4 +82,5 @@ jobs:
           node --check scripts/materialize-changed-skills.mjs
           node --check scripts/resolve-manual-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs
-          node --test scripts/tests/*.test.mjs
+          node --check scripts/score-cache-closure.mjs
+          CI=true node --test scripts/tests/*.test.mjs

--- a/scripts/recalculate-scores.sh
+++ b/scripts/recalculate-scores.sh
@@ -49,6 +49,8 @@ set -o pipefail
 CLI=""
 SLUGS_CSV=""
 SLUGS_FILE=""
+SUCCESS_SLUGS_FILE=""
+FAILED_SLUGS_FILE=""
 LIMIT=""
 CONCURRENCY=5
 DRY_RUN=0
@@ -66,6 +68,8 @@ Options:
   --cli PATH                  Path to skillstore-cli binary (required)
   --slugs CSV                 Comma-separated slug list (mutually exclusive with --slugs-file/--recalculate)
   --slugs-file PATH            Newline-delimited slug list; keeps full runs out of argv
+  --success-slugs-file PATH    Write the exact successful per-slug set to PATH
+  --failed-slugs-file PATH     Write the exact terminal-failure per-slug set to PATH
   --limit N                   Optional: limit total slugs (applied before per-slug loop)
   --concurrency N             Pass-through to CLI (default: 5)
   --dry-run                   Pass-through to CLI
@@ -83,6 +87,8 @@ while [ $# -gt 0 ]; do
 		--cli)               CLI="${2:-}"; shift 2 ;;
 		--slugs)             SLUGS_CSV="${2:-}"; shift 2 ;;
 		--slugs-file)        SLUGS_FILE="${2:-}"; shift 2 ;;
+		--success-slugs-file) SUCCESS_SLUGS_FILE="${2:-}"; shift 2 ;;
+		--failed-slugs-file) FAILED_SLUGS_FILE="${2:-}"; shift 2 ;;
 		--limit)             LIMIT="${2:-}"; shift 2 ;;
 		--concurrency)       CONCURRENCY="${2:-5}"; shift 2 ;;
 		--dry-run)           DRY_RUN=1; shift ;;
@@ -111,6 +117,14 @@ slug_sources=0
 [ "$RECALCULATE" -eq 1 ] && slug_sources=$((slug_sources + 1))
 if [ "$slug_sources" -gt 1 ]; then
 	echo "::error::--slugs, --slugs-file, and --recalculate are mutually exclusive" >&2
+	exit 2
+fi
+if [ -n "$SUCCESS_SLUGS_FILE" ] && [ "$SUCCESS_SLUGS_FILE" = "$FAILED_SLUGS_FILE" ]; then
+	echo "::error::success and failed slug output files must be different" >&2
+	exit 2
+fi
+if [ "$RECALCULATE" -eq 1 ] && { [ -n "$SUCCESS_SLUGS_FILE" ] || [ -n "$FAILED_SLUGS_FILE" ]; }; then
+	echo "::error::exact slug result files require per-slug mode" >&2
 	exit 2
 fi
 if [ -n "$SLUGS_FILE" ] && [ ! -f "$SLUGS_FILE" ]; then
@@ -142,6 +156,14 @@ PROCESSED=0
 UPDATED=0
 ERRORS=0
 FAILED_SLUGS=()
+SUCCESSFUL_SLUGS=()
+
+for output_file in "$SUCCESS_SLUGS_FILE" "$FAILED_SLUGS_FILE"; do
+	if [ -n "$output_file" ]; then
+		mkdir -p "$(dirname "$output_file")"
+		: > "$output_file"
+	fi
+done
 
 # ---------- per-slug worker ----------
 # Truncates long lines to keep workflow logs readable.
@@ -153,6 +175,26 @@ _truncate() {
 	else
 		printf '%s...[truncated %d chars]' "${s:0:$max}" "$(( ${#s} - max ))"
 	fi
+}
+
+validate_one_slug_success() {
+	local output_path="$1"
+	local processed updated errors
+	processed="$(grep -oE 'Processed:[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
+	updated="$(grep -oE 'Updated:[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
+	# CLI 2.8.0 reports `Final errors:`. Keep accepting the older
+	# aggregate `Errors:` label for compatibility with legacy releases.
+	errors="$(grep -oE '(Final errors|Errors):[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
+	if [ "$processed" != "1" ] || [ "$errors" != "0" ]; then
+		return 1
+	fi
+	if [ "$DRY_RUN" -ne 1 ] && [ "$updated" != "1" ]; then
+		return 1
+	fi
+	if [ "$DRY_RUN" -eq 1 ] && ! [[ "$updated" =~ ^[01]$ ]]; then
+		return 1
+	fi
+	return 0
 }
 
 # Runs the CLI for a single slug with retry/backoff. Echoes CLI's
@@ -224,7 +266,11 @@ score_one_slug() {
 		cat "$stdout_path" || true
 
 		if [ "$rc" -eq 0 ]; then
-			return 0
+			if validate_one_slug_success "$stdout_path"; then
+				return 0
+			fi
+			echo "CLI exited 0 without proving the target slug was processed successfully" >> "$stderr_path"
+			rc=65
 		fi
 		attempt=$(( attempt + 1 ))
 
@@ -257,6 +303,7 @@ ingest_one_slug_output() {
 		# run, so assume 1 (the slug itself) on success. This matches
 		# prior semantics: per-slug success == 1 update.
 		UPDATED=$(( UPDATED + 1 ))
+		SUCCESSFUL_SLUGS+=("$slug")
 	else
 		ERRORS=$(( ERRORS + 1 ))
 		FAILED_SLUGS+=("$slug")
@@ -337,7 +384,7 @@ if [ "$RECALCULATE" -eq 1 ]; then
 	if [ "$rc" -eq 0 ]; then
 		PROCESSED="$(grep -oE 'Processed:\s*[0-9]+' "$stdout_path" | tail -n1 | grep -oE '[0-9]+' || echo 0)"
 		UPDATED="$(grep -oE 'Updated:\s*[0-9]+' "$stdout_path" | tail -n1 | grep -oE '[0-9]+' || echo 0)"
-		ERRORS="$(grep -oE 'Errors:\s*[0-9]+' "$stdout_path" | tail -n1 | grep -oE '[0-9]+' || echo 0)"
+		ERRORS="$(grep -oE '(Final errors|Errors):[[:space:]]*[0-9]+' "$stdout_path" | tail -n1 | grep -oE '[0-9]+' || echo 0)"
 	else
 		ERRORS=1
 	fi
@@ -470,6 +517,29 @@ else
 	while [ "${#ACTIVE_PIDS[@]}" -gt 0 ]; do
 		collect_next_finished_job
 	done
+fi
+
+write_slug_result_file() {
+	local output_file="$1"
+	shift
+	if [ -z "$output_file" ]; then
+		return 0
+	fi
+	: > "$output_file"
+	if [ "$#" -gt 0 ]; then
+		printf '%s\n' "$@" | LC_ALL=C sort -u > "$output_file"
+	fi
+}
+
+if [ "${#SUCCESSFUL_SLUGS[@]}" -gt 0 ]; then
+	write_slug_result_file "$SUCCESS_SLUGS_FILE" "${SUCCESSFUL_SLUGS[@]}"
+else
+	write_slug_result_file "$SUCCESS_SLUGS_FILE"
+fi
+if [ "${#FAILED_SLUGS[@]}" -gt 0 ]; then
+	write_slug_result_file "$FAILED_SLUGS_FILE" "${FAILED_SLUGS[@]}"
+else
+	write_slug_result_file "$FAILED_SLUGS_FILE"
 fi
 
 # ---------- summary (matches workflow grep format) ----------

--- a/scripts/score-cache-closure.mjs
+++ b/scripts/score-cache-closure.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readOption(args, name, { fallback, required = false } = {}) {
+  const index = args.indexOf(name);
+  if (index < 0) {
+    if (required) fail(`missing required option ${name}`);
+    return fallback;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) {
+    fail(`missing value for ${name}`);
+  }
+  return args[index + 1];
+}
+
+function positiveInteger(value, name, maximum) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || (maximum && parsed > maximum)) {
+    fail(`${name} must be an integer between 1 and ${maximum || Number.MAX_SAFE_INTEGER}`);
+  }
+  return parsed;
+}
+
+export function normalizeSlugs(values, { allowEmpty = false, maximum = 10_000 } = {}) {
+  const slugs = [...new Set(values.map((value) => String(value).trim()).filter(Boolean))].sort();
+  if (!allowEmpty && slugs.length === 0) fail('slug set is empty');
+  if (slugs.length > maximum) fail(`slug count ${slugs.length} exceeds maximum ${maximum}`);
+  for (const slug of slugs) {
+    if (!SLUG_RE.test(slug)) fail(`invalid canonical slug: ${slug}`);
+  }
+  return slugs;
+}
+
+function lastMetric(log, name) {
+  const matches = [...log.matchAll(new RegExp(`${name}:\\s*(\\d+)`, 'g'))];
+  if (matches.length === 0) fail(`source score log is missing ${name}`);
+  return Number(matches.at(-1)[1]);
+}
+
+export function parseScoreRunLog(log) {
+  const failureMatches = [...log.matchAll(/score ultimately failed for slug=([a-z0-9][a-z0-9-]*) after \d+ attempts/g)];
+  const failedSlugs = normalizeSlugs(failureMatches.map((match) => match[1]), { allowEmpty: true });
+  const processed = lastMetric(log, 'Processed');
+  const updated = lastMetric(log, 'Updated');
+  const errors = lastMetric(log, 'Errors');
+
+  if (processed !== updated + errors) {
+    fail(`source score summary is inconsistent: processed=${processed}, updated=${updated}, errors=${errors}`);
+  }
+  if (failureMatches.length !== failedSlugs.length) {
+    fail(`source score log repeats terminal failures: matches=${failureMatches.length}, unique=${failedSlugs.length}`);
+  }
+  if (failedSlugs.length !== errors) {
+    fail(`source score failure count mismatch: log=${failedSlugs.length}, summary=${errors}`);
+  }
+  return { errors, failedSlugs, processed, updated };
+}
+
+export async function fetchApprovedCatalog({ fetchImpl = fetch, supabaseUrl, serviceRoleKey }) {
+  if (!supabaseUrl || !serviceRoleKey) fail('Supabase credentials are required');
+  const slugs = [];
+  const pageSize = 1000;
+  for (let offset = 0; ; offset += pageSize) {
+    const url = new URL('/rest/v1/skills', supabaseUrl);
+    url.searchParams.set('select', 'slug');
+    url.searchParams.set('public_eligible', 'eq.true');
+    url.searchParams.set('order', 'slug.asc');
+    url.searchParams.set('limit', String(pageSize));
+    url.searchParams.set('offset', String(offset));
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Profile': 'skillstore',
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+      },
+    });
+    if (!response.ok) fail(`approved catalog query failed: HTTP ${response.status}`);
+    const page = await response.json();
+    if (!Array.isArray(page)) fail('approved catalog query returned a non-array');
+    for (const row of page) slugs.push(row?.slug);
+    if (page.length < pageSize) break;
+  }
+  return normalizeSlugs(slugs);
+}
+
+export async function fetchScoreEvidence({
+  fetchImpl = fetch,
+  requireSnapshot = false,
+  serviceRoleKey,
+  slugs,
+  supabaseUrl,
+}) {
+  if (!supabaseUrl || !serviceRoleKey) fail('Supabase credentials are required');
+  const requested = normalizeSlugs(slugs);
+  const requestedSet = new Set(requested);
+  const rows = [];
+  const pageSize = 1000;
+  for (let offset = 0; ; offset += pageSize) {
+    const url = new URL('/rest/v1/skills', supabaseUrl);
+    url.searchParams.set(
+      'select',
+      'slug,quality_score,quality_tier,quality_score_calculated_at,current_quality_score_snapshot_id',
+    );
+    url.searchParams.set('order', 'slug.asc');
+    url.searchParams.set('limit', String(pageSize));
+    url.searchParams.set('offset', String(offset));
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Profile': 'skillstore',
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+      },
+    });
+    if (!response.ok) fail(`score evidence query failed: HTTP ${response.status}`);
+    const page = await response.json();
+    if (!Array.isArray(page)) fail('score evidence query returned a non-array');
+    rows.push(...page.filter((row) => requestedSet.has(row?.slug)));
+    if (page.length < pageSize) break;
+  }
+
+  const bySlug = new Map();
+  for (const row of rows) {
+    if (bySlug.has(row.slug)) fail(`score evidence query returned duplicate slug ${row.slug}`);
+    const qualityScore = row.quality_score;
+    const qualityTier = row.quality_tier;
+    const calculatedAt = row.quality_score_calculated_at;
+    const snapshotId = row.current_quality_score_snapshot_id;
+    if (qualityScore !== null && (typeof qualityScore !== 'number' || !Number.isFinite(qualityScore))) {
+      fail(`invalid quality score for ${row.slug}`);
+    }
+    if (qualityTier !== null && typeof qualityTier !== 'string') fail(`invalid quality tier for ${row.slug}`);
+    if (calculatedAt !== null && (typeof calculatedAt !== 'string' || Number.isNaN(Date.parse(calculatedAt)))) {
+      fail(`invalid calculatedAt for ${row.slug}`);
+    }
+    if (snapshotId !== null && (typeof snapshotId !== 'string' || !/^[0-9a-f-]{36}$/.test(snapshotId))) {
+      fail(`invalid score snapshot id for ${row.slug}`);
+    }
+    if (requireSnapshot && (qualityScore === null || calculatedAt === null || snapshotId === null)) {
+      fail(`rescored slug ${row.slug} has no current score snapshot identity`);
+    }
+    bySlug.set(row.slug, { calculatedAt, qualityScore, qualityTier, slug: row.slug, snapshotId });
+  }
+  const missing = requested.filter((slug) => !bySlug.has(slug));
+  if (missing.length > 0) fail(`score evidence is missing ${missing.length} slug(s): ${missing.slice(0, 10).join(', ')}`);
+  return requested.map((slug) => bySlug.get(slug));
+}
+
+function scoreEvidenceBySlug(scores, name) {
+  if (!Array.isArray(scores)) fail(`${name} score evidence must be an array`);
+  const slugs = normalizeSlugs(scores.map((item) => item?.slug));
+  if (slugs.length !== scores.length) fail(`${name} score evidence contains duplicate slugs`);
+  return new Map(scores.map((item) => [item.slug, item]));
+}
+
+export function verifyScoreTransitions({ afterScores, beforeScores, runBoundary }) {
+  const boundaryMs = Date.parse(runBoundary);
+  if (typeof runBoundary !== 'string' || Number.isNaN(boundaryMs)) {
+    fail('run boundary must be an ISO-8601 timestamp');
+  }
+
+  const beforeBySlug = scoreEvidenceBySlug(beforeScores, 'before');
+  const afterBySlug = scoreEvidenceBySlug(afterScores, 'after');
+  const missingBefore = [...afterBySlug.keys()].filter((slug) => !beforeBySlug.has(slug));
+  if (missingBefore.length > 0) {
+    fail(`before score evidence is missing ${missingBefore.length} slug(s): ${missingBefore.slice(0, 10).join(', ')}`);
+  }
+
+  const transitions = [];
+  for (const [slug, after] of afterBySlug) {
+    const before = beforeBySlug.get(slug);
+    if (typeof after.snapshotId !== 'string' || !/^[0-9a-f-]{36}$/.test(after.snapshotId)) {
+      fail(`after score evidence has no valid snapshot identity for ${slug}`);
+    }
+    const calculatedAtMs = Date.parse(after.calculatedAt);
+    if (typeof after.calculatedAt !== 'string' || Number.isNaN(calculatedAtMs)) {
+      fail(`after score evidence has no valid calculatedAt for ${slug}`);
+    }
+
+    const snapshotChanged = before.snapshotId !== after.snapshotId;
+    const beforeCalculatedAtMs = Date.parse(before.calculatedAt);
+    const calculatedAtAdvanced = calculatedAtMs >= boundaryMs
+      && (before.calculatedAt === null || (!Number.isNaN(beforeCalculatedAtMs) && calculatedAtMs > beforeCalculatedAtMs));
+    if (!snapshotChanged && !calculatedAtAdvanced) {
+      fail(`${slug} did not prove a causal score write: snapshot identity is unchanged and calculatedAt did not advance past the run boundary`);
+    }
+    transitions.push({
+      afterCalculatedAt: after.calculatedAt,
+      afterSnapshotId: after.snapshotId,
+      beforeCalculatedAt: before.calculatedAt,
+      beforeSnapshotId: before.snapshotId,
+      calculatedAtAdvanced,
+      slug,
+      snapshotChanged,
+    });
+  }
+
+  return { provenCount: transitions.length, runBoundary, transitions };
+}
+
+async function fetchWithTimeout(fetchImpl, url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'skillstore-score-cache-closure' },
+      redirect: 'error',
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readSkill(fetchImpl, siteUrl, slug, timeoutMs) {
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    `${siteUrl.replace(/\/+$/, '')}/api/skills/${encodeURIComponent(slug)}`,
+    timeoutMs,
+  );
+  if (!response.ok) fail(`${slug} cache readback returned HTTP ${response.status}`);
+  const body = await response.json();
+  if (body?.data?.slug !== slug) fail(`${slug} cache readback returned the wrong record`);
+  const result = {
+    build: response.headers.get('x-skillstore-build'),
+    cache: response.headers.get('x-kv-cache'),
+    key: response.headers.get('x-kv-key'),
+    version: response.headers.get('x-kv-version'),
+    write: response.headers.get('x-kv-write'),
+  };
+  if (!result.build || !result.key || !result.version) {
+    fail(`${slug} cache readback omitted build/key/version identity`);
+  }
+  return { body, ...result };
+}
+
+function readMatchesExpectedScore(read, expected) {
+  const actualScore = read.body?.data?.qualityScore ?? null;
+  const actualTier = read.body?.data?.qualityTier ?? null;
+  const actualCalculatedAt = read.body?.data?.qualityBreakdown?.calculatedAt ?? null;
+  return actualScore === expected.qualityScore
+    && actualTier === expected.qualityTier
+    && actualCalculatedAt === expected.calculatedAt;
+}
+
+function firstReadCanClose(read) {
+  return (read.cache === 'MISS' && read.write === 'STORED')
+    || (read.cache === 'HIT' && read.write === 'SKIPPED');
+}
+
+export async function verifyCacheReadback({
+  attempts = 3,
+  concurrency = 8,
+  fetchImpl = fetch,
+  siteUrl = 'https://skillstore.io',
+  expectedScores,
+  timeoutMs = 30_000,
+}) {
+  if (!Array.isArray(expectedScores)) fail('expected score evidence must be an array');
+  const normalized = normalizeSlugs(expectedScores.map((item) => item?.slug));
+  if (normalized.length !== expectedScores.length) fail('expected score evidence contains duplicate slugs');
+  const expectedBySlug = new Map(expectedScores.map((item) => [item.slug, item]));
+  const results = new Array(normalized.length);
+  const failures = [];
+  let cursor = 0;
+
+  async function verifyOne(slug) {
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const first = await readSkill(fetchImpl, siteUrl, slug, timeoutMs);
+        const second = await readSkill(fetchImpl, siteUrl, slug, timeoutMs);
+        if (!firstReadCanClose(first)) {
+          fail(`${slug} first read was ${first.cache || 'missing'}+${first.write || 'missing'}`);
+        }
+        const expected = expectedBySlug.get(slug);
+        if (!readMatchesExpectedScore(first, expected) || !readMatchesExpectedScore(second, expected)) {
+          fail(`${slug} API score identity does not match frozen DB evidence`);
+        }
+        if (second.cache !== 'HIT' || second.write !== 'SKIPPED') {
+          fail(`${slug} second read was ${second.cache || 'missing'}+${second.write || 'missing'}`);
+        }
+        for (const field of ['build', 'key', 'version']) {
+          if (first[field] !== second[field]) fail(`${slug} changed ${field} between cache reads`);
+        }
+        const { body: _firstBody, ...firstIdentity } = first;
+        const { body: _secondBody, ...secondIdentity } = second;
+        return { first: firstIdentity, second: secondIdentity, slug };
+      } catch (error) {
+        lastError = error;
+        if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+    throw lastError;
+  }
+
+  async function worker() {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= normalized.length) return;
+      try {
+        results[index] = await verifyOne(normalized[index]);
+      } catch (error) {
+        failures.push({ slug: normalized[index], error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, normalized.length) }, () => worker()));
+  const builds = [...new Set(results.filter(Boolean).map((result) => result.second.build))].sort();
+  if (builds.length > 1) failures.push({ slug: '*', error: `production build changed during readback: ${builds.join(', ')}` });
+  return { builds, failures, results: results.filter(Boolean), slugCount: normalized.length };
+}
+
+function writeSlugs(path, slugs) {
+  writeFileSync(path, `${slugs.join('\n')}\n`, { mode: 0o600 });
+}
+
+function appendOutput(name, value) {
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === 'extract-run-log') {
+    const log = readFileSync(readOption(args, '--log', { required: true }), 'utf8');
+    const output = readOption(args, '--output', { required: true });
+    const expected = readOption(args, '--expected-failures');
+    const parsed = parseScoreRunLog(log);
+    if (expected !== undefined && parsed.errors !== positiveInteger(expected, 'expected-failures', 10_000)) {
+      fail(`expected ${expected} failures but source log proved ${parsed.errors}`);
+    }
+    writeSlugs(output, parsed.failedSlugs);
+    appendOutput('slug_count', parsed.failedSlugs.length);
+    appendOutput('processed', parsed.processed);
+    appendOutput('updated', parsed.updated);
+    return;
+  }
+  if (command === 'approved-catalog') {
+    const slugs = await fetchApprovedCatalog({
+      supabaseUrl: process.env.PUBLIC_SUPABASE_URL,
+      serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    });
+    writeSlugs(readOption(args, '--output', { required: true }), slugs);
+    appendOutput('slug_count', slugs.length);
+    return;
+  }
+  if (command === 'freeze-score-evidence') {
+    const slugs = normalizeSlugs(readFileSync(readOption(args, '--slugs-file', { required: true }), 'utf8').split(/\r?\n/));
+    const expectedScores = await fetchScoreEvidence({
+      requireSnapshot: readOption(args, '--require-snapshot', { fallback: 'false' }) === 'true',
+      serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+      slugs,
+      supabaseUrl: process.env.PUBLIC_SUPABASE_URL,
+    });
+    const output = readOption(args, '--output', { required: true });
+    writeFileSync(output, `${JSON.stringify({ schemaVersion: 1, scores: expectedScores }, null, 2)}\n`, { mode: 0o600 });
+    appendOutput('slug_count', expectedScores.length);
+    return;
+  }
+  if (command === 'verify-score-transitions') {
+    const beforeDocument = JSON.parse(readFileSync(readOption(args, '--before', { required: true }), 'utf8'));
+    const afterDocument = JSON.parse(readFileSync(readOption(args, '--after', { required: true }), 'utf8'));
+    if (beforeDocument?.schemaVersion !== 1 || afterDocument?.schemaVersion !== 1) {
+      fail('unsupported score transition evidence schema');
+    }
+    const proof = verifyScoreTransitions({
+      afterScores: afterDocument.scores,
+      beforeScores: beforeDocument.scores,
+      runBoundary: readOption(args, '--run-boundary', { required: true }),
+    });
+    writeFileSync(
+      readOption(args, '--output', { required: true }),
+      `${JSON.stringify({ schemaVersion: 1, ...proof }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+    appendOutput('proven_count', proof.provenCount);
+    return;
+  }
+  if (command === 'readback') {
+    const expectedPath = readOption(args, '--expected-score-evidence', { required: true });
+    const expectedDocument = JSON.parse(readFileSync(expectedPath, 'utf8'));
+    if (expectedDocument?.schemaVersion !== 1) fail('unsupported expected score evidence schema');
+    const expectedScores = expectedDocument.scores;
+    if (!Array.isArray(expectedScores)) fail('expected score evidence scores must be an array');
+    const slugs = normalizeSlugs(expectedScores.map((item) => item?.slug));
+    const evidencePath = readOption(args, '--evidence', { required: true });
+    const evidence = await verifyCacheReadback({
+      attempts: positiveInteger(readOption(args, '--attempts', { fallback: '3' }), 'attempts', 5),
+      concurrency: positiveInteger(readOption(args, '--concurrency', { fallback: '8' }), 'concurrency', 16),
+      siteUrl: readOption(args, '--site-url', { fallback: 'https://skillstore.io' }),
+      expectedScores,
+      timeoutMs: positiveInteger(readOption(args, '--timeout-ms', { fallback: '30000' }), 'timeout-ms', 120_000),
+    });
+    const result = {
+      ...evidence,
+      generatedAt: new Date().toISOString(),
+      schemaVersion: 1,
+      slugSha256: createHash('sha256').update(`${slugs.join('\n')}\n`).digest('hex'),
+    };
+    writeFileSync(evidencePath, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
+    appendOutput('slug_count', slugs.length);
+    appendOutput('failed_count', evidence.failures.length);
+    if (evidence.failures.length > 0) {
+      fail(`cache readback failed for ${evidence.failures.length} item(s): ${evidence.failures.slice(0, 10).map((item) => `${item.slug}: ${item.error}`).join('; ')}`);
+    }
+    return;
+  }
+  fail('usage: score-cache-closure.mjs <extract-run-log|approved-catalog|freeze-score-evidence|verify-score-transitions|readback> [options]');
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/fake-cli.sh
+++ b/scripts/tests/fake-cli.sh
@@ -11,6 +11,7 @@
 #                            the slug in FAKE_CLI_TIMEOUT_SLUG, then
 #                            succeed.
 #   recalc-fail            - --recalculate mode always fails
+#   no-skills              - exits 0 but proves no target was processed
 #   help                   - print usage
 #
 # It records every invocation to $FAKE_CLI_LOG (one line per call:
@@ -69,7 +70,7 @@ if [ "$RECALC" -eq 1 ]; then
 		*)
 			echo "Processed: 5"
 			echo "Updated: 5"
-			echo "Errors: 0"
+			echo "Final errors: 0"
 			echo "Duration: 10s"
 			exit 0
 			;;
@@ -88,6 +89,9 @@ slug_call_count() {
 for slug in "${ARR[@]}"; do
 	slug="$(echo "$slug" | xargs)"  # trim
 	case "$MODE" in
+		no-skills)
+			echo "No skills found"
+			;;
 		success)
 			echo "[ok] slug=$slug"
 			;;
@@ -126,9 +130,17 @@ for slug in "${ARR[@]}"; do
 	esac
 done
 
+if [ "$MODE" = "no-skills" ]; then
+	echo "Processed: 0"
+	echo "Updated: 0"
+	echo "Final errors: 0"
+	echo "Duration: 0s"
+	exit 0
+fi
+
 # Emit summary lines that the wrapper's legacy mode might parse.
 echo "Processed: ${#ARR[@]}"
 echo "Updated: ${#ARR[@]}"
-echo "Errors: 0"
+echo "Final errors: 0"
 echo "Duration: 1s"
 exit 0

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -20,7 +20,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -31,8 +31,11 @@ const WRAPPER = join(REPO_ROOT, 'scripts', 'recalculate-scores.sh');
 const FAKE_CLI = join(REPO_ROOT, 'scripts', 'tests', 'fake-cli.sh');
 const RECALCULATE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'recalculate-scores.yml');
 const SYNC_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
+const SCRAPE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'scrape-skills-sh.yml');
+const TEST_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'test-recalculate-scores.yml');
 const MONITOR_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'monitor-skill-sources.yml');
 const DOWNLOAD_CLI_ACTION = join(REPO_ROOT, '.github', 'actions', 'download-skillstore-cli', 'action.yml');
+const WORKFLOWS_DIR = join(REPO_ROOT, '.github', 'workflows');
 
 function runWrapper({
 	mode,
@@ -49,10 +52,13 @@ function runWrapper({
 	slowSlug,
 	slowSeconds,
 	timeoutSeconds = 0,
+	resultFiles = false,
 }) {
 	const tmp = mkdtempSync(join(tmpdir(), 'recalc-test-'));
 	const fakeCli = join(tmp, 'skillstore-cli');
 	const log = join(tmp, 'fake-cli.log');
+	const successSlugs = join(tmp, 'successful-slugs.txt');
+	const failedSlugs = join(tmp, 'failed-slugs.txt');
 	// Copy fake CLI to a stable path with the +x bit set.
 	writeFileSync(fakeCli, readFileSync(FAKE_CLI), { mode: 0o755 });
 
@@ -87,6 +93,9 @@ function runWrapper({
 		args.push('--slugs', 'a,b,c,d,e');
 	}
 	if (dryRun) args.push('--dry-run');
+	if (resultFiles) {
+		args.push('--success-slugs-file', successSlugs, '--failed-slugs-file', failedSlugs);
+	}
 
 	const result = spawnSync('/bin/bash', args, {
 		env,
@@ -94,7 +103,7 @@ function runWrapper({
 		timeout: 30_000,
 	});
 
-	return { result, tmp, fakeCli, log };
+	return { result, tmp, fakeCli, log, successSlugs, failedSlugs };
 }
 
 function lastSummary(stdout) {
@@ -166,6 +175,19 @@ test('a slug that fails repeatedly lets the run finish; partial success -> exit 
 	assert.match(result.stdout, /doomed/, 'failed slug name should be surfaced in summary');
 });
 
+test('writes exact disjoint success and terminal-failure slug artifacts', () => {
+	const { result, successSlugs, failedSlugs } = runWrapper({
+		mode: 'fail-slug-always',
+		failSlug: 'doomed',
+		slugs: 'beta,doomed,alpha',
+		maxAttempts: 1,
+		resultFiles: true,
+	});
+	assert.equal(result.status, 0);
+	assert.equal(readFileSync(successSlugs, 'utf8'), 'alpha\nbeta\n');
+	assert.equal(readFileSync(failedSlugs, 'utf8'), 'doomed\n');
+});
+
 test('all slugs fail -> exit 1 (no partial success)', () => {
 	// Use a different env that fails every slug. Easiest: re-run the
 	// fail-slug-always mode but with a slug set where the FAIL_SLUG
@@ -202,6 +224,21 @@ test('all slugs succeed -> exit 0, errors=0', () => {
 	assert.equal(sum.processed, '3');
 	assert.equal(sum.errors, '0');
 	assert.equal(sum.updated, '3');
+	assert.match(result.stdout, /Final errors:\s*0/, 'fixture must model the fixed CLI 2.8.0 score summary contract');
+});
+
+test('CLI exit 0 without processing the target is a terminal failure', () => {
+	const { result } = runWrapper({
+		mode: 'no-skills',
+		slugs: 'missing-slug',
+		maxAttempts: 1,
+	});
+	assert.equal(result.status, 1);
+	assert.match(result.stdout, /score ultimately failed for slug=missing-slug/);
+	const summary = lastSummary(result.stdout);
+	assert.equal(summary.processed, '1');
+	assert.equal(summary.updated, '0');
+	assert.equal(summary.errors, '1');
 });
 
 test('per-slug mode honors wrapper-level concurrency', () => {
@@ -356,10 +393,14 @@ test('recalculate-scores workflow default all-skills path uses per-slug wrapper'
 	assert.match(workflow, /WRAPPER_ARGS\+=\( --slugs-file "\$SLUGS_FILE" \)/, 'default full run must pass a slug file, not a giant CSV argv');
 	assert.match(workflow, /--timeout-seconds "\$INPUT_TIMEOUT_SECONDS"/, 'default full run must bound each per-skill CLI child');
 	assert.match(workflow, /CACHE_INVALIDATE_SECRET= bash scripts\/recalculate-scores\.sh/, 'per-slug CLI children must not invalidate cache one-by-one');
-	assert.match(workflow, /INVALIDATE_SLUGS_FILE="\$SLUGS_FILE"/, 'workflow must reuse the full slug file for batched cache invalidation');
-	assert.match(workflow, /Batch invalidating skill score cache/, 'workflow must batch invalidate score cache after successful scoring');
-	assert.match(workflow, /\/api\/cache\/invalidate/, 'workflow must call the Skillstore cache invalidation endpoint');
-	assert.match(workflow, /invalidateArtifacts:\s*false/, 'score recalculation must not invalidate unchanged skill artifacts');
+	assert.match(workflow, /--success-slugs-file "\$SUCCESS_SLUGS_FILE"/, 'workflow must materialize exact successes');
+	assert.match(workflow, /--failed-slugs-file "\$FAILED_SLUGS_FILE"/, 'workflow must materialize exact terminal failures');
+	assert.match(workflow, /name: score-closure-\$\{\{ github\.run_id \}\}/, 'score closure must cross jobs as an artifact');
+	assert.match(workflow, /cache-closure:[\s\S]*runs-on: ubuntu-latest/, 'cache closure must leave the self-hosted runner');
+	assert.match(workflow, /uses: \.\/\.github\/actions\/invalidate-cache/, 'hosted closure must reuse the bounded invalidation action');
+	assert.match(workflow, /invalidate-artifacts: 'false'/, 'score recalculation must not invalidate unchanged skill artifacts');
+	assert.match(workflow, /invalidate-dependent-packs: 'false'/, 'score-only closure must not traverse unchanged Pack artifacts');
+	assert.doesNotMatch(workflow, /Batch cache invalidation failed; scores were already written/, 'cache failure must not be downgraded to a warning');
 	assert.doesNotMatch(workflow, /WRAPPER_ARGS\+=\( --slugs "\$SLUGS_CSV" \)/, 'default full run must not put all slugs in one argv');
 	assert.doesNotMatch(workflow, /SLUGS_CSV=/, 'workflow must not build an all-skills CSV that can exceed ARG_MAX');
 	assert.match(workflow, /SUPPORTS_SLUGS=0/, 'workflow must feature-probe whether the downloaded CLI supports --slugs');
@@ -381,12 +422,62 @@ test('production score writers serialize and avoid multiplicative retries', () =
 	assert.match(sync, /--concurrency 1/, 'incremental sync scoring must remain single-writer');
 });
 
+test('every workflow that invokes the score wrapper is enumerated and holds the production writer mutex', () => {
+	const writerWorkflows = readdirSync(WORKFLOWS_DIR)
+		.filter((name) => name.endsWith('.yml'))
+		.filter((name) => readFileSync(join(WORKFLOWS_DIR, name), 'utf8').includes('bash scripts/recalculate-scores.sh'))
+		.sort();
+	assert.deepEqual(writerWorkflows, [
+		'recalculate-scores.yml',
+		'recover-score-cache-closure.yml',
+		'scrape-skills-sh.yml',
+		'sync-to-supabase.yml',
+	]);
+	for (const name of writerWorkflows) {
+		const workflow = readFileSync(join(WORKFLOWS_DIR, name), 'utf8');
+		assert.match(workflow, /group:\s*production-skill-score-writes/,
+			`${name} must serialize its production score write`);
+	}
+
+	const scrape = readFileSync(SCRAPE_WORKFLOW, 'utf8');
+	const [nonWritingScrape, scoreJob] = scrape.split('\n  rescore-metrics:');
+	assert.ok(scoreJob, 'skills.sh scoring must be isolated in its own job');
+	assert.doesNotMatch(nonWritingScrape, /production-skill-score-writes/,
+		'the non-writing scrape phase must not wait on the production score mutex');
+	assert.match(scoreJob, /concurrency:[\s\S]*group:\s*production-skill-score-writes/,
+		'the isolated skills.sh score job must hold the mutex');
+});
+
+test('malicious cli_version input cannot become shell syntax or select an unpinned binary', () => {
+	const workflow = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
+	const inputUsages = workflow.split('\n').filter((line) => line.includes('inputs.cli_version'));
+	assert.equal(inputUsages.length, 2);
+	for (const line of inputUsages) {
+		assert.match(line, /^\s+INPUT_CLI_VERSION:\s*\$\{\{ inputs\.cli_version/,
+			'operator input may enter the workflow only as an environment value');
+	}
+	assert.match(workflow, /\[\[ "\$INPUT_CLI_VERSION" =~ \^\(cli-v\)\?\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$ \]\]/);
+	assert.match(workflow, /version:\s*\$\{\{ env\.SCORE_CLI_VERSION \}\}/,
+		'the downloaded binary must come from the fixed workflow environment');
+	assert.doesNotMatch(workflow, /version:\s*\$\{\{ inputs\.cli_version/);
+	assert.equal(/^(cli-v)?[0-9]+\.[0-9]+\.[0-9]+$/.test('2.8.0; echo "$SUPABASE_SERVICE_ROLE_KEY"'), false);
+});
+
+test('score test workflow is triggered when the skills.sh production writer changes', () => {
+	const workflow = readFileSync(TEST_WORKFLOW, 'utf8');
+	assert.equal(
+		[...workflow.matchAll(/"\.github\/workflows\/scrape-skills-sh\.yml"/g)].length,
+		2,
+		'pull_request and push path filters must both cover the skills.sh writer',
+	);
+});
+
 test('workflows fail no-success/global scoring failures instead of masking them', () => {
 	const recalc = readFileSync(RECALCULATE_WORKFLOW, 'utf8');
 	const sync = readFileSync(SYNC_WORKFLOW, 'utf8');
 	assert.match(recalc, /SUCCESSFUL=\$\(\( \$\{PROCESSED:-0\} - \$\{ERRORS:-0\} \)\)/);
 	assert.match(recalc, /Recalculation failed: no skills were scored successfully/);
-	assert.match(recalc, /exit "\$EXIT_CODE"/);
+	assert.match(recalc, /Score recalculation has \$\{ERRORS:-0\} terminal failure\(s\); recovery is required/);
 	assert.match(sync, /tee score-output\.log/);
 	assert.match(sync, /Quality scoring failed: no synced skills were scored successfully/);
 	assert.match(sync, /exit "\$EXIT_CODE"/);

--- a/scripts/tests/score-cache-closure.test.mjs
+++ b/scripts/tests/score-cache-closure.test.mjs
@@ -1,0 +1,322 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  fetchApprovedCatalog,
+  fetchScoreEvidence,
+  parseScoreRunLog,
+  verifyCacheReadback,
+  verifyScoreTransitions,
+} from '../score-cache-closure.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const RECOVERY = readFileSync(resolve(ROOT, '.github/workflows/recover-score-cache-closure.yml'), 'utf8');
+const RECALCULATE = readFileSync(resolve(ROOT, '.github/workflows/recalculate-scores.yml'), 'utf8');
+const INVALIDATE_ACTION = readFileSync(resolve(ROOT, '.github/actions/invalidate-cache/action.yml'), 'utf8');
+
+test('strictly extracts unique terminal failures and reconciles the aggregate summary', () => {
+  const parsed = parseScoreRunLog(`
+::error::score ultimately failed for slug=beta after 1 attempts
+::error::score ultimately failed for slug=alpha after 3 attempts
+Processed: 5
+Updated: 3
+Errors: 2
+`);
+  assert.deepEqual(parsed, {
+    errors: 2,
+    failedSlugs: ['alpha', 'beta'],
+    processed: 5,
+    updated: 3,
+  });
+  assert.throws(() => parseScoreRunLog(`
+::error::score ultimately failed for slug=alpha after 1 attempts
+Processed: 5
+Updated: 3
+Errors: 2
+`), /failure count mismatch/);
+  assert.throws(() => parseScoreRunLog(`
+::error::score ultimately failed for slug=alpha after 1 attempts
+::error::score ultimately failed for slug=alpha after 1 attempts
+Processed: 2
+Updated: 0
+Errors: 2
+`), /repeats terminal failures/);
+});
+
+test('approved catalog pagination selects only public eligible canonical slugs', async () => {
+  const requests = [];
+  const slugs = await fetchApprovedCatalog({
+    supabaseUrl: 'https://db.example.test',
+    serviceRoleKey: 'secret',
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), init });
+      return new Response(JSON.stringify([{ slug: 'beta' }, { slug: 'alpha' }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+  assert.deepEqual(slugs, ['alpha', 'beta']);
+  assert.match(requests[0].url, /public_eligible=eq\.true/);
+  assert.equal(requests[0].init.headers['Accept-Profile'], 'skillstore');
+});
+
+test('freezes exact current DB score and snapshot identity for every requested slug', async () => {
+  const evidence = await fetchScoreEvidence({
+    supabaseUrl: 'https://db.example.test',
+    serviceRoleKey: 'secret',
+    slugs: ['alpha'],
+    requireSnapshot: true,
+    fetchImpl: async () => new Response(JSON.stringify([{
+      slug: 'alpha',
+      quality_score: 88,
+      quality_tier: 'silver',
+      quality_score_calculated_at: '2026-07-15T12:00:00+00:00',
+      current_quality_score_snapshot_id: '11111111-1111-4111-8111-111111111111',
+    }]), { status: 200, headers: { 'content-type': 'application/json' } }),
+  });
+  assert.deepEqual(evidence, [{
+    calculatedAt: '2026-07-15T12:00:00+00:00',
+    qualityScore: 88,
+    qualityTier: 'silver',
+    slug: 'alpha',
+    snapshotId: '11111111-1111-4111-8111-111111111111',
+  }]);
+});
+
+test('rejects a claimed update that preserves an old snapshot and predates the trusted run boundary', () => {
+  const unchanged = {
+    calculatedAt: '2026-07-15T11:59:00+00:00',
+    qualityScore: 88,
+    qualityTier: 'silver',
+    slug: 'alpha',
+    snapshotId: '11111111-1111-4111-8111-111111111111',
+  };
+  assert.throws(() => verifyScoreTransitions({
+    beforeScores: [unchanged],
+    afterScores: [unchanged],
+    runBoundary: '2026-07-15T12:00:00.000Z',
+  }), /did not prove a causal score write/);
+});
+
+test('proves a score write by changed snapshot identity or an advanced post-boundary calculatedAt', () => {
+  const before = {
+    calculatedAt: '2026-07-15T11:59:00+00:00',
+    qualityScore: 80,
+    qualityTier: 'bronze',
+    slug: 'alpha',
+    snapshotId: '11111111-1111-4111-8111-111111111111',
+  };
+  const changedSnapshot = verifyScoreTransitions({
+    beforeScores: [before],
+    afterScores: [{ ...before, snapshotId: '22222222-2222-4222-8222-222222222222' }],
+    runBoundary: '2026-07-15T12:00:00.000Z',
+  });
+  assert.equal(changedSnapshot.provenCount, 1);
+  assert.equal(changedSnapshot.transitions[0].snapshotChanged, true);
+
+  const refreshedInPlace = verifyScoreTransitions({
+    beforeScores: [before],
+    afterScores: [{ ...before, calculatedAt: '2026-07-15T12:00:00.000Z' }],
+    runBoundary: '2026-07-15T12:00:00.000Z',
+  });
+  assert.equal(refreshedInPlace.transitions[0].calculatedAtAdvanced, true);
+});
+
+test('rejects an unchanged future timestamp caused by runner and database clock skew', () => {
+  const unchangedFuture = {
+    calculatedAt: '2026-07-15T12:00:05.000Z',
+    qualityScore: 88,
+    qualityTier: 'silver',
+    slug: 'alpha',
+    snapshotId: '11111111-1111-4111-8111-111111111111',
+  };
+  assert.throws(() => verifyScoreTransitions({
+    beforeScores: [unchangedFuture],
+    afterScores: [unchangedFuture],
+    runBoundary: '2026-07-15T12:00:00.000Z',
+  }), /did not prove a causal score write/);
+});
+
+function cachedResponse(slug, {
+  build = 'build-a', cache, calculatedAt = '2026-07-15T12:00:00+00:00', key = `key-${slug}`,
+  qualityScore = 88, qualityTier = 'silver', version = 'v5', write,
+}) {
+  return new Response(JSON.stringify({
+    data: { slug, qualityScore, qualityTier, qualityBreakdown: { calculatedAt } },
+  }), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'x-kv-cache': cache,
+      'x-kv-key': key,
+      'x-kv-version': version,
+      'x-kv-write': write,
+      'x-skillstore-build': build,
+    },
+  });
+}
+
+test('production readback requires a closed first read and a stable HIT+SKIPPED second read', async () => {
+  const calls = new Map();
+  const evidence = await verifyCacheReadback({
+    expectedScores: ['alpha', 'beta'].map((slug) => ({
+      slug,
+      qualityScore: 88,
+      qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00',
+      snapshotId: '11111111-1111-4111-8111-111111111111',
+    })),
+    attempts: 1,
+    concurrency: 2,
+    fetchImpl: async (url) => {
+      const slug = String(url).split('/').at(-1);
+      const count = (calls.get(slug) || 0) + 1;
+      calls.set(slug, count);
+      return cachedResponse(slug, count === 1
+        ? { cache: 'MISS', write: 'STORED' }
+        : { cache: 'HIT', write: 'SKIPPED' });
+    },
+  });
+  assert.equal(evidence.failures.length, 0);
+  assert.equal(evidence.slugCount, 2);
+  assert.deepEqual(evidence.builds, ['build-a']);
+  assert.deepEqual(Object.fromEntries(calls), { alpha: 2, beta: 2 });
+});
+
+test('readback records unstable cache identity as a failure', async () => {
+  let count = 0;
+  const evidence = await verifyCacheReadback({
+    expectedScores: [{
+      slug: 'alpha', qualityScore: 88, qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00', snapshotId: '11111111-1111-4111-8111-111111111111',
+    }],
+    attempts: 1,
+    concurrency: 1,
+    fetchImpl: async () => {
+      count += 1;
+      return cachedResponse('alpha', count === 1
+        ? { cache: 'MISS', write: 'STORED', version: 'v5' }
+        : { cache: 'HIT', write: 'SKIPPED', version: 'v6' });
+    },
+  });
+  assert.equal(evidence.failures.length, 1);
+  assert.match(evidence.failures[0].error, /changed version/);
+});
+
+test('readback accepts a correct cache entry warmed after invalidation but before verification', async () => {
+  const evidence = await verifyCacheReadback({
+    expectedScores: [{
+      slug: 'alpha', qualityScore: 88, qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00', snapshotId: '11111111-1111-4111-8111-111111111111',
+    }],
+    attempts: 1,
+    concurrency: 1,
+    fetchImpl: async () => cachedResponse('alpha', { cache: 'HIT', write: 'SKIPPED' }),
+  });
+  assert.equal(evidence.failures.length, 0);
+  assert.equal(evidence.results[0].first.cache, 'HIT');
+});
+
+test('readback rejects a stale HIT that disagrees with frozen DB score evidence', async () => {
+  const evidence = await verifyCacheReadback({
+    expectedScores: [{
+      slug: 'alpha', qualityScore: 88, qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00', snapshotId: '11111111-1111-4111-8111-111111111111',
+    }],
+    attempts: 1,
+    concurrency: 1,
+    fetchImpl: async () => cachedResponse('alpha', {
+      cache: 'HIT', qualityScore: 87, write: 'SKIPPED',
+    }),
+  });
+  assert.equal(evidence.failures.length, 1);
+  assert.match(evidence.failures[0].error, /API score identity does not match frozen DB evidence/);
+});
+
+test('readback rejects a freshly stored cache body that disagrees with frozen DB score evidence', async () => {
+  let count = 0;
+  const evidence = await verifyCacheReadback({
+    expectedScores: [{
+      slug: 'alpha', qualityScore: 88, qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00', snapshotId: '11111111-1111-4111-8111-111111111111',
+    }],
+    attempts: 1,
+    concurrency: 1,
+    fetchImpl: async () => {
+      count += 1;
+      return cachedResponse('alpha', {
+        cache: count === 1 ? 'MISS' : 'HIT',
+        qualityScore: 87,
+        write: count === 1 ? 'STORED' : 'SKIPPED',
+      });
+    },
+  });
+  assert.equal(evidence.failures.length, 1);
+  assert.match(evidence.failures[0].error, /API score identity does not match frozen DB evidence/);
+});
+
+test('daily workflow moves score cache closure to a fail-closed hosted job', () => {
+  assert.match(RECALCULATE, /cache-closure:[\s\S]*runs-on: ubuntu-latest/);
+  assert.match(RECALCULATE, /actions\/upload-artifact@v4[\s\S]*score-closure-\$\{\{ github\.run_id \}\}/);
+  assert.match(RECALCULATE, /actions\/download-artifact@v5[\s\S]*score-closure-\$\{\{ github\.run_id \}\}/);
+  assert.match(RECALCULATE, /Verify every production API cache readback/);
+  assert.match(RECALCULATE, /freeze-score-evidence/);
+  assert.match(RECALCULATE, /--expected-score-evidence/);
+  assert.match(RECALCULATE, /^concurrency:\n(?:.*\n){0,5}\s+group: production-skill-score-writes/m);
+  assert.doesNotMatch(RECALCULATE, /\|\| echo "::warning::Batch cache invalidation failed/);
+});
+
+test('manual recovery is file-backed, fixed-CLI, bounded, and red on any remaining failure', () => {
+  assert.match(RECOVERY, /source_run_id:/);
+  assert.match(RECOVERY, /gh run view "\$SOURCE_RUN_ID"[\s\S]*--log > "\$plan\/source-run\.log"/);
+  assert.match(RECOVERY, /extract-run-log/);
+  assert.match(RECOVERY, /approved-catalog/);
+  assert.match(RECOVERY, /name: score-cache-recovery-plan-\$\{\{ github\.run_id \}\}/);
+  assert.match(RECOVERY, /RECOVERY_CLI_VERSION: '2\.8\.0'/);
+  assert.match(RECOVERY, /RECOVERY_CLI_SHA256: '[0-9a-f]{64}'/);
+  assert.match(RECOVERY, /runs-on: ubuntu-latest/);
+  assert.match(RECOVERY, /group: production-skill-score-writes/);
+  assert.match(RECOVERY, /--concurrency "\$\{\{ inputs\.score_concurrency \}\}"/);
+  assert.match(RECOVERY, /Invalidate selected score API entries/);
+  assert.match(RECOVERY, /Require complete score and cache recovery/);
+  assert.match(RECOVERY, /freeze-score-evidence/);
+  assert.match(RECOVERY, /before-score-evidence\.json/);
+  assert.match(RECOVERY, /verify-score-transitions/);
+  assert.match(RECOVERY, /causallyProvenCount/);
+  assert.match(RECOVERY, /test "\$proven_count" -eq "\$successful_count"/);
+  assert.match(RECOVERY, /--expected-score-evidence/);
+  assert.match(RECOVERY, /test "\$REMAINING" -eq 0/);
+  assert.doesNotMatch(RECOVERY, /workflow run|repository_dispatch/);
+});
+
+test('every single-file score closure sparse checkout disables cone mode', () => {
+  for (const [name, workflow] of [
+    ['recalculate', RECALCULATE],
+    ['recovery', RECOVERY],
+  ]) {
+    const checkoutBlocks = [...workflow.matchAll(
+      /uses: actions\/checkout@v5\n\s{8}with:\n((?:\s{10,}[^\n]*\n)*)/g,
+    )]
+      .map((match) => match[1])
+      .filter((block) => block.includes('scripts/score-cache-closure.mjs'));
+    assert.ok(checkoutBlocks.length > 0, `${name} must checkout the score closure runtime`);
+    for (const block of checkoutBlocks) {
+      assert.match(block, /sparse-checkout-cone-mode:\s*false/,
+        `${name} single-file sparse checkout must disable cone mode`);
+    }
+  }
+});
+
+test('shared invalidation action preserves score-only closure flags and validates response identity', () => {
+  assert.match(INVALIDATE_ACTION, /invalidate-artifacts:/);
+  assert.match(INVALIDATE_ACTION, /invalidate-dependent-packs:/);
+  assert.match(INVALIDATE_ACTION, /invalidateArtifacts: \$invalidateArtifacts/);
+  assert.match(INVALIDATE_ACTION, /invalidateDependentPacks: \$invalidateDependentPacks/);
+  assert.match(INVALIDATE_ACTION, /Cache invalidation response violated the requested closure contract/);
+  assert.match(INVALIDATE_ACTION, /--max-time 90/);
+  assert.match(INVALIDATE_ACTION, /local max_attempts=4/);
+});


### PR DESCRIPTION
## 背景

Run 29391570765 表面成功，但实际有 499 条终态评分失败，且 106/106 个缓存失效批次超时。该 PR 修复日常评分闭环，并提供受控恢复通道。

## 变更

- 固定并校验 CLI 2.8.0 与 Linux SHA256，阻止输入选择非固定二进制
- 识别 CLI 2.8.0 的真实 Final errors 输出，拒绝 rc=0 但未证明处理/写入的 slug
- 所有生产 score writer 共享 production-skill-score-writes mutex
- 写前/写后冻结 snapshot 与 calculatedAt，逐 slug 证明本次 score write
- score 成功集以文件和 SHA256 artifact 跨 job 传递
- hosted runner 分批失效缓存，任何失败保持 red
- production readback 同时比对冻结 DB score、tier、calculatedAt，并验证稳定 HIT 与 cache identity
- 新增 source-run-failures 与 approved-catalog-cache 两个受控恢复 scope
- 修复单文件 sparse checkout cone mode 与正常用户提前预热造成的不可恢复假红

## 验证

- CI=true 定向 Node tests：38/38
- Node syntax、Bash syntax、4 个 workflow YAML parse、git diff --check 全部通过
- 独立 P0/P1 复审：无剩余 P0/P1
- 生产只读抽样确认 DB 与 API score/tier/calculatedAt 逐字节一致

## 上线顺序

1. 合并本 PR
2. source-run-failures 恢复 Run 29391570765 的 499 条失败
3. approved-catalog-cache 关闭完整 public catalog 缓存
4. 两个 run 均绿后才恢复 artifact Batch 7