### PR TITLE
fix(governance): resume rows after expected timestamp advance

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -495,6 +495,7 @@ test('freezes and verifies one exact dry-run boundary', () => {
       artifact_revision: 1,
       current_artifact_version_id: ARTIFACT_ID,
       public_eligibility_audit_id: DERIVED_AUDIT_ID,
+      updated_at: '2026-07-16T01:34:36.244Z',
     };
     resumable.artifacts = [{
       id: ARTIFACT_ID,
@@ -529,6 +530,19 @@ test('freezes and verifies one exact dry-run boundary', () => {
       expectedRunId: '12345',
     });
     assert.equal(resumed.resumableCount, 1);
+    const resumableTimestampRegression = structuredClone(resumable);
+    resumableTimestampRegression.rows[0].updated_at = '2025-12-31T00:00:00.000Z';
+    assert.throws(() => verifyLegacyGovernanceBoundary({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      frozenInventory: fixture.preInventory,
+      currentInventory: resumableTimestampRegression,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      currentSourceEvidence: resumableSourceEvidence,
+      paths: fixture.files,
+      expectedRunId: '12345',
+    }), /production state changed incompatibly/);
     assert.throws(() => verifyLegacyGovernanceBoundary({
       boundary: fixture.boundary,
       plan: fixture.plan,

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -634,7 +634,7 @@ export function verifyLegacyGovernanceBoundary({
       || !UUID_RE.test(String(current.public_eligibility_audit_id || ''))
       || current.public_eligibility_audit_id === selected.publicEligibilityAuditId
       || !sameTimestamp(current.published_at, selected.publishedAt)
-      || !sameTimestamp(current.updated_at, selected.updatedAt)
+      || !timestampDoesNotRegress(selected.updatedAt, current.updated_at)
       || artifact?.id !== current.current_artifact_version_id
       || artifact?.artifact_revision !== 1
       || artifact?.content_hash !== repair.packagedContentHash
@@ -677,6 +677,12 @@ function sameTimestamp(left, right) {
   return Number.isFinite(Date.parse(left))
     && Number.isFinite(Date.parse(right))
     && Date.parse(left) === Date.parse(right);
+}
+
+function timestampDoesNotRegress(before, after) {
+  return Number.isFinite(Date.parse(before))
+    && Number.isFinite(Date.parse(after))
+    && Date.parse(after) >= Date.parse(before);
 }
 
 export function verifyLegacyGovernanceExecution({


### PR DESCRIPTION
## Root cause
Run 29465969661 stopped before writes because the resumable verifier required a governed Skill's updated_at to equal its frozen r0 timestamp. Governance and score rebinding intentionally advance that timestamp.

## Fix
- for rows already proven resumable by exact revision, artifact, hash provenance, observation, derived audit pointer, source metadata, and Pack invariants, require updated_at to be valid and non-regressing
- keep exact equality for untouched/non-legacy rows
- reject timestamp regression explicitly

## Evidence
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9/9)
- replayed the failed run's uploaded frozen/current evidence locally: execution_preflight_verified, resumableCount=112, legacyCount=472
- production writes in failed run: none