### PR TITLE
fix(governance): verify expected post-execution transitions

### DIFF
--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -655,6 +655,8 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       }],
     };
     postInventory.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
+    const postSourceEvidence = structuredClone(fixture.sourceEvidence);
+    postSourceEvidence.skills[0].public_eligibility_audit_id = DERIVED_AUDIT_ID;
     const readback = {
       skills: [{
         ...fixture.sourceEvidence.skills[0],
@@ -698,10 +700,9 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
-      postSourceEvidence: structuredClone(fixture.sourceEvidence),
+      postSourceEvidence,
     });
     assert.equal(verified.executedCount, 1);
-    postInventory.packs[0].updated_at = '2026-07-15T00:00:01.000Z';
     assert.throws(() => verifyLegacyGovernanceExecution({
       boundary: fixture.boundary,
       plan: fixture.plan,
@@ -713,7 +714,47 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
       postSourceEvidence: structuredClone(fixture.sourceEvidence),
-    }), /Pack state changed during governance execution/);
+    }), /Skill metadata or source audit changed/);
+    const changedPostMetadata = structuredClone(postSourceEvidence);
+    changedPostMetadata.skills[0].description = 'changed during execution';
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      currentInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence: changedPostMetadata,
+    }), /Skill metadata or source audit changed/);
+    postInventory.packs[0].updated_at = '2026-07-15T00:00:01.000Z';
+    assert.equal(verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      currentInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence,
+    }).executedCount, 1);
+    postInventory.packs[0].updated_at = '2026-07-14T00:00:00.000Z';
+    assert.throws(() => verifyLegacyGovernanceExecution({
+      boundary: fixture.boundary,
+      plan: fixture.plan,
+      classification: fixture.classification,
+      executionResults,
+      frozenInventory: fixture.preInventory,
+      currentInventory,
+      postInventory,
+      readback,
+      frozenSourceEvidence: fixture.sourceEvidence,
+      postSourceEvidence,
+    }), /Pack updated_at regressed/);
     postInventory.packs[0].updated_at = '2026-07-15T00:00:00.000Z';
     readback.scoreSnapshots[0].score_subject.auditId = SOURCE_AUDIT_ID;
     assert.throws(() => verifyLegacyGovernanceExecution({
@@ -726,7 +767,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
-      postSourceEvidence: structuredClone(fixture.sourceEvidence),
+      postSourceEvidence,
     }), /production readback mismatch/);
     readback.scoreSnapshots[0].score_subject.auditId = DERIVED_AUDIT_ID;
     readback.audits[0].summary = 'changed during execution';
@@ -740,10 +781,10 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       postInventory,
       readback,
       frozenSourceEvidence: fixture.sourceEvidence,
-      postSourceEvidence: structuredClone(fixture.sourceEvidence),
+      postSourceEvidence,
     }), /production readback mismatch/);
 
-    const changedPostEvidence = structuredClone(fixture.sourceEvidence);
+    const changedPostEvidence = structuredClone(postSourceEvidence);
     changedPostEvidence.audits[0].summary = 'changed during execution';
     assert.throws(() => verifyLegacyGovernanceExecution({
       boundary: fixture.boundary,
@@ -759,7 +800,7 @@ test('verifies artifact, derived audit, score, Pack, and attestation execution e
       },
       frozenSourceEvidence: fixture.sourceEvidence,
       postSourceEvidence: changedPostEvidence,
-    }), /source audit changed during governance execution/);
+    }), /Skill metadata or source audit changed/);
   } finally {
     rmSync(fixture.directory, { recursive: true, force: true });
   }

--- a/scripts/verify-legacy-equivalent-governance.mjs
+++ b/scripts/verify-legacy-equivalent-governance.mjs
@@ -99,17 +99,6 @@ function canonicalPackTopology(inventory) {
   return canonicalJson({ packMemberships, packs });
 }
 
-function canonicalPackState(inventory) {
-  const packMemberships = [...(inventory?.packMemberships || [])]
-    .sort((left, right) => `${left.skill_id}:${left.pack_id}`.localeCompare(
-      `${right.skill_id}:${right.pack_id}`,
-      'en-US'
-    ));
-  const packs = [...(inventory?.packs || [])]
-    .sort((left, right) => String(left.id).localeCompare(String(right.id), 'en-US'));
-  return canonicalJson({ packMemberships, packs });
-}
-
 function assertPackUpdatedAtDoesNotRegress(beforeInventory, afterInventory, context) {
   const before = asMap(beforeInventory?.packs || [], 'id', `${context} prior Packs`);
   const after = asMap(afterInventory?.packs || [], 'id', `${context} current Packs`);
@@ -697,9 +686,6 @@ export function verifyLegacyGovernanceExecution({
   frozenSourceEvidence,
   postSourceEvidence,
 }) {
-  if (canonicalSourceEvidence(frozenSourceEvidence) !== canonicalSourceEvidence(postSourceEvidence)) {
-    fail('Skill metadata or source audit changed during governance execution');
-  }
   assertQualificationMatchesEvidence(classification, frozenSourceEvidence);
   const groups = legacyGroups(plan, classification);
   if (!Array.isArray(executionResults) || executionResults.length !== groups.length) {
@@ -726,6 +712,12 @@ export function verifyLegacyGovernanceExecution({
   const attestations = readback.attestations || [];
   const legacyRows = governableLegacyRows(classification);
   const legacySlugs = new Set(legacyRows.map((row) => row.slug));
+  assertSourceEvidenceUnchangedOrResumable({
+    frozenSourceEvidence,
+    currentSourceEvidence: postSourceEvidence,
+    currentSkills: postSkills,
+    resumableSkillIds: new Set(legacyRows.map((row) => row.id)),
+  });
   const rawLegacy = asMap(classification.cohorts.legacy_algorithm_equivalent, 'slug', 'legacy cohort');
   const sourceAuditUnproven = classification.governance.unproven.map((decision) => rawLegacy.get(decision.slug));
 
@@ -740,9 +732,11 @@ export function verifyLegacyGovernanceExecution({
     currentInventory,
     'dependent Pack state before governance'
   );
-  if (canonicalPackState(currentInventory) !== canonicalPackState(postInventory)) {
-    fail('dependent Pack state changed during governance execution');
-  }
+  assertPackUpdatedAtDoesNotRegress(
+    currentInventory,
+    postInventory,
+    'dependent Pack state during governance execution'
+  );
 
   for (const frozen of classification.cohorts.exact.concat(
     classification.cohorts.actual_or_unproven_drift,


### PR DESCRIPTION
## Root cause
Run 29466796673 completed all 472 governance records, but the final evidence verifier rejected two expected effects: every Skill moved from its frozen source audit pointer to the verified derived audit pointer, and one dependent Pack advanced updated_at after cache closure.

## Fix
- preserve exact source audits, bindings, Skill metadata, ID coverage, and post-inventory pointer binding while allowing only the governed public_eligibility_audit_id transition
- preserve exact Pack topology, slug, published_at, and membership while allowing only non-regressing updated_at
- retain the existing per-row artifact, provenance, observation, derived audit, score snapshot/breakdown, and no-attestation checks

## Verification
- CI=true node --test scripts/tests/legacy-equivalent-governance.test.mjs (9/9)
- replayed the complete 143 MB evidence from run 29466796673: executed_and_verified, executedCount=472
- production governed/total=1998/5295, revision0=3297, broken pointer=0