### PR TITLE
fix(governance): separate boundary and execution CLI identity

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -467,11 +467,17 @@ jobs:
       - name: Verify frozen CLI binary identity
         run: |
           set -euo pipefail
-          audited='c596ca3b6d27875fdcd231bfb889899f08ea8ae95217def7bf46de2aa3722b81'
-          expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
+          execution_audited='c596ca3b6d27875fdcd231bfb889899f08ea8ae95217def7bf46de2aa3722b81'
+          boundary_version=$(jq -r .cliVersion "$RUNNER_TEMP/boundary/boundary.json")
+          boundary_actual=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/boundary.json")
+          case "$boundary_version" in
+            2.11.1) boundary_audited='9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367' ;;
+            2.11.2) boundary_audited="$execution_audited" ;;
+            *) echo '::error::frozen boundary CLI version is not executable'; exit 1 ;;
+          esac
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          test "$expected" = "$audited" && test "$actual" = "$audited" || {
-            echo '::error::binding-aware CLI binary differs from the frozen dry-run boundary'; exit 1;
+          test "$boundary_actual" = "$boundary_audited" && test "$actual" = "$execution_audited" || {
+            echo '::error::boundary or execution CLI binary differs from its audited release'; exit 1;
           }
 
       - name: Materialize only frozen legacy groups

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -833,7 +833,9 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /boundaries may only be created from main/);
   assert.match(workflow, /execute may only run from main/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
-  assert.match(workflow, /binding-aware CLI binary differs from the frozen dry-run boundary/);
+  assert.match(workflow, /boundary or execution CLI binary differs from its audited release/);
+  assert.match(workflow, /2\.11\.1\) boundary_audited='9aa6a6e15d249e52bed690049974d8312f3257c205025823a68d249cc5cc8367'/);
+  assert.match(workflow, /test "\$boundary_actual" = "\$boundary_audited" && test "\$actual" = "\$execution_audited"/);
   assert.ok((workflow.match(/c596ca3b6d27875fdcd231bfb889899f08ea8ae95217def7bf46de2aa3722b81/g) || []).length >= 2);
   assert.match(workflow, /--phase execute-preflight/);
   assert.match(workflow, /--current-inventory "\$RUNNER_TEMP\/current-inventory\.json"/);


### PR DESCRIPTION
## Summary
- verify the frozen boundary CLI against its own audited 2.11.1 or 2.11.2 digest
- independently require the downloaded execution CLI to match the audited 2.11.2 digest
- reject unknown boundary CLI versions before materialization or writes

## Evidence
- run 29463437919 passed resumable boundary validation, then stopped before writes because the workflow incorrectly required the 2.11.1 frozen digest to equal the 2.11.2 execution digest

## Verification
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9 passed)

## Rollout
After merge, rerun frozen boundary 29460652611 with CLI 2.11.2.