### PR TITLE
fix(workflow): pin pack production CLI 2.11.3

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   # Immutable release required by the v3 evaluator/API contract. Bump only
   # together with a Skillstore CLI release and its checksums.txt asset.
-  PACK_PRODUCTION_CLI_VERSION: '2.11.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.11.3'
 
 jobs:
   plan:

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -278,7 +278,7 @@ test('planning is bounded to three artifact scenarios and CLI release is immutab
   assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v3/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.11\.0'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.11\.3'/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
   assert.match(plan, /repositories: marketplace,skillstore/);


### PR DESCRIPTION
## Summary

- pin Generate Pack production workflow to the released Skillstore CLI 2.11.3
- update the immutable-version regression test
- carry collision-safe evaluator aliases and stale Pack schema smoke fixes into production runs

## Verification

- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-production.test.mjs scripts/tests/pack-evaluator-proxy.test.mjs
- 35 passed, 1 Linux-only skipped, 0 failed
- git diff --check

## Production safety

- workflow-only version pin; no database migration, SQL, backfill, or server SSH
- production validation will use one serial canary and public API readback