### PR TITLE
feat(packs): ship bounded production workflow

### DIFF
--- a/.github/actions/download-skillstore-cli/action.yml
+++ b/.github/actions/download-skillstore-cli/action.yml
@@ -17,11 +17,18 @@ inputs:
     description: 'Fail if the resolved CLI is older than this version (for example, 1.52.2)'
     required: false
     default: ''
+  require-checksum:
+    description: 'Require and verify checksums.txt from the immutable CLI release'
+    required: false
+    default: 'false'
 
 outputs:
   cli-path:
     description: 'Path to the CLI binary'
     value: ${{ github.workspace }}/skillstore-cli
+  cli-sha256:
+    description: 'Verified SHA-256 of the downloaded CLI (empty unless require-checksum=true)'
+    value: ${{ steps.checksum.outputs.cli-sha256 }}
 
 runs:
   using: composite
@@ -55,6 +62,7 @@ runs:
       env:
         CACHE_DIR: ${{ inputs.cache-dir }}
         RELEASE_TAG: ${{ steps.resolve.outputs.release-tag }}
+        REQUIRE_CHECKSUM: ${{ inputs.require-checksum }}
       run: |
         # Auto-create cache directory if it doesn't exist
         if [ ! -d "$CACHE_DIR" ]; then
@@ -76,14 +84,19 @@ runs:
           cp "$CACHE_FILE" "$GITHUB_WORKSPACE/skillstore-cli"
           chmod +x "$GITHUB_WORKSPACE/skillstore-cli"
 
-          EXPECTED_VERSION=${RELEASE_TAG#cli-v}
-          CACHED_VERSION=$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
-          if [ "$CACHED_VERSION" != "$EXPECTED_VERSION" ]; then
-            echo "::warning::Local CLI cache version mismatch: expected $EXPECTED_VERSION, got ${CACHED_VERSION:-unknown}. Invalidating cache entry."
-            rm -f "$CACHE_FILE" "$GITHUB_WORKSPACE/skillstore-cli"
-            echo "cache-hit=false" >> $GITHUB_OUTPUT
-            echo "cache-file=$CACHE_FILE" >> $GITHUB_OUTPUT
-            exit 0
+          # Legacy callers do not require a release checksum, so retain their
+          # stale-cache self-healing behavior. Checksum-required callers must
+          # never execute cache bytes before the checksum gate below.
+          if [ "$REQUIRE_CHECKSUM" != "true" ]; then
+            EXPECTED_VERSION=${RELEASE_TAG#cli-v}
+            CACHED_VERSION=$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 | grep -Eo '[0-9]+([.][0-9]+){1,3}([-+][0-9A-Za-z._-]+)?' | head -n1 || true)
+            if [ "$CACHED_VERSION" != "$EXPECTED_VERSION" ]; then
+              echo "::warning::Local CLI cache version mismatch: expected $EXPECTED_VERSION, got ${CACHED_VERSION:-unknown}. Invalidating cache entry."
+              rm -f "$CACHE_FILE" "$GITHUB_WORKSPACE/skillstore-cli"
+              echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+              echo "cache-file=$CACHE_FILE" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           echo "cache-hit=true" >> $GITHUB_OUTPUT
@@ -134,30 +147,47 @@ runs:
 
         chmod +x "$GITHUB_WORKSPACE/skillstore-cli"
 
-    - name: Save to local cache (self-hosted runners)
-      if: inputs.cache-dir != '' && steps.local-cache.outputs.cache-hit != 'true' && steps.local-cache.outputs.cache-disabled != 'true'
-      shell: bash
-      env:
-        CACHE_DIR: ${{ inputs.cache-dir }}
-      run: |
-        CACHE_FILE="${{ steps.local-cache.outputs.cache-file }}"
-
-        # Ensure cache directory exists (should already exist from check step)
-        mkdir -p "$CACHE_DIR"
-
-        # Copy to cache
-        cp "$GITHUB_WORKSPACE/skillstore-cli" "$CACHE_FILE"
-
-        echo "✅ Saved to local cache: $CACHE_FILE"
-        echo "📋 File size: $(du -h "$CACHE_FILE" | cut -f1)"
-        echo "🚀 Next run will use cached version (instant!)"
-
     - name: Restore executable permissions
       if: inputs.cache-dir == '' && steps.cache-cli.outputs.cache-hit == 'true'
       shell: bash
       run: |
         echo "✅ Using cached CLI (${{ steps.resolve.outputs.release-tag }})"
         chmod +x "$GITHUB_WORKSPACE/skillstore-cli"
+
+    # This must run before the first execution and before a downloaded binary is
+    # written to the shared self-hosted cache. A cache hit is untrusted input too.
+    - name: Verify release checksum before execution
+      id: checksum
+      if: inputs.require-checksum == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        CLI_REPO: aiskillstore/skillstore
+        RELEASE_TAG: ${{ steps.resolve.outputs.release-tag }}
+      run: |
+        CHECKSUM_DIR=$(mktemp -d)
+        trap 'rm -rf "$CHECKSUM_DIR"' EXIT
+        gh release download "$RELEASE_TAG" \
+          --repo "$CLI_REPO" \
+          --pattern checksums.txt \
+          --dir "$CHECKSUM_DIR"
+
+        EXPECTED=$(awk '$2 == "skillstore-cli-linux-x64" { print $1 }' "$CHECKSUM_DIR/checksums.txt")
+        if ! [[ "$EXPECTED" =~ ^[0-9a-f]{64}$ ]]; then
+          echo "::error::Release $RELEASE_TAG has no valid checksum for skillstore-cli-linux-x64"
+          exit 1
+        fi
+        if command -v sha256sum >/dev/null 2>&1; then
+          ACTUAL=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{ print $1 }')
+        else
+          ACTUAL=$(shasum -a 256 "$GITHUB_WORKSPACE/skillstore-cli" | awk '{ print $1 }')
+        fi
+        if [ "$ACTUAL" != "$EXPECTED" ]; then
+          echo "::error::CLI checksum mismatch for $RELEASE_TAG: expected $EXPECTED, got $ACTUAL"
+          exit 1
+        fi
+        echo "cli-sha256=$ACTUAL" >> "$GITHUB_OUTPUT"
+        echo "✅ Verified CLI SHA-256 before execution: $ACTUAL"
 
     - name: Verify CLI
       id: verify
@@ -211,3 +241,20 @@ runs:
           fi
           echo "✅ Minimum CLI version satisfied: $ACTUAL_VERSION >= $MINIMUM_VERSION"
         fi
+
+    - name: Save verified CLI to local cache (self-hosted runners)
+      if: inputs.cache-dir != '' && steps.local-cache.outputs.cache-hit != 'true' && steps.local-cache.outputs.cache-disabled != 'true'
+      shell: bash
+      env:
+        CACHE_DIR: ${{ inputs.cache-dir }}
+      run: |
+        CACHE_FILE="${{ steps.local-cache.outputs.cache-file }}"
+        mkdir -p "$CACHE_DIR"
+        TEMP_CACHE_FILE="${CACHE_FILE}.tmp.$$"
+        trap 'rm -f "$TEMP_CACHE_FILE"' EXIT
+        cp "$GITHUB_WORKSPACE/skillstore-cli" "$TEMP_CACHE_FILE"
+        chmod +x "$TEMP_CACHE_FILE"
+        mv -f "$TEMP_CACHE_FILE" "$CACHE_FILE"
+
+        echo "✅ Saved verified CLI atomically: $CACHE_FILE"
+        echo "📋 Cache file size: $(du -h "$CACHE_FILE" | cut -f1)"

--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -38,7 +38,9 @@ jobs:
         id: cli
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: latest
+          version: '2.9.0'
+          minimum-version: '2.9.0'
+          require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
@@ -65,3 +67,16 @@ jobs:
             FLAGS+=(--guide-only)
           fi
           "$CLI" pack generate-content --slug "$SLUG" --issue "$ISSUE" "${FLAGS[@]}"
+
+      - name: Dispatch translation after content is complete
+        if: github.event.client_payload.generationId != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SLUG: ${{ github.event.client_payload.slug }}
+          GENERATION_ID: ${{ github.event.client_payload.generationId }}
+        run: |
+          jq -n \
+            --arg slug "$SLUG" \
+            --arg generationId "$GENERATION_ID" \
+            '{event_type:"translate-packs",client_payload:{pack_slugs:$slug,source_generation_id:$generationId,cli_version:"2.9.0"}}' \
+            | gh api --method POST repos/aiskillstore/marketplace/dispatches --input -

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -1,185 +1,470 @@
-# Generate a curated skill pack on a clean self-hosted runner.
-# Runs the full pipeline: candidate skills (keyword + real search->install
-# behavior) -> best-of-breed verify (PK) -> LLM compose -> whole-pack verify
-# -> optionally write a candidate to Supabase (review_status=generated).
-# Clean runner HOME = accurate used-skill scoring (no personal global skills).
-# Uses `skillstore-cli pack generate` (CLI >= 1.41.0 for --scenario).
-
 name: Generate Pack
 
 on:
-  # Daily candidate generation: one scenario/day on a 7-day rotation. The CLI's
-  # built-in catalog (`--scenario daily-rotation`) picks today's scenario and
-  # forces a stable slug, so re-runs are idempotent and approved packs are never
-  # overwritten (an approved slug writes a rolling `-candidate` instead).
   schedule:
     - cron: '17 19 * * *'
   workflow_dispatch:
     inputs:
       scenario:
-        description: 'Built-in scenario id or "daily-rotation" (fills task/keywords/slug; leave task/keywords blank)'
+        description: 'Optional exact production scenario id/slug; blank uses the dynamic queue'
         type: string
         required: false
-      task:
-        description: 'End-to-end task the pack must solve (ignored when scenario is set)'
-        type: string
-        required: false
-      keywords:
-        description: 'Comma-separated candidate search terms (ignored when scenario is set)'
-        type: string
-        required: false
-      max_candidates:
-        description: 'Max skills to PK (default: 5)'
-        type: string
-        default: '5'
-      pick:
-        description: 'Max skills in the final pack (default: 3)'
-        type: string
-        default: '3'
-      model:
-        description: 'Run agent (default: sonnet -> Claude Code, where skills load)'
-        type: string
-        default: 'sonnet'
-      judge_model:
-        description: 'Judge agent (default: gpt-5.5 -> Codex, independent)'
-        type: string
-        default: 'gpt-5.5'
-      runs:
-        description: 'Run+judge iterations per verify (default: 1)'
-        type: string
-        default: '1'
-      threshold:
-        description: 'Pass threshold for the median score 0-10 (default: 7)'
-        type: string
-        default: '7'
-      write:
-        description: 'Write the candidate pack to Supabase (review_status=generated)'
+      auto_publish:
+        description: 'Request auto-publish; repository rollout gate must also be enabled'
         type: boolean
         default: false
-      cli_version:
-        description: 'Skillstore CLI version (default: latest)'
-        type: string
-        default: 'latest'
+
+permissions:
+  contents: read
 
 concurrency:
-  group: generate-pack
+  group: generate-pack-production-v2
   cancel-in-progress: false
 
-jobs:
-  generate:
-    runs-on: self-hosted
-    timeout-minutes: 360
-    steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          repositories: marketplace,skillstore
+env:
+  # Immutable release required by the v2 evaluator/API contract. Bump only
+  # together with a Skillstore CLI release and its checksums.txt asset.
+  PACK_PRODUCTION_CLI_VERSION: '2.9.0'
 
-      - name: Checkout repository
+jobs:
+  plan:
+    name: Plan bounded scenario queue
+    runs-on: self-hosted
+    timeout-minutes: 20
+    outputs:
+      has_scenarios: ${{ steps.queue.outputs.has_scenarios }}
+      scenario_count: ${{ steps.queue.outputs.scenario_count }}
+    steps:
+      - name: Prepare isolated checkout
+        run: rm -rf "$GITHUB_WORKSPACE/marketplace-plan" "$GITHUB_WORKSPACE/pack-plan"
+
+      - name: Checkout immutable workflow revision
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          path: marketplace-plan
+          ref: ${{ github.sha }}
           fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
 
-      - name: Download Skillstore CLI
+      - name: Download pinned Skillstore CLI
         id: cli
-        uses: ./.github/actions/download-skillstore-cli
+        uses: ./marketplace-plan/.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version }}
-          token: ${{ steps.app-token.outputs.token }}
+          version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          minimum-version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          require-checksum: 'true'
+          token: ${{ github.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
-      - name: Generate pack
-        id: gen
+      - name: Select up to three scenarios
+        id: queue
         env:
           CLI: ${{ steps.cli.outputs.cli-path }}
-          EVENT: ${{ github.event_name }}
           SCENARIO: ${{ inputs.scenario }}
-          TASK: ${{ inputs.task }}
-          KEYWORDS: ${{ inputs.keywords }}
-          MAXC: ${{ inputs.max_candidates }}
-          PICK: ${{ inputs.pick }}
-          MODEL: ${{ inputs.model }}
-          JUDGE: ${{ inputs.judge_model }}
-          RUNS: ${{ inputs.runs }}
-          THRESHOLD: ${{ inputs.threshold }}
-          # CLI reads these names; map from the repo's existing Supabase secrets
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
-          # lets `pack generate` generate a cover image via Helm (gemini-3.1-flash-image);
-          # absent => cover step is skipped (best-effort, never fails the pack)
-          HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
-          # lets `pack generate` dispatch the translate-packs workflow after writing a pack
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: marketplace-plan
         run: |
-          set +e  # pack generate exits non-zero when the pack FAILs verification; that's data, not a job error
-          mkdir -p pack-results
-
-          ARGS=(pack generate --skills-dir skills --json)
-          if [ "$EVENT" = "schedule" ]; then
-            # Daily rotation: today's scenario, written as a generated candidate.
-            ARGS+=(--scenario daily-rotation --write \
-              --max-candidates 8 --pick 3 \
-              --model sonnet --judge-model gpt-5.5 --runs 1 --threshold 7)
+          mkdir -p "$GITHUB_WORKSPACE/pack-plan"
+          ARGS=(pack scenario-queue --limit 3 --lookback-days 30 --cooldown-days 7 --json)
+          if [ -n "$SCENARIO" ]; then
+            ARGS+=(--scenario "$SCENARIO")
+          fi
+          "$CLI" "${ARGS[@]}" > "$GITHUB_WORKSPACE/pack-plan/plan.json"
+          jq -e '
+            .schemaVersion == "pack-production-queue/v1" and
+            (.scenarios | type == "array" and length <= 3) and
+            ((.scenarios | length) > 0 or .source == "signals") and
+            (all(.scenarios[]; (.capabilitySlots | length >= 1) and (.requiredArtifacts | length >= 1)))
+          ' "$GITHUB_WORKSPACE/pack-plan/plan.json"
+          SCENARIO_COUNT=$(jq -r '.scenarios | length' "$GITHUB_WORKSPACE/pack-plan/plan.json")
+          echo "scenario_count=$SCENARIO_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$SCENARIO_COUNT" -eq 0 ]; then
+            echo "has_scenarios=false" >> "$GITHUB_OUTPUT"
+            jq \
+              --arg runId "${{ github.run_id }}" \
+              --argjson runAttempt "${{ github.run_attempt }}" \
+              --arg commitSha "${{ github.sha }}" \
+              '{
+              schemaVersion: "marketplace.pack-production-noop/v1",
+              outcome: "no_op",
+              reason: "no_eligible_scenarios",
+              workflow: {
+                repository: "aiskillstore/marketplace",
+                runId: $runId,
+                runAttempt: $runAttempt,
+                commitSha: $commitSha
+              },
+              planSchemaVersion: .schemaVersion,
+              source,
+              generatedAt,
+              lookbackDays,
+              scenarioCount: (.scenarios | length)
+            }' "$GITHUB_WORKSPACE/pack-plan/plan.json" > "$GITHUB_WORKSPACE/pack-plan/no-op.json"
+            echo "No eligible scenario is due; recording an audited no-op." >> "$GITHUB_STEP_SUMMARY"
           else
