### PR TITLE
fix(governance): resume audited prior boundary

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -230,7 +230,7 @@ function createBoundaryFixture() {
       repository: 'aiskillstore/marketplace',
       workflowCommit: 'f'.repeat(40),
       cliVersion: '2.11.2',
-      cliSha256: '9'.repeat(64),
+      cliSha256: 'c596ca3b6d27875fdcd231bfb889899f08ea8ae95217def7bf46de2aa3722b81',
     },
   });
   return { ...values, directory, files, boundary };
@@ -386,6 +386,33 @@ test('freezes and verifies one exact dry-run boundary', () => {
       expectedRunId: '12345',
     });
     assert.equal(verified.status, 'execution_preflight_verified');
+    const priorCliBoundary = {
+      ...fixture.boundary,
+      cliVersion: '2.11.1',
+      cliSha256: '9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367',
+    };
+    assert.equal(verifyLegacyGovernanceBoundary({
+      boundary: priorCliBoundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: structuredClone(fixture.preInventory),
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: structuredClone(fixture.sourceEvidence),
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }).status, 'execution_preflight_verified');
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: { ...priorCliBoundary, cliVersion: '2.11.0' },
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: structuredClone(fixture.preInventory),
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: structuredClone(fixture.sourceEvidence),
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /downloaded boundary metadata is invalid/);
     const reorderedSourceEvidence = structuredClone(fixture.sourceEvidence);
     reorderedSourceEvidence.skills.reverse();
     reorderedSourceEvidence.audits.reverse();

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -6,6 +6,10 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const CLI_VERSION = '2.11.2';
+const EXECUTABLE_BOUNDARY_CLI_SHA256 = new Map([
+  ['2.11.1', '9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367'],
+  ['2.11.2', 'c596ca3b6d27875fdcd231bfb889899f08ea8ae95217def7bf46de2aa3722b81'],
+]);
 const MAX_BATCH_SIZE = 500;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
@@ -460,7 +464,7 @@ export function createLegacyGovernanceBoundary({
 }) {
   if (
     metadata.cliVersion !== CLI_VERSION
-    || !SHA256_RE.test(String(metadata.cliSha256 || ''))
+    || metadata.cliSha256 !== EXECUTABLE_BOUNDARY_CLI_SHA256.get(CLI_VERSION)
     || !/^\d+$/.test(String(metadata.runId))
     || !/^[0-9a-f]{40}$/.test(String(metadata.workflowCommit || ''))
     || metadata.repository !== 'aiskillstore/marketplace'
@@ -525,8 +529,7 @@ export function verifyLegacyGovernanceBoundary({
     || boundary?.workflow !== 'govern-legacy-equivalent-artifacts'
     || boundary?.repository !== 'aiskillstore/marketplace'
     || boundary?.runId !== String(expectedRunId)
-    || boundary?.cliVersion !== CLI_VERSION
-    || !SHA256_RE.test(String(boundary?.cliSha256 || ''))
+    || EXECUTABLE_BOUNDARY_CLI_SHA256.get(boundary?.cliVersion) !== boundary?.cliSha256
   ) {
     fail('downloaded boundary metadata is invalid');
   }


### PR DESCRIPTION
## Summary
- allow execute preflight to resume the exact frozen CLI 2.11.1 boundary with CLI 2.11.2
- bind both accepted boundary versions to their audited Linux SHA256, rejecting unknown versions or mismatched digests
- keep new dry-run boundary creation pinned exclusively to CLI 2.11.2

## Evidence
- run 29462749201 failed before writes because boundary 29460652611 correctly records CLI 2.11.1
- CLI 2.11.2 changes only cache execution batching/retry; it revalidates the same frozen source, hashes, CAS, and resumable projections before writes

## Verification
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9 passed)

## Rollout
After merge, rerun execute with dry_run_id=29460652611 and cli_version=2.11.2.