### PR TITLE
fix(governance): trust runner CA bundle for cache preflight

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -496,12 +496,30 @@ jobs:
             git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/boundary.json")
 
+      - name: Prepare audited CLI TLS trust
+        run: |
+          set -euo pipefail
+          bundle=/etc/ssl/certs/ca-certificates.crt
+          if command -v update-ca-certificates >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo update-ca-certificates
+            else
+              update-ca-certificates
+            fi
+          fi
+          test -s "$bundle" || { echo '::error::runner CA bundle is unavailable'; exit 1; }
+          status=$(curl -sS -o /dev/null -w '%{http_code}' https://skillstore.io/api/cache/invalidate)
+          test "$status" = 405 || { echo "::error::cache TLS probe returned HTTP $status"; exit 1; }
+
       - name: Execute frozen legacy cohort with four bounded workers
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           SKILLSTORE_SITE_URL: https://skillstore.io
+          NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+          SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+          NODE_OPTIONS: --use-openssl-ca
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/execution-groups"

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -863,6 +863,11 @@ test('workflow is two-phase, exactly pinned, bounded, and never executes ordinar
   assert.match(workflow, /skill govern-legacy-equivalent/);
   assert.match(workflow, /four bounded workers/);
   assert.equal((workflow.match(/--concurrency 4/g) || []).length, 2);
+  assert.match(workflow, /Prepare audited CLI TLS trust/);
+  assert.match(workflow, /status=\$\(curl -sS -o \/dev\/null -w '%\{http_code\}' https:\/\/skillstore\.io\/api\/cache\/invalidate\)/);
+  assert.match(workflow, /NODE_EXTRA_CA_CERTS: \/etc\/ssl\/certs\/ca-certificates\.crt/);
+  assert.match(workflow, /SSL_CERT_FILE: \/etc\/ssl\/certs\/ca-certificates\.crt/);
+  assert.match(workflow, /NODE_OPTIONS: --use-openssl-ca/);
   assert.match(workflow, /execute-boundary:[\s\S]{0,160}group: production-skill-score-writes/);
   assert.match(workflow, /legacy-equivalent-boundary-/);
   assert.match(workflow, /legacy-equivalent-execution-/);


### PR DESCRIPTION
## Root cause
Runs 29466326075 and 29466444963 passed the frozen-boundary verifier but stopped before writes because the Bun standalone CLI did not use the self-hosted runner's current system CA bundle for skillstore.io.

## Fix
- rebuild/verify the Ubuntu CA bundle before governance execution
- probe the production cache endpoint over system TLS before invoking the CLI
- bind Bun/Node TLS to /etc/ssl/certs/ca-certificates.crt with NODE_EXTRA_CA_CERTS and SSL_CERT_FILE
- retain cache preflight before the first database write

## Verification
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9/9)
- local production certificate verification: Google Trust Services WE1, verify code 0
- failed runs performed no new governance writes