### PR TITLE
fix(packs): 让生产评测可观测并严格失败关闭

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   # Immutable release required by the v2 evaluator/API contract. Bump only
   # together with a Skillstore CLI release and its checksums.txt asset.
-  PACK_PRODUCTION_CLI_VERSION: '2.9.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.10.0'
 
 jobs:
   plan:
@@ -258,7 +258,10 @@ jobs:
             /opt/pack-evaluator/codex-home/log \
             /opt/pack-evaluator/codex-home/sessions
           sudo install -d -o root -g root -m 0700 /opt/pack-evaluator/results
-          mkdir -p "$GITHUB_WORKSPACE/pack-results"
+          sudo install -d -o root -g root -m 0711 /opt/pack-evaluator/generations
+          mkdir -p \
+            "$GITHUB_WORKSPACE/pack-diagnostics" \
+            "$GITHUB_WORKSPACE/pack-harvest"
           printf '%s\n' \
             'model_provider = "pack_evaluator_proxy"' \
             '[model_providers.pack_evaluator_proxy]' \
@@ -285,11 +288,83 @@ jobs:
           test -x "$NODE_BIN"
           PROXY_LOG=$(mktemp)
           chmod 0600 "$PROXY_LOG"
+          CHECKPOINT_LOCK="$RUNNER_TEMP/pack-production-checkpoint.lock"
+          CHECKPOINT_PID=''
+          EVALUATOR_PID=''
+          EVALUATOR_FINISHED=false
+          CLEANUP_DONE=false
+          checkpoint_progress() {
+            (
+              flock -x 9
+              for name in evaluate-progress.ndjson evaluate-checkpoint.json evaluate-summary.json; do
+                if sudo test -f "/opt/pack-evaluator/results/$name"; then
+                  temporary="$GITHUB_WORKSPACE/pack-diagnostics/.${name}.tmp.${BASHPID}"
+                  sudo cp "/opt/pack-evaluator/results/$name" "$temporary"
+                  sudo chown "$(id -u):$(id -g)" "$temporary"
+                  chmod 0600 "$temporary"
+                  mv -f "$temporary" "$GITHUB_WORKSPACE/pack-diagnostics/$name"
+                fi
+              done
+            ) 9>"$CHECKPOINT_LOCK"
+          }
+          checkpoint_loop() {
+            trap - EXIT INT TERM
+            while true; do
+              sleep 30
+              checkpoint_progress || true
+            done
+          }
           cleanup() {
+            local exit_code="${1:-$?}"
+            if [ "$CLEANUP_DONE" = "true" ]; then
+              return "$exit_code"
+            fi
+            CLEANUP_DONE=true
+            set +e
+            if [ -n "$EVALUATOR_PID" ]; then
+              sudo kill -TERM "$EVALUATOR_PID" 2>/dev/null || true
+            fi
+            sudo pkill -TERM -f '/opt/pack-evaluator/lib/pack-production.mjs evaluate' 2>/dev/null || true
+            for _ in $(seq 1 20); do
+              if ! sudo pgrep -f '/opt/pack-evaluator/lib/pack-production.mjs evaluate' >/dev/null 2>&1; then
+                break
+              fi
+              sleep 0.1
+            done
+            sudo pkill -KILL -f '/opt/pack-evaluator/lib/pack-production.mjs evaluate' 2>/dev/null || true
+            if [ -n "$CHECKPOINT_PID" ]; then
+              kill "$CHECKPOINT_PID" 2>/dev/null || true
+              wait "$CHECKPOINT_PID" 2>/dev/null || true
+            fi
+            checkpoint_progress || true
+            sudo pkill -TERM -u packeval 2>/dev/null || true
+            for _ in $(seq 1 20); do
+              if ! sudo pgrep -u packeval >/dev/null 2>&1; then
+                break
+              fi
+              sleep 0.1
+            done
+            sudo pkill -KILL -u packeval 2>/dev/null || true
+            checkpoint_progress || true
+            if [ "$EVALUATOR_FINISHED" != "true" ]; then
+              printf 'evaluator_interrupted=true\n' \
+                > "$GITHUB_WORKSPACE/pack-diagnostics/evaluator-interrupted.txt"
+              chmod 0600 "$GITHUB_WORKSPACE/pack-diagnostics/"* 2>/dev/null || true
+            fi
             sudo pkill -u packproxy -f pack-evaluator-proxy.mjs 2>/dev/null || true
             rm -f "$PROXY_LOG"
+            return "$exit_code"
           }
-          trap cleanup EXIT
+          terminate_step() {
+            local exit_code="$1"
+            cleanup "$exit_code"
+            trap - EXIT
+            exit "$exit_code"
+          }
+          trap 'terminate_step 143' TERM
+          trap 'terminate_step 130' INT
+          trap 'terminate_step 129' HUP
+          trap 'cleanup $?' EXIT
 
           sudo -u packproxy env -i \
             PATH=/opt/pack-evaluator/bin:/usr/bin:/bin \
@@ -320,13 +395,14 @@ jobs:
           done
           if [ "$PROXY_READY" != "true" ]; then
             echo "::error::Pack evaluator proxy did not become healthy within 30 seconds"
-            if [ -s "$PROXY_LOG" ]; then
-              sed -E 's/(Bearer|helm_live_)[^[:space:]]+/[REDACTED]/g' "$PROXY_LOG" \
-                | tee "$GITHUB_WORKSPACE/pack-results/proxy-failure.log" >&2
-            else
-              echo 'proxy exited without diagnostic output' \
-                | tee "$GITHUB_WORKSPACE/pack-results/proxy-failure.log" >&2
-            fi
+            PROXY_BYTES=$(wc -c < "$PROXY_LOG")
+            PROXY_SHA256=$(sha256sum "$PROXY_LOG" | awk '{print $1}')
+            jq -n \
+              --arg outcome startup_failed \
+              --argjson bytes "$PROXY_BYTES" \
+              --arg sha256 "$PROXY_SHA256" \
+              '{outcome: $outcome, bytes: $bytes, sha256: $sha256}' \
+              > "$GITHUB_WORKSPACE/pack-diagnostics/proxy-diagnostics.json"
             kill "$PROXY_LAUNCH_PID" 2>/dev/null || true
             wait "$PROXY_LAUNCH_PID" 2>/dev/null || true
             exit 1
@@ -359,6 +435,7 @@ jobs:
               ! test -w /opt/pack-evaluator/runtime
               ! test -w /opt/pack-evaluator/runtime/bin
               ! test -w /opt/pack-evaluator/runtime/lib
+              ! test -w /opt/pack-evaluator/generations
               test -x /opt/pack-evaluator/runtime/bin/claude
               test -x /opt/pack-evaluator/runtime/bin/codex
               test -r /opt/pack-evaluator/codex-home/config.toml
@@ -367,12 +444,14 @@ jobs:
               ! test -r /opt/pack-evaluator/results
             '; then
             echo 'evaluator isolation preflight failed' \
-              > "$GITHUB_WORKSPACE/pack-results/preflight-failure.txt"
+              > "$GITHUB_WORKSPACE/pack-diagnostics/preflight-failure.txt"
             exit 1
           fi
 
           PACKEVAL_UID=$(id -u packeval)
           PACKEVAL_GID=$(id -g packeval)
+          checkpoint_loop &
+          CHECKPOINT_PID=$!
           set +e
           sudo env -i \
             PATH=/opt/pack-evaluator/runtime/bin:/opt/pack-evaluator/bin:/usr/bin:/bin \
@@ -388,7 +467,7 @@ jobs:
             ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
             ANTHROPIC_AUTH_TOKEN="$LOCAL_TOKEN" \
             NO_PROXY=127.0.0.1,localhost \
-            timeout --signal=TERM 4h \
+            timeout --signal=TERM --kill-after=30s 4h \
             prlimit --nproc=256:256 --as=6442450944:6442450944 -- \
             "$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs evaluate \
             --plan /opt/pack-evaluator/input/plan.json \
@@ -399,6 +478,7 @@ jobs:
             --evaluator-uid "$PACKEVAL_UID" \
             --evaluator-gid "$PACKEVAL_GID" \
             --evaluator-cwd /home/packeval \
+            --evaluator-runtime-root /opt/pack-evaluator/generations \
             --run-id "${{ github.run_id }}" \
             --run-attempt "${{ github.run_attempt }}" \
             --commit-sha "${{ github.sha }}" \
@@ -411,8 +491,18 @@ jobs:
             --threshold 7 \
             --baseline-delta 1 \
             --auto-publish-threshold 8 \
-            > "$GITHUB_WORKSPACE/pack-results/evaluate-command.json"
+            --evaluation-budget-ms 13800000 \
+            --scenario-timeout-ms 7200000 \
+            --minimum-fallback-ms 2700000 \
+            > "$GITHUB_WORKSPACE/pack-diagnostics/evaluate-command.json" &
+          EVALUATOR_PID=$!
+          wait "$EVALUATOR_PID"
           EVALUATOR_RC=$?
+          EVALUATOR_PID=''
+          EVALUATOR_FINISHED=true
+          kill "$CHECKPOINT_PID" 2>/dev/null || true
+          wait "$CHECKPOINT_PID" 2>/dev/null || true
+          CHECKPOINT_PID=''
           set -e
           sudo pkill -TERM -u packeval 2>/dev/null || true
           for _ in $(seq 1 20); do
@@ -430,7 +520,7 @@ jobs:
           fi
           if [ "$EVALUATOR_PROCESSES_STOPPED" != "true" ]; then
             echo 'evaluator processes survived TERM and KILL' \
-              > "$GITHUB_WORKSPACE/pack-results/process-termination-failure.txt"
+              > "$GITHUB_WORKSPACE/pack-diagnostics/process-termination-failure.txt"
           else
             RESULT_BYTES=$(sudo du -sb /opt/pack-evaluator/results | awk '{print $1}')
             RESULT_FILES=$(sudo find /opt/pack-evaluator/results -type f | wc -l)
@@ -444,25 +534,25 @@ jobs:
               echo '::error::Evaluator result directory contains a non-regular entry'
               EVALUATOR_RC=1
             else
