### PR TITLE
fix(packs): allow isolated Codex state

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -252,7 +252,10 @@ jobs:
             "$GITHUB_WORKSPACE/pack-production-input"
           sudo install -d -o packeval -g packeval -m 0700 \
             /home/packeval/tmp
-          sudo install -d -o root -g root -m 0555 \
+          # Codex 0.139 creates ephemeral state files directly under CODEX_HOME.
+          # A root-owned sticky directory lets packeval create only its own state
+          # while preventing it from replacing the root-owned immutable config.
+          sudo install -d -o root -g root -m 1777 \
             /opt/pack-evaluator/codex-home
           sudo install -d -o packeval -g packeval -m 0700 \
             /opt/pack-evaluator/codex-home/log \
@@ -476,7 +479,8 @@ jobs:
               test -x /opt/pack-evaluator/runtime/bin/claude
               test -x /opt/pack-evaluator/runtime/bin/codex
               test -r /opt/pack-evaluator/codex-home/config.toml
-              ! test -w /opt/pack-evaluator/codex-home
+               test -w /opt/pack-evaluator/codex-home
+               test "$(stat -c '%U:%G:%a' /opt/pack-evaluator/codex-home)" = 'root:root:1777'
               ! test -w /opt/pack-evaluator/codex-home/config.toml
               ! test -r /opt/pack-evaluator/results
             '; then
@@ -550,6 +554,28 @@ jobs:
           CODEX_PREFLIGHT_STDERR_BYTES=$(wc -c < "$CODEX_PREFLIGHT_STDERR")
           CODEX_PREFLIGHT_STDOUT_SHA256=$(sha256sum "$CODEX_PREFLIGHT_STDOUT" | awk '{print $1}')
           CODEX_PREFLIGHT_STDERR_SHA256=$(sha256sum "$CODEX_PREFLIGHT_STDERR" | awk '{print $1}')
+          classify_preflight_error() {
+            local file="$1"
+            if [ ! -s "$file" ]; then
+              printf 'none\n'
+            elif grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' "$file"; then
+              printf 'state_storage\n'
+            elif grep -Eqi '401|unauthoriz|authentication|api key' "$file"; then
+              printf 'authentication\n'
+            elif grep -Eqi '404|model.*not found|unsupported model' "$file"; then
+              printf 'model_route\n'
+            elif grep -Eqi 'timed out|timeout' "$file"; then
+              printf 'timeout\n'
+            elif grep -Eqi 'unknown argument|unexpected argument|usage:' "$file"; then
+              printf 'cli_arguments\n'
+            elif grep -Eqi 'connect|connection|transport|request' "$file"; then
+              printf 'upstream_transport\n'
+            else
+              printf 'unknown\n'
+            fi
+          }
+          CLAUDE_PREFLIGHT_ERROR_CLASS=$(classify_preflight_error "$CLAUDE_PREFLIGHT_STDERR")
+          CODEX_PREFLIGHT_ERROR_CLASS=$(classify_preflight_error "$CODEX_PREFLIGHT_STDERR")
           PREFLIGHT_CLEANUP_OUTCOME=passed
           sudo pkill -TERM -u packeval 2>/dev/null || true
           for _ in $(seq 1 10); do
@@ -574,11 +600,13 @@ jobs:
             --argjson claudeStderrBytes "$CLAUDE_PREFLIGHT_STDERR_BYTES" \
             --arg claudeStdoutSha256 "$CLAUDE_PREFLIGHT_STDOUT_SHA256" \
             --arg claudeStderrSha256 "$CLAUDE_PREFLIGHT_STDERR_SHA256" \
+            --arg claudeErrorClass "$CLAUDE_PREFLIGHT_ERROR_CLASS" \
             --arg codexOutcome "$CODEX_PREFLIGHT_OUTCOME" \
             --argjson codexStdoutBytes "$CODEX_PREFLIGHT_STDOUT_BYTES" \
             --argjson codexStderrBytes "$CODEX_PREFLIGHT_STDERR_BYTES" \
             --arg codexStdoutSha256 "$CODEX_PREFLIGHT_STDOUT_SHA256" \
             --arg codexStderrSha256 "$CODEX_PREFLIGHT_STDERR_SHA256" \
