### PR TITLE
fix(packs): enter isolated cwd before sudo

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -295,7 +295,8 @@ jobs:
           PROXY_PID=$(pgrep -u packproxy -f pack-evaluator-proxy.mjs | head -n1)
           test -n "$PROXY_PID"
 
-          sudo --chdir=/home/packeval -u packeval env -i \
+          pushd /home/packeval >/dev/null
+          sudo -u packeval env -i \
             PATH=/usr/local/bin:/usr/bin:/bin \
             HOME=/home/packeval \
             PROXY_PID="$PROXY_PID" \
@@ -310,7 +311,7 @@ jobs:
             '
 
           set +e
-          sudo --chdir=/home/packeval -u packeval env -i \
+          sudo -u packeval env -i \
             PATH=/usr/local/bin:/usr/bin:/bin \
             HOME=/home/packeval \
             CODEX_HOME=/home/packeval/.codex \
@@ -346,6 +347,7 @@ jobs:
             --auto-publish-threshold 8 \
             > /home/packeval/results/evaluate-command.json
           EVALUATOR_RC=$?
+          popd >/dev/null
           set -e
           test ! -s "$PROXY_LOG" || sed -E 's/(Bearer|helm_live_)[^[:space:]]+/[REDACTED]/g' "$PROXY_LOG" >&2
           sudo cp -a /home/packeval/results/. "$GITHUB_WORKSPACE/pack-results/"

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -61,7 +61,9 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /\/home\/packeval\/results/);
   assert.match(evaluate, /cp -a \/home\/packeval\/results\/\./);
   assert.match(evaluate, /sudo -u packproxy env -i/);
-  assert.equal((evaluate.match(/sudo --chdir=\/home\/packeval -u packeval env -i/g) ?? []).length, 2);
+  assert.match(evaluate, /pushd \/home\/packeval >\/dev\/null/);
+  assert.equal((evaluate.match(/sudo -u packeval env -i/g) ?? []).length, 2);
+  assert.match(evaluate, /EVALUATOR_RC=\$\?[\s\S]*popd >\/dev\/null[\s\S]*set -e/);
   assert.match(evaluate, /! sudo -n true/);
   assert.match(evaluate, /! test -r .*PROXY_PID.*environ/);
   assert.match(evaluate, /PACK_EVALUATOR_HELM_API_KEY: \$\{\{ secrets\.PACK_EVALUATOR_HELM_API_KEY \}\}/);


### PR DESCRIPTION
## Root cause evidence

Canary 29440483752 stopped before evaluator execution because the GitHub runner sudoers policy rejects sudo -D/--chdir for /usr/bin/env.

## Fix

The trusted shell now pushd enters /home/packeval before both sudo calls and restores its cwd after capturing evaluator status. This gives child processes the intended isolated cwd without requiring a restricted sudo option.

## Verification

- Focused Pack tests: 22/22 passed
- Workflow YAML parsed successfully
- git diff --check passed