### PR TITLE
fix(scores): replay residual recovery failures

### DIFF
--- a/.github/workflows/recalculate-scores.yml
+++ b/.github/workflows/recalculate-scores.yml
@@ -34,7 +34,7 @@ on:
       cli_version:
         description: 'Pinned score CLI version'
         type: string
-        default: '2.8.0'
+        default: '2.8.1'
       timeout_seconds:
         description: 'Per-skill CLI timeout in seconds (0 disables)'
         type: string
@@ -48,8 +48,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SCORE_CLI_VERSION: '2.8.0'
-  SCORE_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+  SCORE_CLI_VERSION: '2.8.1'
+  SCORE_CLI_SHA256: '0c53207352b1fe1c5bc73c9d544ee7d97067ed55ab6b72f00e5624b7ee0c7c5c'
 
 jobs:
   recalculate:
@@ -84,7 +84,7 @@ jobs:
 
       - name: Validate requested version and fixed CLI identity
         env:
-          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.0' }}
+          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.1' }}
         run: |
           set -euo pipefail
           [[ "$INPUT_CLI_VERSION" =~ ^(cli-v)?[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
@@ -108,7 +108,7 @@ jobs:
           INPUT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '180' }}
-          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.0' }}
+          INPUT_CLI_VERSION: ${{ inputs.cli_version || '2.8.1' }}
         run: |
           echo "=== Skill Quality Score Recalculation ==="
           echo "Time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"

--- a/.github/workflows/recover-score-cache-closure.yml
+++ b/.github/workflows/recover-score-cache-closure.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: 'Recover terminal score failures from one run, or close cache for the current approved catalog'
+        description: 'Recover failures from a score/recovery run, or close cache for the current approved catalog'
         type: choice
         required: true
         default: source-run-failures
-        options: [source-run-failures, approved-catalog-cache]
+        options: [source-run-failures, recovery-run-failures, approved-catalog-cache]
       source_run_id:
-        description: 'Completed Recalculate Skill Scores run ID (required for source-run-failures)'
+        description: 'Completed score or recovery run ID (required for either failure scope)'
         type: string
         required: false
         default: ''
       expected_failures:
-        description: 'Optional exact terminal-failure count asserted against the source log'
+        description: 'Optional exact terminal-failure count asserted against frozen source evidence'
         type: string
         required: false
         default: ''
@@ -37,8 +37,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RECOVERY_CLI_VERSION: '2.8.0'
-  RECOVERY_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+  RECOVERY_CLI_VERSION: '2.8.1'
+  RECOVERY_CLI_SHA256: '0c53207352b1fe1c5bc73c9d544ee7d97067ed55ab6b72f00e5624b7ee0c7c5c'
 
 jobs:
   plan:
@@ -69,6 +69,16 @@ jobs:
           plan="$RUNNER_TEMP/score-cache-recovery-plan"
           mkdir -p "$plan"
 
+          require_source_ancestor() {
+            local source_sha="$1"
+            local compare_status
+            compare_status=$(gh api "repos/$GITHUB_REPOSITORY/compare/$source_sha...$GITHUB_SHA" --jq .status)
+            if [ "$compare_status" != ahead ] && [ "$compare_status" != identical ]; then
+              echo "::error::source run commit is not an ancestor of the current recovery workflow"
+              exit 2
+            fi
+          }
+
           if [ "$SCOPE" = source-run-failures ]; then
             [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
               echo '::error::source_run_id must be a positive GitHub Actions run ID'
@@ -80,6 +90,7 @@ jobs:
               '.databaseId == $runId and .displayTitle == "Recalculate Skill Scores"
                and .status == "completed" and (.headSha | test("^[0-9a-f]{40}$"))' \
               <<< "$run_json" >/dev/null
+            require_source_ancestor "$(jq -r .headSha <<< "$run_json")"
             printf '%s\n' "$run_json" > "$plan/source-run.json"
             gh run view "$SOURCE_RUN_ID" --repo "$GITHUB_REPOSITORY" --log > "$plan/source-run.log"
             args=(extract-run-log --log "$plan/source-run.log" --output "$plan/requested-slugs.txt")
@@ -87,6 +98,32 @@ jobs:
               args+=(--expected-failures "$EXPECTED_FAILURES")
             fi
             node scripts/score-cache-closure.mjs "${args[@]}"
+          elif [ "$SCOPE" = recovery-run-failures ]; then
+            [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+              echo '::error::source_run_id must be a positive GitHub Actions run ID'
+              exit 2
+            }
+            run_json=$(gh run view "$SOURCE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId,displayTitle,status,conclusion,headSha,event)
+            jq -e --argjson runId "$SOURCE_RUN_ID" \
+              '.databaseId == $runId and .displayTitle == "Recover Score and Cache Closure"
+               and .status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled")
+               and .event == "workflow_dispatch" and (.headSha | test("^[0-9a-f]{40}$"))' \
+              <<< "$run_json" >/dev/null
+            require_source_ancestor "$(jq -r .headSha <<< "$run_json")"
+            printf '%s\n' "$run_json" > "$plan/source-run.json"
+            source_result="$RUNNER_TEMP/source-recovery-result"
+            gh run download "$SOURCE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+              --name "score-cache-recovery-result-$SOURCE_RUN_ID" --dir "$source_result"
+            (cd "$source_result" && sha256sum --check SHA256SUMS)
+            args=(extract-recovery-result --result-dir "$source_result" --output "$plan/requested-slugs.txt")
+            if [ -n "$EXPECTED_FAILURES" ]; then
+              args+=(--expected-failures "$EXPECTED_FAILURES")
+            fi
+            node scripts/score-cache-closure.mjs "${args[@]}"
+            cp "$source_result/metadata.json" "$plan/source-result-metadata.json"
+            cp "$source_result/SHA256SUMS" "$plan/source-result-SHA256SUMS"
+            cp "$source_result/failed-slugs.txt" "$plan/source-failed-slugs.txt"
           else
             test "$SCOPE" = approved-catalog-cache
             test -z "$SOURCE_RUN_ID" || {
@@ -121,7 +158,7 @@ jobs:
 
   rescore-failures:
     needs: plan
-    if: needs.plan.outputs.scope == 'source-run-failures'
+    if: needs.plan.outputs.scope != 'approved-catalog-cache'
     runs-on: ubuntu-latest
     timeout-minutes: 1440
     steps:
@@ -258,7 +295,7 @@ jobs:
           path: ${{ runner.temp }}/score-cache-recovery-plan
 
       - name: Download rescore result
-        if: needs.plan.outputs.scope == 'source-run-failures'
+        if: needs.plan.outputs.scope != 'approved-catalog-cache'
         uses: actions/download-artifact@v5
         with:
           name: score-cache-recovery-result-${{ github.run_id }}
@@ -273,7 +310,7 @@ jobs:
           (cd "$RUNNER_TEMP/score-cache-recovery-plan" && sha256sum --check SHA256SUMS)
           target="$RUNNER_TEMP/cache-closure-slugs.txt"
           expected="$RUNNER_TEMP/cache-closure-expected-score-evidence.json"
-          if [ "$SCOPE" = source-run-failures ]; then
+          if [ "$SCOPE" != approved-catalog-cache ]; then
             result="$RUNNER_TEMP/score-cache-recovery-result"
             (cd "$result" && sha256sum --check SHA256SUMS)
             jq -e '.successfulCount > 0 and .causallyProvenCount == .successfulCount' "$result/metadata.json" >/dev/null

--- a/scripts/recalculate-scores.sh
+++ b/scripts/recalculate-scores.sh
@@ -182,7 +182,7 @@ validate_one_slug_success() {
 	local processed updated errors
 	processed="$(grep -oE 'Processed:[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
 	updated="$(grep -oE 'Updated:[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
-	# CLI 2.8.0 reports `Final errors:`. Keep accepting the older
+	# CLI 2.8.x reports `Final errors:`. Keep accepting the older
 	# aggregate `Errors:` label for compatibility with legacy releases.
 	errors="$(grep -oE '(Final errors|Errors):[[:space:]]*[0-9]+' "$output_path" | tail -n1 | grep -oE '[0-9]+' || true)"
 	if [ "$processed" != "1" ] || [ "$errors" != "0" ]; then
@@ -276,12 +276,20 @@ score_one_slug() {
 
 		# Surface a one-line hint to workflow logs (warnings are visible
 		# in GitHub Actions UI without failing the step).
-		local err_summary
-		err_summary="$(_truncate "$(tail -n 5 "$stderr_path" 2>/dev/null | tr '\n' ' ')" 200)"
+		local err_summary root_error
+		# The fixed CLI writes the actionable failure before its final stack.
+		# Prefer that line so recovery evidence keeps the real database/data
+		# error instead of only a generic citty stack tail.
+		root_error="$(grep -F "error scoring $slug:" "$stderr_path" 2>/dev/null | tail -n1 || true)"
+		if [ -n "$root_error" ]; then
+			err_summary="$(_truncate "$(printf '%s' "$root_error" | tr '\n' ' ')" 500)"
+		else
+			err_summary="$(_truncate "$(tail -n 5 "$stderr_path" 2>/dev/null | tr '\n' ' ')" 300)"
+		fi
 		if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
 			err_summary="timed out after ${TIMEOUT_SECONDS}s ${err_summary}"
 		fi
-		echo "::warning::score failed for slug=$slug attempt=$current_attempt/$MAX_ATTEMPTS exit=$rc err=$( _truncate "$err_summary" 200 )"
+		echo "::warning::score failed for slug=$slug attempt=$current_attempt/$MAX_ATTEMPTS exit=$rc err=$( _truncate "$err_summary" 500 )"
 	done
 
 	echo "::error::score ultimately failed for slug=$slug after $MAX_ATTEMPTS attempts"

--- a/scripts/score-cache-closure.mjs
+++ b/scripts/score-cache-closure.mjs
@@ -2,6 +2,7 @@
 
 import { createHash } from 'node:crypto';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
@@ -63,6 +64,41 @@ export function parseScoreRunLog(log) {
     fail(`source score failure count mismatch: log=${failedSlugs.length}, summary=${errors}`);
   }
   return { errors, failedSlugs, processed, updated };
+}
+
+function recoveryCount(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 10_000) {
+    fail(`recovery result ${name} must be an integer between 0 and 10000`);
+  }
+  return value;
+}
+
+export function parseRecoveryResult({ failedText, metadata, successfulText }) {
+  if (metadata?.schemaVersion !== 1) fail('unsupported recovery result schema');
+  const requestedCount = recoveryCount(metadata.requestedCount, 'requestedCount');
+  const successfulCount = recoveryCount(metadata.successfulCount, 'successfulCount');
+  const failedCount = recoveryCount(metadata.failedCount, 'failedCount');
+  const causallyProvenCount = recoveryCount(metadata.causallyProvenCount, 'causallyProvenCount');
+  if (requestedCount !== successfulCount + failedCount) {
+    fail('recovery result counts do not reconcile');
+  }
+  if (causallyProvenCount !== successfulCount) {
+    fail('recovery result does not causally prove every success');
+  }
+  if (failedCount === 0) fail('recovery result has no residual failures');
+
+  const successfulSlugs = normalizeSlugs(successfulText.split(/\r?\n/), { allowEmpty: true });
+  const failedSlugs = normalizeSlugs(failedText.split(/\r?\n/));
+  if (successfulSlugs.length !== successfulCount || failedSlugs.length !== failedCount) {
+    fail('recovery result slug files do not match metadata counts');
+  }
+  const successfulSet = new Set(successfulSlugs);
+  const overlap = failedSlugs.filter((slug) => successfulSet.has(slug));
+  if (overlap.length > 0) fail(`recovery result success/failure overlap: ${overlap.slice(0, 10).join(', ')}`);
+  if (successfulSlugs.length + failedSlugs.length !== requestedCount) {
+    fail('recovery result slug union does not match requested count');
+  }
+  return { failedCount, failedSlugs, requestedCount, successfulCount };
 }
 
 export async function fetchApprovedCatalog({ fetchImpl = fetch, supabaseUrl, serviceRoleKey }) {
@@ -347,6 +383,21 @@ async function main() {
     appendOutput('updated', parsed.updated);
     return;
   }
+  if (command === 'extract-recovery-result') {
+    const resultDir = readOption(args, '--result-dir', { required: true });
+    const parsed = parseRecoveryResult({
+      failedText: readFileSync(join(resultDir, 'failed-slugs.txt'), 'utf8'),
+      metadata: JSON.parse(readFileSync(join(resultDir, 'metadata.json'), 'utf8')),
+      successfulText: readFileSync(join(resultDir, 'successful-slugs.txt'), 'utf8'),
+    });
+    const expected = readOption(args, '--expected-failures');
+    if (expected !== undefined && parsed.failedCount !== positiveInteger(expected, 'expected-failures', 10_000)) {
+      fail(`expected ${expected} failures but recovery result proved ${parsed.failedCount}`);
+    }
+    writeSlugs(readOption(args, '--output', { required: true }), parsed.failedSlugs);
+    appendOutput('slug_count', parsed.failedSlugs.length);
+    return;
+  }
   if (command === 'approved-catalog') {
     const slugs = await fetchApprovedCatalog({
       supabaseUrl: process.env.PUBLIC_SUPABASE_URL,
@@ -417,7 +468,7 @@ async function main() {
     }
     return;
   }
-  fail('usage: score-cache-closure.mjs <extract-run-log|approved-catalog|freeze-score-evidence|verify-score-transitions|readback> [options]');
+  fail('usage: score-cache-closure.mjs <extract-run-log|extract-recovery-result|approved-catalog|freeze-score-evidence|verify-score-transitions|readback> [options]');
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {

--- a/scripts/tests/fake-cli.sh
+++ b/scripts/tests/fake-cli.sh
@@ -100,6 +100,7 @@ for slug in "${ARR[@]}"; do
 				n=$(slug_call_count "$slug")
 				# Fail the first FAIL_TIMES times, then succeed.
 				if [ "$n" -le "$FAIL_TIMES" ]; then
+					echo "✗ First pass error scoring $slug: simulated transient root cause" >&2
 					echo "::fake::simulated failure for $slug (call $n/$FAIL_TIMES)" >&2
 					exit "$FAIL_EXIT"
 				fi
@@ -108,6 +109,7 @@ for slug in "${ARR[@]}"; do
 			;;
 		fail-slug-always)
 			if [ "$slug" = "${FAKE_CLI_FAIL_SLUG:-}" ]; then
+				echo "✗ First pass error scoring $slug: simulated persistent root cause" >&2
 				echo "::fake::permanent failure for $slug" >&2
 				exit "$FAIL_EXIT"
 			fi

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -173,6 +173,8 @@ test('a slug that fails repeatedly lets the run finish; partial success -> exit 
 	assert.equal(sum.processed, '3');
 	assert.equal(sum.errors, '1');
 	assert.match(result.stdout, /doomed/, 'failed slug name should be surfaced in summary');
+	assert.match(result.stdout, /simulated persistent root cause/,
+		'actionable CLI root errors must survive into recovery evidence');
 });
 
 test('writes exact disjoint success and terminal-failure slug artifacts', () => {
@@ -224,7 +226,7 @@ test('all slugs succeed -> exit 0, errors=0', () => {
 	assert.equal(sum.processed, '3');
 	assert.equal(sum.errors, '0');
 	assert.equal(sum.updated, '3');
-	assert.match(result.stdout, /Final errors:\s*0/, 'fixture must model the fixed CLI 2.8.0 score summary contract');
+	assert.match(result.stdout, /Final errors:\s*0/, 'fixture must model the fixed CLI 2.8.x score summary contract');
 });
 
 test('CLI exit 0 without processing the target is a terminal failure', () => {

--- a/scripts/tests/score-cache-closure.test.mjs
+++ b/scripts/tests/score-cache-closure.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import {
   fetchApprovedCatalog,
   fetchScoreEvidence,
+  parseRecoveryResult,
   parseScoreRunLog,
   verifyCacheReadback,
   verifyScoreTransitions,
@@ -44,6 +45,36 @@ Processed: 2
 Updated: 0
 Errors: 2
 `), /repeats terminal failures/);
+});
+
+test('extracts only checksum-verified residual failures from a prior recovery result', () => {
+  const metadata = {
+    schemaVersion: 1,
+    requestedCount: 5,
+    successfulCount: 3,
+    failedCount: 2,
+    causallyProvenCount: 3,
+  };
+  assert.deepEqual(parseRecoveryResult({
+    metadata,
+    successfulText: 'charlie\nalpha\nbravo\n',
+    failedText: 'echo\ndelta\n',
+  }), {
+    failedCount: 2,
+    failedSlugs: ['delta', 'echo'],
+    requestedCount: 5,
+    successfulCount: 3,
+  });
+  assert.throws(() => parseRecoveryResult({
+    metadata: { ...metadata, causallyProvenCount: 2 },
+    successfulText: 'alpha\nbravo\ncharlie\n',
+    failedText: 'delta\necho\n',
+  }), /does not causally prove every success/);
+  assert.throws(() => parseRecoveryResult({
+    metadata,
+    successfulText: 'alpha\nbravo\ndelta\n',
+    failedText: 'delta\necho\n',
+  }), /success\/failure overlap/);
 });
 
 test('approved catalog pagination selects only public eligible canonical slugs', async () => {
@@ -274,9 +305,18 @@ test('manual recovery is file-backed, fixed-CLI, bounded, and red on any remaini
   assert.match(RECOVERY, /source_run_id:/);
   assert.match(RECOVERY, /gh run view "\$SOURCE_RUN_ID"[\s\S]*--log > "\$plan\/source-run\.log"/);
   assert.match(RECOVERY, /extract-run-log/);
+  assert.match(RECOVERY, /recovery-run-failures/);
+  assert.match(RECOVERY, /\.conclusion == "failure" or \.conclusion == "cancelled"/);
+  assert.match(RECOVERY, /score-cache-recovery-result-\$SOURCE_RUN_ID/);
+  assert.match(RECOVERY, /sha256sum --check SHA256SUMS/);
+  assert.match(RECOVERY, /extract-recovery-result/);
+  assert.match(RECOVERY, /source-result-metadata\.json/);
+  assert.match(RECOVERY, /compare\/\$source_sha\.\.\.\$GITHUB_SHA/);
+  assert.match(RECOVERY, /source run commit is not an ancestor/);
   assert.match(RECOVERY, /approved-catalog/);
   assert.match(RECOVERY, /name: score-cache-recovery-plan-\$\{\{ github\.run_id \}\}/);
-  assert.match(RECOVERY, /RECOVERY_CLI_VERSION: '2\.8\.0'/);
+  assert.match(RECOVERY, /RECOVERY_CLI_VERSION: '2\.8\.1'/);
+  assert.match(RECOVERY, /RECOVERY_CLI_SHA256: '0c53207352b1fe1c5bc73c9d544ee7d97067ed55ab6b72f00e5624b7ee0c7c5c'/);
   assert.match(RECOVERY, /RECOVERY_CLI_SHA256: '[0-9a-f]{64}'/);
   assert.match(RECOVERY, /runs-on: ubuntu-latest/);
   assert.match(RECOVERY, /group: production-skill-score-writes/);


### PR DESCRIPTION
## Summary
- add a fail-closed `recovery-run-failures` scope that replays only residual failures from a prior recovery artifact
- verify prior run identity, conclusion, source commit ancestry, artifact checksums, metadata counts, and success/failure disjointness before replay
- pin score recovery and recalculation to Skillstore CLI 2.8.1 and preserve the first real CLI root error in wrapper logs

## Why
Recovery run 29428162186 produced 472 causally proven writes and 27 deterministic projection failures. CLI 2.8.1 fixes the canonical score input hash, so only the exact 27 residual slugs should be retried.

## Verification
- `CI=true pnpm exec vitest run scripts/tests/recalculate-scores.test.mjs scripts/tests/score-cache-closure.test.mjs` — 39/39
- real artifact replay for run 29428162186 — exactly 27 residual failures
- all 8 artifact files pass `SHA256SUMS`
- YAML, Node, Bash syntax checks and `git diff --check` pass
- independent P0/P1 review: no findings