-            # Manual: a scenario id (fills task/keywords) OR explicit task+keywords.
-            if [ -n "$SCENARIO" ]; then
-              ARGS+=(--scenario "$SCENARIO")
-            else
-              ARGS+=(--task "$TASK" --keywords "$KEYWORDS")
+            echo "has_scenarios=true" >> "$GITHUB_OUTPUT"
+          fi
+          jq '{source, scenarios: [.scenarios[] | {id, version, queueScore, reasons}]}' \
+            "$GITHUB_WORKSPACE/pack-plan/plan.json" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable plan
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-plan
+          path: pack-plan/
+          if-no-files-found: error
+          retention-days: 90
+
+  evaluate:
+    name: Evaluate without production credentials
+    needs: plan
+    if: needs.plan.outputs.has_scenarios == 'true'
+    # GitHub-hosted runners are single-use VMs. The evaluator never reuses the
+    # persistent OAuth HOME or sibling workspaces from our self-hosted pool.
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - name: Checkout immutable skills and orchestrator
+        uses: actions/checkout@v5
+        with:
+          path: marketplace-evaluate
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
+
+      - name: Download plan
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-plan
+          path: pack-production-input
+
+      - name: Download and checksum pinned Skillstore CLI
+        id: cli
+        uses: ./marketplace-evaluate/.github/actions/download-skillstore-cli
+        with:
+          version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          minimum-version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          require-checksum: 'true'
+          token: ${{ github.token }}
+          cache-dir: ''
+
+      - name: Install evaluator runtimes before secrets are available
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ffmpeg poppler-utils
+          sudo npm install --global \
+            @anthropic-ai/claude-code@2.1.210 \
+            @openai/codex@0.139.0
+          command -v ffprobe
+          command -v pdfinfo
+          command -v pdftotext
+          test "$(claude --version | awk '{print $1}')" = '2.1.210'
+          test "$(codex --version | awk '{print $2}')" = '0.139.0'
+
+      - name: Prepare disposable evaluator identities and filesystem
+        env:
+          CLI: ${{ steps.cli.outputs.cli-path }}
+        run: |
+          RUNNER_GROUP=$(id -gn)
+          sudo useradd --system --create-home --home-dir /home/packproxy --shell /usr/sbin/nologin packproxy
+          sudo useradd --create-home --home-dir /home/packeval --shell /bin/bash packeval
+          sudo install -o root -g root -m 0555 "$CLI" /usr/local/bin/skillstore-cli-pack-evaluator
+          sudo chown -R root:root \
+            "$GITHUB_WORKSPACE/marketplace-evaluate" \
+            "$GITHUB_WORKSPACE/pack-production-input"
+          sudo chmod -R a=rX,u+w \
+            "$GITHUB_WORKSPACE/marketplace-evaluate" \
+            "$GITHUB_WORKSPACE/pack-production-input"
+          sudo install -d -o packeval -g "$RUNNER_GROUP" -m 0770 \
+            "$GITHUB_WORKSPACE/pack-results"
+          sudo install -d -o packeval -g packeval -m 0700 \
+            /home/packeval/tmp \
+            /home/packeval/.codex
+          printf '%s\n' \
+            'model_provider = "pack_evaluator_proxy"' \
+            '[model_providers.pack_evaluator_proxy]' \
+            'name = "Job-local Pack evaluator proxy"' \
+            'base_url = "http://127.0.0.1:18765/v1"' \
+            'env_key = "PACK_EVALUATOR_PROXY_TOKEN"' \
+            'wire_api = "responses"' \
+            'supports_websockets = false' \
+            | sudo tee /home/packeval/.codex/config.toml >/dev/null
+          sudo chown packeval:packeval /home/packeval/.codex/config.toml
+          sudo chmod 0600 /home/packeval/.codex/config.toml
+
+      # The real Helm credential exists only in this runner-owned shell and the
+      # separate packproxy process. Agent commands run as a different, non-sudo
+      # user with an empty environment and receive only a localhost-scoped token.
+      - name: Evaluate queue until one candidate is ready
+        env:
+          PACK_EVALUATOR_HELM_API_KEY: ${{ secrets.PACK_EVALUATOR_HELM_API_KEY }}
+          SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+        run: |
+          set -euo pipefail
+          LOCAL_TOKEN=$(openssl rand -hex 32)
+          PROXY_LOG=$(mktemp)
+          chmod 0600 "$PROXY_LOG"
+          cleanup() {
+            sudo pkill -u packproxy -f pack-evaluator-proxy.mjs 2>/dev/null || true
+            rm -f "$PROXY_LOG"
+          }
+          trap cleanup EXIT
+
+          sudo -u packproxy env -i \
+            PATH=/usr/local/bin:/usr/bin:/bin \
+            PACK_EVALUATOR_LOCAL_TOKEN="$LOCAL_TOKEN" \
+            PACK_EVALUATOR_UPSTREAM_KEY="$PACK_EVALUATOR_HELM_API_KEY" \
+            PACK_EVALUATOR_UPSTREAM_URL=https://helm.easymeta.au \
+            PACK_EVALUATOR_PROXY_PORT=18765 \
+            PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5.5 \
+            PACK_EVALUATOR_MAX_REQUESTS=256 \
+            PACK_EVALUATOR_MAX_CONCURRENT=4 \
+            PACK_EVALUATOR_MAX_OUTPUT_TOKENS=65536 \
+            PACK_EVALUATOR_TTL_MS=14400000 \
+            PACK_EVALUATOR_REQUEST_TIMEOUT_MS=600000 \
+            node "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-evaluator-proxy.mjs" \
+            >"$PROXY_LOG" 2>&1 &
+          unset PACK_EVALUATOR_HELM_API_KEY
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent \
+              -H "Authorization: Bearer $LOCAL_TOKEN" \
+              http://127.0.0.1:18765/healthz >/dev/null; then
+              break
             fi
-            ARGS+=(--max-candidates "$MAXC" --pick "$PICK" \
-              --model "$MODEL" --judge-model "$JUDGE" \
-              --runs "$RUNS" --threshold "$THRESHOLD")
-            [ "${{ inputs.write }}" = "true" ] && ARGS+=(--write)
-          fi
+            sleep 1
+          done
+          curl --fail --silent \
+            -H "Authorization: Bearer $LOCAL_TOKEN" \
+            http://127.0.0.1:18765/healthz >/dev/null
+          PROXY_PID=$(pgrep -u packproxy -f pack-evaluator-proxy.mjs | head -n1)
+          test -n "$PROXY_PID"
 
-          "$CLI" "${ARGS[@]}" > pack-results/result.json 2> >(tee pack-results/run.log >&2)
-          RC=$?
-          echo "exit code: $RC"
-          cat pack-results/result.json || true
+          sudo -u packeval env -i \
+            PATH=/usr/local/bin:/usr/bin:/bin \
+            HOME=/home/packeval \
+            PROXY_PID="$PROXY_PID" \
+            bash -c '
+              set -euo pipefail
+              ! sudo -n true 2>/dev/null
+              ! test -r "/proc/$PROXY_PID/environ"
+              ! test -e /home/packeval/.codex/auth.json
+              ! test -e /home/packeval/.claude
+              ! test -r /var/run/docker.sock
+              ! env | grep -Eq "SUPABASE|HELM|GITHUB_TOKEN|GH_TOKEN|AUTOMATION|APP_PRIVATE_KEY|CALLBACK|CACHE_INVALIDATE"
+            '
 
