### PR TITLE
fix(packs): retry preflight timeouts

### DIFF
--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -15,22 +15,23 @@ trap cleanup_files EXIT
 
 classify_error() {
   local file="$1"
-  if [ ! -s "$file" ]; then
-    printf 'none\n'
-  elif grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' "$file"; then
+  local exit_code="$2"
+  if grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' "$file"; then
     printf 'state_storage\n'
   elif grep -Eqi '401|403|unauthoriz|authentication|api key' "$file"; then
     printf 'authentication\n'
   elif grep -Eqi '404|model.*not found|unsupported model' "$file"; then
     printf 'model_route\n'
-  elif grep -Eqi 'timed out|timeout' "$file"; then
-    printf 'timeout\n'
   elif grep -Eqi 'unknown argument|unexpected argument|usage:' "$file"; then
     printf 'cli_arguments\n'
+  elif [ "$exit_code" -eq 124 ] || grep -Eqi 'timed out|timeout' "$file"; then
+    printf 'timeout\n'
   elif grep -Eqi 'error sending request|failed to send request|connection (reset|refused|closed|aborted)|transport.*(closed|error)|unexpected (eof|end of file)|temporary failure in name resolution|dns.*temporary|tls.*(handshake|temporary)|http[^0-9]*(408|429|502|503|504)|status( code)?[^0-9]*(408|429|502|503|504)' "$file"; then
     printf 'upstream_transport\n'
-  else
+  elif [ -s "$file" ] || [ "$exit_code" -ne 0 ]; then
     printf 'unknown\n'
+  else
+    printf 'none\n'
   fi
 }
 
@@ -56,45 +57,105 @@ cleanup_processes() {
   return 0
 }
 
