### PR TITLE
fix(cache): fall back to bounded single invalidation

### DIFF
--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -9,6 +9,10 @@ MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 RETRY_BASE_SECONDS="${RETRY_BASE_SECONDS:-5}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
+FALLBACK_MAX_ATTEMPTS="${FALLBACK_MAX_ATTEMPTS:-4}"
+FALLBACK_RETRY_BASE_SECONDS="${FALLBACK_RETRY_BASE_SECONDS:-5}"
+FALLBACK_CURL_MAX_TIME="${FALLBACK_CURL_MAX_TIME:-90}"
+MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-1200}"
 CONTENT_TYPE="${CONTENT_TYPE:-}"
 SLUGS_STR="${SLUGS_STR:-}"
 SLUGS_FILE="${SLUGS_FILE:-}"
@@ -50,6 +54,12 @@ fi
 if [ -n "$SLUGS_STR" ]; then
   printf '%s\n' "$SLUGS_STR" | normalize_items >> "$ITEMS_FILE"
 fi
+
+if ! awk '!seen[$0]++' "$ITEMS_FILE" > "$WORK_DIR/items-unique"; then
+  echo "::error::Failed to normalize cache invalidation items" >&2
+  exit 1
+fi
+mv "$WORK_DIR/items-unique" "$ITEMS_FILE"
 
 SLUGS=()
 while IFS= read -r slug; do
@@ -96,16 +106,38 @@ if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
   exit 1
 fi
 