-              sudo cp -a /opt/pack-evaluator/results/. "$GITHUB_WORKSPACE/pack-results/"
+              sudo cp -a /opt/pack-evaluator/results/. "$GITHUB_WORKSPACE/pack-harvest/"
             fi
           fi
-          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/pack-results"
-          find "$GITHUB_WORKSPACE/pack-results" -type d -exec chmod 0700 {} +
-          find "$GITHUB_WORKSPACE/pack-results" -type f -exec chmod 0600 {} +
-          if find "$GITHUB_WORKSPACE/pack-results" ! -type f ! -type d -print -quit | grep -q .; then
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/pack-harvest"
+          find "$GITHUB_WORKSPACE/pack-harvest" -type d -exec chmod 0700 {} +
+          find "$GITHUB_WORKSPACE/pack-harvest" -type f -exec chmod 0600 {} +
+          if find "$GITHUB_WORKSPACE/pack-harvest" ! -type f ! -type d -print -quit | grep -q .; then
             echo '::error::Copied evaluator evidence contains a non-regular entry'
-            rm -rf "$GITHUB_WORKSPACE/pack-results"
-            mkdir -p "$GITHUB_WORKSPACE/pack-results"
+            rm -rf "$GITHUB_WORKSPACE/pack-harvest"
+            mkdir -p "$GITHUB_WORKSPACE/pack-harvest"
             echo 'copied evaluator evidence failed regular-file validation' \
-              > "$GITHUB_WORKSPACE/pack-results/evidence-validation-failure.txt"
+              > "$GITHUB_WORKSPACE/pack-diagnostics/evidence-validation-failure.txt"
             EVALUATOR_RC=1
           fi
           if [ "$EVALUATOR_RC" -eq 0 ]; then
             if ! env -i PATH=/opt/pack-evaluator/runtime/bin:/opt/pack-evaluator/bin:/usr/bin:/bin \
               "$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs verify \
               --plan /opt/pack-evaluator/input/plan.json \
-              --results-dir "$GITHUB_WORKSPACE/pack-results" \
+              --results-dir "$GITHUB_WORKSPACE/pack-harvest" \
               --cli /opt/pack-evaluator/bin/skillstore-cli \
               --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
               --run-id "${{ github.run_id }}" \
@@ -470,33 +560,63 @@ jobs:
               --commit-sha "${{ github.sha }}" \
               --model sonnet \
               --judge-model gpt-5.5 \
-              > "$GITHUB_WORKSPACE/pack-results/verification-command.json"; then
+              > "$GITHUB_WORKSPACE/pack-diagnostics/verification-command.json"; then
               echo 'trusted evaluation closure verification failed' \
-                > "$GITHUB_WORKSPACE/pack-results/verification-failure.txt"
+                > "$GITHUB_WORKSPACE/pack-diagnostics/verification-failure.txt"
               EVALUATOR_RC=1
             fi
           fi
-          find "$GITHUB_WORKSPACE/pack-results" -type f -exec chmod 0600 {} +
-          if [ -s "$PROXY_LOG" ]; then
-            sed -E 's/(Bearer|helm_live_)[^[:space:]]+/[REDACTED]/g' "$PROXY_LOG" \
-              | tee "$GITHUB_WORKSPACE/pack-results/proxy.log" >&2
+          rm -f "$GITHUB_WORKSPACE/pack-harvest/"*.stdout.partial
+          if [ "$EVALUATOR_RC" -eq 0 ]; then
+            mkdir -p "$GITHUB_WORKSPACE/pack-trusted"
+            cp "$GITHUB_WORKSPACE/pack-harvest/evaluate-summary.json" \
+              "$GITHUB_WORKSPACE/pack-harvest/evaluation-verification.json" \
+              "$GITHUB_WORKSPACE/pack-harvest/"*.evaluation.json \
+              "$GITHUB_WORKSPACE/pack-harvest/"*.stdout.json \
+              "$GITHUB_WORKSPACE/pack-trusted/"
+            find "$GITHUB_WORKSPACE/pack-trusted" -type f -exec chmod 0600 {} +
           fi
+          for name in evaluate-progress.ndjson evaluate-checkpoint.json evaluate-summary.json; do
+            if [ -f "$GITHUB_WORKSPACE/pack-harvest/$name" ]; then
+              cp "$GITHUB_WORKSPACE/pack-harvest/$name" "$GITHUB_WORKSPACE/pack-diagnostics/$name"
+            fi
+          done
+          find "$GITHUB_WORKSPACE/pack-harvest" -maxdepth 1 -type f -name '*.run.log' \
+            -exec cp {} "$GITHUB_WORKSPACE/pack-diagnostics/" \;
+          find "$GITHUB_WORKSPACE/pack-diagnostics" -type f -exec chmod 0600 {} +
+          PROXY_BYTES=$(wc -c < "$PROXY_LOG")
+          PROXY_SHA256=$(sha256sum "$PROXY_LOG" | awk '{print $1}')
+          jq -n \
+            --arg outcome completed \
+            --argjson bytes "$PROXY_BYTES" \
+            --arg sha256 "$PROXY_SHA256" \
+            '{outcome: $outcome, bytes: $bytes, sha256: $sha256}' \
+            > "$GITHUB_WORKSPACE/pack-diagnostics/proxy-diagnostics.json"
           if [ "$EVALUATOR_RC" -ne 0 ]; then
             printf 'evaluator_exit_code=%s\n' "$EVALUATOR_RC" \
-              > "$GITHUB_WORKSPACE/pack-results/evaluator-failure.txt"
+              > "$GITHUB_WORKSPACE/pack-diagnostics/evaluator-failure.txt"
             echo "::error::Pack evaluator exited with code $EVALUATOR_RC"
             exit "$EVALUATOR_RC"
           fi
-          jq '{attempts: [.reports[] | {scenarioId, outcome, outcomeReason}], selectedGenerationId}' \
-            "$GITHUB_WORKSPACE/pack-results/evaluate-summary.json" >> "$GITHUB_STEP_SUMMARY"
+          jq '{attempts: [.attempts[] | {scenarioId, status, outcome, durationMs}], selectedGenerationId}' \
+            "$GITHUB_WORKSPACE/pack-harvest/evaluate-summary.json" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload complete evaluation evidence
-        if: always()
+      - name: Upload trusted evaluation evidence
+        if: success()
         uses: actions/upload-artifact@v6
         with:
           name: pack-production-evaluation
-          path: pack-results/
+          path: pack-trusted/
           if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload bounded evaluation diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-diagnostics
+          path: pack-diagnostics/
+          if-no-files-found: warn
           retention-days: 90
 
   persist:

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
 import { createHash, randomUUID } from 'node:crypto';
