### PR TITLE
chore(packs): 对齐 v3 Workflow 元数据

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -18,11 +18,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: generate-pack-production-v2
+  group: generate-pack-production-v3
   cancel-in-progress: false
 
 env:
-  # Immutable release required by the v2 evaluator/API contract. Bump only
+  # Immutable release required by the v3 evaluator/API contract. Bump only
   # together with a Skillstore CLI release and its checksums.txt asset.
   PACK_PRODUCTION_CLI_VERSION: '2.10.0'
 

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -183,6 +183,7 @@ test('planning is bounded to three artifact scenarios and CLI release is immutab
   assert.match(evaluate, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(WORKFLOW, /group: generate-pack-production-v3/);
   assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.10\.0'/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);


### PR DESCRIPTION
将 Generate Pack concurrency group 和契约注释从 v2 更新到 v3，并增加静态回归断言。\n\n验证：CI=true Node test 10/10、YAML parse、git diff --check。