+if ! [[ "$FALLBACK_MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
+  [ "$FALLBACK_MAX_ATTEMPTS" -lt 1 ] ||
+  [ "$FALLBACK_MAX_ATTEMPTS" -gt 10 ]; then
+  echo "::error::FALLBACK_MAX_ATTEMPTS must be between 1 and 10" >&2
+  exit 1
+fi
+
 if ! [[ "$RETRY_BASE_SECONDS" =~ ^[0-9]+$ ]] ||
   [ "$RETRY_BASE_SECONDS" -gt 300 ]; then
   echo "::error::RETRY_BASE_SECONDS must be between 0 and 300" >&2
   exit 1
 fi
 
+if ! [[ "$FALLBACK_RETRY_BASE_SECONDS" =~ ^[0-9]+$ ]] ||
+  [ "$FALLBACK_RETRY_BASE_SECONDS" -gt 300 ]; then
+  echo "::error::FALLBACK_RETRY_BASE_SECONDS must be between 0 and 300" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_RUNTIME_SECONDS" =~ ^[0-9]+$ ]] ||
+  [ "$MAX_RUNTIME_SECONDS" -lt 1 ] ||
+  [ "$MAX_RUNTIME_SECONDS" -gt 1200 ]; then
+  echo "::error::MAX_RUNTIME_SECONDS must be between 1 and 1200" >&2
+  exit 1
+fi
+
 if ! [[ "$CURL_CONNECT_TIMEOUT" =~ ^[0-9]+$ ]] ||
   [ "$CURL_CONNECT_TIMEOUT" -lt 1 ] ||
   ! [[ "$CURL_MAX_TIME" =~ ^[0-9]+$ ]] ||
-  [ "$CURL_MAX_TIME" -lt 1 ]; then
+  [ "$CURL_MAX_TIME" -lt 1 ] ||
+  ! [[ "$FALLBACK_CURL_MAX_TIME" =~ ^[0-9]+$ ]] ||
+  [ "$FALLBACK_CURL_MAX_TIME" -lt 1 ]; then
   echo "::error::curl timeouts must be positive integers" >&2
   exit 1
 fi
@@ -130,15 +162,36 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+DEADLINE_EPOCH=$(($(date +%s) + MAX_RUNTIME_SECONDS))
+
+remaining_seconds() {
+  local remaining=$((DEADLINE_EPOCH - $(date +%s)))
+  if [ "$remaining" -lt 0 ]; then
+    remaining=0
+  fi
+  printf '%s\n' "$remaining"
+}
+
 request_batch_once() {
   local body_file="$1"
   local response_file="$2"
+  local max_time="$3"
   local status
   local curl_exit
+  local remaining
+
+  remaining=$(remaining_seconds)
+  if [ "$remaining" -lt 1 ]; then
+    echo "    Global cache invalidation runtime budget exhausted" >&2
+    return 77
+  fi
+  if [ "$max_time" -gt "$remaining" ]; then
+    max_time="$remaining"
+  fi
 
   if status=$(curl -sS -o "$response_file" -w "%{http_code}" \
       --connect-timeout "$CURL_CONNECT_TIMEOUT" \
-      --max-time "$CURL_MAX_TIME" \
+      --max-time "$max_time" \
       -X POST "$SITE_URL/api/cache/invalidate" \
       -H "Authorization: Bearer $CACHE_SECRET" \
       -H "Content-Type: application/json" \
@@ -152,11 +205,55 @@ request_batch_once() {
 
   case "$status" in
     2[0-9][0-9])
-      return 0
+      local canonical_type="$CONTENT_TYPE"
+      if [ "$canonical_type" = "plugins" ]; then
+        canonical_type="packs"
+      fi
+
+      if jq -e \
+        --arg canonical_type "$canonical_type" \
+        --slurpfile request "$body_file" \
+        'def non_negative_integer:
+          type == "number" and isfinite and floor == . and . >= 0;
+        ($request | length) == 1
+          and .preflight == false
+          and .type == $canonical_type
+          and (.slugs | type) == "array"
+          and ((.slugs | sort) == ($request[0].slugs | sort))
+          and (.invalidated | type) == "object"
+          and (.invalidated.total | non_negative_integer)
+          and (.invalidated.page | non_negative_integer)
+          and (.invalidated.api | non_negative_integer)
+          and (.invalidated.artifacts | non_negative_integer)
+          and (.invalidated.total > 0)
+          and (.invalidated.total ==
+            (.invalidated.page + .invalidated.api + .invalidated.artifacts))
+          and (.invalidated.listVersionBumped | type) == "boolean"
+          and (if ($canonical_type == "skills" or $canonical_type == "packs")
+            then .invalidated.listVersionBumped == true
+            else .invalidated.listVersionBumped == false
+          end)
+          and .invalidated.listMaxStaleSeconds == 0' \
+        "$response_file" >/dev/null 2>&1; then
+        return 0
+      fi
+
+      echo "    Cache invalidation response violated the requested contract" >&2
+      return 76
       ;;
     408|429|5[0-9][0-9])
       echo "    Transient HTTP $status" >&2
       return 75
+      ;;
+    409)
+      if jq -e \
+        '.message == "Dependent pack closure exceeds the 100-pack cap"' \
+        "$response_file" >/dev/null 2>&1; then
+        echo "    Cache closure overflow is safe to split into single-item requests" >&2
+        return 76
+      fi
+      echo "    Non-transient HTTP 409" >&2
+      return 1
       ;;
     ''|000)
       if [ "$curl_exit" -ne 0 ]; then
@@ -188,15 +285,19 @@ request_batch_once() {
 
 invalidate_batch() {
   local body_file="$1"
-  local batch_number="$2"
+  local request_label="$2"
+  local max_attempts="$3"
+  local retry_base_seconds="$4"
+  local max_time="$5"
   local attempt
   local delay
   local request_status
-  local response_file="$WORK_DIR/response-$batch_number"
+  local remaining
+  local response_file="$WORK_DIR/response-$request_label"
 
-  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     : > "$response_file"
-    if request_batch_once "$body_file" "$response_file"; then
+    if request_batch_once "$body_file" "$response_file" "$max_time"; then
       request_status=0
     else
       request_status=$?
@@ -207,23 +308,73 @@ invalidate_batch() {
     fi
 
     if [ "$request_status" -ne 75 ]; then
-      return 1
+      return "$request_status"
     fi
 
-    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-      delay=$((attempt * RETRY_BASE_SECONDS))
-      echo "    Attempt $attempt/$MAX_ATTEMPTS failed; retrying in ${delay}s" >&2
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      delay=$((attempt * retry_base_seconds))
+      remaining=$(remaining_seconds)
+      if [ "$delay" -ge "$remaining" ]; then
+        echo "    Global cache invalidation runtime budget exhausted before retry" >&2
+        return 77
+      fi
+      echo "    Attempt $attempt/$max_attempts failed; retrying in ${delay}s" >&2
       sleep "$delay"
     fi
   done
 
-  echo "    Retry budget exhausted after $MAX_ATTEMPTS attempts" >&2
+  echo "    Retry budget exhausted after $max_attempts attempts" >&2
+  return 75
+}
+
+create_body() {
+  local body_file="$1"
+  shift
+
+  if ! printf '%s\n' "$@" |
+    jq -Rsc --arg type "$CONTENT_TYPE" \
+      '{type: $type, slugs: (split("\n") | map(select(length > 0))), invalidateApi: true}' \
+      > "$body_file"; then
+    echo "::error::Failed to construct cache invalidation JSON" >&2
+    return 1
+  fi
+}
+
+SUCCESS=0
+SUCCESS_ITEMS_FILE="$WORK_DIR/success-items"
+: > "$SUCCESS_ITEMS_FILE"
+
+record_success() {
+  printf '%s\n' "$1" >> "$SUCCESS_ITEMS_FILE"
+  SUCCESS=$((SUCCESS + 1))
+}
+
+finish_invalidation() {
+  local failed_items_file="$WORK_DIR/failed-items"
+  local failed_json
+  local slug
+
+  : > "$failed_items_file"
+  for slug in "${SLUGS[@]}"; do
+    if ! grep -Fqx -- "$slug" "$SUCCESS_ITEMS_FILE"; then
+      printf '%s\n' "$slug" >> "$failed_items_file"
+    fi
+  done
+
+  FAILED=$((TOTAL - SUCCESS))
+  write_counts "$TOTAL" "$SUCCESS" "$FAILED"
+
+  if [ "$FAILED" -eq 0 ]; then
+    echo "Cache invalidation complete: $SUCCESS item(s)"
+    return 0
+  fi
+
+  failed_json=$(jq -Rsc 'split("\n") | map(select(length > 0))' < "$failed_items_file")
+  echo "::error::Cache invalidation failed for $FAILED item(s): $failed_json" >&2
   return 1
 }
 
-write_output total_count "$TOTAL"
 BATCHES=$(((TOTAL + BATCH_SIZE - 1) / BATCH_SIZE))
-SUCCESS=0
 
 echo "Invalidating $TOTAL $CONTENT_TYPE item(s) in $BATCHES batch(es)"
 
@@ -232,24 +383,54 @@ for ((offset = 0; offset < TOTAL; offset += BATCH_SIZE)); do
   BATCH_NUMBER=$((offset / BATCH_SIZE + 1))
   BODY_FILE="$WORK_DIR/body-$BATCH_NUMBER.json"
 
-  if ! printf '%s\n' "${BATCH[@]}" |
-    jq -Rsc --arg type "$CONTENT_TYPE" \
-      '{type: $type, slugs: (split("\n") | map(select(length > 0))), invalidateApi: true}' \
-      > "$BODY_FILE"; then
-    echo "::error::Failed to construct cache invalidation JSON" >&2
-    write_counts "$TOTAL" "$SUCCESS" "$((TOTAL - SUCCESS))"
+  if ! create_body "$BODY_FILE" "${BATCH[@]}"; then
+    finish_invalidation || true
     exit 1
   fi
 
   echo "  Batch $BATCH_NUMBER/$BATCHES (${#BATCH[@]} items)"
-  if ! invalidate_batch "$BODY_FILE" "$BATCH_NUMBER"; then
-    write_counts "$TOTAL" "$SUCCESS" "$((TOTAL - SUCCESS))"
-    echo "::error::Cache invalidation batch $BATCH_NUMBER/$BATCHES failed" >&2
-    exit 1
+  if invalidate_batch \
+    "$BODY_FILE" \
+    "batch-$BATCH_NUMBER" \
+    "$MAX_ATTEMPTS" \
+    "$RETRY_BASE_SECONDS" \
+    "$CURL_MAX_TIME"; then
+    for slug in "${BATCH[@]}"; do
+      record_success "$slug"
+    done
+    continue
+  else
+    batch_status=$?
+  fi
+  if { [ "$batch_status" -ne 75 ] && [ "$batch_status" -ne 76 ]; } ||
+    [ "${#BATCH[@]}" -eq 1 ]; then
+    echo "::error::Cache invalidation batch $BATCH_NUMBER/$BATCHES failed without a safe fallback" >&2
+    continue
   fi
 
-  SUCCESS=$((SUCCESS + ${#BATCH[@]}))
+  echo "::warning::Batch $BATCH_NUMBER/$BATCHES failed; falling back to ${#BATCH[@]} single-item request(s)" >&2
+  for index in "${!BATCH[@]}"; do
+    slug="${BATCH[$index]}"
+    FALLBACK_BODY_FILE="$WORK_DIR/body-$BATCH_NUMBER-fallback-$index.json"
+    if ! create_body "$FALLBACK_BODY_FILE" "$slug"; then
+      finish_invalidation || true
+      exit 1
+    fi
+
+    echo "    Fallback $((index + 1))/${#BATCH[@]}: $slug"
+    if invalidate_batch \
+      "$FALLBACK_BODY_FILE" \
+      "batch-$BATCH_NUMBER-fallback-$index" \
+      "$FALLBACK_MAX_ATTEMPTS" \
+      "$FALLBACK_RETRY_BASE_SECONDS" \
+      "$FALLBACK_CURL_MAX_TIME"; then
+      record_success "$slug"
+      continue
+    fi
+
+  done
 done
 
-write_counts "$TOTAL" "$SUCCESS" 0
-echo "Cache invalidation complete: $SUCCESS item(s)"
+if ! finish_invalidation; then
+  exit 1
+fi

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -32,6 +32,7 @@ printf '%s' "$count" > "$count_file"
 
 response_file=""
 payload_arg=""
+max_time=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -o)
@@ -42,7 +43,11 @@ while [ "$#" -gt 0 ]; do
       payload_arg="$2"
       shift 2
       ;;
-    -H|-X|-w|--connect-timeout|--max-time)
+    --max-time)
+      max_time="$2"
+      shift 2
+      ;;
+    -H|-X|-w|--connect-timeout)
       shift 2
       ;;
     *)
@@ -53,11 +58,12 @@ done
 
 payload_file="\${payload_arg#@}"
 cp "$payload_file" "$FAKE_CURL_LOG_DIR/payload-$count.json"
+printf '%s' "$max_time" > "$FAKE_CURL_LOG_DIR/max-time-$count"
 
 IFS=',' read -r -a results <<< "$FAKE_CURL_RESULTS"
 result_index=$((count - 1))
 if [ "$result_index" -ge "\${#results[@]}" ]; then
-  result_index=$(("\${#results[@]}" - 1))
+  result_index=$((\${#results[@]} - 1))
 fi
 result="\${results[$result_index]}"
 
@@ -73,9 +79,49 @@ case "$result" in
     if [ "$response" != "$status" ]; then
       curl_exit="\${response#*:}"
     fi
-    printf '{"ok":true}' > "$response_file"
+    jq '{
+      preflight: false,
+      type: (if .type == "plugins" then "packs" else .type end),
+      slugs,
+      invalidated: {
+        total: (.slugs | length),
+        page: (.slugs | length),
+        api: 0,
+        artifacts: 0,
+        listVersionBumped: (if (.type == "skills" or .type == "packs" or .type == "plugins") then true else false end),
+        listMaxStaleSeconds: 0
+      }
+    }' "$payload_file" > "$response_file"
     printf '%s' "$status"
     exit "$curl_exit"
+    ;;
+  contract:malformed)
+    printf '{' > "$response_file"
+    printf '200'
+    ;;
+  contract:preflight)
+    jq '{preflight: true, type, slugs, invalidated: {total: 1, page: 1, api: 0, artifacts: 0, listVersionBumped: true, listMaxStaleSeconds: 0}}' "$payload_file" > "$response_file"
+    printf '200'
+    ;;
+  contract:wrong-slugs)
+    jq '{preflight: false, type, slugs: ["unexpected"], invalidated: {total: 1, page: 1, api: 0, artifacts: 0, listVersionBumped: true, listMaxStaleSeconds: 0}}' "$payload_file" > "$response_file"
+    printf '200'
+    ;;
+  contract:missing-invalidated)
+    jq '{preflight: false, type, slugs}' "$payload_file" > "$response_file"
+    printf '200'
+    ;;
+  contract:zero-invalidated)
+    jq '{preflight: false, type, slugs, invalidated: {total: 0, page: 0, api: 0, artifacts: 0, listVersionBumped: false, listMaxStaleSeconds: 0}}' "$payload_file" > "$response_file"
+    printf '200'
+    ;;
+  contract:no-list-bump)
+    jq '{preflight: false, type, slugs, invalidated: {total: 1, page: 1, api: 0, artifacts: 0, listVersionBumped: false, listMaxStaleSeconds: 0}}' "$payload_file" > "$response_file"
+    printf '200'
+    ;;
+  closure-overflow)
+    printf '{"message":"Dependent pack closure exceeds the 100-pack cap"}' > "$response_file"
+    printf '409'
     ;;
   *)
     echo "unknown fake curl result: $result" >&2
