### PR TITLE
fix(workflow): pin pack production CLI 2.12.0

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   # Immutable release required by the v3 evaluator/API contract. Bump only
   # together with a Skillstore CLI release and its checksums.txt asset.
-  PACK_PRODUCTION_CLI_VERSION: '2.11.3'
+  PACK_PRODUCTION_CLI_VERSION: '2.12.0'
 
 jobs:
   plan:

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -278,7 +278,7 @@ test('planning is bounded to three artifact scenarios and CLI release is immutab
   assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v3/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.11\.3'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.12\.0'/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
   assert.match(plan, /repositories: marketplace,skillstore/);


### PR DESCRIPTION
## Summary

- pin Generate Pack to released Skillstore CLI 2.12.0
- update immutable-version regression test
- enable non-redundant slot selection, heterogeneous automatic scenarios, and validated whole-Pack execution plans

## Verification

- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-production.test.mjs scripts/tests/pack-evaluator-proxy.test.mjs
- 35 passed, 1 Linux-only skipped, 0 failed
- git diff --check

## Safety

- version pin only; no migration, SQL, backfill, SSH, or direct database operation
- production rollout remains one serial canary with fail-closed Persist/Publish and exact public API readback