-CLAUDE_OUTCOME=passed
-if ! printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
-  sudo -u packeval env -i \
-    PATH=/opt/pack-evaluator/runtime/bin:/opt/pack-evaluator/bin:/usr/bin:/bin \
-    HOME=/home/packeval \
-    CODEX_HOME=/opt/pack-evaluator/codex-home \
-    TMPDIR=/home/packeval/tmp \
-    CI=true \
-    NO_COLOR=1 \
-    ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
-    ANTHROPIC_AUTH_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
-    NO_PROXY=127.0.0.1,localhost \
-    timeout --signal=TERM --kill-after=5s 60s \
-    /opt/pack-evaluator/runtime/bin/claude \
-      --print \
-      --output-format text \
-      --permission-mode bypassPermissions \
-      --model sonnet \
-      - \
-    > "$CLAUDE_STDOUT" \
-    2> "$CLAUDE_STDERR"; then
-  CLAUDE_OUTCOME=command_failed
-elif [ "$(tr -d '\r\n' < "$CLAUDE_STDOUT")" != 'PACK_EVALUATOR_READY' ]; then
-  CLAUDE_OUTCOME=invalid_response
-fi
-
+CLAUDE_OUTCOME=not_run
+CLAUDE_ERROR_CLASS=none
+CLAUDE_ATTEMPTS='[]'
+RETRY_CLEANUP_OUTCOME=not_needed
+for ATTEMPT in 1 2; do
+  : > "$CLAUDE_STDOUT"
+  : > "$CLAUDE_STDERR"
+  STARTED_MS=$(date +%s%3N)
+  set +e
+  printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
+    sudo -u packeval env -i \
+      PATH=/opt/pack-evaluator/runtime/bin:/opt/pack-evaluator/bin:/usr/bin:/bin \
+      HOME=/home/packeval \
+      CODEX_HOME=/opt/pack-evaluator/codex-home \
+      TMPDIR=/home/packeval/tmp \
+      CI=true \
+      NO_COLOR=1 \
+      ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
+      ANTHROPIC_AUTH_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
+      NO_PROXY=127.0.0.1,localhost \
+      timeout --signal=TERM --kill-after=5s 60s \
+      /opt/pack-evaluator/runtime/bin/claude \
+        --print \
+        --output-format text \
+        --permission-mode bypassPermissions \
+        --model sonnet \
+        - \
+      > "$CLAUDE_STDOUT" \
+      2> "$CLAUDE_STDERR"
+  CLAUDE_EXIT_CODE=$?
+  set -e
+  if [ "$CLAUDE_EXIT_CODE" -ne 0 ]; then
+    CLAUDE_OUTCOME=command_failed
+  elif [ "$(tr -d '\r\n' < "$CLAUDE_STDOUT")" != 'PACK_EVALUATOR_READY' ]; then
+    CLAUDE_OUTCOME=invalid_response
+  else
+    CLAUDE_OUTCOME=passed
+  fi
+  DURATION_MS=$(( $(date +%s%3N) - STARTED_MS ))
+  STDOUT_BYTES=$(wc -c < "$CLAUDE_STDOUT")
+  STDERR_BYTES=$(wc -c < "$CLAUDE_STDERR")
+  STDOUT_SHA256=$(sha256sum "$CLAUDE_STDOUT" | awk '{print $1}')
+  STDERR_SHA256=$(sha256sum "$CLAUDE_STDERR" | awk '{print $1}')
+  CLAUDE_ERROR_CLASS=$(classify_error "$CLAUDE_STDERR" "$CLAUDE_EXIT_CODE")
+  CLAUDE_ATTEMPTS=$(jq -c \
+    --argjson attempt "$ATTEMPT" \
+    --arg outcome "$CLAUDE_OUTCOME" \
+    --arg errorClass "$CLAUDE_ERROR_CLASS" \
+    --argjson exitCode "$CLAUDE_EXIT_CODE" \
+    --argjson durationMs "$DURATION_MS" \
+    --argjson stdoutBytes "$STDOUT_BYTES" \
+    --argjson stderrBytes "$STDERR_BYTES" \
+    --arg stdoutSha256 "$STDOUT_SHA256" \
+    --arg stderrSha256 "$STDERR_SHA256" \
+    '. + [{
+      attempt: $attempt,
+      outcome: $outcome,
+      errorClass: $errorClass,
+      exitCode: $exitCode,
+      durationMs: $durationMs,
+      stdoutBytes: $stdoutBytes,
+      stderrBytes: $stderrBytes,
+      stdoutSha256: $stdoutSha256,
+      stderrSha256: $stderrSha256
+    }]' <<< "$CLAUDE_ATTEMPTS")
+  if [ "$CLAUDE_OUTCOME" = "passed" ] || \
+     [ "$CLAUDE_OUTCOME" != "command_failed" ] || \
+     { [ "$CLAUDE_ERROR_CLASS" != "upstream_transport" ] && \
+       [ "$CLAUDE_ERROR_CLASS" != "timeout" ]; } || \
+     [ "$ATTEMPT" -eq 2 ]; then
+    break
+  fi
+  if cleanup_processes; then
+    RETRY_CLEANUP_OUTCOME=passed
+  else
+    CLEANUP_RC=$?
+    if [ "$CLEANUP_RC" -eq 1 ]; then
+      RETRY_CLEANUP_OUTCOME=failed
+    else
+      RETRY_CLEANUP_OUTCOME=probe_failed
+    fi
+    break
+  fi
+  sleep 5
+done
 CODEX_OUTCOME=not_run
 CODEX_ERROR_CLASS=none
+CODEX_EXIT_CODE=-1
 CODEX_ATTEMPTS='[]'
-RETRY_CLEANUP_OUTCOME=not_needed
 if [ "$CLAUDE_OUTCOME" = "passed" ]; then
-  # Retry only one narrowly classified transport failure. Permission, auth,
-  # routing, CLI, timeout, response-shape, and unknown failures stay fail-closed.
+  # Retry only one narrowly classified transport failure or an explicit
+  # timeout. Permission, auth, routing, CLI, response-shape, and unknown
+  # failures stay fail-closed.
   for ATTEMPT in 1 2; do
     : > "$CODEX_STDOUT"
     : > "$CODEX_STDERR"
     STARTED_MS=$(date +%s%3N)
