### PR TITLE
fix(packs): run evaluator from isolated home

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -295,7 +295,7 @@ jobs:
           PROXY_PID=$(pgrep -u packproxy -f pack-evaluator-proxy.mjs | head -n1)
           test -n "$PROXY_PID"
 
-          sudo -u packeval env -i \
+          sudo --chdir=/home/packeval -u packeval env -i \
             PATH=/usr/local/bin:/usr/bin:/bin \
             HOME=/home/packeval \
             PROXY_PID="$PROXY_PID" \
@@ -310,7 +310,7 @@ jobs:
             '
 
           set +e
-          sudo -u packeval env -i \
+          sudo --chdir=/home/packeval -u packeval env -i \
             PATH=/usr/local/bin:/usr/bin:/bin \
             HOME=/home/packeval \
             CODEX_HOME=/home/packeval/.codex \

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -61,7 +61,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /\/home\/packeval\/results/);
   assert.match(evaluate, /cp -a \/home\/packeval\/results\/\./);
   assert.match(evaluate, /sudo -u packproxy env -i/);
-  assert.match(evaluate, /sudo -u packeval env -i/);
+  assert.equal((evaluate.match(/sudo --chdir=\/home\/packeval -u packeval env -i/g) ?? []).length, 2);
   assert.match(evaluate, /! sudo -n true/);
   assert.match(evaluate, /! test -r .*PROXY_PID.*environ/);
   assert.match(evaluate, /PACK_EVALUATOR_HELM_API_KEY: \$\{\{ secrets\.PACK_EVALUATOR_HELM_API_KEY \}\}/);


### PR DESCRIPTION
## Root cause evidence

Canary 29440018916 read the isolated plan successfully, then spawnSync returned EACCES for the verified CLI because pack-production inherited the inaccessible runner workspace as its child cwd.

## Fix

Start both packeval commands with sudo --chdir=/home/packeval. Child agents now inherit the isolated, writable HOME as cwd while plan/Skills remain root-owned under /opt and runner HOME remains inaccessible.

## Verification

- Focused Pack tests: 22/22 passed
- Workflow YAML parsed successfully
- git diff --check passed