-import { spawnSync } from 'node:child_process';
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { chmod, chown, copyFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
+import { finished } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
 
 const CLI_SCHEMA = 'pack-generation-evaluation/v2';
-const API_SCHEMA = 'skillstore.pack-evaluation/v2';
+const API_SCHEMA = 'skillstore.pack-evaluation/v3';
 const STATUS_SCHEMA = 'skillstore.pack-production-status/v1';
 const READBACK_SCHEMA = 'skillstore.pack-production-readback/v1';
 const SLO_SCHEMA = 'marketplace.pack-production-slo/v1';
@@ -18,6 +20,7 @@ const KNOWN_CLI_EXIT = new Map([
   ['evaluation_inconclusive', 20],
   ['infrastructure_failed', 30],
 ]);
+const EVALUATOR_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024;
 
 function fail(message) {
   throw new Error(message);
@@ -78,6 +81,341 @@ async function sha256File(file) {
   return sha256(await readFile(file));
 }
 
+export function normalizeEvaluatorProgressLine(line) {
+  if (typeof line !== 'string' || Buffer.byteLength(line, 'utf8') > 512) return null;
+  let match = line.match(
+    /^\[1\/5\] scenario ([a-z0-9][a-z0-9-]{0,79})@([0-9A-Za-z._-]{1,32}): [A-Za-z0-9][A-Za-z0-9 .,&()'\/-]{0,159}$/,
+  );
+  if (match) return `[1/5] scenario ${match[1]}@${match[2]}`;
+  match = line.match(/^\[2\/5\] evaluating ([1-9][0-9]*) capability slots independently$/);
+  if (match) return `[2/5] evaluating ${match[1]} capability slots independently`;
+  if (line === '[3/5] composing a slot-complete pack') return line;
+  match = line.match(/^\[4\/5\] verifying the whole pack ([1-9][0-9]*) times with deterministic artifact gates$/);
+  if (match) return `[4/5] verifying the whole pack ${match[1]} times`;
+  match = line.match(/^\[5\/5\] running ([1-9][0-9]*)-run no-skill baseline$/);
+  if (match) return `[5/5] running ${match[1]}-run no-skill baseline`;
+  match = line.match(/^\s{0,12}slot ([a-z0-9][a-z0-9-]{0,79}): finding candidates for [A-Za-z0-9 .,+_\/-]{1,200}$/);
+  if (match) return `slot ${match[1]}: finding candidates`;
+  match = line.match(
+    /^\s{0,12}slot ([a-z0-9][a-z0-9-]{0,79}): verifying ([a-z0-9][a-z0-9-]{0,79})$/,
+  );
+  if (match) return `slot ${match[1]}: verifying ${match[2]}`;
+  match = line.match(/^run ([1-9][0-9]*)\/([1-9][0-9]*): (executing task\.\.\.|judging output\.\.\.)$/);
+  if (match) return `run ${match[1]}/${match[2]}: ${match[3]}`;
+  match = line.match(
+    /^run ([1-9][0-9]*)\/([1-9][0-9]*): score=(10|[0-9])\/10 task_completed=(true|false) used_skill=(true|false)(?: artifacts=(PASS|FAIL))?(?: \[ENV-BLOCKED\])?$/,
+  );
+  if (!match) return null;
+  return `run ${match[1]}/${match[2]}: score=${match[3]}/10 task_completed=${match[4]} used_skill=${match[5]}`
+    + (match[6] ? ` artifacts=${match[6]}` : '');
+}
+
+export function isSafeEvaluatorProgressLine(line) {
+  return normalizeEvaluatorProgressLine(line) !== null;
+}
+
+export function allocateScenarioBudgetMs({
+  remainingBudgetMs,
+  remainingScenarios,
+  maxScenarioMs,
+  minimumFallbackMs,
+}) {
+  if (!Number.isSafeInteger(remainingBudgetMs) || remainingBudgetMs < 1) return 0;
+  if (!Number.isSafeInteger(remainingScenarios) || remainingScenarios < 1) {
+    fail('remainingScenarios must be a positive integer');
+  }
+  const maximum = Math.max(1, Math.floor(maxScenarioMs));
+  const fallback = Math.max(1, Math.floor(minimumFallbackMs));
+  if (remainingScenarios === 1) return Math.min(maximum, remainingBudgetMs);
+  const reservedForFallbacks = fallback * (remainingScenarios - 1);
+  const fairShare = Math.max(1, Math.floor(remainingBudgetMs / remainingScenarios));
+  const available = remainingBudgetMs - reservedForFallbacks;
+  return Math.min(maximum, Math.max(1, available > 0 ? available : fairShare));
+}
+
+function terminateEvaluatorProcesses(uid) {
+  const userId = String(uid);
+  spawnSync('/usr/bin/pkill', ['-TERM', '-u', userId], { stdio: 'ignore' });
+  spawnSync('/bin/sleep', ['0.1'], { stdio: 'ignore' });
+  spawnSync('/usr/bin/pkill', ['-KILL', '-u', userId], { stdio: 'ignore' });
+  const remaining = spawnSync('/usr/bin/pgrep', ['-u', userId], { stdio: 'ignore' });
+  if (remaining.status === 0) fail(`Evaluator uid ${userId} still has live processes`);
+}
+
+async function prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseEnv) {
+  const scenarioRoot = resolve(runtimeRoot, generationId);
+  const home = resolve(scenarioRoot, 'home');
+  const tmp = resolve(scenarioRoot, 'tmp');
+  const codexHome = resolve(scenarioRoot, 'codex-home');
+  const codexLog = resolve(codexHome, 'log');
+  const codexSessions = resolve(codexHome, 'sessions');
+  const sourceCodexHome = baseEnv.CODEX_HOME;
+  if (!sourceCodexHome) fail('CODEX_HOME is required for evaluator identity separation');
+
+  await mkdir(runtimeRoot, { recursive: true, mode: 0o711 });
+  await chmod(runtimeRoot, 0o711);
+  await mkdir(scenarioRoot, { recursive: true, mode: 0o711 });
+  await chmod(scenarioRoot, 0o711);
+  await Promise.all([
+    mkdir(home, { recursive: true, mode: 0o700 }),
+    mkdir(tmp, { recursive: true, mode: 0o700 }),
+    mkdir(codexHome, { recursive: true, mode: 0o555 }),
+    mkdir(codexLog, { recursive: true, mode: 0o700 }),
+    mkdir(codexSessions, { recursive: true, mode: 0o700 }),
+  ]);
+  await Promise.all([
+    chown(home, uid, gid),
+    chown(tmp, uid, gid),
+    chown(codexLog, uid, gid),
+    chown(codexSessions, uid, gid),
+  ]);
+  await Promise.all([
+    chmod(home, 0o700),
+    chmod(tmp, 0o700),
+    chmod(codexHome, 0o555),
+    chmod(codexLog, 0o700),
+    chmod(codexSessions, 0o700),
+  ]);
+  const configFile = resolve(codexHome, 'config.toml');
+  await copyFile(resolve(sourceCodexHome, 'config.toml'), configFile);
+  await chmod(configFile, 0o444);
+
+  return {
+    cwd: home,
+    env: {
+      ...baseEnv,
+      HOME: home,
+      TMPDIR: tmp,
+      CODEX_HOME: codexHome,
+    },
+  };
+}
+
+export async function runEvaluatorProcess(command, commandArgs, options) {
+  const startedAt = Date.now();
+  const stdoutStream = createWriteStream(options.stdoutFile, { flags: 'w', mode: 0o600 });
+  const stderrStream = createWriteStream(options.stderrFile, { flags: 'w', mode: 0o600 });
+  const progressStream = createWriteStream(options.progressFile, { flags: 'a', mode: 0o600 });
+  const onProgress = options.onProgress ?? ((message) => process.stderr.write(`${message}\n`));
+  const heartbeatMs = positiveInteger(options.heartbeatMs, 'heartbeat-ms', 60_000);
+  const timeoutMs = positiveInteger(options.timeoutMs, 'scenario-timeout-ms', 150 * 60_000);
+  const killGraceMs = positiveInteger(options.killGraceMs, 'kill-grace-ms', 10_000);
+  const label = options.label ?? 'unknown';
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let outputExceeded = false;
+  let timedOut = false;
+  let interruptedSignal = null;
+  let stderrRemainder = '';
+  let killTimer = null;
+  const stderrDigest = createHash('sha256');
+  let checkpointWrites = Promise.resolve();
+  let checkpointError = null;
+  let progressSequence = options.progressSequenceStart ?? 0;
+
+  const writeProgressEvent = (event) => {
+    const entry = {
+      schemaVersion: 'marketplace.pack-production-progress/v1',
+      seq: ++progressSequence,
+      at: new Date().toISOString(),
+      ...event,
+    };
+    progressStream.write(`${JSON.stringify(entry)}\n`);
+    if (options.checkpointFile) {
+      const temporary = `${options.checkpointFile}.tmp`;
+      checkpointWrites = checkpointWrites
+        .then(() => writeFile(temporary, `${JSON.stringify(entry, null, 2)}\n`, { mode: 0o600 }))
+        .then(() => rename(temporary, options.checkpointFile))
+        .catch((error) => {
+          checkpointError ??= error;
+        });
+    }
+  };
+
+  writeProgressEvent({
+    event: 'scenario.started',
+    scenarioId: label,
+    generationId: options.generationId ?? null,
+    scenarioIndex: options.scenarioIndex ?? null,
+    scenarioCount: options.scenarioCount ?? null,
+    timeoutMs,
+  });
+  onProgress(`[pack-evaluator] scenario=${label} started timeout=${Math.ceil(timeoutMs / 60_000)}m`);
+
+  const child = spawn(command, commandArgs, {
+    cwd: options.cwd,
+    env: options.env,
+    ...(options.uid == null ? {} : { uid: options.uid }),
+    ...(options.gid == null ? {} : { gid: options.gid }),
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const signalProcessGroup = (signal) => {
+    if (process.platform !== 'win32' && child.pid) {
+      try {
+        process.kill(-child.pid, signal);
+        return;
+      } catch {
+        // The group may already be gone; fall through to the direct child.
+      }
+    }
+    child.kill(signal);
+  };
+
+  const requestTermination = (reason, signal = 'SIGTERM') => {
+    writeProgressEvent({
+      event: reason,
+      scenarioId: label,
+      elapsedMs: Date.now() - startedAt,
+      signal,
+    });
+    signalProcessGroup(signal);
+    if (killTimer == null) {
+      killTimer = setTimeout(() => signalProcessGroup('SIGKILL'), killGraceMs);
+    }
+  };
+
+  const stopForOutputLimit = (kind) => {
+    if (outputExceeded) return;
+    outputExceeded = true;
+    onProgress(`[pack-evaluator] scenario=${label} stopped: ${kind} exceeded 16 MiB`);
+    requestTermination('scenario.output_limit_exceeded');
+    child.stdout.destroy();
+    child.stderr.destroy();
+  };
+
+  const writeBoundedStdout = (chunk) => {
+    if (outputExceeded) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const previous = stdoutBytes;
+    const remaining = Math.max(0, EVALUATOR_OUTPUT_LIMIT_BYTES - stdoutBytes);
+    if (remaining > 0) stdoutStream.write(buffer.subarray(0, remaining));
+    stdoutBytes += buffer.length;
+    if (previous + buffer.length > EVALUATOR_OUTPUT_LIMIT_BYTES) stopForOutputLimit('stdout');
+  };
+
+  const recordSafeProgress = (line) => {
+    const message = normalizeEvaluatorProgressLine(line);
+    if (!message) return;
+    stderrStream.write(`${message}\n`);
+    writeProgressEvent({
+      event: 'scenario.progress',
+      scenarioId: label,
+      elapsedMs: Date.now() - startedAt,
+      message,
+    });
+    onProgress(`[pack-evaluator] scenario=${label} ${message}`);
+  };
+
+  child.stdout.on('data', writeBoundedStdout);
+  child.stderr.on('data', (chunk) => {
+    if (outputExceeded) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const previous = stderrBytes;
+    stderrBytes += buffer.length;
+    const remaining = Math.max(0, EVALUATOR_OUTPUT_LIMIT_BYTES - previous);
+    if (remaining > 0) stderrDigest.update(buffer.subarray(0, remaining));
+    if (previous + buffer.length > EVALUATOR_OUTPUT_LIMIT_BYTES) {
+      stopForOutputLimit('stderr');
+      return;
+    }
+    const text = `${stderrRemainder}${chunk.toString('utf8')}`;
+    const lines = text.split(/\r?\n/);
+    stderrRemainder = lines.pop() ?? '';
+    if (stderrRemainder.length > 4096) stderrRemainder = '';
+    for (const line of lines) recordSafeProgress(line);
+  });
+
+  const heartbeatTimer = setInterval(() => {
+    const elapsedMs = Date.now() - startedAt;
+    writeProgressEvent({
+      event: 'scenario.heartbeat',
+      scenarioId: label,
+      elapsedMs,
+    });
+    onProgress(`[pack-evaluator] scenario=${label} heartbeat elapsed=${Math.floor(elapsedMs / 1000)}s`);
+  }, heartbeatMs);
+  const scenarioTimer = setTimeout(() => {
+    timedOut = true;
+    onProgress(`[pack-evaluator] scenario=${label} reached its ${Math.ceil(timeoutMs / 60_000)}m hard limit`);
+    requestTermination('scenario.timeout');
+  }, timeoutMs);
+  const onSignal = (signal) => {
+    interruptedSignal ??= signal;
+    requestTermination('scenario.signal_received', signal);
+  };
+  const onSigint = () => onSignal('SIGINT');
+  const onSigterm = () => onSignal('SIGTERM');
+  const onSighup = () => onSignal('SIGHUP');
+  process.once('SIGINT', onSigint);
+  process.once('SIGTERM', onSigterm);
+  process.once('SIGHUP', onSighup);
+
+  let result;
+  let processError = null;
+  try {
+    result = await new Promise((resolveChild, rejectChild) => {
+      child.once('error', rejectChild);
+      child.once('close', (status, signal) => resolveChild({ status, signal }));
+    });
+  } catch (error) {
+    processError = error;
+    writeProgressEvent({
+      event: 'scenario.spawn_failed',
+      scenarioId: label,
+      elapsedMs: Date.now() - startedAt,
+      errorCode: error?.code ?? null,
+    });
+  } finally {
+    signalProcessGroup('SIGTERM');
+    await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+    signalProcessGroup('SIGKILL');
+    clearInterval(heartbeatTimer);
+    clearTimeout(scenarioTimer);
+    if (killTimer != null) clearTimeout(killTimer);
+    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGTERM', onSigterm);
+    process.removeListener('SIGHUP', onSighup);
+    if (stderrRemainder) recordSafeProgress(stderrRemainder);
+    writeProgressEvent({
+      event: 'scenario.process_exited',
+      scenarioId: label,
+      elapsedMs: Date.now() - startedAt,
+      status: result?.status ?? null,
+      signal: result?.signal ?? null,
+      timedOut,
+      outputExceeded,
+      stdoutBytes,
+      stderrBytes,
+      stderrSha256: stderrDigest.digest('hex'),
+      interruptedSignal,
+    });
+    stdoutStream.end();
+    stderrStream.end();
+    progressStream.end();
+    await Promise.all([
+      finished(stdoutStream),
+      finished(stderrStream),
+      finished(progressStream),
+    ]);
+    await checkpointWrites;
+  }
+
+  if (processError) throw processError;
+  if (checkpointError) throw new Error(`Unable to write evaluator checkpoint: ${checkpointError.message}`);
+  return {
+    ...result,
+    timedOut,
+    outputExceeded,
+    interruptedSignal,
+    stdoutBytes,
+    stderrBytes,
+    durationMs: Date.now() - startedAt,
+    progressSequence,
+  };
+}
+
 async function readJson(file) {
   return JSON.parse(await readFile(file, 'utf8'));
 }
@@ -108,7 +446,9 @@ function artifactReferences(raw) {
 function apiVerdicts(raw) {
   return (raw.packVerification?.verdicts ?? []).map((verdict) => ({
     usedSkill: Boolean(verdict.used_skill),
+    usedSkills: Array.isArray(verdict.used_skills) ? [...new Set(verdict.used_skills.map(String))] : [],
     taskCompleted: Boolean(verdict.task_completed),
+    artifactVerified: verdict.artifact_requirements_met === true,
     envBlocked: Boolean(verdict.env_blocked),
     score: Number(verdict.score),
     reason: String(verdict.reason || 'No grader reason supplied'),
@@ -116,11 +456,62 @@ function apiVerdicts(raw) {
   }));
 }
 
+function requiredCapabilitySlots(raw) {
+  if (!Array.isArray(raw.scenario?.capabilitySlots)) {
+    fail('candidate_ready scenario lacks capability slot evidence');
+  }
+  const required = raw.scenario.capabilitySlots
+    .filter((slot) => slot?.required === true)
+    .map((slot) => String(slot.id ?? ''));
+  if (
+    required.length < 1
+    || new Set(required).size !== required.length
+    || required.some((slot) => !/^[a-z0-9][a-z0-9-]{0,79}$/.test(slot))
+  ) {
+    fail('candidate_ready scenario has invalid required capability slots');
+  }
+  return required;
+}
+
+function apiSlotAssignments(raw, manifestSkills, requiredSlots) {
+  const source = raw.manifest?.slot_assignments;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    fail('candidate_ready manifest lacks slot assignment evidence');
+  }
+  const manifestSkillSet = new Set(manifestSkills);
+  const assignments = {};
+  for (const [slotId, values] of Object.entries(source)) {
+    if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(slotId) || !Array.isArray(values)) {
+      fail(`candidate_ready manifest has invalid assignment for slot ${slotId}`);
+    }
+    const skills = [...new Set(values.map(String))];
+    if (skills.length !== values.length || skills.some((skill) => !manifestSkillSet.has(skill))) {
+      fail(`candidate_ready slot ${slotId} has duplicate or non-manifest Skills`);
+    }
+    assignments[slotId] = skills;
+  }
+  for (const slotId of requiredSlots) {
+    if (!Array.isArray(assignments[slotId]) || assignments[slotId].length < 1) {
+      fail(`candidate_ready required slot ${slotId} is not assigned`);
+    }
+  }
+  if (Object.keys(assignments).length !== requiredSlots.length) {
+    fail('candidate_ready manifest contains non-required capability slot assignments');
+  }
+  const assignedSkills = new Set(Object.values(assignments).flat());
+  if (manifestSkills.some((skill) => !assignedSkills.has(skill))) {
+    fail('candidate_ready manifest contains a Skill with no slot assignment');
+  }
+  return assignments;
+}
+
 export function buildApiEvaluation(raw, context) {
   if (raw.schemaVersion !== CLI_SCHEMA) fail(`Unsupported CLI report schema: ${raw.schemaVersion}`);
   if (!KNOWN_CLI_EXIT.has(raw.outcome)) fail(`Unsupported CLI outcome: ${raw.outcome}`);
   if (raw.generationId !== context.generationId) fail('CLI report generationId changed during evaluation');
   if (raw.scenario?.id !== context.scenarioId) fail('CLI report scenario differs from the queue plan');
+
+  const requiredSlots = requiredCapabilitySlots(raw);
 
   let candidate = null;
   if (raw.outcome === 'candidate_ready') {
@@ -133,6 +524,60 @@ export function buildApiEvaluation(raw, context) {
     const references = artifactReferences(raw);
     const artifactKind = raw.scenario.requiredArtifacts?.length > 0 ? 'file' : 'text';
     const produced = artifactKind === 'file' ? references.length > 0 : summary.taskCompletedRate === 1;
+    const manifestSkills = Array.isArray(raw.manifest.skills) ? raw.manifest.skills.map(String) : [];
+    const manifestSkillSet = new Set(manifestSkills);
+    if (manifestSkills.length < 2 || manifestSkillSet.size !== manifestSkills.length) {
+      fail('candidate_ready report must contain at least two distinct manifest Skills');
+    }
+    const slotAssignments = apiSlotAssignments(raw, manifestSkills, requiredSlots);
+    if (verdicts.length !== 3) fail('candidate_ready report must contain exactly three final-run verdicts');
+    verdicts.forEach((verdict, index) => {
+      if (verdict.usedSkill !== (verdict.usedSkills.length > 0)) {
+        fail(`candidate_ready run ${index + 1} has inconsistent used_skill and used_skills evidence`);
+      }
+      if (verdict.usedSkills.length < 2) {
+        fail(`candidate_ready run ${index + 1} used fewer than two distinct Skills`);
+      }
+      if (verdict.usedSkills.some((skill) => !manifestSkillSet.has(skill))) {
+        fail(`candidate_ready run ${index + 1} claims Skill use outside the manifest`);
+      }
+      if (!verdict.taskCompleted || !verdict.artifactVerified || verdict.envBlocked || verdict.score < 7) {
+        fail(`candidate_ready run ${index + 1} did not pass the task, artifact, environment, and score gates`);
+      }
+    });
+    const verdictUsedSkills = [...new Set(verdicts.flatMap((verdict) => verdict.usedSkills))].sort();
+    const summaryUsedSkills = Array.isArray(summary.usedSkills)
+      ? [...new Set(summary.usedSkills.map(String))].sort()
+      : [];
+    if (canonicalJson(verdictUsedSkills) !== canonicalJson(summaryUsedSkills)) {
+      fail('candidate_ready summary usedSkills differs from final-run verdicts');
+    }
+    if (manifestSkills.some((skill) => !summaryUsedSkills.includes(skill))) {
+      fail('candidate_ready manifest contains a Skill with no final-run use evidence');
+    }
+    const minimumDistinctSkillsUsed = Number(summary.minimumDistinctSkillsUsed);
+    const distinctSkillUseRate = Number(summary.distinctSkillUseRate);
+    const minimumScore = Number(summary.minimumScore);
+    const minimumRunScore = Number(summary.minimumRunScore);
+    if (
+      minimumDistinctSkillsUsed < 2
+      || distinctSkillUseRate !== 1
+      || minimumScore < 7
+      || minimumRunScore < 7
+    ) {
+      fail('candidate_ready summary does not satisfy the multi-Skill and per-run score gates');
+    }
+    if (raw.composition?.fallbackUsed) fail('candidate_ready report used composition fallback');
+    const baselineScores = Array.isArray(baseline.scores) ? baseline.scores.map(Number) : [];
+    const baselineRuns = Number(baseline.runs);
+    const baselineErrors = (raw.baselineVerification?.errors ?? []).map(String);
+    if (
+      baselineRuns !== 3
+      || baselineScores.length !== baselineRuns
+      || baselineScores.some((score) => !Number.isFinite(score) || score < 0 || score > 10)
+    ) {
+      fail('candidate_ready baseline lacks exactly three valid run scores');
+    }
     candidate = {
       manifest: {
         name: raw.manifest.name,
@@ -140,7 +585,8 @@ export function buildApiEvaluation(raw, context) {
         description: raw.manifest.description,
         scenarioTags: raw.manifest.scenario_tags,
         riskFlags: raw.manifest.risk_flags,
-        skills: raw.manifest.skills,
+        skills: manifestSkills,
+        slotAssignments,
         rationale: raw.manifest.rationale,
       },
       fitness: {
@@ -148,8 +594,14 @@ export function buildApiEvaluation(raw, context) {
         passed: Boolean(summary.passed && summary.usedSkillEver),
         runs: verdicts.length,
         usedSkillRate: summary.usedSkillRate,
+        usedSkills: summaryUsedSkills,
+        minimumDistinctSkillsUsed,
+        distinctSkillUseRate,
+        minimumScore,
+        minimumRunScore,
         taskCompletionRate: summary.taskCompletedRate,
         envBlockedRate: summary.envBlockedRate,
+        compositionFallbackUsed: Boolean(raw.composition?.fallbackUsed),
         artifact: {
           kind: artifactKind,
           produced,
@@ -157,11 +609,16 @@ export function buildApiEvaluation(raw, context) {
           references,
         },
         baseline: {
+          runs: baselineRuns,
+          scores: baselineScores,
           score: baseline.medianScore,
           improvement: summary.medianScore - baseline.medianScore,
+          errors: baselineErrors,
         },
         verdicts,
         errors: [
+          ...(raw.errors ?? []).map((error) => `evaluation: ${error}`),
+          ...(raw.composition?.errors ?? []).map((error) => `composition: ${error}`),
           ...(raw.packVerification?.errors ?? []).map((error) => `pack: ${error}`),
           ...(raw.baselineVerification?.errors ?? []).map((error) => `baseline: ${error}`),
         ],
@@ -186,6 +643,7 @@ export function buildApiEvaluation(raw, context) {
       slug: raw.scenario.slug,
       name: raw.scenario.name,
       tags: raw.scenario.tags,
+      requiredCapabilitySlots: requiredSlots,
     },
     evaluator: {
       cliVersion: context.cliVersion,
@@ -237,7 +695,26 @@ async function evaluate(args) {
   const expectedVersion = required(args, 'expected-cli-version');
   if (version !== expectedVersion) fail(`CLI version mismatch: expected ${expectedVersion}, got ${version}`);
   const checksum = await sha256File(cli);
+  const evaluationBudgetMs = positiveInteger(
+    args['evaluation-budget-ms'],
+    'evaluation-budget-ms',
+    230 * 60_000,
+  );
+  const maxScenarioMs = positiveInteger(
+    args['scenario-timeout-ms'],
+    'scenario-timeout-ms',
+    120 * 60_000,
+  );
+  const minimumFallbackMs = positiveInteger(
+    args['minimum-fallback-ms'],
+    'minimum-fallback-ms',
+    45 * 60_000,
+  );
+  const progressFile = resolve(resultsDir, 'evaluate-progress.ndjson');
+  const checkpointFile = resolve(resultsDir, 'evaluate-checkpoint.json');
+  await writeFile(progressFile, '', { mode: 0o600 });
   const reports = [];
+  const attempts = [];
   const hasEvaluatorIdentity = args['evaluator-uid'] != null || args['evaluator-gid'] != null;
   if (hasEvaluatorIdentity && (args['evaluator-uid'] == null || args['evaluator-gid'] == null)) {
     fail('--evaluator-uid and --evaluator-gid must be supplied together');
@@ -251,13 +728,51 @@ async function evaluate(args) {
   const evaluatorCwd = hasEvaluatorIdentity
     ? resolve(required(args, 'evaluator-cwd'))
     : process.cwd();
+  const evaluatorRuntimeRoot = hasEvaluatorIdentity
+    ? resolve(required(args, 'evaluator-runtime-root'))
+    : null;
   if (hasEvaluatorIdentity && typeof process.getuid === 'function' && process.getuid() !== 0) {
     fail('Evaluator identity separation requires a root orchestrator');
   }
+  const evaluationDeadline = Date.now() + evaluationBudgetMs;
+  let interruptedSignal = null;
+  let progressSequence = 0;
 
-  for (const scenario of plan.scenarios) {
+  const buildSummary = () => ({
+    schemaVersion: 'marketplace.pack-production-evaluate/v1',
+    cliVersion: version,
+    cliSha256: checksum,
+    evaluationBudgetMs,
+    attempts,
+    reports,
+    selectedGenerationId: reports.find((report) => report.outcome === 'candidate_ready')?.generationId ?? null,
+  });
+
+  const checkpointSummary = async () => {
+    await writeJson(resolve(resultsDir, 'evaluate-summary.json'), buildSummary());
+  };
+
+  for (const [scenarioIndex, scenario] of plan.scenarios.entries()) {
     if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(scenario.id || '')) fail(`Unsafe scenario id: ${scenario.id}`);
-    const ordinal = String(reports.length + 1).padStart(2, '0');
+    const remainingBudgetMs = evaluationDeadline - Date.now();
+    const scenarioBudgetMs = allocateScenarioBudgetMs({
+      remainingBudgetMs,
+      remainingScenarios: plan.scenarios.length - scenarioIndex,
+      maxScenarioMs,
+      minimumFallbackMs,
+    });
+    if (scenarioBudgetMs < 1) {
+      attempts.push({
+        planIndex: scenarioIndex,
+        scenarioId: scenario.id,
+        generationId: null,
+        status: 'budget_exhausted',
+        durationMs: 0,
+      });
+      await checkpointSummary();
+      break;
+    }
+    const ordinal = String(scenarioIndex + 1).padStart(2, '0');
     const generationId = randomUUID();
     const context = workflowContext(args, generationId, scenario.id, cli, version, checksum);
     const commandArgs = [
@@ -276,51 +791,126 @@ async function evaluate(args) {
       '--auto-publish-threshold', args['auto-publish-threshold'] ?? '8',
       '--json',
     ];
-    const result = spawnSync(cli, commandArgs, {
-      cwd: evaluatorCwd,
-      encoding: 'utf8',
-      maxBuffer: 16 * 1024 * 1024,
-      ...(hasEvaluatorIdentity ? { uid: evaluatorUid, gid: evaluatorGid } : {}),
-      env: {
-        ...process.env,
-        SKILLSTORE_AGENT_ENV_MODE: 'strict',
-      },
-    });
-    if (result.error) fail(`Evaluator process failed for ${scenario.id}: ${result.error.message}`);
-    await writeFile(resolve(resultsDir, `${ordinal}-${scenario.id}.stdout.json`), result.stdout || '');
-    await writeFile(resolve(resultsDir, `${ordinal}-${scenario.id}.run.log`), result.stderr || '');
+    const partialStdoutFile = resolve(resultsDir, `${ordinal}-${scenario.id}.stdout.partial`);
+    const stdoutFile = resolve(resultsDir, `${ordinal}-${scenario.id}.stdout.json`);
+    const runLogFile = resolve(resultsDir, `${ordinal}-${scenario.id}.run.log`);
+    const baseEnv = {
+      ...process.env,
+      SKILLSTORE_AGENT_ENV_MODE: 'strict',
+    };
+    let runtime = { cwd: evaluatorCwd, env: baseEnv };
+    let result;
+    try {
+      if (hasEvaluatorIdentity) {
+        terminateEvaluatorProcesses(evaluatorUid);
+        runtime = await prepareScenarioRuntime(
+          evaluatorRuntimeRoot,
+          generationId,
+          evaluatorUid,
+          evaluatorGid,
+          baseEnv,
+        );
+      }
+      result = await runEvaluatorProcess(cli, commandArgs, {
+        cwd: runtime.cwd,
+        stdoutFile: partialStdoutFile,
+        stderrFile: runLogFile,
+        progressFile,
+        checkpointFile,
+        label: scenario.id,
+        generationId,
+        scenarioIndex: scenarioIndex + 1,
+        scenarioCount: plan.scenarios.length,
+        progressSequenceStart: progressSequence,
+        timeoutMs: scenarioBudgetMs,
+        ...(hasEvaluatorIdentity ? { uid: evaluatorUid, gid: evaluatorGid } : {}),
+        env: runtime.env,
+      });
+    } catch (error) {
+      attempts.push({
+        planIndex: scenarioIndex,
+        scenarioId: scenario.id,
+        generationId,
+        status: 'spawn_failed',
+        durationMs: 0,
+        errorCode: error?.code ?? null,
+      });
+      await checkpointSummary();
+      break;
+    } finally {
+      if (hasEvaluatorIdentity) terminateEvaluatorProcesses(evaluatorUid);
+    }
+    const attempt = {
+      planIndex: scenarioIndex,
+      scenarioId: scenario.id,
+      generationId,
+      durationMs: result.durationMs,
+      timeoutMs: scenarioBudgetMs,
+    };
+    progressSequence = result.progressSequence;
+    if (result.interruptedSignal) {
+      interruptedSignal = result.interruptedSignal;
+      attempts.push({ ...attempt, status: 'cancelled', signal: result.interruptedSignal });
+      await checkpointSummary();
+      break;
+    }
+    if (result.timedOut) {
+      attempts.push({ ...attempt, status: 'timed_out' });
+      await checkpointSummary();
+      continue;
+    }
+    if (result.outputExceeded) {
+      attempts.push({ ...attempt, status: 'output_limit_exceeded' });
+      await checkpointSummary();
+      continue;
+    }
+    const stdout = await readFile(partialStdoutFile, 'utf8');
     let raw;
     try {
-      raw = JSON.parse(result.stdout);
+      raw = JSON.parse(stdout);
     } catch {
-      fail(`Evaluator returned invalid JSON for ${scenario.id} (exit ${result.status}): ${result.stderr}`);
+      attempts.push({
+        ...attempt,
+        status: 'terminal_report_missing',
+        exitCode: result.status ?? null,
+        signal: result.signal ?? null,
+      });
+      await checkpointSummary();
+      continue;
     }
     const expectedExit = KNOWN_CLI_EXIT.get(raw.outcome);
     if (result.status !== expectedExit) {
       fail(`Evaluator exit/outcome mismatch for ${scenario.id}: exit ${result.status}, outcome ${raw.outcome}`);
     }
+    await rename(partialStdoutFile, stdoutFile);
     const evaluation = buildApiEvaluation(raw, context);
     const file = resolve(resultsDir, `${ordinal}-${scenario.id}.evaluation.json`);
     await writeJson(file, evaluation);
     reports.push({
+      planIndex: scenarioIndex,
       scenarioId: scenario.id,
       generationId,
       outcome: raw.outcome,
       outcomeReason: raw.outcomeReason,
       file,
     });
+    attempts.push({ ...attempt, status: 'completed', outcome: raw.outcome });
+    await checkpointSummary();
     if (raw.outcome === 'candidate_ready') break;
   }
 
-  const summary = {
-    schemaVersion: 'marketplace.pack-production-evaluate/v1',
-    cliVersion: version,
-    cliSha256: checksum,
-    reports,
-    selectedGenerationId: reports.find((report) => report.outcome === 'candidate_ready')?.generationId ?? null,
-  };
-  await writeJson(resolve(resultsDir, 'evaluate-summary.json'), summary);
+  const summary = buildSummary();
+  await checkpointSummary();
   process.stdout.write(`${JSON.stringify(summary)}\n`);
+  if (interruptedSignal) fail(`Evaluator interrupted by ${interruptedSignal}`);
+  const operationalFailures = attempts.filter((attempt) => attempt.status !== 'completed');
+  if (operationalFailures.length > 0) {
+    fail(
+      `Evaluation contained operationally incomplete attempts: `
+      + operationalFailures.map((attempt) => `${attempt.scenarioId}:${attempt.status}`).join(', '),
+    );
+  }
+  if (reports.length === 0) fail('No scenario produced a complete trusted evaluation report');
 }
 
 async function verifyEvaluation(args) {
@@ -338,6 +928,16 @@ async function verifyEvaluation(args) {
   if (!Array.isArray(summary.reports) || summary.reports.length < 1 || summary.reports.length > plan.scenarios.length) {
     fail('Evaluate summary report count is outside the immutable plan');
   }
+  if (!Array.isArray(summary.attempts) || summary.attempts.length < 1) {
+    fail('Evaluate summary attempts are missing');
+  }
+  const incompleteAttempts = summary.attempts.filter((attempt) => attempt?.status !== 'completed');
+  if (incompleteAttempts.length > 0) {
+    fail(
+      `Evaluate summary contains operationally incomplete attempts: `
+      + incompleteAttempts.map((attempt) => `${attempt?.scenarioId ?? 'unknown'}:${attempt?.status ?? 'missing'}`).join(', '),
+    );
+  }
 
   const version = cliVersion(cli);
   const expectedVersion = required(args, 'expected-cli-version');
@@ -351,16 +951,23 @@ async function verifyEvaluation(args) {
   const verifiedFiles = [];
   let selectedGenerationId = null;
   let candidateSeen = false;
+  let previousPlanIndex = -1;
   for (const [index, report] of summary.reports.entries()) {
-    const scenario = plan.scenarios[index];
-    if (!scenario || report.scenarioId !== scenario.id) fail('Evaluate summary scenario order differs from the plan');
+    const planIndex = report.planIndex ?? index;
+    if (!Number.isSafeInteger(planIndex) || planIndex < 0 || planIndex >= plan.scenarios.length) {
+      fail(`Invalid evaluate summary plan index: ${report.planIndex}`);
+    }
+    if (planIndex <= previousPlanIndex) fail('Evaluate summary plan indexes are not strictly increasing');
+    previousPlanIndex = planIndex;
+    const scenario = plan.scenarios[planIndex];
+    if (!scenario || report.scenarioId !== scenario.id) fail('Evaluate summary scenario differs from the immutable plan');
     if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(scenario.id)) fail(`Unsafe scenario id: ${scenario.id}`);
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(report.generationId || '')) {
       fail(`Invalid generation id for ${scenario.id}`);
     }
     if (candidateSeen) fail('Evaluate summary contains reports after a ready candidate');
 
-    const ordinal = String(index + 1).padStart(2, '0');
+    const ordinal = String(planIndex + 1).padStart(2, '0');
     const prefix = `${ordinal}-${scenario.id}`;
     const stdoutFile = `${prefix}.stdout.json`;
     const evaluationFile = `${prefix}.evaluation.json`;

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -80,6 +80,8 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /--evaluator-uid "\$PACKEVAL_UID"/);
   assert.match(evaluate, /--evaluator-gid "\$PACKEVAL_GID"/);
   assert.match(evaluate, /--evaluator-cwd \/home\/packeval/);
+  assert.match(evaluate, /--evaluator-runtime-root \/opt\/pack-evaluator\/generations/);
+  assert.match(evaluate, /! test -w \/opt\/pack-evaluator\/generations/);
   assert.match(evaluate, /sudo -u packproxy env -i/);
   assert.match(evaluate, /sudo -u packeval env -i/);
   assert.match(evaluate, /! sudo -n true/);
@@ -101,7 +103,8 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /PACK_EVALUATOR_MAX_CONCURRENT=4/);
   assert.match(evaluate, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS=65536/);
   assert.match(evaluate, /Pack evaluator proxy did not become healthy within 30 seconds/);
-  assert.match(evaluate, /proxy-failure\.log/);
+  assert.match(evaluate, /proxy-diagnostics\.json/);
+  assert.doesNotMatch(evaluate, /sed -E .*Bearer|proxy\.log|proxy-failure\.log/);
   assert.match(evaluate, /evaluator-failure\.txt/);
   assert.match(evaluate, /pkill -TERM -u packeval/);
   assert.match(evaluate, /pkill -KILL -u packeval/);
@@ -111,9 +114,9 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /RESULT_FILES=.*find \/opt\/pack-evaluator\/results -type f/);
   assert.match(evaluate, /find \/opt\/pack-evaluator\/results ! -type f ! -type d/);
   assert.match(evaluate, /cp -a \/opt\/pack-evaluator\/results\/\./);
-  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-results" -type d -exec chmod 0700/);
-  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-results" -type f -exec chmod 0600/);
-  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-results" ! -type f ! -type d/);
+  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-harvest" -type d -exec chmod 0700/);
+  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-harvest" -type f -exec chmod 0600/);
+  assert.match(evaluate, /find "\$GITHUB_WORKSPACE\/pack-harvest" ! -type f ! -type d/);
   const preflightIndex = evaluate.indexOf('if ! sudo -u packeval env -i');
   const relaxedErrorIndex = evaluate.indexOf('set +e', preflightIndex);
   const evaluatorIndex = evaluate.indexOf('sudo env -i', relaxedErrorIndex);
@@ -122,10 +125,46 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(evaluatorIndex > relaxedErrorIndex);
   assert.match(evaluate, /pack-production\.mjs verify/);
   assert.match(evaluate, /trusted evaluation closure verification failed/);
-  assert.match(evaluate, /timeout --signal=TERM 4h/);
+  assert.match(evaluate, /timeout --signal=TERM --kill-after=30s 4h/);
   assert.match(evaluate, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy request budget exhausted/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy token has expired/);
+});
+
+test('evaluate emits bounded progress and checkpoints cancellation-safe evidence', () => {
+  const evaluate = section('  evaluate:', '  persist:');
+  assert.match(evaluate, /checkpoint_loop\(\)/);
+  assert.match(evaluate, /checkpoint_loop\(\) \{\n\s+trap - EXIT INT TERM/);
+  assert.match(evaluate, /flock -x 9/);
+  assert.match(evaluate, /\.tmp\.\$\{BASHPID\}/);
+  assert.match(evaluate, /mv -f "\$temporary"/);
+  assert.match(evaluate, /sleep 30/);
+  assert.match(evaluate, /evaluate-progress\.ndjson/);
+  assert.match(evaluate, /evaluate-checkpoint\.json/);
+  assert.match(evaluate, /evaluate-summary\.json/);
+  assert.match(evaluate, /evaluator-interrupted\.txt/);
+  assert.doesNotMatch(evaluate, /proxy-interrupted\.log/);
+  assert.match(evaluate, /EVALUATOR_FINISHED=false/);
+  assert.match(evaluate, /EVALUATOR_PID=\$!/);
+  assert.match(evaluate, /wait "\$EVALUATOR_PID"/);
+  assert.match(evaluate, /trap 'terminate_step 143' TERM/);
+  assert.match(evaluate, /trap 'terminate_step 130' INT/);
+  assert.match(evaluate, /trap 'terminate_step 129' HUP/);
+  assert.match(evaluate, /--evaluation-budget-ms 13800000/);
+  assert.match(evaluate, /--scenario-timeout-ms 7200000/);
+  assert.match(evaluate, /--minimum-fallback-ms 2700000/);
+  assert.match(evaluate, /name: Upload trusted evaluation evidence\n\s+if: success\(\)/);
+  assert.match(evaluate, /name: Upload bounded evaluation diagnostics\n\s+if: always\(\)/);
+  assert.match(evaluate, /name: pack-production-diagnostics/);
+  assert.match(evaluate, /if-no-files-found: warn/);
+  assert.match(evaluate, /path: pack-trusted\//);
+  assert.match(evaluate, /path: pack-diagnostics\//);
+  assert.doesNotMatch(evaluate, /path: pack-harvest\//);
+  assert.doesNotMatch(evaluate, /pack-diagnostics\/.*stdout\.(?:partial|json)/);
+  const checkpointIndex = evaluate.indexOf('checkpoint_loop &');
+  const evaluatorIndex = evaluate.indexOf('"$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs evaluate', checkpointIndex);
+  const finishIndex = evaluate.indexOf('EVALUATOR_FINISHED=true', evaluatorIndex);
+  assert.ok(checkpointIndex >= 0 && evaluatorIndex > checkpointIndex && finishIndex > evaluatorIndex);
 });
 
 test('planning is bounded to three artifact scenarios and CLI release is immutable', () => {
@@ -144,7 +183,7 @@ test('planning is bounded to three artifact scenarios and CLI release is immutab
   assert.match(evaluate, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.9\.0'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.10\.0'/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
   assert.match(plan, /repositories: marketplace,skillstore/);
@@ -161,7 +200,7 @@ test('trusted phases use the Automation API and retain full evidence for 90 days
   assert.match(finalize, /pack-production\.mjs finalize/);
   assert.match(finalize, /final-result\.json/);
   assert.match(finalize, /pack-production\.mjs finalize/);
-  assert.equal((WORKFLOW.match(/retention-days: 90/g) ?? []).length, 5);
+  assert.equal((WORKFLOW.match(/retention-days: 90/g) ?? []).length, 6);
   assert.match(finalize, /PACK_PRODUCTION_AUTO_PUBLISH_ENABLED == 'true'/);
   assert.match(WORKFLOW, /auto_publish:[\s\S]*?default: false/);
 });

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -12,11 +12,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  allocateScenarioBudgetMs,
   buildApiEvaluation,
   buildPublicReadbackExpectation,
   buildSloResult,
   canonicalJson,
+  isSafeEvaluatorProgressLine,
+  normalizeEvaluatorProgressLine,
   readExactPublicPack,
+  runEvaluatorProcess,
   validatePublicPackReadback,
 } from '../pack-production.mjs';
 
@@ -32,6 +36,11 @@ function cliReport() {
     envBlockedRate: 0,
     envBlocked: false,
     usedSkillEver: true,
+    usedSkills: ['spreadsheet-skill', 'workbook-validator'],
+    minimumDistinctSkillsUsed: 2,
+    distinctSkillUseRate: 1,
+    minimumScore: 8,
+    minimumRunScore: 7,
     taskCompletedRate: 1,
     taskCompletedEver: true,
     taskCompletedThreshold: 1,
@@ -56,7 +65,7 @@ function cliReport() {
       tags: ['excel', 'dashboard'],
       keywords: ['xlsx'],
       task: 'Create a real workbook.',
-      capabilitySlots: [{ id: 'workbook', required: true }],
+      capabilitySlots: [{ id: 'workbook', required: true }, { id: 'validation', required: true }],
       requiredArtifacts: [{ id: 'workbook', extensions: ['.xlsx'], minimumCount: 1 }],
     },
     slotEvaluations: [],
@@ -66,17 +75,17 @@ function cliReport() {
       description: 'A verified real workbook.',
       scenario_tags: ['excel', 'dashboard'],
       risk_flags: [],
-      skills: ['spreadsheet-skill'],
-      slot_assignments: { workbook: ['spreadsheet-skill'] },
-      rationale: 'The skill created and validated the workbook.',
+      skills: ['spreadsheet-skill', 'workbook-validator'],
+      slot_assignments: { workbook: ['spreadsheet-skill'], validation: ['workbook-validator'] },
+      rationale: 'One Skill created the workbook and another validated it.',
     },
     composition: { attempts: 1, fallbackUsed: false, errors: [] },
     packVerification: {
       summary,
       verdicts: [
-        { used_skill: true, task_completed: true, score: 8, reason: 'complete', issues: [] },
-        { used_skill: true, task_completed: true, score: 8, reason: 'complete', issues: [] },
-        { used_skill: true, task_completed: true, score: 9, reason: 'excellent', issues: [] },
+        { used_skill: true, used_skills: ['spreadsheet-skill', 'workbook-validator'], task_completed: true, artifact_requirements_met: true, env_blocked: false, score: 8, reason: 'complete', issues: [] },
+        { used_skill: true, used_skills: ['spreadsheet-skill', 'workbook-validator'], task_completed: true, artifact_requirements_met: true, env_blocked: false, score: 8, reason: 'complete', issues: [] },
+        { used_skill: true, used_skills: ['spreadsheet-skill', 'workbook-validator'], task_completed: true, artifact_requirements_met: true, env_blocked: false, score: 9, reason: 'excellent', issues: [] },
       ],
       artifactEvidence: [{
         run: 1,
@@ -103,7 +112,7 @@ const context = {
   runId: '123456789',
   runAttempt: 1,
   commitSha: 'a'.repeat(40),
-  cliVersion: '2.9.0',
+  cliVersion: '2.10.0',
   cliSha256: 'b'.repeat(64),
   model: 'sonnet',
   judgeModel: 'gpt-5.5',
@@ -112,7 +121,7 @@ const context = {
 function verificationFixture() {
   const directory = mkdtempSync(join(tmpdir(), 'pack-production-verify-'));
   const cli = join(directory, 'skillstore-cli');
-  writeFileSync(cli, '#!/bin/sh\necho "skillstore-cli 2.9.0"\n');
+  writeFileSync(cli, '#!/bin/sh\necho "skillstore-cli 2.10.0"\n');
   chmodSync(cli, 0o755);
   const cliSha256 = createHash('sha256').update(readFileSync(cli)).digest('hex');
   const report = cliReport();
@@ -127,8 +136,16 @@ function verificationFixture() {
   writeFileSync(join(directory, `${prefix}.evaluation.json`), `${JSON.stringify(evaluation)}\n`);
   writeFileSync(join(directory, 'evaluate-summary.json'), `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-evaluate/v1',
-    cliVersion: '2.9.0',
+    cliVersion: '2.10.0',
     cliSha256,
+    attempts: [{
+      planIndex: 0,
+      scenarioId: report.scenario.id,
+      generationId: report.generationId,
+      status: 'completed',
+      outcome: report.outcome,
+      durationMs: 1,
+    }],
     reports: [{
       scenarioId: report.scenario.id,
       generationId: report.generationId,
@@ -148,7 +165,7 @@ function runVerification(fixture) {
     '--plan', join(fixture.directory, 'plan.json'),
     '--results-dir', fixture.directory,
     '--cli', fixture.cli,
-    '--expected-cli-version', '2.9.0',
+    '--expected-cli-version', '2.10.0',
     '--run-id', context.runId,
     '--run-attempt', String(context.runAttempt),
     '--commit-sha', context.commitSha,
@@ -161,15 +178,261 @@ test('canonical JSON is stable across object key order', () => {
   assert.equal(canonicalJson({ z: 1, a: { y: 2, x: 3 } }), canonicalJson({ a: { x: 3, y: 2 }, z: 1 }));
 });
 
+test('async evaluator streams only allowlisted progress and persists heartbeat evidence', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-production-progress-'));
+  const stdoutFile = join(directory, 'stdout.json');
+  const stderrFile = join(directory, 'run.log');
+  const progressFile = join(directory, 'progress.ndjson');
+  const messages = [];
+  const childScript = [
+    "process.stderr.write('[1/5] scenario excel-dashboard@1.1.0: Excel dashboard\\n')",
+    "process.stderr.write('run 1/1: executing task...\\n')",
+    "process.stderr.write('do-not-forward arbitrary child output\\n')",
+    "setTimeout(() => process.stdout.write('{\\\"outcome\\\":\\\"quality_rejected\\\"}\\n'), 35)",
+  ].join(';');
+  const result = await runEvaluatorProcess(process.execPath, ['-e', childScript], {
+    cwd: directory,
+    env: process.env,
+    stdoutFile,
+    stderrFile,
+    progressFile,
+    checkpointFile: join(directory, 'checkpoint.json'),
+    label: 'excel-dashboard',
+    generationId: context.generationId,
+    scenarioIndex: 1,
+    scenarioCount: 1,
+    heartbeatMs: 10,
+    timeoutMs: 1_000,
+    killGraceMs: 100,
+    onProgress: (message) => messages.push(message),
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.timedOut, false);
+  assert.match(readFileSync(stdoutFile, 'utf8'), /quality_rejected/);
+  assert.match(readFileSync(stderrFile, 'utf8'), /\[1\/5\] scenario/);
+  assert.doesNotMatch(readFileSync(stderrFile, 'utf8'), /do-not-forward arbitrary child output/);
+  assert.ok(messages.some((message) => message.includes('[1/5] scenario')));
+  assert.ok(messages.some((message) => message.includes('heartbeat')));
+  assert.ok(messages.every((message) => !message.includes('do-not-forward')));
+  const events = readFileSync(progressFile, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.deepEqual(events.map((event) => event.seq), events.map((_, index) => index + 1));
+  assert.ok(events.some((event) => event.event === 'scenario.started'));
+  assert.ok(events.some((event) => event.event === 'scenario.progress'));
+  assert.ok(events.some((event) => event.event === 'scenario.heartbeat'));
+  assert.ok(events.some((event) => event.event === 'scenario.process_exited'));
+  assert.equal(
+    JSON.parse(readFileSync(join(directory, 'checkpoint.json'), 'utf8')).event,
+    'scenario.process_exited',
+  );
+  assert.equal(isSafeEvaluatorProgressLine('arbitrary child output'), false);
+  assert.equal(
+    normalizeEvaluatorProgressLine(
+      '[1/5] scenario excel-dashboard@1.1.0: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    ),
+    '[1/5] scenario excel-dashboard@1.1.0',
+  );
+});
+
+test('async evaluator bounds a hung child and records the timeout terminal signal', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-production-timeout-'));
+  const progressFile = join(directory, 'progress.ndjson');
+  const result = await runEvaluatorProcess(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1000)'],
+    {
+      cwd: directory,
+      env: process.env,
+      stdoutFile: join(directory, 'stdout.json'),
+      stderrFile: join(directory, 'run.log'),
+      progressFile,
+      label: 'excel-dashboard',
+      heartbeatMs: 10,
+      timeoutMs: 30,
+      killGraceMs: 100,
+      onProgress: () => {},
+    },
+  );
+
+  assert.equal(result.timedOut, true);
+  assert.equal(result.signal, 'SIGTERM');
+  const events = readFileSync(progressFile, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.ok(events.some((event) => event.event === 'scenario.timeout'));
+  assert.ok(events.some((event) => event.event === 'scenario.process_exited' && event.timedOut));
+});
+
+test('scenario budgets reserve real execution time for the fallback queue', () => {
+  assert.equal(allocateScenarioBudgetMs({
+    remainingBudgetMs: 13_800_000,
+    remainingScenarios: 3,
+    maxScenarioMs: 7_200_000,
+    minimumFallbackMs: 2_700_000,
+  }), 7_200_000);
+  assert.equal(allocateScenarioBudgetMs({
+    remainingBudgetMs: 6_600_000,
+    remainingScenarios: 2,
+    maxScenarioMs: 7_200_000,
+    minimumFallbackMs: 2_700_000,
+  }), 3_900_000);
+  assert.equal(allocateScenarioBudgetMs({
+    remainingBudgetMs: 2_700_000,
+    remainingScenarios: 1,
+    maxScenarioMs: 7_200_000,
+    minimumFallbackMs: 2_700_000,
+  }), 2_700_000);
+});
+
+test('a timed-out scenario keeps later evidence diagnostic-only and blocks workflow success', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-production-fallback-'));
+  const cli = join(directory, 'fake-skillstore-cli');
+  const scenarios = {
+    slow: {
+      id: 'slow', version: '1.0.0', slug: 'slow-pack', name: 'Slow Pack',
+      task: 'Create a slow artifact.', tags: ['slow'], keywords: ['slow'],
+      capabilitySlots: [{ id: 'artifact', required: true }],
+      requiredArtifacts: [{ id: 'artifact', extensions: ['.txt'], minimumCount: 1 }],
+    },
+    fast: {
+      id: 'fast', version: '1.0.0', slug: 'fast-pack', name: 'Fast Pack',
+      task: 'Create a fast artifact.', tags: ['fast'], keywords: ['fast'],
+      capabilitySlots: [{ id: 'artifact', required: true }],
+      requiredArtifacts: [{ id: 'artifact', extensions: ['.txt'], minimumCount: 1 }],
+    },
+  };
+  const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes('--version')) { console.log('skillstore-cli 2.10.0'); process.exit(0); }
+const value = (name) => args[args.indexOf(name) + 1];
+const scenarioId = value('--scenario');
+if (scenarioId === 'slow') {
+  setInterval(() => {}, 1000);
+} else {
+  const scenarios = ${JSON.stringify(scenarios)};
+  const now = new Date().toISOString();
+  process.stdout.write(JSON.stringify({
+    schemaVersion: 'pack-generation-evaluation/v2',
+    generationId: value('--generation-id'),
+    evaluationStartedAt: now,
+    evaluationCompletedAt: now,
+    outcome: 'quality_rejected',
+    outcomeReason: 'fixture rejection',
+    autoPublishEligible: false,
+    scenario: scenarios[scenarioId],
+    slotEvaluations: [],
+    manifest: null,
+    composition: null,
+    packVerification: null,
+    baselineVerification: null,
+    baselineScoreDelta: null,
+    errors: [],
+  }));
+  process.exit(10);
+}
+`;
+  writeFileSync(cli, script);
+  chmodSync(cli, 0o755);
+  const planFile = join(directory, 'plan.json');
+  const resultsDir = join(directory, 'results');
+  writeFileSync(planFile, `${JSON.stringify({
+    schemaVersion: 'pack-production-queue/v1',
+    scenarios: [scenarios.slow, scenarios.fast],
+  })}\n`);
+
+  const common = [
+    '--plan', planFile,
+    '--results-dir', resultsDir,
+    '--cli', cli,
+    '--expected-cli-version', '2.10.0',
+    '--skills-dir', directory,
+    '--run-id', context.runId,
+    '--run-attempt', String(context.runAttempt),
+    '--commit-sha', context.commitSha,
+    '--model', context.model,
+    '--judge-model', context.judgeModel,
+  ];
+  const evaluation = spawnSync(process.execPath, [
+    PACK_PRODUCTION, 'evaluate', ...common,
+    '--evaluation-budget-ms', '2000',
+    '--scenario-timeout-ms', '500',
+    '--minimum-fallback-ms', '500',
+  ], { encoding: 'utf8', timeout: 5_000 });
+  assert.equal(evaluation.status, 1);
+  assert.match(evaluation.stderr, /operationally incomplete attempts: slow:timed_out/);
+
+  const summary = JSON.parse(readFileSync(join(resultsDir, 'evaluate-summary.json'), 'utf8'));
+  assert.deepEqual(summary.attempts.map((attempt) => attempt.status), ['timed_out', 'completed']);
+  assert.equal(summary.reports[0].planIndex, 1);
+  assert.equal(summary.reports[0].scenarioId, 'fast');
+  assert.equal(readFileSync(join(resultsDir, '01-slow.run.log'), 'utf8'), '');
+  assert.throws(() => readFileSync(join(resultsDir, '01-slow.evaluation.json')));
+
+  const verification = spawnSync(process.execPath, [PACK_PRODUCTION, 'verify', ...common], {
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  assert.notEqual(verification.status, 0);
+  assert.match(verification.stderr, /operationally incomplete attempts: slow:timed_out/);
+  assert.throws(() => readFileSync(join(resultsDir, 'evaluation-verification.json')));
+});
+
 test('adapter binds workflow identity, artifact evidence, baseline, and digest', () => {
   const evaluation = buildApiEvaluation(cliReport(), context);
-  assert.equal(evaluation.schemaVersion, 'skillstore.pack-evaluation/v2');
+  assert.equal(evaluation.schemaVersion, 'skillstore.pack-evaluation/v3');
   assert.equal(evaluation.workflow.runId, '123456789');
   assert.equal(evaluation.scenario.version, '1.0.0');
+  assert.deepEqual(evaluation.scenario.requiredCapabilitySlots, ['workbook', 'validation']);
+  assert.deepEqual(evaluation.candidate.manifest.slotAssignments, {
+    workbook: ['spreadsheet-skill'],
+    validation: ['workbook-validator'],
+  });
   assert.deepEqual(evaluation.candidate.fitness.artifact.references, ['sales.xlsx']);
-  assert.equal(evaluation.candidate.fitness.baseline.improvement, 4);
+  assert.deepEqual(evaluation.candidate.fitness.usedSkills, ['spreadsheet-skill', 'workbook-validator']);
+  assert.equal(evaluation.candidate.fitness.minimumDistinctSkillsUsed, 2);
+  assert.equal(evaluation.candidate.fitness.distinctSkillUseRate, 1);
+  assert.equal(evaluation.candidate.fitness.minimumScore, 8);
+  assert.equal(evaluation.candidate.fitness.minimumRunScore, 7);
+  assert.deepEqual(evaluation.candidate.fitness.baseline, {
+    runs: 3,
+    scores: [4, 4, 5],
+    score: 4,
+    improvement: 4,
+    errors: [],
+  });
+  assert.deepEqual(evaluation.candidate.fitness.verdicts[0].usedSkills, ['spreadsheet-skill', 'workbook-validator']);
+  assert.equal(evaluation.candidate.fitness.verdicts[0].artifactVerified, true);
   assert.match(evaluation.evidenceDigest, /^[0-9a-f]{64}$/);
   assert.equal(evaluation.evidence.cliReport.schemaVersion, 'pack-generation-evaluation/v2');
+});
+
+test('adapter rejects one-Skill or incomplete candidate_ready evidence before persistence', () => {
+  const oneSkill = cliReport();
+  oneSkill.manifest.skills = ['spreadsheet-skill'];
+  assert.throws(() => buildApiEvaluation(oneSkill, context), /at least two distinct manifest Skills/);
+
+  const incomplete = cliReport();
+  incomplete.packVerification.verdicts[1].artifact_requirements_met = false;
+  assert.throws(() => buildApiEvaluation(incomplete, context), /did not pass the task, artifact, environment, and score gates/);
+
+  const invented = cliReport();
+  invented.packVerification.verdicts[1].used_skills = ['spreadsheet-skill', 'invented-skill'];
+  assert.throws(() => buildApiEvaluation(invented, context), /outside the manifest/);
+
+  const missingSlot = cliReport();
+  delete missingSlot.manifest.slot_assignments.validation;
+  assert.throws(() => buildApiEvaluation(missingSlot, context), /required slot validation is not assigned/);
+
+  const extraSlot = cliReport();
+  extraSlot.manifest.slot_assignments.unplanned = ['spreadsheet-skill'];
+  assert.throws(() => buildApiEvaluation(extraSlot, context), /non-required capability slot assignments/);
+
+  const inconsistentSummary = cliReport();
+  inconsistentSummary.packVerification.summary.usedSkills = ['spreadsheet-skill'];
+  assert.throws(() => buildApiEvaluation(inconsistentSummary, context), /summary usedSkills differs/);
+
+  const incompleteBaseline = cliReport();
+  incompleteBaseline.baselineVerification.summary.runs = 2;
+  incompleteBaseline.baselineVerification.summary.scores = [4, 5];
+  assert.throws(() => buildApiEvaluation(incompleteBaseline, context), /baseline lacks exactly three valid run scores/);
 });
 
 test('adapter rejects an exit artifact whose scenario differs from the immutable plan', () => {
@@ -203,7 +466,7 @@ test('finalize binds public readback to the selected Pack and candidate Skill or
     generationId: request.generationId,
     packId: 'pack-123',
     publicSlug: 'monthly-sales-excel-workbook',
-    skillSlugs: ['spreadsheet-skill'],
+    skillSlugs: ['spreadsheet-skill', 'workbook-validator'],
   });
 });
 


### PR DESCRIPTION
## 变更\n\n- evaluator 改为异步进程组，60 秒 heartbeat、原子 checkpoint、16 MiB 输出上限\n- 每个 generation 使用独立 HOME/TMP/CODEX_HOME/cwd，并清理残留进程\n- TERM/INT/HUP/EXIT 可靠终止 root evaluator；超时、取消、缺 terminal report 均阻止 Persist\n- trusted、diagnostics、harvest artifact 完全分离，partial/raw proxy log 不进入发布链\n- adapter 升级为 pack-evaluation/v3，验证 2+ Skill、完整 slot、三次逐 run artifact/任务/最低分与三次 baseline\n- Workflow 固定 CLI 2.10.0 并核验 release checksum\n\n## 验证\n\n- CI=true node --test: 26/26\n- YAML parse、Node syntax、git diff --check\n\n## 上线门槛\n\n依赖 Skillstore PR #249、CLI 2.10.0 release 和生产 v3 RPC。合并后先跑 Excel 与 cross-format canary；只有 published + exact public readback 才计入 SLO。\n