### PR TITLE
chore(governance): pin CLI 2.11.1

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -15,7 +15,7 @@ on:
         description: 'Exact audited skillstore-cli version'
         type: string
         required: true
-        default: '2.7.0'
+        default: '2.11.1'
       batch_size:
         description: 'Maximum Skills classified by a new dry-run boundary (1-500)'
         type: number
@@ -86,7 +86,7 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.7.0' || { echo '::error::workflow is pinned to skillstore-cli 2.7.0'; exit 1; }
+          test "$CLI_VERSION" = '2.11.1' || { echo '::error::workflow is pinned to skillstore-cli 2.11.1'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::frozen boundaries may only be created from main'; exit 1; }
           [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] && [ "$BATCH_SIZE" -ge 1 ] && [ "$BATCH_SIZE" -le 500 ] || {
             echo '::error::batch_size must be between 1 and 500'; exit 1;
@@ -145,14 +145,14 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.7.0'
-          minimum-version: '2.7.0'
+          version: '2.11.1'
+          minimum-version: '2.11.1'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify audited binding-aware CLI binary identity
         run: |
           set -euo pipefail
-          expected='cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
+          expected='9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$actual" = "$expected" || {
             echo '::error::binding-aware CLI binary does not match the audited linux-x64 digest'; exit 1;
@@ -294,7 +294,7 @@ jobs:
             --source-evidence "$boundary/source-evidence.json" \
             --previous-report-manifest "$boundary/legacy-previous-report-manifest.json" \
             --run-id "$GITHUB_RUN_ID" --repository "$GITHUB_REPOSITORY" \
-            --workflow-commit "$GITHUB_SHA" --cli-version '2.7.0' \
+            --workflow-commit "$GITHUB_SHA" --cli-version '2.11.1' \
             --cli-sha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --output "$boundary/boundary.json"
           (cd "$boundary" && sha256sum plan.json classification.json pre-inventory.json governance-dry-run.json source-evidence.json legacy-previous-report-manifest.json boundary.json > SHA256SUMS)
@@ -315,7 +315,7 @@ jobs:
           {
             echo '## Legacy-equivalent frozen boundary'
             echo "- Run ID: \`$GITHUB_RUN_ID\`"
-            echo "- CLI: \`2.7.0\`"
+            echo "- CLI: \`2.11.1\`"
             echo "- Selected: \`${{ steps.plan.outputs.selected_count }}\` (maximum 500)"
             echo "- Scan end: \`${{ steps.plan.outputs.last_selected }}\`"
             echo "- Hash-equivalent: \`$(jq -r .governance.hashEquivalentCount "$RUNNER_TEMP/classification.json")\`; governable: \`$(jq -r .governance.eligibleCount "$RUNNER_TEMP/classification.json")\`; source-audit unproven: \`$(jq -r .governance.unprovenCount "$RUNNER_TEMP/classification.json")\`"
@@ -373,7 +373,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git sparse-checkout disable
           git reset --hard HEAD
-          test "$CLI_VERSION" = '2.7.0' || { echo '::error::workflow is pinned to skillstore-cli 2.7.0'; exit 1; }
+          test "$CLI_VERSION" = '2.11.1' || { echo '::error::workflow is pinned to skillstore-cli 2.11.1'; exit 1; }
           test "$GITHUB_REF_NAME" = 'main' || { echo '::error::execute may only run from main'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires a numeric dry_run_id'; exit 1; }
           [ -z "$START_AFTER$END_AT" ] || { echo '::error::execute uses only its frozen boundary'; exit 1; }
@@ -460,14 +460,14 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.7.0'
-          minimum-version: '2.7.0'
+          version: '2.11.1'
+          minimum-version: '2.11.1'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7'
+          audited='9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$audited" && test "$actual" = "$audited" || {
@@ -583,7 +583,7 @@ jobs:
           {
             echo '## Legacy-equivalent execution verified'
             echo "- Frozen boundary run: \`${{ inputs.dry_run_id }}\`"
-            echo '- CLI: `2.7.0`'
+            echo '- CLI: `2.11.1`'
             echo "- Executed: \`$(jq -r .executedCount "$RUNNER_TEMP/execution-verification.json")\`"
             echo '- Artifact, observation, derived audit, score binding, Pack timestamps, and no-attestation invariants passed.'
             echo '- Cache authorization was preflighted before writes; API and artifact invalidation was bounded to groups of ten.'

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -229,7 +229,7 @@ function createBoundaryFixture() {
       runId: '12345',
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
-      cliVersion: '2.7.0',
+      cliVersion: '2.11.1',
       cliSha256: '9'.repeat(64),
     },
   });
@@ -769,8 +769,8 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
     resolve(import.meta.dirname, '../../.github/workflows/backfill-artifact-versions.yml'),
     'utf8'
   );
-  assert.match(workflow, /default: '2\.7\.0'/);
-  assert.match(workflow, /test "\$CLI_VERSION" = '2\.7\.0'/);
+  assert.match(workflow, /default: '2\.11\.1'/);
+  assert.match(workflow, /test "\$CLI_VERSION" = '2\.11\.1'/);
   assert.doesNotMatch(workflow, /version:\s*(latest|'latest'|"latest")/);
   assert.match(workflow, /batch_size must be between 1 and 500/);
   assert.match(workflow, /dry_run_id/);
@@ -781,7 +781,7 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /binding-aware CLI binary differs from the frozen dry-run boundary/);
-  assert.ok((workflow.match(/cc987bdb22b3c19b7f7dec60b707032979823579167c0b911e408771ed9e13d7/g) || []).length >= 2);
+  assert.ok((workflow.match(/9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/current-inventory\.json/);

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const CLI_VERSION = '2.7.0';
+const CLI_VERSION = '2.11.1';
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;


### PR DESCRIPTION
## Summary
- pin legacy artifact governance dry-run and execute to released Skillstore CLI 2.11.1
- verify the exact Linux x64 SHA-256 `9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367` in both phases
- update frozen-boundary verifier metadata and workflow contract tests

## Why
Batch 7 dry-run 29458779039 reproduced all byte identities but failed because historical `Archive.zip` omitted optional `lines` while canonical metadata recorded 35. Skillstore PR #251 and production migration now accept only genuinely unobserved line counts; explicit drift still fails.

## Verification
- release `cli-v2.11.1` is published, non-draft, non-prerelease
- GitHub asset digest equals checksums.txt
- `CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs` (9/9)
- `git diff --check`