### PR TITLE
fix: retry unknown pack evaluator preflight once

### DIFF
--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -35,6 +35,23 @@ classify_error() {
   fi
 }
 
+# A preflight is read-only, isolated, and capped at two attempts. Retry one
+# otherwise-unclassified command failure because upstream/CLI failures do not
+# always expose a stable error string. Known auth, routing, argument, and state
+# failures remain fail-closed on the first attempt.
+should_retry_preflight() {
+  local outcome="$1"
+  local error_class="$2"
+  local attempt="$3"
+  if [ "$outcome" != "command_failed" ] || [ "$attempt" -ge 2 ]; then
+    return 1
+  fi
+  case "$error_class" in
+    upstream_transport|timeout|unknown) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 cleanup_processes() {
   local probe_rc
   sudo pkill -TERM -u packeval 2>/dev/null || true
@@ -122,11 +139,8 @@ for ATTEMPT in 1 2; do
       stdoutSha256: $stdoutSha256,
       stderrSha256: $stderrSha256
     }]' <<< "$CLAUDE_ATTEMPTS")
-  if [ "$CLAUDE_OUTCOME" = "passed" ] || \
-     [ "$CLAUDE_OUTCOME" != "command_failed" ] || \
-     { [ "$CLAUDE_ERROR_CLASS" != "upstream_transport" ] && \
-       [ "$CLAUDE_ERROR_CLASS" != "timeout" ]; } || \
-     [ "$ATTEMPT" -eq 2 ]; then
+  if ! should_retry_preflight \
+    "$CLAUDE_OUTCOME" "$CLAUDE_ERROR_CLASS" "$ATTEMPT"; then
     break
   fi
   if cleanup_processes; then
@@ -213,11 +227,8 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
         stdoutSha256: $stdoutSha256,
         stderrSha256: $stderrSha256
       }]' <<< "$CODEX_ATTEMPTS")
-    if [ "$CODEX_OUTCOME" = "passed" ] || \
-       [ "$CODEX_OUTCOME" != "command_failed" ] || \
-       { [ "$CODEX_ERROR_CLASS" != "upstream_transport" ] && \
-         [ "$CODEX_ERROR_CLASS" != "timeout" ]; } || \
-       [ "$ATTEMPT" -eq 2 ]; then
+    if ! should_retry_preflight \
+      "$CODEX_OUTCOME" "$CODEX_ERROR_CLASS" "$ATTEMPT"; then
       break
     fi
     if cleanup_processes; then

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -136,8 +136,9 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /CLAUDE_OUTCOME=command_failed/);
   assert.match(evaluate, /CODEX_OUTCOME=command_failed/);
   assert.match(evaluate, /for ATTEMPT in 1 2/);
-  assert.match(evaluate, /CODEX_ERROR_CLASS.*upstream_transport/s);
-  assert.match(evaluate, /ATTEMPT" -eq 2/);
+  assert.match(evaluate, /should_retry_preflight[\s\\]+"\$CODEX_OUTCOME" "\$CODEX_ERROR_CLASS" "\$ATTEMPT"/);
+  assert.match(EVALUATOR_PREFLIGHT, /upstream_transport\|timeout\|unknown/);
+  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$attempt" -ge 2 \]/);
   assert.match(evaluate, /cleanup_processes\(\)/);
   assert.match(evaluate, /RETRY_CLEANUP_OUTCOME=passed/);
   assert.match(evaluate, /sleep 5/);
@@ -202,6 +203,48 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /exitCode: \$exitCode/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /if ! printf '%s\\n' 'Reply with exactly PACK_EVALUATOR_READY/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/agent-preflight-diagnostics\.json/);
+});
+
+test('evaluator preflight retries only bounded transient or unknown command failures', () => {
+  const start = EVALUATOR_PREFLIGHT.indexOf('should_retry_preflight() {');
+  const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
+  assert.ok(start >= 0 && end > start, 'retry policy function must be extractable');
+  const policy = EVALUATOR_PREFLIGHT.slice(start, end + 3);
+
+  for (const errorClass of ['upstream_transport', 'timeout', 'unknown']) {
+    const result = spawnSync(
+      'bash',
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', errorClass, '1'],
+      { encoding: 'utf8' }
+    );
+    assert.equal(result.status, 0, `${errorClass} should receive one retry`);
+  }
+  for (const errorClass of ['authentication', 'model_route', 'cli_arguments', 'state_storage']) {
+    const result = spawnSync(
+      'bash',
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', errorClass, '1'],
+      { encoding: 'utf8' }
+    );
+    assert.equal(result.status, 1, `${errorClass} must fail closed without retry`);
+  }
+  assert.equal(
+    spawnSync(
+      'bash',
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', 'unknown', '2'],
+      { encoding: 'utf8' }
+    ).status,
+    1,
+    'the second unknown failure must stop'
+  );
+  assert.equal(
+    spawnSync(
+      'bash',
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'invalid_response', 'unknown', '1'],
+      { encoding: 'utf8' }
+    ).status,
+    1,
+    'invalid responses must not be retried'
+  );
 });
 
 test('evaluate emits bounded progress and checkpoints cancellation-safe evidence', () => {


### PR DESCRIPTION
## Summary
- retry one otherwise-unclassified read-only evaluator preflight failure
- keep authentication, routing, CLI-argument, and state failures fail-closed
- preserve the two-attempt cap and mandatory process cleanup between attempts

## Production evidence
Run 29468803990 stopped before scenario execution because Codex preflight exited 1 with errorClass unknown. Claude and cleanup passed; Persist and Publish were skipped.

## Verification
- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-production.test.mjs scripts/tests/pack-evaluator-cleanup-linux.test.mjs
- bash -n scripts/pack-evaluator-preflight.sh
- git diff --check

31 tests passed; 2 Linux-only tests skipped on macOS.