### PR TITLE
fix(packs): invoke evaluator preflight

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -480,8 +480,8 @@ jobs:
             exit 1
           fi
 
-          PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \\
-          PACK_DIAGNOSTICS_DIR="$GITHUB_WORKSPACE/pack-diagnostics" \\
+          PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
+          PACK_DIAGNOSTICS_DIR="$GITHUB_WORKSPACE/pack-diagnostics" \
           bash "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-evaluator-preflight.sh"
           PACKEVAL_UID=$(id -u packeval)
           PACKEVAL_GID=$(id -g packeval)

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -48,6 +48,13 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   const evaluateWorkflow = section('  evaluate:', '  persist:');
   const evaluate = `${evaluateWorkflow}\n${EVALUATOR_PREFLIGHT}`;
   assert.match(evaluateWorkflow, /scripts\/pack-evaluator-preflight\.sh/);
+  const continuation = String.fromCharCode(92);
+  const preflightCallLines = evaluateWorkflow
+    .split('\n')
+    .filter((line) => /^ {10}(PACK_EVALUATOR_PROXY_TOKEN|PACK_DIAGNOSTICS_DIR)=/.test(line));
+  assert.equal(preflightCallLines.length, 2);
+  assert.ok(preflightCallLines.every((line) => line.endsWith(` ${continuation}`)));
+  assert.ok(preflightCallLines.every((line) => !line.endsWith(` ${continuation}${continuation}`)));
   assert.match(evaluate, /runs-on: ubuntu-latest/);
   assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
   assert.match(evaluate, /@openai\/codex@0\.139\.0/);


### PR DESCRIPTION
## Root cause

Run 29461557526 compiled successfully but failed before preflight with exit 127 because two workflow continuation lines contained two backslashes. Bash treated the second backslash as a command. Persist and publish were skipped.

## Fix

- use exactly one continuation backslash for both preflight environment lines
- add a regression assertion that rejects double backslashes

## Database safety

No database behavior changes. The failed run stopped before preflight, evaluation, persistence, or publication.

## Verification

- 30 targeted tests passed; 1 Linux-only test skipped locally
- extracted Evaluate bash passes bash -n
- workflow inline block is 13,590 bytes
- git diff --check