@@ -88,6 +134,21 @@ const FAKE_SLEEP = `#!/usr/bin/env bash
 printf '%s\n' "$1" >> "$FAKE_SLEEP_LOG"
 `;
 
+const FAKE_DATE = `#!/usr/bin/env bash
+count=0
+if [ -f "$FAKE_DATE_COUNT" ]; then
+  count=$(cat "$FAKE_DATE_COUNT")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$FAKE_DATE_COUNT"
+IFS=',' read -r -a epochs <<< "$FAKE_DATE_EPOCHS"
+index=$((count - 1))
+if [ "$index" -ge "\${#epochs[@]}" ]; then
+  index=$((\${#epochs[@]} - 1))
+fi
+printf '%s\n' "\${epochs[$index]}"
+`;
+
 function runInvalidator({
   slugs = '',
   slugsFile = '',
@@ -96,19 +157,27 @@ function runInvalidator({
   maxAttempts = 3,
   maxItems = 100,
   retryBaseSeconds = 1,
+  fallbackMaxAttempts = 2,
+  fallbackRetryBaseSeconds = 1,
+  fallbackCurlMaxTime = 9,
   results = 'http:200',
   contentType = 'skills',
   mktempFails = false,
+  fakeDateEpochs = '',
 } = {}) {
   const tmp = mkdtempSync(join(tmpdir(), 'invalidate-cache-test-'));
   const bin = join(tmp, 'bin');
   const curlLogDir = join(tmp, 'curl-log');
   const sleepLog = join(tmp, 'sleep.log');
   const githubOutput = join(tmp, 'github-output');
+  const fakeDateCount = join(tmp, 'date-count');
   mkdirSync(bin);
   mkdirSync(curlLogDir);
   writeFileSync(join(bin, 'curl'), FAKE_CURL, { mode: 0o755 });
   writeFileSync(join(bin, 'sleep'), FAKE_SLEEP, { mode: 0o755 });
+  if (fakeDateEpochs) {
+    writeFileSync(join(bin, 'date'), FAKE_DATE, { mode: 0o755 });
+  }
   if (mktempFails) {
     writeFileSync(join(bin, 'mktemp'), '#!/usr/bin/env bash\nexit 1\n', { mode: 0o755 });
   }
@@ -128,12 +197,17 @@ function runInvalidator({
       MAX_ATTEMPTS: String(maxAttempts),
       MAX_ITEMS: String(maxItems),
       RETRY_BASE_SECONDS: String(retryBaseSeconds),
+      FALLBACK_MAX_ATTEMPTS: String(fallbackMaxAttempts),
+      FALLBACK_RETRY_BASE_SECONDS: String(fallbackRetryBaseSeconds),
+      FALLBACK_CURL_MAX_TIME: String(fallbackCurlMaxTime),
       CURL_CONNECT_TIMEOUT: '1',
       CURL_MAX_TIME: '2',
       GITHUB_OUTPUT: githubOutput,
       FAKE_CURL_LOG_DIR: curlLogDir,
       FAKE_CURL_RESULTS: results,
       FAKE_SLEEP_LOG: sleepLog,
+      FAKE_DATE_COUNT: fakeDateCount,
+      FAKE_DATE_EPOCHS: fakeDateEpochs,
     },
   });
 
@@ -144,6 +218,10 @@ function runInvalidator({
   const sleeps = readdirSync(tmp).includes('sleep.log')
     ? readFileSync(sleepLog, 'utf8').trim().split('\n').filter(Boolean)
     : [];
+  const maxTimes = readdirSync(curlLogDir)
+    .filter((name) => /^max-time-\d+$/.test(name))
+    .sort((a, b) => Number(a.match(/\d+/)[0]) - Number(b.match(/\d+/)[0]))
+    .map((name) => Number(readFileSync(join(curlLogDir, name), 'utf8')));
   const outputs = {};
   if (readdirSync(tmp).includes('github-output')) {
     for (const line of readFileSync(githubOutput, 'utf8').trim().split('\n').filter(Boolean)) {
@@ -154,7 +232,7 @@ function runInvalidator({
   }
 
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(SECRET));
-  return { result, payloads, sleeps, outputs };
+  return { result, payloads, sleeps, maxTimes, outputs };
 }
 
 test('empty input succeeds without validating a secret or making an HTTP request', () => {
@@ -203,6 +281,16 @@ test('single and 96-item inputs use deterministic bounded JSON batches', () => {
   assert.deepEqual(unbounded.payloads, []);
 });
 
+test('plugin and release responses obey their canonical list-version contracts', () => {
+  const plugin = runInvalidator({ slugs: 'alpha', contentType: 'plugins' });
+  assert.equal(plugin.result.status, 0);
+  assert.equal(plugin.payloads[0].type, 'plugins');
+
+  const release = runInvalidator({ slugs: 'alpha', contentType: 'releases' });
+  assert.equal(release.result.status, 0);
+  assert.equal(release.payloads[0].type, 'releases');
+});
+
 test('inputs above the explicit 100-item budget fail before making an HTTP request', () => {
   const slugs = Array.from({ length: 101 }, (_, index) => `skill-${index}`);
   const { result, payloads, sleeps } = runInvalidator({
@@ -211,7 +299,7 @@ test('inputs above the explicit 100-item budget fail before making an HTTP reque
     maxItems: 100,
   });
 
-  assert.notEqual(result.status, 0);
+  assert.notEqual(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
   assert.deepEqual(payloads, []);
   assert.deepEqual(sleeps, []);
   assert.match(result.stderr, /item count 101 exceeds MAX_ITEMS 100/);
@@ -223,7 +311,7 @@ test('temporary workspace failure fails closed before making an HTTP request', (
     mktempFails: true,
   });
 
-  assert.notEqual(result.status, 0);
+  assert.notEqual(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
   assert.deepEqual(payloads, []);
   assert.deepEqual(outputs, {});
   assert.match(result.stderr, /Failed to create temporary workspace/);
@@ -265,13 +353,40 @@ test('HTTP 408, 429, and 5xx responses are transient and use finite retries', ()
   }
 });
 
+test('the exact pre-mutation closure overflow 409 safely splits into single requests', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
+    slugs: 'alpha,beta',
+    results: 'closure-overflow,http:200,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.deepEqual(payloads.map((payload) => payload.slugs), [
+    ['alpha', 'beta'],
+    ['alpha'],
+    ['beta'],
+  ]);
+  assert.deepEqual(sleeps, []);
+  assert.deepEqual(outputs, { total_count: 2, success_count: 2, failed_count: 0 });
+});
+
+test('unrecognized 409 responses fail closed without split fallback', () => {
+  const { result, payloads, outputs } = runInvalidator({
+    slugs: 'alpha,beta',
+    results: 'http:409',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(outputs, { total_count: 2, success_count: 0, failed_count: 2 });
+});
+
 test('HTTP 401 takes precedence over curl exit 18 and fails after one request', () => {
   const { result, payloads, sleeps } = runInvalidator({
     slugs: 'alpha',
     results: 'http:401:18,http:200',
   });
 
-  assert.notEqual(result.status, 0);
+  assert.notEqual(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
   assert.equal(payloads.length, 1);
   assert.deepEqual(sleeps, []);
   assert.match(result.stderr, /Non-transient HTTP 401/);
@@ -283,7 +398,7 @@ test('HTTP 403 takes precedence over curl exit 28 and fails after one request', 
     results: 'http:403:28,http:200',
   });
 
-  assert.notEqual(result.status, 0);
+  assert.notEqual(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
   assert.equal(payloads.length, 1);
   assert.deepEqual(sleeps, []);
   assert.match(result.stderr, /Non-transient HTTP 403/);
@@ -316,6 +431,32 @@ test('HTTP 200 takes precedence over curl exit 18 and succeeds without retrying'
   assert.doesNotMatch(result.stderr, /curl transport failure|retrying/);
 });
 
+test('2xx responses fail closed when the cache response contract is invalid', () => {
+  for (const scenario of [
+    'contract:malformed',
+    'contract:preflight',
+    'contract:wrong-slugs',
+    'contract:missing-invalidated',
+    'contract:zero-invalidated',
+    'contract:no-list-bump',
+  ]) {
+    const { result, payloads, sleeps, outputs } = runInvalidator({
+      slugs: 'alpha',
+      results: scenario,
+    });
+
+    assert.notEqual(result.status, 0, scenario);
+    assert.equal(payloads.length, 1, scenario);
+    assert.deepEqual(sleeps, [], scenario);
+    assert.deepEqual(outputs, {
+      total_count: 1,
+      success_count: 0,
+      failed_count: 1,
+    });
+    assert.match(result.stderr, /response violated the requested contract/);
+  }
+});
+
 test('status 000 with curl exit 28 uses transport retries within the finite budget', () => {
   const { result, payloads, sleeps } = runInvalidator({
     slugs: 'alpha',
@@ -330,52 +471,99 @@ test('status 000 with curl exit 28 uses transport retries within the finite budg
   assert.match(result.stderr, /Transient curl transport failure \(exit 28\)/);
 });
 
-test('non-transient curl failures fail closed without retrying', () => {
-  const { result, payloads, sleeps } = runInvalidator({
+test('non-transient curl failures fail closed without retrying the failed batch', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
     slugs: 'alpha,beta,gamma',
     results: 'transport:3,http:200',
   });
 
   assert.notEqual(result.status, 0);
-  assert.equal(payloads.length, 1);
+  assert.equal(payloads.length, 2);
   assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.deepEqual(payloads[1].slugs, ['gamma']);
   assert.deepEqual(sleeps, []);
+  assert.deepEqual(outputs, { total_count: 3, success_count: 1, failed_count: 2 });
 });
 
-test('non-transient HTTP failures fail closed without retrying', () => {
-  const { result, payloads, sleeps } = runInvalidator({
+test('non-transient HTTP failures fail closed without retrying the failed batch', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
     slugs: 'alpha,beta,gamma',
     results: 'http:400,http:200',
   });
 
   assert.notEqual(result.status, 0);
-  assert.equal(payloads.length, 1);
+  assert.equal(payloads.length, 2);
   assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.deepEqual(payloads[1].slugs, ['gamma']);
   assert.deepEqual(sleeps, []);
+  assert.deepEqual(outputs, { total_count: 3, success_count: 1, failed_count: 2 });
 });
 
-test('an exhausted batch fails immediately without sending later batches', () => {
-  const { result, payloads, sleeps, outputs } = runInvalidator({
+test('an exhausted multi-item batch falls back to bounded single-item requests', () => {
+  const { result, payloads, sleeps, maxTimes, outputs } = runInvalidator({
     slugs: 'alpha,beta,gamma,delta,epsilon',
-    maxAttempts: 3,
-    results: 'http:200,http:503',
+    maxAttempts: 2,
+    fallbackMaxAttempts: 2,
+    results: 'http:200,http:503,http:503,http:200,http:200,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.equal(payloads.length, 6);
+  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
+  assert.deepEqual(payloads.slice(1).map((payload) => payload.slugs), [
+    ['gamma', 'delta'],
+    ['gamma', 'delta'],
+    ['gamma'],
+    ['delta'],
+    ['epsilon'],
+  ]);
+  assert.deepEqual(sleeps, ['1']);
+  assert.deepEqual(maxTimes, [2, 2, 2, 9, 9, 2]);
+  assert.deepEqual(outputs, {
+    total_count: 5,
+    success_count: 5,
+    failed_count: 0,
+  });
+  assert.equal(outputs.total_count, outputs.success_count + outputs.failed_count);
+});
+
+test('single-item fallback failures preserve exact counts and fail closed', () => {
+  const { result, payloads, outputs } = runInvalidator({
+    slugs: 'alpha,beta',
+    maxAttempts: 2,
+    fallbackMaxAttempts: 2,
+    results: 'http:503,http:503,http:200,http:503,http:503',
   });
 
   assert.notEqual(result.status, 0);
-  assert.equal(payloads.length, 4);
-  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta']);
-  assert.ok(
-    payloads.slice(1).every(
-      (payload) => JSON.stringify(payload.slugs) === '["gamma","delta"]',
-    ),
-  );
-  assert.equal(sleeps.length, 2);
+  assert.deepEqual(payloads.map((payload) => payload.slugs), [
+    ['alpha', 'beta'],
+    ['alpha', 'beta'],
+    ['alpha'],
+    ['beta'],
+    ['beta'],
+  ]);
   assert.deepEqual(outputs, {
-    total_count: 5,
-    success_count: 2,
-    failed_count: 3,
+    total_count: 2,
+    success_count: 1,
+    failed_count: 1,
   });
   assert.equal(outputs.total_count, outputs.success_count + outputs.failed_count);
+});
+
+test('the global deadline stops retries and fallback before the workflow timeout', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
+    slugs: 'alpha,beta',
+    maxAttempts: 3,
+    results: 'http:503',
+    fakeDateEpochs: '100,100,1300',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(sleeps, []);
+  assert.deepEqual(outputs, { total_count: 2, success_count: 0, failed_count: 2 });
+  assert.match(result.stderr, /runtime budget exhausted/);
 });
 
 test('sync workflow uses an artifact-backed bounded invalidator and preserves downstream success gates', () => {
@@ -415,8 +603,9 @@ test('sync workflow uses an artifact-backed bounded invalidator and preserves do
   );
 });
 
-test('each cache invalidation shard has a fixed 10-batch budget below its own timeout', () => {
+test('each cache invalidation shard has a hard runtime deadline below its own timeout', () => {
   const workflow = readFileSync(SYNC_WORKFLOW, 'utf8');
+  const invalidator = readFileSync(INVALIDATOR, 'utf8');
   const invalidationJob = workflow.slice(
     workflow.indexOf('  cache-invalidate-shard:'),
     workflow.indexOf('  cache-invalidate:'),
@@ -470,4 +659,15 @@ test('each cache invalidation shard has a fixed 10-batch budget below its own ti
   assert.equal(worstSecondsPerBatch, 105);
   assert.equal(worstCaseSeconds, 1050);
   assert.ok(worstCaseSeconds < timeoutMinutes * 60);
+
+  const runtimeMatch = invalidator.match(
+    /^MAX_RUNTIME_SECONDS="\$\{MAX_RUNTIME_SECONDS:-([0-9]+)\}"$/m,
+  );
+  assert.ok(runtimeMatch, 'invalidator must declare a fixed default runtime deadline');
+  const maxRuntimeSeconds = Number(runtimeMatch[1]);
+  assert.ok(maxRuntimeSeconds <= 1200);
+  assert.ok(
+    maxRuntimeSeconds <= timeoutMinutes * 60 - 60,
+    'script deadline must leave at least one minute for setup and teardown',
+  );
 });


### PR DESCRIPTION
## Summary\n\n- fall back from exhausted cache invalidation batches to independently bounded single-skill requests\n- enforce a 20-minute script deadline below the 25-minute shard timeout\n- accept split fallback only for transient failures, invalid 2xx contracts, or the exact pre-mutation dependent-pack closure overflow\n- validate the complete success response before counting any slug as cache-closed\n\n## Safety\n\n- skills/packs/plugins require ; releases require \n- , exact slug identity, and invalidation count reconciliation are mandatory\n- all unrecognized 409/4xx responses remain fail-closed\n- total/success/failure outputs reconcile over the exact deduplicated input set\n\n## Verification\n\n- ✔ planner maps 1, 100, 101, and 5263 slugs to bounded shards (23.68175ms)
✔ planner and extractor are deterministic and exactly-once across the artifact (62.52925ms)
✔ empty artifact is a successful no-op (0.115833ms)
✔ planner enforces 100 slugs per shard and the GitHub 256-job matrix limit (511.80975ms)
✔ plan CLI writes only shard ids and counts to GITHUB_OUTPUT (27.702667ms)
✔ extract CLI materializes only the selected bounded shard from the artifact (25.94125ms)
✔ workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3 (1.186292ms)
✔ workflow full_sync inputs above 100 use the configured bounded matrix (24.020625ms)
✔ workflow treats an empty sync as a no-op before planning or invalidation (0.325916ms)
✔ incremental detection resolves both sides from pinned Git trees (0.172583ms)
✔ sync materializes only the detected paths from the exact workflow commit (0.217167ms)
✔ sync downloads the security-event-capable CLI release (0.113292ms)
✔ one permanently failed shard makes the aggregate fail closed (6.980292ms)
✔ CI tracks and executes the planner, aggregate guard, and full script suite (0.13775ms)
✔ downstream finalizer and translation require aggregate success (0.191667ms)
✔ empty input succeeds without validating a secret or making an HTTP request (13.576834ms)
✔ single and 96-item inputs use deterministic bounded JSON batches (398.079041ms)
✔ plugin and release responses obey their canonical list-version contracts (67.712542ms)
✔ inputs above the explicit 100-item budget fail before making an HTTP request (13.913166ms)
✔ temporary workspace failure fails closed before making an HTTP request (5.682875ms)
✔ retryable curl transport failures retry the same idempotent batch (543.624375ms)
✔ HTTP 408, 429, and 5xx responses are transient and use finite retries (148.3655ms)
✔ the exact pre-mutation closure overflow 409 safely splits into single requests (67.922125ms)
✔ unrecognized 409 responses fail closed without split fallback (37.084792ms)
✔ HTTP 401 takes precedence over curl exit 18 and fails after one request (32.136875ms)
✔ HTTP 403 takes precedence over curl exit 28 and fails after one request (31.858ms)
✔ HTTP 503 takes precedence over curl exit 18 and retries within the finite budget (65.115042ms)
✔ HTTP 200 takes precedence over curl exit 18 and succeeds without retrying (35.843041ms)
✔ 2xx responses fail closed when the cache response contract is invalid (222.028791ms)
✔ status 000 with curl exit 28 uses transport retries within the finite budget (66.615834ms)
✔ non-transient curl failures fail closed without retrying the failed batch (49.312792ms)
✔ non-transient HTTP failures fail closed without retrying the failed batch (53.983959ms)
✔ an exhausted multi-item batch falls back to bounded single-item requests (129.126583ms)
✔ single-item fallback failures preserve exact counts and fail closed (100.331ms)
✔ the global deadline stops retries and fallback before the workflow timeout (45.599958ms)
✔ sync workflow uses an artifact-backed bounded invalidator and preserves downstream success gates (0.379667ms)
✔ each cache invalidation shard has a hard runtime deadline below its own timeout (0.510917ms)
✔ strictly extracts unique terminal failures and reconciles the aggregate summary (1.162125ms)
✔ extracts only checksum-verified residual failures from a prior recovery result (0.722083ms)
✔ approved catalog pagination selects only public eligible canonical slugs (10.053083ms)
✔ freezes exact current DB score and snapshot identity for every requested slug (0.417542ms)
✔ rejects a claimed update that preserves an old snapshot and predates the trusted run boundary (0.193167ms)
✔ proves a score write by changed snapshot identity or an advanced post-boundary calculatedAt (0.094542ms)
✔ rejects an unchanged future timestamp caused by runner and database clock skew (0.070625ms)
✔ production readback requires a closed first read and a stable HIT+SKIPPED second read (0.992333ms)
✔ readback records unstable cache identity as a failure (0.382375ms)
✔ readback accepts a correct cache entry warmed after invalidation but before verification (1.011041ms)
✔ readback rejects a stale HIT that disagrees with frozen DB score evidence (0.350959ms)
✔ readback rejects a freshly stored cache body that disagrees with frozen DB score evidence (0.225084ms)
✔ daily workflow moves score cache closure to a fail-closed hosted job (0.2185ms)
✔ manual recovery is file-backed, fixed-CLI, bounded, and red on any remaining failure (0.223875ms)
✔ every single-file score closure sparse checkout disables cone mode (0.206042ms)
✔ shared invalidation action preserves score-only closure flags and validates response identity (0.060125ms)
ℹ tests 53
ℹ suites 0
ℹ pass 53
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2171.857083 — 53/53\n- \n- \n- two independent P0/P1 reviews: 0/0