-          R=pack-results/result.json
-          if jq -e . "$R" >/dev/null 2>&1; then
-            NAME=$(jq -r '.manifest.name' "$R")
-            SLUG=$(jq -r '.manifest.slug' "$R")
-            SKILLS=$(jq -r '.manifest.skills | join(", ")' "$R")
-            FIT=$(jq -r '.packFitness.medianScore' "$R")
-            PASS=$(jq -r 'if .packFitness.passed then "✅ PASS" else "❌ FAIL" end' "$R")
-            USED=$(jq -r '(.packFitness.usedSkillRate*100)|floor' "$R")
-            WRITTEN=$(jq -r 'if .written then ((.written.packId // .written.pluginId) + " (review_status=generated)" + (if .comparisonOf then " [comparison of " + .comparisonOf + "]" else "" end)) elif .skippedReason then ("skipped — " + .skippedReason) elif .writeError then ("write failed — " + .writeError) else "dry-run" end' "$R")
-            {
-              echo "## Pack Generation"
-              echo ""
-              echo "**Pack:** $NAME (\`$SLUG\`)"
-              echo ""
-              echo "**Skills:** $SKILLS"
-              echo ""
-              echo "**Fitness:** $FIT/10 — $PASS  (used-skill ${USED}%)"
-              echo ""
-              echo "**Written:** $WRITTEN"
-              echo ""
-              echo "### Candidates (best-of-breed PK)"
-              echo "| skill | score | used-skill |"
-              echo "|---|--:|--:|"
-              jq -r '.candidates[] | "| \(.slug) | \(.score)/10 | \((.usedSkillRate*100)|floor)% |"' "$R"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "## Pack Generation"
-              echo "Pipeline produced no JSON (exit $RC). See the run.log artifact."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-          exit 0
+          sudo -u packeval env -i \
+            PATH=/usr/local/bin:/usr/bin:/bin \
+            HOME=/home/packeval \
+            CODEX_HOME=/home/packeval/.codex \
+            TMPDIR=/home/packeval/tmp \
+            CI=true \
+            NO_COLOR=1 \
+            SKILLSTORE_AGENTS="$SKILLSTORE_AGENTS" \
+            SKILLSTORE_AGENT_ENV_MODE=strict \
+            SKILLSTORE_AGENT_ENV_ALLOWLIST=CODEX_HOME,PACK_EVALUATOR_PROXY_TOKEN,ANTHROPIC_BASE_URL,ANTHROPIC_AUTH_TOKEN,NO_PROXY \
+            PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
+            ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
+            ANTHROPIC_AUTH_TOKEN="$LOCAL_TOKEN" \
+            NO_PROXY=127.0.0.1,localhost \
+            timeout --signal=TERM 4h \
+            prlimit --nproc=256:256 --as=6442450944:6442450944 -- \
+            node "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-production.mjs" evaluate \
+            --plan "$GITHUB_WORKSPACE/pack-production-input/plan.json" \
+            --results-dir "$GITHUB_WORKSPACE/pack-results" \
+            --cli /usr/local/bin/skillstore-cli-pack-evaluator \
+            --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
+            --skills-dir "$GITHUB_WORKSPACE/marketplace-evaluate/skills" \
+            --run-id "${{ github.run_id }}" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --commit-sha "${{ github.sha }}" \
+            --model sonnet \
+            --judge-model gpt-5.5 \
+            --max-candidates 3 \
+            --pick 4 \
+            --runs 1 \
+            --final-runs 3 \
+            --threshold 7 \
+            --baseline-delta 1 \
+            --auto-publish-threshold 8 \
+            > "$GITHUB_WORKSPACE/pack-results/evaluate-command.json"
+          test ! -s "$PROXY_LOG" || sed -E 's/(Bearer|helm_live_)[^[:space:]]+/[REDACTED]/g' "$PROXY_LOG" >&2
+          jq '{attempts: [.reports[] | {scenarioId, outcome, outcomeReason}], selectedGenerationId}' \
+            "$GITHUB_WORKSPACE/pack-results/evaluate-summary.json" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload results
+      - name: Upload complete evaluation evidence
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: pack-results
+          name: pack-production-evaluation
           path: pack-results/
-          retention-days: 7
+          if-no-files-found: error
+          retention-days: 90
+
+  persist:
+    name: Persist through trusted API
+    needs: [plan, evaluate]
+    if: needs.plan.outputs.has_scenarios == 'true' && needs.evaluate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout orchestrator only
+        uses: actions/checkout@v5
+        with:
+          path: marketplace-persist
+          ref: ${{ github.sha }}
+          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download evaluation evidence
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-evaluation
+          path: pack-results
+
+      - name: Persist every attempt atomically
+        env:
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          PACK_PRODUCTION_AUTOMATION_KEY: ${{ secrets.PACK_PRODUCTION_AUTOMATION_KEY }}
+        run: |
+          node marketplace-persist/scripts/pack-production.mjs persist \
+            --results-dir "$GITHUB_WORKSPACE/pack-results" \
+            --api-url "$SKILLSTORE_API_URL" \
+            --token "$PACK_PRODUCTION_AUTOMATION_KEY" \
+            > "$GITHUB_WORKSPACE/pack-results/persist-command.json"
+
+      - name: Upload persistence readback
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-persisted
+          path: pack-results/
+          if-no-files-found: error
+          retention-days: 90
+
+  enrich_publish_readback:
+    name: Enrich, gate, publish, and prove production
+    needs: [plan, persist]
+    if: needs.plan.outputs.has_scenarios == 'true' && needs.persist.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout orchestrator only
+        uses: actions/checkout@v5
+        with:
+          path: marketplace-finalize
+          ref: ${{ github.sha }}
+          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download persisted evidence
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-persisted
+          path: pack-results
+
+      - name: Await enrichment and enforce publish gates
+        env:
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          PACK_PRODUCTION_AUTOMATION_KEY: ${{ secrets.PACK_PRODUCTION_AUTOMATION_KEY }}
+          # Fail closed until the hardened evaluator-container canary passes and
+          # PACK_PRODUCTION_AUTO_PUBLISH_ENABLED is explicitly enabled.
+          AUTO_PUBLISH: ${{ vars.PACK_PRODUCTION_AUTO_PUBLISH_ENABLED == 'true' && (github.event_name == 'schedule' || inputs.auto_publish) && 'true' || 'false' }}
+        run: |
+          node marketplace-finalize/scripts/pack-production.mjs finalize \
+            --results-dir "$GITHUB_WORKSPACE/pack-results" \
+            --api-url "$SKILLSTORE_API_URL" \
+            --token "$PACK_PRODUCTION_AUTOMATION_KEY" \
+            --auto-publish "$AUTO_PUBLISH" \
+            --max-wait-seconds 1800 \
+            --poll-seconds 30 \
+            > "$GITHUB_WORKSPACE/pack-results/finalize-command.json"
+          jq . "$GITHUB_WORKSPACE/pack-results/final-result.json" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload final production evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-final
+          path: pack-results/
+          if-no-files-found: error
+          retention-days: 90
+
+  production_slo:
+    name: Report rolling seven-day production SLO
+    needs: [plan, evaluate, persist, enrich_publish_readback]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout SLO reporter only
+        uses: actions/checkout@v5
+        with:
+          path: marketplace-slo
+          ref: ${{ github.sha }}
+          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download audited plan or no-op evidence
+        if: needs.plan.result == 'success'
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-plan
+          path: pack-plan
+
+      - name: Query and report rolling seven-day SLO
+        env:
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          PACK_PRODUCTION_AUTOMATION_KEY: ${{ secrets.PACK_PRODUCTION_AUTOMATION_KEY }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+          EVALUATE_RESULT: ${{ needs.evaluate.result }}
+          PERSIST_RESULT: ${{ needs.persist.result }}
+          FINALIZE_RESULT: ${{ needs.enrich_publish_readback.result }}
+          HAS_SCENARIOS: ${{ needs.plan.outputs.has_scenarios }}
+          SCENARIO_COUNT: ${{ needs.plan.outputs.scenario_count }}
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/pack-slo"
+          node marketplace-slo/scripts/pack-production.mjs slo \
+            --results-dir "$GITHUB_WORKSPACE/pack-slo" \
+            --api-url "$SKILLSTORE_API_URL" \
+            --token "$PACK_PRODUCTION_AUTOMATION_KEY" \
+            > "$GITHUB_WORKSPACE/pack-slo/slo-command.json"
+
+          SLO="$GITHUB_WORKSPACE/pack-slo/slo-result.json"
+          PASSED=$(jq -r '.met' "$SLO")
+          ACTUAL=$(jq -r '.publishedReadbackPassed' "$SLO")
+          TARGET=$(jq -r '.target' "$SLO")
+          {
+            echo "## Rolling 7-Day Pack Production SLO"
+            echo ""
+            echo "- Published + readback passed: $ACTUAL/$TARGET"
+            echo "- Plan: $PLAN_RESULT ($SCENARIO_COUNT scenarios)"
+            echo "- Evaluate: $EVALUATE_RESULT"
+            echo "- Persist: $PERSIST_RESULT"
+            echo "- Finalize: $FINALIZE_RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PASSED" != "true" ]; then
+            echo "::error::Rolling 7-day Pack production SLO is below target: $ACTUAL/$TARGET"
+            echo "- Failure: SLO is below target; quality gates remain unchanged." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Upload terminal SLO and no-op evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-slo
+          path: |
+            pack-slo/
+            pack-plan/no-op.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/translate-packs.yml
+++ b/.github/workflows/translate-packs.yml
@@ -58,11 +58,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
+          persist-credentials: false
 
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version || 'latest' }}
+          version: ${{ github.event.client_payload.cli_version || inputs.cli_version || 'latest' }}
+          minimum-version: ${{ github.event.client_payload.source_generation_id && github.event.client_payload.cli_version || '' }}
+          require-checksum: ${{ github.event.client_payload.source_generation_id && 'true' || 'false' }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
@@ -98,6 +101,7 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+          SKILLSTORE_AGENT_ENV_MODE: strict
           SLUGS: ${{ steps.detect.outputs.slugs_csv }}
           CONCURRENCY: ${{ inputs.concurrency || '5' }}
         run: |

--- a/scripts/pack-evaluator-proxy.mjs
+++ b/scripts/pack-evaluator-proxy.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { timingSafeEqual } from 'node:crypto';
+import { createServer } from 'node:http';
+import { pathToFileURL } from 'node:url';
+
+const ALLOWED_PATHS = new Set([
+  '/v1/messages',
+  '/v1/messages/count_tokens',
+  '/v1/responses',
+  '/v1/responses/compact',
+]);
+const STRIPPED_HEADERS = new Set([
+  'authorization',
+  'connection',
+  'content-encoding',
+  'content-length',
+  'cookie',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'x-api-key',
+]);
+const MAX_BODY_BYTES = 32 * 1024 * 1024;
+const DEFAULT_ALLOWED_MODELS = new Set([
+  'claude-sonnet-4.6',
+  'claude-sonnet-4-6',
+  'claude-sonnet-5',
+  'sonnet',
+  'gpt-5.5',
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function reject(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  throw error;
+}
+
+function sameToken(actual, expected) {
+  const left = Buffer.from(actual || '');
+  const right = Buffer.from(expected || '');
+  return left.length === right.length && left.length > 0 && timingSafeEqual(left, right);
+}
+
+function requestToken(request) {
+  const authorization = request.headers.authorization;
+  if (authorization?.startsWith('Bearer ')) return authorization.slice('Bearer '.length);
+  const apiKey = request.headers['x-api-key'];
+  return Array.isArray(apiKey) ? apiKey[0] : apiKey;
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.length;
+    if (size > MAX_BODY_BYTES) fail('request body exceeds 32 MiB');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function positiveInteger(value, name, fallback) {
+  if (value == null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) fail(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function allowedModelSet(value = DEFAULT_ALLOWED_MODELS) {
+  const models = value instanceof Set
+    ? value
+    : new Set(String(value).split(',').map((model) => model.trim()).filter(Boolean));
+  if (models.size === 0) fail('PACK_EVALUATOR_ALLOWED_MODELS must not be empty');
+  return models;
+}
+
+function boundedInferenceBody(body, pathname, allowedModels, maxOutputTokens) {
+  let payload;
+  try {
+    payload = JSON.parse(body.toString('utf8'));
+  } catch {
+    reject('inference request body must be valid JSON', 400);
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    reject('inference request body must be a JSON object', 400);
+  }
+
+  const model = typeof payload.model === 'string' ? payload.model.trim() : '';
+  if (!model || !allowedModels.has(model)) reject(`model is not allowed: ${model || '(missing)'}`, 403);
+
+  for (const field of ['max_tokens', 'max_output_tokens']) {
+    if (payload[field] == null) continue;
+    if (!Number.isSafeInteger(payload[field]) || payload[field] < 1 || payload[field] > maxOutputTokens) {
+      reject(`${field} must be between 1 and ${maxOutputTokens}`, 400);
+    }
+  }
+  if (pathname === '/v1/messages' && payload.max_tokens == null) payload.max_tokens = maxOutputTokens;
+  if (pathname === '/v1/responses' && payload.max_output_tokens == null) {
+    payload.max_output_tokens = maxOutputTokens;
+  }
+  return Buffer.from(JSON.stringify(payload));
+}
+
+function upstreamHeaders(request, upstreamKey) {
+  const headers = new Headers();
+  for (const [name, rawValue] of Object.entries(request.headers)) {
+    if (STRIPPED_HEADERS.has(name.toLowerCase()) || rawValue == null) continue;
+    const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+    for (const value of values) headers.append(name, value);
+  }
+  headers.set('authorization', `Bearer ${upstreamKey}`);
+  return headers;
+}
+
+function responseHeaders(upstream) {
+  const headers = {};
+  for (const [name, value] of upstream.headers.entries()) {
+    if (STRIPPED_HEADERS.has(name.toLowerCase()) || name.toLowerCase() === 'set-cookie') continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function json(response, status, payload) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(`${JSON.stringify(payload)}\n`);
+}
+
+export function createPackEvaluatorProxy({
+  localToken,
+  upstreamKey,
+  upstreamBaseUrl,
+  fetchImpl = fetch,
+  allowedModels = DEFAULT_ALLOWED_MODELS,
+  maxRequests = 256,
+  maxConcurrent = 4,
+  maxOutputTokens = 65_536,
+  ttlMs = 4 * 60 * 60 * 1000,
+  requestTimeoutMs = 10 * 60 * 1000,
+}) {
+  if (!localToken || localToken.length < 32) fail('PACK_EVALUATOR_LOCAL_TOKEN must be at least 32 characters');
+  if (!upstreamKey) fail('PACK_EVALUATOR_UPSTREAM_KEY is required');
+  const modelAllowlist = allowedModelSet(allowedModels);
+  const requestLimit = positiveInteger(maxRequests, 'maxRequests', 256);
+  const concurrencyLimit = positiveInteger(maxConcurrent, 'maxConcurrent', 4);
+  const outputTokenLimit = positiveInteger(maxOutputTokens, 'maxOutputTokens', 65_536);
+  const lifetimeMs = positiveInteger(ttlMs, 'ttlMs', 4 * 60 * 60 * 1000);
+  const timeoutMs = positiveInteger(requestTimeoutMs, 'requestTimeoutMs', 10 * 60 * 1000);
+  const expiresAt = Date.now() + lifetimeMs;
+  let requestsStarted = 0;
+  let activeRequests = 0;
+  const upstreamBase = new URL(upstreamBaseUrl);
+  if (upstreamBase.protocol !== 'https:' && upstreamBase.hostname !== '127.0.0.1') {
+    fail('PACK_EVALUATOR_UPSTREAM_URL must use HTTPS');
+  }
+
+  return createServer(async (request, response) => {
+    try {
+      if (!sameToken(requestToken(request), localToken)) {
+        json(response, 401, { error: 'invalid local proxy token' });
+        return;
+      }
+      const incoming = new URL(request.url || '/', 'http://127.0.0.1');
+      if (request.method === 'GET' && incoming.pathname === '/healthz') {
+        json(response, 200, { ok: true });
+        return;
+      }
+      if (request.method !== 'POST' || !ALLOWED_PATHS.has(incoming.pathname)) {
+        json(response, 403, { error: 'endpoint is not allowed by the evaluator proxy' });
+        return;
+      }
+
+      if (Date.now() >= expiresAt) {
+        json(response, 403, { error: 'evaluator proxy token has expired' });
+        return;
+      }
+      if (requestsStarted >= requestLimit) {
+        json(response, 429, { error: 'evaluator proxy request budget exhausted' });
+        return;
+      }
+      if (activeRequests >= concurrencyLimit) {
+        json(response, 429, { error: 'evaluator proxy concurrency limit reached' });
+        return;
+      }
+
+      const target = new URL(`${incoming.pathname}${incoming.search}`, upstreamBase);
+      const body = boundedInferenceBody(
+        await requestBody(request),
+        incoming.pathname,
+        modelAllowlist,
+        outputTokenLimit,
+      );
+      requestsStarted += 1;
+      activeRequests += 1;
+      try {
+        const upstream = await fetchImpl(target, {
+          method: 'POST',
+          headers: upstreamHeaders(request, upstreamKey),
+          body,
+          redirect: 'error',
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        response.writeHead(upstream.status, responseHeaders(upstream));
+        if (!upstream.body) {
+          response.end();
+          return;
+        }
+        const reader = upstream.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!response.write(Buffer.from(value))) {
+            await new Promise((resolve) => response.once('drain', resolve));
+          }
+        }
+        response.end();
+      } finally {
+        activeRequests -= 1;
+      }
+    } catch (error) {
+      const status = Number.isSafeInteger(error?.status) ? error.status : 502;
+      json(response, status, { error: error instanceof Error ? error.message : 'proxy request failed' });
+    }
+  });
+}
+
+export async function startPackEvaluatorProxy(environment = process.env) {
+  const port = Number(environment.PACK_EVALUATOR_PROXY_PORT || '18765');
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) fail('invalid PACK_EVALUATOR_PROXY_PORT');
+  const server = createPackEvaluatorProxy({
+    localToken: environment.PACK_EVALUATOR_LOCAL_TOKEN,
+    upstreamKey: environment.PACK_EVALUATOR_UPSTREAM_KEY,
+    upstreamBaseUrl: environment.PACK_EVALUATOR_UPSTREAM_URL || 'https://helm.easymeta.au',
+    allowedModels: environment.PACK_EVALUATOR_ALLOWED_MODELS,
+    maxRequests: environment.PACK_EVALUATOR_MAX_REQUESTS,
+    maxConcurrent: environment.PACK_EVALUATOR_MAX_CONCURRENT,
+    maxOutputTokens: environment.PACK_EVALUATOR_MAX_OUTPUT_TOKENS,
+    ttlMs: environment.PACK_EVALUATOR_TTL_MS,
+    requestTimeoutMs: environment.PACK_EVALUATOR_REQUEST_TIMEOUT_MS,
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+  process.stderr.write(`Pack evaluator inference proxy listening on 127.0.0.1:${port}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  startPackEvaluatorProxy().catch((error) => {
+    process.stderr.write(`Pack evaluator proxy failed: ${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -1,0 +1,671 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CLI_SCHEMA = 'pack-generation-evaluation/v2';
+const API_SCHEMA = 'skillstore.pack-evaluation/v2';
+const STATUS_SCHEMA = 'skillstore.pack-production-status/v1';
+const READBACK_SCHEMA = 'skillstore.pack-production-readback/v1';
+const SLO_SCHEMA = 'marketplace.pack-production-slo/v1';
+const KNOWN_CLI_EXIT = new Map([
+  ['candidate_ready', 0],
+  ['quality_rejected', 10],
+  ['evaluation_inconclusive', 20],
+  ['infrastructure_failed', 30],
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = { command };
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith('--')) fail(`Unexpected argument: ${token}`);
+    const key = token.slice(2);
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) fail(`Missing value for --${key}`);
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function required(args, name) {
+  const value = args[name];
+  if (!value) fail(`--${name} is required`);
+  return value;
+}
+
+function positiveInteger(value, name, fallback) {
+  if (value == null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) fail(`--${name} must be a positive integer`);
+  return parsed;
+}
+
+function normalizeJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeJson(entry)]),
+    );
+  }
+  fail('Value is not canonical JSON');
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(normalizeJson(value));
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function sha256File(file) {
+  return sha256(await readFile(file));
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function cliVersion(cli) {
+  const result = spawnSync(cli, ['--version'], { encoding: 'utf8' });
+  if (result.status !== 0) fail(`Cannot read CLI version: ${result.stderr || result.stdout}`);
+  const version = `${result.stdout}\n${result.stderr}`.match(/[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z._-]+)?/)?.[0];
+  if (!version) fail('CLI version output is not parseable');
+  return version;
+}
+
+function artifactReferences(raw) {
+  const evidence = raw.packVerification?.artifactEvidence ?? [];
+  return [...new Set(evidence.flatMap((run) => {
+    const required = (run.requirements ?? []).flatMap((requirement) => requirement.validMatches ?? []);
+    if (required.length > 0) return required;
+    return (run.artifacts ?? [])
+      .filter((artifact) => artifact.valid)
+      .map((artifact) => artifact.relativePath);
+  }))].slice(0, 20);
+}
+
+function apiVerdicts(raw) {
+  return (raw.packVerification?.verdicts ?? []).map((verdict) => ({
+    usedSkill: Boolean(verdict.used_skill),
+    taskCompleted: Boolean(verdict.task_completed),
+    envBlocked: Boolean(verdict.env_blocked),
+    score: Number(verdict.score),
+    reason: String(verdict.reason || 'No grader reason supplied'),
+    issues: Array.isArray(verdict.issues) ? verdict.issues.map(String) : [],
+  }));
+}
+
+export function buildApiEvaluation(raw, context) {
+  if (raw.schemaVersion !== CLI_SCHEMA) fail(`Unsupported CLI report schema: ${raw.schemaVersion}`);
+  if (!KNOWN_CLI_EXIT.has(raw.outcome)) fail(`Unsupported CLI outcome: ${raw.outcome}`);
+  if (raw.generationId !== context.generationId) fail('CLI report generationId changed during evaluation');
+  if (raw.scenario?.id !== context.scenarioId) fail('CLI report scenario differs from the queue plan');
+
+  let candidate = null;
+  if (raw.outcome === 'candidate_ready') {
+    const summary = raw.packVerification?.summary;
+    const baseline = raw.baselineVerification?.summary;
+    const verdicts = apiVerdicts(raw);
+    if (!raw.manifest || !summary || !baseline || verdicts.length === 0) {
+      fail('candidate_ready report lacks manifest, pack verification, baseline, or verdicts');
+    }
+    const references = artifactReferences(raw);
+    const artifactKind = raw.scenario.requiredArtifacts?.length > 0 ? 'file' : 'text';
+    const produced = artifactKind === 'file' ? references.length > 0 : summary.taskCompletedRate === 1;
+    candidate = {
+      manifest: {
+        name: raw.manifest.name,
+        slug: raw.manifest.slug,
+        description: raw.manifest.description,
+        scenarioTags: raw.manifest.scenario_tags,
+        riskFlags: raw.manifest.risk_flags,
+        skills: raw.manifest.skills,
+        rationale: raw.manifest.rationale,
+      },
+      fitness: {
+        score: summary.medianScore,
+        passed: Boolean(summary.passed && summary.usedSkillEver),
+        runs: verdicts.length,
+        usedSkillRate: summary.usedSkillRate,
+        taskCompletionRate: summary.taskCompletedRate,
+        envBlockedRate: summary.envBlockedRate,
+        artifact: {
+          kind: artifactKind,
+          produced,
+          verified: Boolean(produced && summary.artifactsPassed),
+          references,
+        },
+        baseline: {
+          score: baseline.medianScore,
+          improvement: summary.medianScore - baseline.medianScore,
+        },
+        verdicts,
+        errors: [
+          ...(raw.packVerification?.errors ?? []).map((error) => `pack: ${error}`),
+          ...(raw.baselineVerification?.errors ?? []).map((error) => `baseline: ${error}`),
+        ],
+      },
+    };
+  }
+
+  const unsigned = {
+    schemaVersion: API_SCHEMA,
+    generationId: context.generationId,
+    workflow: {
+      repository: 'aiskillstore/marketplace',
+      runId: context.runId,
+      runAttempt: context.runAttempt,
+      runUrl: `https://github.com/aiskillstore/marketplace/actions/runs/${context.runId}`,
+      commitSha: context.commitSha,
+    },
+    scenario: {
+      id: raw.scenario.id,
+      version: String(raw.scenario.version),
+      task: raw.scenario.task,
+      slug: raw.scenario.slug,
+      name: raw.scenario.name,
+      tags: raw.scenario.tags,
+    },
+    evaluator: {
+      cliVersion: context.cliVersion,
+      cliSha256: context.cliSha256,
+      model: context.model,
+      judgeModel: context.judgeModel,
+      startedAt: raw.evaluationStartedAt,
+      completedAt: raw.evaluationCompletedAt,
+    },
+    outcome: raw.outcome,
+    candidate,
+    evidence: { cliReport: raw },
+  };
+  return { ...unsigned, evidenceDigest: sha256(canonicalJson(unsigned)) };
+}
+
+function workflowContext(args, generationId, scenarioId, cli, version, checksum) {
+  const runId = required(args, 'run-id');
+  if (!/^[1-9][0-9]*$/.test(runId)) fail('--run-id must be a GitHub Actions numeric run id');
+  const runAttempt = positiveInteger(args['run-attempt'], 'run-attempt', 1);
+  const commitSha = required(args, 'commit-sha');
+  if (!/^[0-9a-f]{40}$/.test(commitSha)) fail('--commit-sha must be a 40-character lowercase SHA');
+  return {
+    generationId,
+    scenarioId,
+    runId,
+    runAttempt,
+    commitSha,
+    cli,
+    cliVersion: version,
+    cliSha256: checksum,
+    model: args.model ?? 'sonnet',
+    judgeModel: args['judge-model'] ?? 'gpt-5.5',
+  };
+}
+
+async function evaluate(args) {
+  const cli = resolve(required(args, 'cli'));
+  const plan = await readJson(resolve(required(args, 'plan')));
+  const resultsDir = resolve(required(args, 'results-dir'));
+  const skillsDir = resolve(required(args, 'skills-dir'));
+  if (plan.schemaVersion !== 'pack-production-queue/v1') fail(`Unsupported plan schema: ${plan.schemaVersion}`);
+  if (!Array.isArray(plan.scenarios) || plan.scenarios.length < 1 || plan.scenarios.length > 3) {
+    fail('Plan must contain one to three scenarios');
+  }
+  await mkdir(resultsDir, { recursive: true });
+
+  const version = cliVersion(cli);
+  const expectedVersion = required(args, 'expected-cli-version');
+  if (version !== expectedVersion) fail(`CLI version mismatch: expected ${expectedVersion}, got ${version}`);
+  const checksum = await sha256File(cli);
+  const reports = [];
+
+  for (const scenario of plan.scenarios) {
+    const ordinal = String(reports.length + 1).padStart(2, '0');
+    const generationId = randomUUID();
+    const context = workflowContext(args, generationId, scenario.id, cli, version, checksum);
+    const commandArgs = [
+      'pack', 'generate',
+      '--scenario', scenario.id,
+      '--generation-id', generationId,
+      '--skills-dir', skillsDir,
+      '--max-candidates', args['max-candidates'] ?? '3',
+      '--pick', args.pick ?? '4',
+      '--model', context.model,
+      '--judge-model', context.judgeModel,
+      '--runs', args.runs ?? '1',
+      '--final-runs', args['final-runs'] ?? '3',
+      '--threshold', args.threshold ?? '7',
+      '--baseline-delta', args['baseline-delta'] ?? '1',
+      '--auto-publish-threshold', args['auto-publish-threshold'] ?? '8',
+      '--json',
+    ];
+    const result = spawnSync(cli, commandArgs, {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      env: {
+        ...process.env,
+        SKILLSTORE_AGENT_ENV_MODE: 'strict',
+      },
+    });
+    if (result.error) fail(`Evaluator process failed for ${scenario.id}: ${result.error.message}`);
+    await writeFile(resolve(resultsDir, `${ordinal}-${scenario.id}.stdout.json`), result.stdout || '');
+    await writeFile(resolve(resultsDir, `${ordinal}-${scenario.id}.run.log`), result.stderr || '');
+    let raw;
+    try {
+      raw = JSON.parse(result.stdout);
+    } catch {
+      fail(`Evaluator returned invalid JSON for ${scenario.id} (exit ${result.status}): ${result.stderr}`);
+    }
+    const expectedExit = KNOWN_CLI_EXIT.get(raw.outcome);
+    if (result.status !== expectedExit) {
+      fail(`Evaluator exit/outcome mismatch for ${scenario.id}: exit ${result.status}, outcome ${raw.outcome}`);
+    }
+    const evaluation = buildApiEvaluation(raw, context);
+    const file = resolve(resultsDir, `${ordinal}-${scenario.id}.evaluation.json`);
+    await writeJson(file, evaluation);
+    reports.push({
+      scenarioId: scenario.id,
+      generationId,
+      outcome: raw.outcome,
+      outcomeReason: raw.outcomeReason,
+      file,
+    });
+    if (raw.outcome === 'candidate_ready') break;
+  }
+
+  const summary = {
+    schemaVersion: 'marketplace.pack-production-evaluate/v1',
+    cliVersion: version,
+    cliSha256: checksum,
+    reports,
+    selectedGenerationId: reports.find((report) => report.outcome === 'candidate_ready')?.generationId ?? null,
+  };
+  await writeJson(resolve(resultsDir, 'evaluate-summary.json'), summary);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+async function apiRequest(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...options.headers,
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { message: text };
+  }
+  if (!response.ok) {
+    const error = new Error(`HTTP ${response.status} from ${url}: ${text.slice(0, 2000)}`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+  return body;
+}
+
+function apiBase(args) {
+  return required(args, 'api-url').replace(/\/$/, '');
+}
+
+export function buildPublicReadbackExpectation(persisted, selected, publicSlug) {
+  const generationId = selected?.generationId;
+  const packId = selected?.pack?.id;
+  if (typeof generationId !== 'string' || !generationId) {
+    fail('Persist response did not bind the selected generation');
+  }
+  if (typeof packId !== 'string' || !packId) {
+    fail('Persist response did not bind the selected Pack id');
+  }
+  if (typeof publicSlug !== 'string' || !publicSlug) {
+    fail('Publish response did not bind the public Pack slug');
+  }
+  const persistedAttempt = persisted?.persisted?.find(
+    (item) => item?.request?.generationId === generationId,
+  );
+  const skillSlugs = persistedAttempt?.request?.candidate?.manifest?.skills;
+  if (!Array.isArray(skillSlugs) || skillSlugs.length < 1 || skillSlugs.some(
+    (slug) => typeof slug !== 'string' || !slug,
+  )) {
+    fail('Persisted candidate evidence did not contain exact Skill slugs');
+  }
+  return { generationId, packId, publicSlug, skillSlugs: [...skillSlugs] };
+}
+
+export function validatePublicPackReadback(pack, expected) {
+  const mismatches = [];
+  if (!pack || typeof pack !== 'object') {
+    return { matched: false, mismatches: ['response data is not a Pack object'], actualSkillSlugs: [] };
+  }
+  if (pack.id !== expected.packId) {
+    mismatches.push(`Pack id mismatch: expected ${expected.packId}, got ${String(pack.id ?? 'missing')}`);
+  }
+  if (pack.slug !== expected.publicSlug) {
+    mismatches.push(`Pack slug mismatch: expected ${expected.publicSlug}, got ${String(pack.slug ?? 'missing')}`);
+  }
+  // The public Pack detail contract is camelCase even though the database field
+  // is review_status.
+  if (pack.reviewStatus !== 'approved') {
+    mismatches.push(`Pack reviewStatus is ${String(pack.reviewStatus ?? 'missing')}, expected approved`);
+  }
+  const actualSkillSlugs = Array.isArray(pack.skills)
+    ? pack.skills.map((skill) => skill?.slug)
+    : [];
+  if (actualSkillSlugs.some((slug) => typeof slug !== 'string')) {
+    mismatches.push('Pack skills contain a missing or invalid slug');
+  } else if (
+    actualSkillSlugs.length !== expected.skillSlugs.length ||
+    actualSkillSlugs.some((slug, index) => slug !== expected.skillSlugs[index])
+  ) {
+    mismatches.push(
+      `Pack Skill slugs mismatch: expected ${expected.skillSlugs.join(',')}, got ${actualSkillSlugs.join(',')}`,
+    );
+  }
+  return { matched: mismatches.length === 0, mismatches, actualSkillSlugs };
+}
+
+export async function readExactPublicPack(base, expected, fetchImpl = fetch) {
+  const response = await fetchImpl(
+    `${base}/api/packs/${encodeURIComponent(expected.publicSlug)}?lang=en`,
+    { headers: { Accept: 'application/json', 'Cache-Control': 'no-cache' } },
+  );
+  if (!response.ok) {
+    return { pack: null, mismatches: [`public Pack API returned HTTP ${response.status}`] };
+  }
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    return { pack: null, mismatches: ['public Pack API returned invalid JSON'] };
+  }
+  const pack = body?.data;
+  const validation = validatePublicPackReadback(pack, expected);
+  return {
+    pack: validation.matched ? pack : null,
+    mismatches: validation.mismatches,
+  };
+}
+
+async function persist(args) {
+  const resultsDir = resolve(required(args, 'results-dir'));
+  const token = required(args, 'token');
+  const base = apiBase(args);
+  const files = (await readdir(resultsDir))
+    .filter((file) => file.endsWith('.evaluation.json'))
+    .sort();
+  if (files.length === 0) fail('No evaluation artifacts found to persist');
+
+  const persisted = [];
+  for (const file of files) {
+    const evaluation = await readJson(resolve(resultsDir, file));
+    const response = await apiRequest(`${base}/api/automation/packs/production`, token, {
+      method: 'POST',
+      body: JSON.stringify(evaluation),
+    });
+    persisted.push({ file, request: evaluation, response });
+  }
+  const summary = {
+    schemaVersion: 'marketplace.pack-production-persist/v1',
+    persisted,
+    selected: persisted.find((item) => item.request.outcome === 'candidate_ready')?.response?.data ?? null,
+  };
+  await writeJson(resolve(resultsDir, 'persist-summary.json'), summary);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+function readiness(attempt) {
+  const state = attempt.packReadiness ?? attempt.readiness ?? null;
+  if (!state) return null;
+  if (typeof state.contentReady === 'boolean' && typeof state.translationReady === 'boolean') {
+    return {
+      contentReady: state.contentReady,
+      translationReady: state.translationReady,
+      blockers: state.blockers ?? [],
+    };
+  }
+  const cover = state.coverImageUrl ?? state.cover_image_url;
+  const guide = state.usageGuideStatus ?? state.usage_guide_status;
+  const translation = state.translationStatus ?? state.translation_status;
+  return {
+    contentReady: Boolean(cover) && guide === 'completed',
+    translationReady: translation === 'completed',
+    cover,
+    guide,
+    translation,
+  };
+}
+
+export function buildSloResult(value, checkedAt = new Date().toISOString()) {
+  if (!value || typeof value !== 'object') fail('Pack production SLO response is missing');
+  const windowDays = Number(value.windowDays);
+  const target = Number(value.target);
+  const publishedReadbackPassed = Number(value.publishedReadbackPassed);
+  if (windowDays !== 7) fail(`Pack production SLO window must be 7 days, got ${value.windowDays}`);
+  if (target !== 2) fail(`Pack production SLO target must be 2, got ${value.target}`);
+  if (!Number.isSafeInteger(publishedReadbackPassed) || publishedReadbackPassed < 0) {
+    fail('Pack production SLO published count is invalid');
+  }
+  if (typeof value.met !== 'boolean' || value.met !== (publishedReadbackPassed >= target)) {
+    fail('Pack production SLO met flag is inconsistent with its count and target');
+  }
+  if (typeof value.windowStartedAt !== 'string' || !Number.isFinite(Date.parse(value.windowStartedAt))) {
+    fail('Pack production SLO window start is invalid');
+  }
+  return {
+    schemaVersion: SLO_SCHEMA,
+    checkedAt,
+    windowDays,
+    windowStartedAt: value.windowStartedAt,
+    target,
+    publishedReadbackPassed,
+    met: value.met,
+  };
+}
+
+async function patchStatus(base, token, generationId, body) {
+  return apiRequest(`${base}/api/automation/packs/production/${generationId}`, token, {
+    method: 'PATCH',
+    body: JSON.stringify({ schemaVersion: STATUS_SCHEMA, ...body }),
+  });
+}
+
+function wait(milliseconds) {
+  return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
+}
+
+async function finalize(args) {
+  const resultsDir = resolve(required(args, 'results-dir'));
+  const persisted = await readJson(resolve(resultsDir, 'persist-summary.json'));
+  const selected = persisted.selected;
+  const rawOutcomes = persisted.persisted.map((item) => item.request.outcome);
+  if (!selected) {
+    if (rawOutcomes.some((outcome) => outcome === 'infrastructure_failed' || outcome === 'evaluation_inconclusive')) {
+      fail(`No candidate was produced because evaluation was not conclusive: ${rawOutcomes.join(', ')}`);
+    }
+    const result = { outcome: 'quality_rejected', attempts: rawOutcomes.length };
+    await writeJson(resolve(resultsDir, 'final-result.json'), result);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  const token = required(args, 'token');
+  const base = apiBase(args);
+  const generationId = selected.generationId;
+  const maxWaitSeconds = positiveInteger(args['max-wait-seconds'], 'max-wait-seconds', 1800);
+  const pollSeconds = positiveInteger(args['poll-seconds'], 'poll-seconds', 30);
+  const deadline = Date.now() + maxWaitSeconds * 1000;
+  let attempt;
+  let ready;
+  while (Date.now() < deadline) {
+    const response = await apiRequest(`${base}/api/automation/packs/production/${generationId}`, token);
+    const readback = response?.data;
+    attempt = readback?.attempt ?? readback;
+    ready = readiness(readback);
+    if (ready?.contentReady && ready.translationReady) break;
+    if (attempt?.outcome === 'enrichment_failed') {
+      fail(`Enrichment failed for ${generationId}: ${attempt.last_error ?? 'unknown error'}`);
+    }
+    await wait(pollSeconds * 1000);
+  }
+  if (!ready?.contentReady || !ready.translationReady) {
+    await patchStatus(base, token, generationId, {
+      outcome: 'enrichment_failed',
+      contentStatus: ready?.contentReady ? 'succeeded' : 'failed',
+      translationStatus: ready?.translationReady ? 'succeeded' : 'failed',
+      error: `enrichment readiness timed out after ${maxWaitSeconds}s`,
+    });
+    fail(`Enrichment timed out for ${generationId}`);
+  }
+
+  await patchStatus(base, token, generationId, {
+    outcome: 'review_pending',
+    contentStatus: 'succeeded',
+    translationStatus: 'succeeded',
+    error: null,
+  });
+  const autoPublishEnabled = (args['auto-publish'] ?? 'true') === 'true';
+  if (!autoPublishEnabled || !selected.autoPublishEligible || selected.comparisonOf) {
+    const result = {
+      outcome: 'review_pending',
+      generationId,
+      pack: selected.pack,
+      reason: selected.comparisonOf
+        ? 'comparison candidates require human review'
+        : !autoPublishEnabled
+          ? 'automatic publish was disabled for this run'
+          : 'candidate did not meet the automatic publish gate',
+    };
+    await writeJson(resolve(resultsDir, 'final-result.json'), result);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  const publish = await apiRequest(
+    `${base}/api/automation/packs/${encodeURIComponent(selected.pack.slug)}/publish`,
+    token,
+    { method: 'POST', body: JSON.stringify({ generationId }) },
+  );
+  const publicSlug = publish?.data?.slug;
+  if (!publicSlug) fail('Publish response did not include the public slug');
+  const expectedPublicPack = buildPublicReadbackExpectation(persisted, selected, publicSlug);
+
+  let publicPack = null;
+  let readbackMismatches = [];
+  for (let attemptNumber = 1; attemptNumber <= 20; attemptNumber += 1) {
+    try {
+      const readback = await readExactPublicPack(base, expectedPublicPack);
+      publicPack = readback.pack;
+      readbackMismatches = readback.mismatches;
+      if (publicPack) break;
+    } catch (cause) {
+      // Production cache/readback may lag; retry within the bounded window.
+      readbackMismatches = [cause instanceof Error ? cause.message : String(cause)];
+    }
+    await wait(15_000);
+  }
+  const checkedAt = new Date().toISOString();
+  if (!publicPack) {
+    const readbackError = `exact public Pack readback failed: ${readbackMismatches.join('; ') || 'no matching Pack returned'}`;
+    await apiRequest(`${base}/api/automation/packs/production/${generationId}`, token, {
+      method: 'POST',
+      body: JSON.stringify({
+        schemaVersion: READBACK_SCHEMA,
+        status: 'failed',
+        packSlug: publicSlug,
+        checkedAt,
+        error: readbackError,
+      }),
+    }).catch(() => {});
+    fail(`Published pack ${publicSlug} failed production readback: ${readbackError}`);
+  }
+
+  await apiRequest(`${base}/api/automation/packs/production/${generationId}`, token, {
+    method: 'POST',
+    body: JSON.stringify({
+      schemaVersion: READBACK_SCHEMA,
+      status: 'succeeded',
+      packSlug: publicSlug,
+      checkedAt,
+      error: null,
+    }),
+  });
+  const slo = (await apiRequest(`${base}/api/automation/packs/production?windowDays=7`, token))?.data;
+  if (slo && !slo.met) {
+    process.stderr.write(`::error::Rolling 7-day Pack production SLO is below target: ${slo.publishedReadbackPassed}/${slo.target}\n`);
+  }
+
+  const result = {
+    outcome: 'published',
+    generationId,
+    pack: { id: publicPack.id, slug: publicSlug, skillCount: publicPack.skills.length },
+    readbackPassed: true,
+    rollingSevenDaySlo: slo ?? null,
+  };
+  await writeJson(resolve(resultsDir, 'final-result.json'), result);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function reportSlo(args) {
+  const resultsDir = resolve(required(args, 'results-dir'));
+  const token = required(args, 'token');
+  const base = apiBase(args);
+  await mkdir(resultsDir, { recursive: true });
+  const response = await apiRequest(`${base}/api/automation/packs/production?windowDays=7`, token);
+  const result = buildSloResult(response?.data);
+  await writeJson(resolve(resultsDir, 'slo-result.json'), result);
+  if (!result.met) {
+    process.stderr.write(
+      `::error::Rolling 7-day Pack production SLO is below target: ${result.publishedReadbackPassed}/${result.target}\n`,
+    );
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  switch (args.command) {
+    case 'evaluate':
+      return evaluate(args);
+    case 'persist':
+      return persist(args);
+    case 'finalize':
+      return finalize(args);
+    case 'slo':
+      return reportSlo(args);
+    default:
+      fail('Usage: pack-production.mjs <evaluate|persist|finalize|slo> [options]');
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack ?? error.message ?? String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -1,0 +1,171 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/generate-packs.yml'), 'utf8');
+const DOWNLOAD_ACTION = readFileSync(join(REPO_ROOT, '.github/actions/download-skillstore-cli/action.yml'), 'utf8');
+const EVALUATOR_PROXY = readFileSync(join(REPO_ROOT, 'scripts/pack-evaluator-proxy.mjs'), 'utf8');
+const GENERATE_CONTENT = readFileSync(join(REPO_ROOT, '.github/workflows/generate-content.yml'), 'utf8');
+const TRANSLATE_PACKS = readFileSync(join(REPO_ROOT, '.github/workflows/translate-packs.yml'), 'utf8');
+
+function section(start, end) {
+  const startIndex = WORKFLOW.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing workflow section ${start}`);
+  const endIndex = end ? WORKFLOW.indexOf(end, startIndex + start.length) : WORKFLOW.length;
+  assert.notEqual(endIndex, -1, `missing workflow boundary ${end}`);
+  return WORKFLOW.slice(startIndex, endIndex);
+}
+
+test('workflow has separate Plan, secret-free Evaluate, Persist, production Readback, and terminal SLO jobs', () => {
+  assert.match(WORKFLOW, /  plan:/);
+  assert.match(WORKFLOW, /  evaluate:/);
+  assert.match(WORKFLOW, /  persist:/);
+  assert.match(WORKFLOW, /  enrich_publish_readback:/);
+  assert.match(WORKFLOW, /  production_slo:/);
+  assert.match(WORKFLOW, /permissions:\n  contents: read/);
+});
+
+test('evaluate job cannot interpolate production write credentials', () => {
+  const evaluate = section('  evaluate:', '  persist:');
+  assert.doesNotMatch(
+    evaluate,
+    /secrets\.(SUPABASE|APP_PRIVATE_KEY|AUTOMATION_API_KEY|SKILLSTORE_CALLBACK_TOKEN|CACHE_INVALIDATE_SECRET)/
+  );
+  assert.doesNotMatch(evaluate, /--write|set \+e|continue-on-error/);
+  assert.match(evaluate, /SKILLSTORE_AGENT_ENV_MODE=strict/);
+  assert.match(evaluate, /persist-credentials: false/);
+});
+
+test('evaluate runs on a disposable VM with a user-separated job-local inference proxy', () => {
+  const evaluate = section('  evaluate:', '  persist:');
+  assert.match(evaluate, /runs-on: ubuntu-latest/);
+  assert.match(evaluate, /cache-dir: ''/);
+  assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
+  assert.match(evaluate, /@openai\/codex@0\.139\.0/);
+  assert.match(evaluate, /apt-get install --yes --no-install-recommends ffmpeg poppler-utils/);
+  assert.match(evaluate, /command -v ffprobe/);
+  assert.match(evaluate, /command -v pdfinfo/);
+  assert.match(evaluate, /command -v pdftotext/);
+  assert.match(evaluate, /useradd .*packproxy/);
+  assert.match(evaluate, /useradd .*packeval/);
+  assert.match(evaluate, /sudo -u packproxy env -i/);
+  assert.match(evaluate, /sudo -u packeval env -i/);
+  assert.match(evaluate, /! sudo -n true/);
+  assert.match(evaluate, /! test -r .*PROXY_PID.*environ/);
+  assert.match(evaluate, /PACK_EVALUATOR_HELM_API_KEY: \$\{\{ secrets\.PACK_EVALUATOR_HELM_API_KEY \}\}/);
+  assert.match(evaluate, /PACK_EVALUATOR_PROXY_TOKEN="\$LOCAL_TOKEN"/);
+  assert.match(evaluate, /supports_websockets = false/);
+  assert.match(evaluate, /! test -e \/home\/packeval\/\.codex\/auth\.json/);
+  assert.doesNotMatch(evaluate, /cp .*\.codex\/auth\.json|\/home\/runner\/_work\/_cache/);
+  assert.match(EVALUATOR_PROXY, /127\.0\.0\.1/);
+  assert.match(EVALUATOR_PROXY, /ALLOWED_PATHS/);
+  assert.match(EVALUATOR_PROXY, /authorization.*Bearer.*upstreamKey/s);
+  assert.match(evaluate, /PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4\.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5\.5/);
+  assert.match(evaluate, /PACK_EVALUATOR_MAX_REQUESTS=256/);
+  assert.match(evaluate, /PACK_EVALUATOR_MAX_CONCURRENT=4/);
+  assert.match(evaluate, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS=65536/);
+  assert.match(evaluate, /timeout --signal=TERM 4h/);
+  assert.match(evaluate, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
+  assert.match(EVALUATOR_PROXY, /evaluator proxy request budget exhausted/);
+  assert.match(EVALUATOR_PROXY, /evaluator proxy token has expired/);
+});
+
+test('planning is bounded to three artifact scenarios and CLI release is immutable', () => {
+  const plan = section('  plan:', '  evaluate:');
+  assert.match(plan, /scenario-queue --limit 3/);
+  assert.match(plan, /requiredArtifacts \| length >= 1/);
+  assert.match(plan, /\(\.scenarios \| length\) > 0 or \.source == "signals"/);
+  assert.match(plan, /marketplace\.pack-production-noop\/v1/);
+  assert.match(plan, /repository: "aiskillstore\/marketplace"/);
+  assert.match(plan, /runId: \$runId/);
+  assert.match(plan, /commitSha: \$commitSha/);
+  assert.match(plan, /has_scenarios=false/);
+  const evaluate = section('  evaluate:', '  persist:');
+  const persist = section('  persist:', '  enrich_publish_readback:');
+  const finalize = section('  enrich_publish_readback:', '  production_slo:');
+  assert.match(evaluate, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.9\.0'/);
+  assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 2);
+  assert.doesNotMatch(WORKFLOW, /version: latest|cli_version:/);
+});
+
+test('trusted phases use the Automation API and retain full evidence for 90 days', () => {
+  const persist = section('  persist:', '  enrich_publish_readback:');
+  const finalize = section('  enrich_publish_readback:', '  production_slo:');
+  assert.match(persist, /pack-production\.mjs persist/);
+  assert.match(persist, /PACK_PRODUCTION_AUTOMATION_KEY: \$\{\{ secrets\.PACK_PRODUCTION_AUTOMATION_KEY \}\}/);
+  assert.match(finalize, /pack-production\.mjs finalize/);
+  assert.match(finalize, /final-result\.json/);
+  assert.match(finalize, /pack-production\.mjs finalize/);
+  assert.equal((WORKFLOW.match(/retention-days: 90/g) ?? []).length, 5);
+  assert.match(finalize, /PACK_PRODUCTION_AUTO_PUBLISH_ENABLED == 'true'/);
+  assert.match(WORKFLOW, /auto_publish:[\s\S]*?default: false/);
+});
+
+test('terminal SLO job runs after every outcome and fails below two published readbacks', () => {
+  const slo = section('  production_slo:');
+  assert.match(slo, /needs: \[plan, evaluate, persist, enrich_publish_readback\]/);
+  assert.match(slo, /if: always\(\)/);
+  assert.match(slo, /pack-production\.mjs slo/);
+  assert.match(slo, /Published \+ readback passed/);
+  assert.match(slo, /::error::Rolling 7-day Pack production SLO is below target/);
+  assert.match(slo, /exit 1/);
+  assert.doesNotMatch(slo, /::warning::Rolling 7-day Pack production SLO is below target/);
+  assert.match(slo, /pack-plan\/no-op\.json/);
+});
+
+test('checkouts use isolated directories and never persist tokens', () => {
+  assert.match(WORKFLOW, /marketplace-plan/);
+  assert.match(WORKFLOW, /marketplace-evaluate/);
+  assert.ok((WORKFLOW.match(/filter: ''/g) ?? []).length >= 1);
+  assert.ok((WORKFLOW.match(/persist-credentials: false/g) ?? []).length >= 4);
+  const persist = section('  persist:', '  enrich_publish_readback:');
+  const finalize = section('  enrich_publish_readback:', '  production_slo:');
+  const slo = section('  production_slo:');
+  assert.match(persist, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
+  assert.match(finalize, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
+  assert.match(slo, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
+});
+
+test('CLI downloader verifies checksum before execution and shared-cache writes', () => {
+  assert.match(DOWNLOAD_ACTION, /require-checksum:/);
+  assert.match(DOWNLOAD_ACTION, /--pattern checksums\.txt/);
+  assert.match(DOWNLOAD_ACTION, /CLI checksum mismatch/);
+  assert.match(DOWNLOAD_ACTION, /cli-sha256=/);
+  const checksumIndex = DOWNLOAD_ACTION.indexOf('    - name: Verify release checksum before execution');
+  const executeIndex = DOWNLOAD_ACTION.indexOf('    - name: Verify CLI');
+  const saveIndex = DOWNLOAD_ACTION.indexOf('    - name: Save verified CLI to local cache');
+  assert.ok(checksumIndex >= 0 && executeIndex > checksumIndex && saveIndex > executeIndex);
+  const cacheReadSection = DOWNLOAD_ACTION.slice(
+    DOWNLOAD_ACTION.indexOf('    - name: Check local cache'),
+    checksumIndex,
+  );
+  assert.match(cacheReadSection, /REQUIRE_CHECKSUM: \$\{\{ inputs\.require-checksum \}\}/);
+  assert.match(
+    cacheReadSection,
+    /if \[ "\$REQUIRE_CHECKSUM" != "true" \]; then[\s\S]*CACHED_VERSION=/,
+  );
+  assert.match(DOWNLOAD_ACTION, /TEMP_CACHE_FILE=/);
+  assert.match(DOWNLOAD_ACTION, /mv -f "\$TEMP_CACHE_FILE" "\$CACHE_FILE"/);
+});
+
+test('translation is dispatched only after generated content succeeds', () => {
+  const contentIndex = GENERATE_CONTENT.indexOf('      - name: Generate content');
+  const translateIndex = GENERATE_CONTENT.indexOf('      - name: Dispatch translation after content is complete');
+  assert.ok(contentIndex >= 0 && translateIndex > contentIndex);
+  assert.match(GENERATE_CONTENT, /if: github\.event\.client_payload\.generationId != ''/);
+  assert.match(GENERATE_CONTENT, /source_generation_id/);
+  assert.match(GENERATE_CONTENT, /cli_version:\"2\.9\.0\"/);
+  assert.match(GENERATE_CONTENT, /version: '2\.9\.0'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.9\.0'/);
+  assert.match(GENERATE_CONTENT, /require-checksum: 'true'/);
+  assert.match(TRANSLATE_PACKS, /github\.event\.client_payload\.cli_version/);
+  assert.match(TRANSLATE_PACKS, /require-checksum: \$\{\{ github\.event\.client_payload\.source_generation_id/);
+  assert.match(TRANSLATE_PACKS, /SKILLSTORE_AGENT_ENV_MODE: strict/);
+});

--- a/scripts/tests/pack-evaluator-proxy.test.mjs
+++ b/scripts/tests/pack-evaluator-proxy.test.mjs
@@ -1,0 +1,142 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { createPackEvaluatorProxy } from '../pack-evaluator-proxy.mjs';
+
+const LOCAL_TOKEN = 'local-token-that-is-longer-than-thirty-two-bytes';
+const UPSTREAM_KEY = 'upstream-secret-that-must-never-be-forwarded-back';
+let upstream;
+let proxy;
+let upstreamUrl;
+let proxyUrl;
+let observed;
+
+before(async () => {
+  upstream = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    observed = {
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      apiKey: request.headers['x-api-key'],
+      body: Buffer.concat(chunks).toString('utf8'),
+    };
+    response.writeHead(200, { 'content-type': 'application/json', 'set-cookie': 'secret=bad' });
+    response.end('{"ok":true}');
+  });
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+  upstreamUrl = `http://127.0.0.1:${upstream.address().port}`;
+
+  proxy = createPackEvaluatorProxy({
+    localToken: LOCAL_TOKEN,
+    upstreamKey: UPSTREAM_KEY,
+    upstreamBaseUrl: upstreamUrl,
+  });
+  proxy.listen(0, '127.0.0.1');
+  await once(proxy, 'listening');
+  proxyUrl = `http://127.0.0.1:${proxy.address().port}`;
+});
+
+after(async () => {
+  await Promise.all([
+    new Promise((resolve) => proxy.close(resolve)),
+    new Promise((resolve) => upstream.close(resolve)),
+  ]);
+});
+
+test('requires the job-local token even for health checks', async () => {
+  assert.equal((await fetch(`${proxyUrl}/healthz`)).status, 401);
+  const response = await fetch(`${proxyUrl}/healthz`, {
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
+  });
+  assert.equal(response.status, 200);
+});
+
+test('allows only the explicit inference endpoint allowlist', async () => {
+  const response = await fetch(`${proxyUrl}/admin/api/keys`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
+  });
+  assert.equal(response.status, 403);
+});
+
+test('replaces local credentials with the bounded upstream credential', async () => {
+  const response = await fetch(`${proxyUrl}/v1/responses?trace=1`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${LOCAL_TOKEN}`,
+      'x-api-key': LOCAL_TOKEN,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'ok' }),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+  assert.equal(observed.method, 'POST');
+  assert.equal(observed.url, '/v1/responses?trace=1');
+  assert.equal(observed.authorization, `Bearer ${UPSTREAM_KEY}`);
+  assert.equal(observed.apiKey, undefined);
+  assert.match(observed.body, /gpt-5\.5/);
+  assert.equal(response.headers.has('set-cookie'), false);
+  assert.equal(JSON.parse(observed.body).max_output_tokens, 65536);
+});
+
+test('rejects models and token requests outside the evaluator budget', async () => {
+  const forbiddenModel = await fetch(`${proxyUrl}/v1/responses`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-unbounded', input: 'no' }),
+  });
+  assert.equal(forbiddenModel.status, 403);
+  assert.match((await forbiddenModel.json()).error, /model is not allowed/);
+
+  const excessiveTokens = await fetch(`${proxyUrl}/v1/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'sonnet', max_tokens: 65537, messages: [] }),
+  });
+  assert.equal(excessiveTokens.status, 400);
+  assert.match((await excessiveTokens.json()).error, /max_tokens/);
+});
+
+test('enforces request, concurrency, and TTL limits', async () => {
+  let release;
+  const blockedFetch = () => new Promise((resolve) => { release = resolve; });
+  const limited = createPackEvaluatorProxy({
+    localToken: LOCAL_TOKEN,
+    upstreamKey: UPSTREAM_KEY,
+    upstreamBaseUrl: upstreamUrl,
+    fetchImpl: blockedFetch,
+    maxRequests: 1,
+    maxConcurrent: 1,
+    ttlMs: 25,
+  });
+  limited.listen(0, '127.0.0.1');
+  await once(limited, 'listening');
+  const url = `http://127.0.0.1:${limited.address().port}`;
+  const first = fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'one' }),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const second = await fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'two' }),
+  });
+  assert.equal(second.status, 429);
+  release(new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } }));
+  assert.equal((await first).status, 200);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const expired = await fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'late' }),
+  });
+  assert.equal(expired.status, 403);
+  await new Promise((resolve) => limited.close(resolve));
+});

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -1,0 +1,218 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildApiEvaluation,
+  buildPublicReadbackExpectation,
+  buildSloResult,
+  canonicalJson,
+  readExactPublicPack,
+  validatePublicPackReadback,
+} from '../pack-production.mjs';
+
+function cliReport() {
+  const summary = {
+    runs: 3,
+    scores: [8, 8, 9],
+    medianScore: 8,
+    usedSkillRate: 1,
+    passed: true,
+    envBlockedRate: 0,
+    envBlocked: false,
+    usedSkillEver: true,
+    taskCompletedRate: 1,
+    taskCompletedEver: true,
+    taskCompletedThreshold: 1,
+    artifactPassRate: 1,
+    artifactThreshold: 1,
+    artifactsRequired: true,
+    artifactsPassed: true,
+  };
+  return {
+    schemaVersion: 'pack-generation-evaluation/v2',
+    generationId: 'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0',
+    evaluationStartedAt: '2026-07-15T10:00:00.000Z',
+    evaluationCompletedAt: '2026-07-15T10:30:00.000Z',
+    outcome: 'candidate_ready',
+    outcomeReason: 'passed',
+    autoPublishEligible: true,
+    scenario: {
+      id: 'excel-dashboard',
+      slug: 'monthly-sales-excel-workbook',
+      name: 'Monthly Sales Excel Dashboard',
+      version: '1.0.0',
+      tags: ['excel', 'dashboard'],
+      keywords: ['xlsx'],
+      task: 'Create a real workbook.',
+      capabilitySlots: [{ id: 'workbook', required: true }],
+      requiredArtifacts: [{ id: 'workbook', extensions: ['.xlsx'], minimumCount: 1 }],
+    },
+    slotEvaluations: [],
+    manifest: {
+      name: 'Monthly Sales Excel Dashboard',
+      slug: 'monthly-sales-excel-workbook',
+      description: 'A verified real workbook.',
+      scenario_tags: ['excel', 'dashboard'],
+      risk_flags: [],
+      skills: ['spreadsheet-skill'],
+      slot_assignments: { workbook: ['spreadsheet-skill'] },
+      rationale: 'The skill created and validated the workbook.',
+    },
+    composition: { attempts: 1, fallbackUsed: false, errors: [] },
+    packVerification: {
+      summary,
+      verdicts: [
+        { used_skill: true, task_completed: true, score: 8, reason: 'complete', issues: [] },
+        { used_skill: true, task_completed: true, score: 8, reason: 'complete', issues: [] },
+        { used_skill: true, task_completed: true, score: 9, reason: 'excellent', issues: [] },
+      ],
+      artifactEvidence: [{
+        run: 1,
+        passed: true,
+        requirements: [{ validMatches: ['sales.xlsx'] }],
+        artifacts: [],
+      }],
+      errors: [],
+    },
+    baselineVerification: {
+      summary: { ...summary, scores: [4, 4, 5], medianScore: 4, passed: false, usedSkillRate: 0, usedSkillEver: false, artifactPassRate: 0, artifactsPassed: false },
+      verdicts: [],
+      artifactEvidence: [],
+      errors: [],
+    },
+    baselineScoreDelta: 4,
+    errors: [],
+  };
+}
+
+const context = {
+  generationId: 'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0',
+  scenarioId: 'excel-dashboard',
+  runId: '123456789',
+  runAttempt: 1,
+  commitSha: 'a'.repeat(40),
+  cliVersion: '2.9.0',
+  cliSha256: 'b'.repeat(64),
+  model: 'sonnet',
+  judgeModel: 'gpt-5.5',
+};
+
+test('canonical JSON is stable across object key order', () => {
+  assert.equal(canonicalJson({ z: 1, a: { y: 2, x: 3 } }), canonicalJson({ a: { x: 3, y: 2 }, z: 1 }));
+});
+
+test('adapter binds workflow identity, artifact evidence, baseline, and digest', () => {
+  const evaluation = buildApiEvaluation(cliReport(), context);
+  assert.equal(evaluation.schemaVersion, 'skillstore.pack-evaluation/v2');
+  assert.equal(evaluation.workflow.runId, '123456789');
+  assert.equal(evaluation.scenario.version, '1.0.0');
+  assert.deepEqual(evaluation.candidate.fitness.artifact.references, ['sales.xlsx']);
+  assert.equal(evaluation.candidate.fitness.baseline.improvement, 4);
+  assert.match(evaluation.evidenceDigest, /^[0-9a-f]{64}$/);
+  assert.equal(evaluation.evidence.cliReport.schemaVersion, 'pack-generation-evaluation/v2');
+});
+
+test('adapter rejects an exit artifact whose scenario differs from the immutable plan', () => {
+  const report = cliReport();
+  report.scenario.id = 'different-scenario';
+  assert.throws(() => buildApiEvaluation(report, context), /scenario differs/);
+});
+
+test('quality rejections persist without a candidate object', () => {
+  const report = cliReport();
+  report.outcome = 'quality_rejected';
+  report.manifest = null;
+  report.packVerification = null;
+  report.baselineVerification = null;
+  const evaluation = buildApiEvaluation(report, context);
+  assert.equal(evaluation.outcome, 'quality_rejected');
+  assert.equal(evaluation.candidate, null);
+});
+
+test('finalize binds public readback to the selected Pack and candidate Skill order', () => {
+  const request = buildApiEvaluation(cliReport(), context);
+  const selected = {
+    generationId: request.generationId,
+    pack: { id: 'pack-123', slug: request.scenario.slug },
+  };
+  const expectation = buildPublicReadbackExpectation({
+    persisted: [{ request }],
+  }, selected, 'monthly-sales-excel-workbook');
+
+  assert.deepEqual(expectation, {
+    generationId: request.generationId,
+    packId: 'pack-123',
+    publicSlug: 'monthly-sales-excel-workbook',
+    skillSlugs: ['spreadsheet-skill'],
+  });
+});
+
+test('exact public readback uses the camelCase API contract and no-cache request', async () => {
+  const expected = {
+    generationId: context.generationId,
+    packId: 'pack-123',
+    publicSlug: 'monthly-sales-excel-workbook',
+    skillSlugs: ['spreadsheet-skill', 'artifact-validator'],
+  };
+  let observed;
+  const result = await readExactPublicPack('https://skillstore.example', expected, async (url, options) => {
+    observed = { url, options };
+    return new Response(JSON.stringify({
+      data: {
+        id: 'pack-123',
+        slug: 'monthly-sales-excel-workbook',
+        reviewStatus: 'approved',
+        skills: [{ slug: 'spreadsheet-skill' }, { slug: 'artifact-validator' }],
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  });
+
+  assert.equal(
+    observed.url,
+    'https://skillstore.example/api/packs/monthly-sales-excel-workbook?lang=en',
+  );
+  assert.equal(observed.options.headers['Cache-Control'], 'no-cache');
+  assert.equal(result.pack.id, 'pack-123');
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('exact public readback rejects wrong identity, snake_case status, and changed Skills', () => {
+  const result = validatePublicPackReadback({
+    id: 'other-pack',
+    slug: 'other-slug',
+    review_status: 'approved',
+    skills: [{ slug: 'artifact-validator' }, { slug: 'spreadsheet-skill' }],
+  }, {
+    packId: 'pack-123',
+    publicSlug: 'monthly-sales-excel-workbook',
+    skillSlugs: ['spreadsheet-skill', 'artifact-validator'],
+  });
+
+  assert.equal(result.matched, false);
+  assert.match(result.mismatches.join('\n'), /Pack id mismatch/);
+  assert.match(result.mismatches.join('\n'), /Pack slug mismatch/);
+  assert.match(result.mismatches.join('\n'), /reviewStatus is missing/);
+  assert.match(result.mismatches.join('\n'), /Pack Skill slugs mismatch/);
+});
+
+test('terminal SLO evidence is fixed to seven days and internally consistent', () => {
+  const result = buildSloResult({
+    windowDays: 7,
+    windowStartedAt: '2026-07-09T00:00:00.000Z',
+    target: 2,
+    publishedReadbackPassed: 1,
+    met: false,
+  }, '2026-07-16T00:00:00.000Z');
+
+  assert.deepEqual(result, {
+    schemaVersion: 'marketplace.pack-production-slo/v1',
+    checkedAt: '2026-07-16T00:00:00.000Z',
+    windowDays: 7,
+    windowStartedAt: '2026-07-09T00:00:00.000Z',
+    target: 2,
+    publishedReadbackPassed: 1,
+    met: false,
+  });
+  assert.throws(() => buildSloResult({ ...result, met: true }), /met flag is inconsistent/);
+  assert.throws(() => buildSloResult({ ...result, windowDays: 30 }), /must be 7 days/);
+  assert.throws(() => buildSloResult({ ...result, target: 1, met: true }), /target must be 2/);
+});


### PR DESCRIPTION
## Outcome

Replaces the daily green/no-output Pack job with a bounded production pipeline: signal-ranked scenario queue, disposable credential-free evaluation, trusted persistence/enrichment, exact-generation publish, exact public readback, and a hard rolling seven-day SLO of two published Packs.

## Safety

- Evaluate uses a single-use GitHub VM and never receives Supabase/GitHub App/automation secrets.
- A separate localhost proxy enforces model, request, concurrency, output-token, timeout, and TTL limits.
- CLI 2.9.0 is pinned and checksum-verified before first execution or cache write.
- ffmpeg and poppler artifact runtimes install before secrets are available.
- Persist/publish/readback bind generation ID, Pack ID, slug, and ordered Skill identity.
- Empty queues retain audited no-op evidence; low SLO fails visibly.

## Verification

- Focused Node tests: 22/22 passed
- Node syntax checks passed
- Four related YAML files parsed successfully
- git diff --check passed