+            --arg codexErrorClass "$CODEX_PREFLIGHT_ERROR_CLASS" \
             --arg cleanupOutcome "$PREFLIGHT_CLEANUP_OUTCOME" \
             '{
               claude: {
@@ -586,14 +614,16 @@ jobs:
                 stdoutBytes: $claudeStdoutBytes,
                 stderrBytes: $claudeStderrBytes,
                 stdoutSha256: $claudeStdoutSha256,
-                stderrSha256: $claudeStderrSha256
+                stderrSha256: $claudeStderrSha256,
+                errorClass: $claudeErrorClass
               },
               codex: {
                 outcome: $codexOutcome,
                 stdoutBytes: $codexStdoutBytes,
                 stderrBytes: $codexStderrBytes,
                 stdoutSha256: $codexStdoutSha256,
-                stderrSha256: $codexStderrSha256
+                stderrSha256: $codexStderrSha256,
+                errorClass: $codexErrorClass
               },
               cleanup: {outcome: $cleanupOutcome}
             }' \

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -65,6 +65,9 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /\/opt\/pack-evaluator\/runtime\/bin\/codex/);
   assert.match(evaluate, /! test -w \/opt\/pack-evaluator\/runtime\/bin/);
   assert.match(evaluate, /CODEX_HOME=\/opt\/pack-evaluator\/codex-home/);
+  assert.match(evaluate, /install -d -o root -g root -m 1777[\s\S]*\/opt\/pack-evaluator\/codex-home/);
+  assert.match(evaluate, /test -w \/opt\/pack-evaluator\/codex-home/);
+  assert.match(evaluate, /stat -c '%U:%G:%a' \/opt\/pack-evaluator\/codex-home/);
   assert.match(evaluate, /! test -w \/opt\/pack-evaluator\/codex-home\/config\.toml/);
   assert.match(evaluate, /PATH=\/opt\/pack-evaluator\/runtime\/bin:\/opt\/pack-evaluator\/bin:\/usr\/bin:\/bin/);
   assert.doesNotMatch(evaluate, /PATH=\/usr\/local\/bin/);
@@ -124,6 +127,13 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /agent-preflight-diagnostics\.json/);
   assert.match(evaluate, /CLAUDE_PREFLIGHT_OUTCOME=invalid_response/);
   assert.match(evaluate, /CODEX_PREFLIGHT_OUTCOME=invalid_response/);
+  assert.match(evaluate, /classify_preflight_error\(\)/);
+  assert.match(evaluate, /state_storage/);
+  assert.match(evaluate, /authentication/);
+  assert.match(evaluate, /model_route/);
+  assert.match(evaluate, /upstream_transport/);
+  assert.match(evaluate, /errorClass: \$claudeErrorClass/);
+  assert.match(evaluate, /errorClass: \$codexErrorClass/);
   assert.match(evaluate, /claude:\s*\{/);
   assert.match(evaluate, /codex:\s*\{/);
   assert.match(evaluate, /cleanup:\s*\{outcome: \$cleanupOutcome\}/);


### PR DESCRIPTION
## Root cause
Run 29458181520 proved Claude preflight passes but Codex exits before evaluation. Codex 0.139 creates ephemeral state directly under CODEX_HOME, while the directory was intentionally read-only.

## Fix
- make CODEX_HOME a root-owned sticky directory so packeval can create only its own state files
- keep config.toml root-owned and read-only; the sticky bit prevents packeval from replacing it
- record only an allowlisted error class plus byte counts/digests for future preflight failures

## Validation
- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-evaluator-cleanup-linux.test.mjs scripts/tests/pack-production.test.mjs
- workflow YAML parse and extracted Evaluate shell bash -n
- git diff --check

No database operation or production data change is included. The failed canary stopped before Persist.