### PR TITLE
fix(packs): install evaluator candidate scanner

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -191,13 +191,14 @@ jobs:
       - name: Install evaluator runtimes before secrets are available
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends ffmpeg poppler-utils
+          sudo apt-get install --yes --no-install-recommends ffmpeg poppler-utils ripgrep
           sudo npm install --global \
             @anthropic-ai/claude-code@2.1.210 \
             @openai/codex@0.139.0
           command -v ffprobe
           command -v pdfinfo
           command -v pdftotext
+          command -v rg
           test "$(claude --version | awk '{print $1}')" = '2.1.210'
           test "$(codex --version | awk '{print $2}')" = '0.139.0'
 
@@ -307,6 +308,9 @@ jobs:
               ! test -e /home/packeval/.codex/auth.json
               ! test -e /home/packeval/.claude
               ! test -r /var/run/docker.sock
+              test -r /opt/pack-evaluator/plan.json
+              test -n "$(find /opt/pack-evaluator/skills -name skill-report.json -print -quit)"
+              command -v rg >/dev/null
               ! env | grep -Eq "SUPABASE|HELM|GITHUB_TOKEN|GH_TOKEN|AUTOMATION|APP_PRIVATE_KEY|CALLBACK|CACHE_INVALIDATE"
             '
 

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -48,10 +48,11 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /runs-on: ubuntu-latest/);
   assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
   assert.match(evaluate, /@openai\/codex@0\.139\.0/);
-  assert.match(evaluate, /apt-get install --yes --no-install-recommends ffmpeg poppler-utils/);
+  assert.match(evaluate, /apt-get install --yes --no-install-recommends ffmpeg poppler-utils ripgrep/);
   assert.match(evaluate, /command -v ffprobe/);
   assert.match(evaluate, /command -v pdfinfo/);
   assert.match(evaluate, /command -v pdftotext/);
+  assert.match(evaluate, /command -v rg/);
   assert.match(evaluate, /useradd .*packproxy/);
   assert.match(evaluate, /useradd .*packeval/);
   assert.match(evaluate, /\/usr\/local\/lib\/pack-evaluator-proxy\.mjs/);
@@ -66,6 +67,8 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /EVALUATOR_RC=\$\?[\s\S]*popd >\/dev\/null[\s\S]*set -e/);
   assert.match(evaluate, /! sudo -n true/);
   assert.match(evaluate, /! test -r .*PROXY_PID.*environ/);
+  assert.match(evaluate, /test -r \/opt\/pack-evaluator\/plan\.json/);
+  assert.match(evaluate, /find \/opt\/pack-evaluator\/skills -name skill-report\.json -print -quit/);
   assert.match(evaluate, /PACK_EVALUATOR_HELM_API_KEY: \$\{\{ secrets\.PACK_EVALUATOR_HELM_API_KEY \}\}/);
   assert.match(evaluate, /PACK_EVALUATOR_PROXY_TOKEN="\$LOCAL_TOKEN"/);
   assert.match(evaluate, /supports_websockets = false/);


### PR DESCRIPTION
## Root cause evidence

Canary 29441180096 completed Evaluate/Persist/Finalize but correctly produced no Pack: every slot had an empty candidate list. CLI 2.9.0 searches skill-report.json with rg, which was absent from the strict evaluator PATH and its scan fallback returned no matches.

## Fix

- Install ripgrep with the other pre-secret evaluator runtimes.
- Require rg in the isolated-user preflight.
- Require readable plan and at least one skill-report before model execution.

## Verification

- Focused Pack tests: 22/22 passed
- Workflow YAML parsed successfully
- git diff --check passed