### PR TITLE
fix(packs): hand off verified CLI to evaluator

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -35,8 +35,16 @@ jobs:
       has_scenarios: ${{ steps.queue.outputs.has_scenarios }}
       scenario_count: ${{ steps.queue.outputs.scenario_count }}
     steps:
+      - name: Generate read-only cross-repository CLI token
+        id: cli-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
       - name: Prepare isolated checkout
-        run: rm -rf "$GITHUB_WORKSPACE/marketplace-plan" "$GITHUB_WORKSPACE/pack-plan"
+        run: rm -rf "$GITHUB_WORKSPACE/marketplace-plan" "$GITHUB_WORKSPACE/pack-plan" "$GITHUB_WORKSPACE/pack-cli"
 
       - name: Checkout immutable workflow revision
         uses: actions/checkout@v5
@@ -55,8 +63,23 @@ jobs:
           version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
           minimum-version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
           require-checksum: 'true'
-          token: ${{ github.token }}
+          token: ${{ steps.cli-app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Stage verified CLI handoff evidence
+        env:
+          CLI: ${{ steps.cli.outputs.cli-path }}
+          CLI_SHA256: ${{ steps.cli.outputs.cli-sha256 }}
+          CLI_VERSION: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/pack-plan" "$GITHUB_WORKSPACE/pack-cli"
+          install -m 0555 "$CLI" "$GITHUB_WORKSPACE/pack-cli/skillstore-cli-linux-x64"
+          printf '%s  skillstore-cli-linux-x64\n' "$CLI_SHA256" > "$GITHUB_WORKSPACE/pack-cli/checksums.txt"
+          jq -n \
+            --arg version "$CLI_VERSION" \
+            --arg sha256 "$CLI_SHA256" \
+            '{version: $version, sha256: $sha256}' \
+            > "$GITHUB_WORKSPACE/pack-plan/cli-identity.json"
 
       - name: Select up to three scenarios
         id: queue
@@ -118,6 +141,15 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+      - name: Upload verified evaluator CLI
+        if: steps.queue.outputs.has_scenarios == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-cli
+          path: pack-cli/
+          if-no-files-found: error
+          retention-days: 1
+
   evaluate:
     name: Evaluate without production credentials
     needs: plan
@@ -143,15 +175,18 @@ jobs:
           name: pack-production-plan
           path: pack-production-input
 
-      - name: Download and checksum pinned Skillstore CLI
-        id: cli
-        uses: ./marketplace-evaluate/.github/actions/download-skillstore-cli
+      - name: Download verified CLI handoff
+        uses: actions/download-artifact@v6
         with:
-          version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
-          minimum-version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
-          require-checksum: 'true'
-          token: ${{ github.token }}
-          cache-dir: ''
+          name: pack-production-cli
+          path: pack-production-cli
+
+      - name: Verify Plan CLI handoff before execution
+        run: |
+          (cd pack-production-cli && sha256sum -c checksums.txt)
+          chmod +x pack-production-cli/skillstore-cli-linux-x64
+          VERSION=$(pack-production-cli/skillstore-cli-linux-x64 --version | grep -Eo '[0-9]+([.][0-9]+){2}' | head -n1)
+          test "$VERSION" = "$PACK_PRODUCTION_CLI_VERSION"
 
       - name: Install evaluator runtimes before secrets are available
         run: |
@@ -168,7 +203,7 @@ jobs:
 
       - name: Prepare disposable evaluator identities and filesystem
         env:
-          CLI: ${{ steps.cli.outputs.cli-path }}
+          CLI: ${{ github.workspace }}/pack-production-cli/skillstore-cli-linux-x64
         run: |
           RUNNER_GROUP=$(id -gn)
           sudo useradd --system --create-home --home-dir /home/packproxy --shell /usr/sbin/nologin packproxy

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -43,7 +43,6 @@ test('evaluate job cannot interpolate production write credentials', () => {
 test('evaluate runs on a disposable VM with a user-separated job-local inference proxy', () => {
   const evaluate = section('  evaluate:', '  persist:');
   assert.match(evaluate, /runs-on: ubuntu-latest/);
-  assert.match(evaluate, /cache-dir: ''/);
   assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
   assert.match(evaluate, /@openai\/codex@0\.139\.0/);
   assert.match(evaluate, /apt-get install --yes --no-install-recommends ffmpeg poppler-utils/);
@@ -61,6 +60,10 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /supports_websockets = false/);
   assert.match(evaluate, /! test -e \/home\/packeval\/\.codex\/auth\.json/);
   assert.doesNotMatch(evaluate, /cp .*\.codex\/auth\.json|\/home\/runner\/_work\/_cache/);
+  assert.match(evaluate, /name: pack-production-cli/);
+  assert.match(evaluate, /sha256sum -c checksums\.txt/);
+  assert.match(evaluate, /Verify Plan CLI handoff before execution/);
+  assert.doesNotMatch(evaluate, /secrets\.APP_PRIVATE_KEY|steps\.cli-app-token/);
   assert.match(EVALUATOR_PROXY, /127\.0\.0\.1/);
   assert.match(EVALUATOR_PROXY, /ALLOWED_PATHS/);
   assert.match(EVALUATOR_PROXY, /authorization.*Bearer.*upstreamKey/s);
@@ -91,7 +94,11 @@ test('planning is bounded to three artifact scenarios and CLI release is immutab
   assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.9\.0'/);
-  assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 2);
+  assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
+  assert.match(plan, /actions\/create-github-app-token@v3/);
+  assert.match(plan, /repositories: marketplace,skillstore/);
+  assert.match(plan, /name: pack-production-cli/);
+  assert.match(plan, /retention-days: 1/);
   assert.doesNotMatch(WORKFLOW, /version: latest|cli_version:/);
 });
 


### PR DESCRIPTION
## Root cause

The first production canary proved that the Marketplace default GitHub token cannot read the private Skillstore CLI release, so Plan failed before evaluation.

## Fix

- Trusted Plan uses the existing cross-repository GitHub App only to download and checksum CLI 2.9.0.
- Plan uploads the verified binary as a one-day, run-scoped Actions artifact.
- Disposable Evaluate downloads that artifact and verifies SHA-256 and version before first execution.
- Evaluate still receives no GitHub App token/private key or production write credentials.

## Verification

- Focused Pack workflow tests: 22/22 passed
- Workflow YAML parsed successfully
- git diff --check passed