### PR TITLE
fix(packs): allow per-generation Codex state

### DIFF
--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -142,7 +142,7 @@ function terminateEvaluatorProcesses(uid) {
   if (remaining.status === 0) fail(`Evaluator uid ${userId} still has live processes`);
 }
 
-async function prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseEnv) {
+export async function prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseEnv) {
   const scenarioRoot = resolve(runtimeRoot, generationId);
   const home = resolve(scenarioRoot, 'home');
   const tmp = resolve(scenarioRoot, 'tmp');
@@ -159,7 +159,10 @@ async function prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseE
   await Promise.all([
     mkdir(home, { recursive: true, mode: 0o700 }),
     mkdir(tmp, { recursive: true, mode: 0o700 }),
-    mkdir(codexHome, { recursive: true, mode: 0o555 }),
+    // Codex 0.139 creates ephemeral state directly under CODEX_HOME. Keep the
+    // directory root-owned and sticky so the evaluator can create only its own
+    // state while the immutable root-owned config remains non-replaceable.
+    mkdir(codexHome, { recursive: true, mode: 0o1777 }),
     mkdir(codexLog, { recursive: true, mode: 0o700 }),
     mkdir(codexSessions, { recursive: true, mode: 0o700 }),
   ]);
@@ -172,7 +175,7 @@ async function prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseE
   await Promise.all([
     chmod(home, 0o700),
     chmod(tmp, 0o700),
-    chmod(codexHome, 0o555),
+    chmod(codexHome, 0o1777),
     chmod(codexLog, 0o700),
     chmod(codexSessions, 0o700),
   ]);

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -4,10 +4,14 @@ import { createHash } from 'node:crypto';
 import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
 import {
+  accessSync,
+  constants,
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -21,6 +25,7 @@ import {
   canonicalJson,
   isSafeEvaluatorProgressLine,
   normalizeEvaluatorProgressLine,
+  prepareScenarioRuntime,
   readExactPublicPack,
   runEvaluatorProcess,
   validatePublicPackReadback,
@@ -179,6 +184,34 @@ function runVerification(fixture) {
 
 test('canonical JSON is stable across object key order', () => {
   assert.equal(canonicalJson({ z: 1, a: { y: 2, x: 3 } }), canonicalJson({ a: { x: 3, y: 2 }, z: 1 }));
+});
+
+test('isolated scenario Codex home permits ephemeral state without weakening config', async (t) => {
+  if (typeof process.getuid !== 'function' || typeof process.getgid !== 'function') {
+    t.skip('POSIX ownership is required');
+    return;
+  }
+  const directory = mkdtempSync(join(tmpdir(), 'pack-production-runtime-'));
+  const sourceCodexHome = join(directory, 'source-codex-home');
+  const runtimeRoot = join(directory, 'generations');
+  mkdirSync(sourceCodexHome, { recursive: true });
+  writeFileSync(join(sourceCodexHome, 'config.toml'), 'model_provider = "fixture"\n');
+
+  const runtime = await prepareScenarioRuntime(
+    runtimeRoot,
+    'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0',
+    process.getuid(),
+    process.getgid(),
+    { CODEX_HOME: sourceCodexHome },
+  );
+  const codexHome = runtime.env.CODEX_HOME;
+  assert.equal(statSync(codexHome).mode & 0o7777, 0o1777);
+  assert.doesNotThrow(() => accessSync(codexHome, constants.W_OK));
+  assert.equal(statSync(join(codexHome, 'config.toml')).mode & 0o777, 0o444);
+  assert.equal(statSync(join(codexHome, 'log')).mode & 0o777, 0o700);
+  assert.equal(statSync(join(codexHome, 'sessions')).mode & 0o777, 0o700);
+  assert.equal(statSync(join(codexHome, 'log')).uid, process.getuid());
+  assert.equal(statSync(join(codexHome, 'sessions')).uid, process.getuid());
 });
 
 test('async evaluator streams only allowlisted progress and persists heartbeat evidence', async () => {


### PR DESCRIPTION
## Root cause

Run 29458624253 passed the shared Codex preflight but every real judge failed with permission denied. The evaluator replaces the shared CODEX_HOME with a per-generation directory, and that real directory was still mode 0555.

## Fix

- make each per-generation Codex home root-owned sticky mode 1777
- keep config.toml immutable at mode 0444
- keep log and sessions private to the unprivileged evaluator
- add a regression test for the actual per-generation runtime path

## Safety

No production database query, migration, scan, or backfill is added. Evaluate still has no production credentials; persistence remains generation-scoped and fail-closed.

## Verification

- CI=true node --test scripts/tests/pack-production.test.mjs scripts/tests/generate-packs-workflow.test.mjs
- 29 passed, 1 Linux-only test skipped locally
- git diff --check