-    CODEX_OUTCOME=passed
-    if ! printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
+    set +e
+    printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
       sudo -u packeval env -i \
         PATH=/opt/pack-evaluator/runtime/bin:/opt/pack-evaluator/bin:/usr/bin:/bin \
         HOME=/home/packeval \
@@ -115,21 +176,27 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
           -m gpt-5.5 \
           - \
         > "$CODEX_STDOUT" \
-        2> "$CODEX_STDERR"; then
+        2> "$CODEX_STDERR"
+    CODEX_EXIT_CODE=$?
+    set -e
+    if [ "$CODEX_EXIT_CODE" -ne 0 ]; then
       CODEX_OUTCOME=command_failed
     elif [ "$(tr -d '\r\n' < "$CODEX_STDOUT")" != 'PACK_EVALUATOR_READY' ]; then
       CODEX_OUTCOME=invalid_response
+    else
+      CODEX_OUTCOME=passed
     fi
     DURATION_MS=$(( $(date +%s%3N) - STARTED_MS ))
     STDOUT_BYTES=$(wc -c < "$CODEX_STDOUT")
     STDERR_BYTES=$(wc -c < "$CODEX_STDERR")
     STDOUT_SHA256=$(sha256sum "$CODEX_STDOUT" | awk '{print $1}')
     STDERR_SHA256=$(sha256sum "$CODEX_STDERR" | awk '{print $1}')
-    CODEX_ERROR_CLASS=$(classify_error "$CODEX_STDERR")
+    CODEX_ERROR_CLASS=$(classify_error "$CODEX_STDERR" "$CODEX_EXIT_CODE")
     CODEX_ATTEMPTS=$(jq -c \
       --argjson attempt "$ATTEMPT" \
       --arg outcome "$CODEX_OUTCOME" \
       --arg errorClass "$CODEX_ERROR_CLASS" \
+      --argjson exitCode "$CODEX_EXIT_CODE" \
       --argjson durationMs "$DURATION_MS" \
       --argjson stdoutBytes "$STDOUT_BYTES" \
       --argjson stderrBytes "$STDERR_BYTES" \
@@ -139,6 +206,7 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
         attempt: $attempt,
         outcome: $outcome,
         errorClass: $errorClass,
+        exitCode: $exitCode,
         durationMs: $durationMs,
         stdoutBytes: $stdoutBytes,
         stderrBytes: $stderrBytes,
@@ -147,7 +215,8 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
       }]' <<< "$CODEX_ATTEMPTS")
     if [ "$CODEX_OUTCOME" = "passed" ] || \
        [ "$CODEX_OUTCOME" != "command_failed" ] || \
-       [ "$CODEX_ERROR_CLASS" != "upstream_transport" ] || \
+       { [ "$CODEX_ERROR_CLASS" != "upstream_transport" ] && \
+         [ "$CODEX_ERROR_CLASS" != "timeout" ]; } || \
        [ "$ATTEMPT" -eq 2 ]; then
       break
     fi
@@ -170,7 +239,6 @@ CLAUDE_STDOUT_BYTES=$(wc -c < "$CLAUDE_STDOUT")
 CLAUDE_STDERR_BYTES=$(wc -c < "$CLAUDE_STDERR")
 CLAUDE_STDOUT_SHA256=$(sha256sum "$CLAUDE_STDOUT" | awk '{print $1}')
 CLAUDE_STDERR_SHA256=$(sha256sum "$CLAUDE_STDERR" | awk '{print $1}')
-CLAUDE_ERROR_CLASS=$(classify_error "$CLAUDE_STDERR")
 CODEX_STDOUT_BYTES=$(wc -c < "$CODEX_STDOUT")
 CODEX_STDERR_BYTES=$(wc -c < "$CODEX_STDERR")
 CODEX_STDOUT_SHA256=$(sha256sum "$CODEX_STDOUT" | awk '{print $1}')
