### PR TITLE
fix(governance): accept derived audit resume pointer

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -513,7 +513,21 @@ test('freezes and verifies one exact dry-run boundary', () => {
       marketplace_commit_sha: COMMIT,
       source_path: fixture.row.path,
     }];
+    const resumableSourceEvidence = structuredClone(fixture.sourceEvidence);
+    resumableSourceEvidence.skills[0].public_eligibility_audit_id = DERIVED_AUDIT_ID;
     const resumed = verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: resumable,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: resumableSourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    });
+    assert.equal(resumed.resumableCount, 1);
+    assert.throws(() => verifyLegacyGovernanceBoundary({
       boundary: fixture.boundary,
       plan: fixture.plan,
       classification: fixture.classification,
@@ -523,8 +537,20 @@ test('freezes and verifies one exact dry-run boundary', () => {
       currentSourceEvidence: fixture.sourceEvidence,
       paths: fixture.files,
       expectedRunId: '12345',
-    });
-    assert.equal(resumed.resumableCount, 1);
+    }), /Skill metadata or source audit changed/);
+    const resumableMetadataDrift = structuredClone(resumableSourceEvidence);
+    resumableMetadataDrift.skills[0].description = 'changed after governance';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: resumable,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: resumableMetadataDrift,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /Skill metadata or source audit changed/);
     const changedAudit = structuredClone(fixture.sourceEvidence);
     changedAudit.audits[0].summary = 'changed after dry-run';
     assert.throws(() => verifyLegacyGovernanceBoundary({

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -44,6 +44,47 @@ export function canonicalSourceEvidence(value) {
   });
 }
 
+function assertSourceEvidenceUnchangedOrResumable({
+  frozenSourceEvidence,
+  currentSourceEvidence,
+  currentSkills,
+  resumableSkillIds,
+}) {
+  if (canonicalSourceEvidence({ ...frozenSourceEvidence, skills: [] })
+    !== canonicalSourceEvidence({ ...currentSourceEvidence, skills: [] })) {
+    fail('Skill metadata or source audit changed after the frozen dry-run boundary');
+  }
+  const frozenMetadata = asMap(frozenSourceEvidence.skills, 'id', 'frozen Skill metadata');
+  const currentMetadata = asMap(currentSourceEvidence.skills, 'id', 'current Skill metadata');
+  if (frozenMetadata.size !== currentMetadata.size) {
+    fail('Skill metadata or source audit changed after the frozen dry-run boundary');
+  }
+  for (const [skillId, frozen] of frozenMetadata) {
+    const current = currentMetadata.get(skillId);
+    const currentInventory = currentSkills.get(frozen.slug);
+    if (canonicalJson(frozen) === canonicalJson(current)) {
+      if (
+        resumableSkillIds.has(skillId)
+        && current?.public_eligibility_audit_id !== currentInventory?.public_eligibility_audit_id
+      ) {
+        fail('Skill metadata or source audit changed after the frozen dry-run boundary');
+      }
+      continue;
+    }
+    if (
+      !current
+      || !resumableSkillIds.has(skillId)
+      || current.public_eligibility_audit_id !== currentInventory?.public_eligibility_audit_id
+      || canonicalJson(frozen) !== canonicalJson({
+        ...current,
+        public_eligibility_audit_id: frozen.public_eligibility_audit_id,
+      })
+    ) {
+      fail('Skill metadata or source audit changed after the frozen dry-run boundary');
+    }
+  }
+}
+
 function canonicalPackTopology(inventory) {
   const packMemberships = [...(inventory?.packMemberships || [])]
     .sort((left, right) => `${left.skill_id}:${left.pack_id}`.localeCompare(
@@ -546,9 +587,6 @@ export function verifyLegacyGovernanceBoundary({
   if (canonicalJson(boundary.groups) !== canonicalJson(expectedGroups)) {
     fail('downloaded boundary groups do not match plan/classification');
   }
-  if (canonicalSourceEvidence(frozenSourceEvidence) !== canonicalSourceEvidence(currentSourceEvidence)) {
-    fail('Skill metadata or source audit changed after the frozen dry-run boundary');
-  }
   assertQualificationMatchesEvidence(classification, frozenSourceEvidence);
   const frozenSkills = asMap(frozenInventory.rows, 'slug', 'frozen Skills');
   const currentSkills = asMap(currentInventory.rows, 'slug', 'current Skills');
@@ -568,6 +606,7 @@ export function verifyLegacyGovernanceBoundary({
     'production state after the frozen dry-run boundary'
   );
   let resumableCount = 0;
+  const resumableSkillIds = new Set();
   for (const selected of plan.selected) {
     const before = frozenSkills.get(selected.slug);
     const current = currentSkills.get(selected.slug);
@@ -610,10 +649,17 @@ export function verifyLegacyGovernanceBoundary({
       fail(`production state changed incompatibly for ${selected.slug}`);
     }
     resumableCount++;
+    resumableSkillIds.add(selected.id);
   }
   if (artifacts.size !== resumableCount || observations.size !== resumableCount) {
     fail('resumable artifact/observation scope contains unexpected rows');
   }
+  assertSourceEvidenceUnchangedOrResumable({
+    frozenSourceEvidence,
+    currentSourceEvidence,
+    currentSkills,
+    resumableSkillIds,
+  });
   return {
     schemaVersion: 1,
     status: 'execution_preflight_verified',


### PR DESCRIPTION
## Summary
- allow source-evidence changes only for exact resumable rows whose public audit pointer moved to the governed derived audit
- require all source audits, bindings, and every other Skill metadata field to remain byte-equivalent
- cross-check the changed pointer against current inventory; stale or unrelated pointer changes still fail closed

## Evidence
- run 29463066228 stopped before writes because exactly 12 source-evidence Skill rows changed only public_eligibility_audit_id
- audits and bindings had zero differences; production artifact, pointer, derived-audit, observation, score, and attestation invariants all pass for those 12 rows

## Verification
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9 passed)

## Rollout
After merge, rerun frozen boundary 29460652611 with CLI 2.11.2.