@@ -194,12 +262,15 @@ jq -n \
   --arg claudeStdoutSha256 "$CLAUDE_STDOUT_SHA256" \
   --arg claudeStderrSha256 "$CLAUDE_STDERR_SHA256" \
   --arg claudeErrorClass "$CLAUDE_ERROR_CLASS" \
+  --argjson claudeExitCode "$CLAUDE_EXIT_CODE" \
+  --argjson claudeAttempts "$CLAUDE_ATTEMPTS" \
   --arg codexOutcome "$CODEX_OUTCOME" \
   --argjson codexStdoutBytes "$CODEX_STDOUT_BYTES" \
   --argjson codexStderrBytes "$CODEX_STDERR_BYTES" \
   --arg codexStdoutSha256 "$CODEX_STDOUT_SHA256" \
   --arg codexStderrSha256 "$CODEX_STDERR_SHA256" \
   --arg codexErrorClass "$CODEX_ERROR_CLASS" \
+  --argjson codexExitCode "$CODEX_EXIT_CODE" \
   --argjson codexAttempts "$CODEX_ATTEMPTS" \
   --arg cleanupOutcome "$CLEANUP_OUTCOME" \
   --arg retryCleanupOutcome "$RETRY_CLEANUP_OUTCOME" \
@@ -210,7 +281,9 @@ jq -n \
       stderrBytes: $claudeStderrBytes,
       stdoutSha256: $claudeStdoutSha256,
       stderrSha256: $claudeStderrSha256,
-      errorClass: $claudeErrorClass
+      errorClass: $claudeErrorClass,
+      exitCode: $claudeExitCode,
+      attempts: $claudeAttempts
     },
     codex: {
       outcome: $codexOutcome,
@@ -219,6 +292,7 @@ jq -n \
       stdoutSha256: $codexStdoutSha256,
       stderrSha256: $codexStderrSha256,
       errorClass: $codexErrorClass,
+      exitCode: $codexExitCode,
       attempts: $codexAttempts
     },
     cleanup: {

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -194,6 +194,13 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   const result = spawnSync('bash', ['-n', EVALUATOR_PREFLIGHT_PATH], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
   assert.match(EVALUATOR_PREFLIGHT, /for ATTEMPT in 1 2/);
+  assert.match(EVALUATOR_PREFLIGHT, /CLAUDE_EXIT_CODE=\$\?/);
+  assert.match(EVALUATOR_PREFLIGHT, /CODEX_EXIT_CODE=\$\?/);
+  assert.match(EVALUATOR_PREFLIGHT, /"\$exit_code" -eq 124/);
+  assert.match(EVALUATOR_PREFLIGHT, /CLAUDE_ATTEMPTS=/);
+  assert.match(EVALUATOR_PREFLIGHT, /--argjson claudeAttempts/);
+  assert.match(EVALUATOR_PREFLIGHT, /exitCode: \$exitCode/);
+  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /if ! printf '%s\\n' 'Reply with exactly PACK_EVALUATOR_READY/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/agent-preflight-diagnostics\.json/);
 });
 


### PR DESCRIPTION
## Incident

Run 29461944056 stopped before evaluation or persistence after the Claude preflight consumed the full 60-second timeout. stdout and stderr were both empty, but the script discarded the command exit code and classified the failure as none.

## Fix

- capture pipeline exit codes under pipefail for both Claude and Codex
- classify timeout exit 124 even when stderr is empty
- give Claude and Codex one bounded retry for only timeout or narrowly classified transport errors
- clean and verify the evaluator process set before retry
- record per-attempt exit code, duration, outcome, hashes, and byte counts
- keep auth, permission, model, CLI, response-shape, and unknown failures fail-closed

## Database safety

All retry logic remains inside credential-free Evaluate before Persist. The incident run skipped Persist and Publish. No database query scope, schema, migration, scan, or write behavior changes.

## Verification

- 30 targeted tests passed; 1 Linux-only test skipped locally
- extracted preflight passes bash -n
- embedded Evaluate script passes bash -n
- git diff --check