### PR TITLE
fix: harden pack evaluator timeouts and cleanup

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -42,6 +42,7 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
+          permission-contents: read
 
       - name: Prepare isolated checkout
         run: rm -rf "$GITHUB_WORKSPACE/marketplace-plan" "$GITHUB_WORKSPACE/pack-plan" "$GITHUB_WORKSPACE/pack-cli"
@@ -380,7 +381,20 @@ jobs:
               echo 'packeval processes survived TERM and KILL' \
                 > "$GITHUB_WORKSPACE/pack-diagnostics/process-termination-failure.txt"
             fi
-            sudo pkill -u packproxy -f pack-evaluator-proxy.mjs 2>/dev/null || true
+            sudo pkill -TERM -u packproxy -f pack-evaluator-proxy.mjs 2>/dev/null || true
+            for _ in $(seq 1 10); do
+              if ! sudo pgrep -u packproxy -f pack-evaluator-proxy.mjs >/dev/null 2>&1; then
+                break
+              fi
+              sleep 0.1
+            done
+            sudo pkill -KILL -u packproxy -f pack-evaluator-proxy.mjs 2>/dev/null || true
+            sleep 0.1
+            if sudo pgrep -u packproxy -f pack-evaluator-proxy.mjs >/dev/null 2>&1; then
+              echo 'packproxy processes survived TERM and KILL' \
+                > "$GITHUB_WORKSPACE/pack-diagnostics/proxy-termination-failure.txt"
+              if [ "$exit_code" -eq 0 ]; then exit_code=1; fi
+            fi
             rm -f "$PROXY_LOG"
             sudo rm -f "$PROXY_ACTIVITY"
             return "$exit_code"
@@ -482,6 +496,7 @@ jobs:
 
           PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
           PACK_DIAGNOSTICS_DIR="$GITHUB_WORKSPACE/pack-diagnostics" \
+          PACK_EVALUATOR_ACTIVITY_FILE="$PROXY_ACTIVITY" \
           bash "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-evaluator-preflight.sh"
           PACKEVAL_UID=$(id -u packeval)
           PACKEVAL_GID=$(id -g packeval)

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 : "${PACK_EVALUATOR_PROXY_TOKEN:?PACK_EVALUATOR_PROXY_TOKEN is required}"
 : "${PACK_DIAGNOSTICS_DIR:?PACK_DIAGNOSTICS_DIR is required}"
+readonly PREFLIGHT_TIMEOUT_SECONDS=180
 
 CLAUDE_STDOUT=$(mktemp)
 CLAUDE_STDERR=$(mktemp)
@@ -94,7 +95,7 @@ for ATTEMPT in 1 2; do
       ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
       ANTHROPIC_AUTH_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
       NO_PROXY=127.0.0.1,localhost \
-      timeout --signal=TERM --kill-after=5s 60s \
+      timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
       /opt/pack-evaluator/runtime/bin/claude \
         --print \
         --output-format text \
@@ -161,9 +162,9 @@ CODEX_ERROR_CLASS=none
 CODEX_EXIT_CODE=-1
 CODEX_ATTEMPTS='[]'
 if [ "$CLAUDE_OUTCOME" = "passed" ]; then
-  # Retry only one narrowly classified transport failure or an explicit
-  # timeout. Permission, auth, routing, CLI, response-shape, and unknown
-  # failures stay fail-closed.
+  # Retry one transport, timeout, or otherwise-unclassified command failure.
+  # Permission, auth, routing, CLI-argument, state, and response-shape failures
+  # stay fail-closed on the first attempt; every second failure stops.
   for ATTEMPT in 1 2; do
     : > "$CODEX_STDOUT"
     : > "$CODEX_STDERR"
@@ -179,7 +180,7 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
         NO_COLOR=1 \
         PACK_EVALUATOR_PROXY_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
         NO_PROXY=127.0.0.1,localhost \
-        timeout --signal=TERM --kill-after=5s 60s \
+        timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
         /opt/pack-evaluator/runtime/bin/codex \
           exec \
           --skip-git-repo-check \
@@ -311,6 +312,15 @@ jq -n \
       retryOutcome: $retryCleanupOutcome
     }
   }' > "$PACK_DIAGNOSTICS_DIR/agent-preflight-diagnostics.json"
+
+if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && \
+   sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
+  sudo cp "$PACK_EVALUATOR_ACTIVITY_FILE" \
+    "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
+  sudo chown "$(id -u):$(id -g)" \
+    "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
+  chmod 0600 "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
+fi
 
 if [ "$CLAUDE_OUTCOME" != "passed" ] || \
    [ "$CODEX_OUTCOME" != "passed" ] || \

--- a/scripts/pack-evaluator-proxy.mjs
+++ b/scripts/pack-evaluator-proxy.mjs
@@ -212,13 +212,26 @@ export function createPackEvaluatorProxy({
       requestsStarted += 1;
       activeRequests += 1;
       recordActivity({ phase: 'started', requestNumber: requestsStarted });
+      const requestNumber = requestsStarted;
+      const upstreamController = new AbortController();
+      const upstreamTimeout = setTimeout(() => upstreamController.abort(), timeoutMs);
+      const abortUpstream = () => {
+        if (!response.writableEnded) upstreamController.abort();
+      };
+      request.once('aborted', abortUpstream);
+      response.once('close', abortUpstream);
       try {
         const upstream = await fetchImpl(target, {
           method: 'POST',
           headers: upstreamHeaders(request, upstreamKey),
           body,
           redirect: 'error',
-          signal: AbortSignal.timeout(timeoutMs),
+          signal: upstreamController.signal,
+        });
+        recordActivity({
+          phase: 'response',
+          requestNumber,
+          statusClass: Math.floor(upstream.status / 100) * 100,
         });
         response.writeHead(upstream.status, responseHeaders(upstream));
         if (!upstream.body) {
@@ -235,10 +248,14 @@ export function createPackEvaluatorProxy({
         }
         response.end();
       } finally {
+        clearTimeout(upstreamTimeout);
+        request.off('aborted', abortUpstream);
+        response.off('close', abortUpstream);
         activeRequests -= 1;
-        recordActivity({ phase: 'completed', requestNumber: requestsStarted });
+        recordActivity({ phase: 'completed', requestNumber });
       }
     } catch (error) {
+      if (response.destroyed || response.writableEnded) return;
       const status = Number.isSafeInteger(error?.status) ? error.status : 502;
       json(response, status, { error: error instanceof Error ? error.message : 'proxy request failed' });
     }
@@ -259,7 +276,11 @@ export async function startPackEvaluatorProxy(environment = process.env) {
     ttlMs: environment.PACK_EVALUATOR_TTL_MS,
     requestTimeoutMs: environment.PACK_EVALUATOR_REQUEST_TIMEOUT_MS,
     onActivity: environment.PACK_EVALUATOR_ACTIVITY_FILE
-      ? () => appendFileSync(environment.PACK_EVALUATOR_ACTIVITY_FILE, `${Date.now()}\n`, { mode: 0o600 })
+      ? (activity) => appendFileSync(
+        environment.PACK_EVALUATOR_ACTIVITY_FILE,
+        `${JSON.stringify({ at: Date.now(), ...activity })}\n`,
+        { mode: 0o600 },
+      )
       : undefined,
   });
   await new Promise((resolve, reject) => {

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -118,11 +118,13 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /PACK_EVALUATOR_MAX_CONCURRENT=4/);
   assert.match(evaluate, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS=65536/);
   assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"/);
+  assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\\]+bash .*pack-evaluator-preflight\.sh/);
   assert.match(evaluate, /sudo rm -f "\$PROXY_ACTIVITY"/);
   assert.match(evaluate, /Pack evaluator proxy did not become healthy within 30 seconds/);
   assert.match(evaluate, /proxy-diagnostics\.json/);
   assert.match(evaluate, /Reply with exactly PACK_EVALUATOR_READY and nothing else/);
-  assert.match(evaluate, /timeout --signal=TERM --kill-after=5s 60s/);
+  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_SECONDS=180/);
+  assert.match(evaluate, /timeout --signal=TERM --kill-after=5s "\$\{PREFLIGHT_TIMEOUT_SECONDS\}s"/);
   assert.match(evaluate, /\/opt\/pack-evaluator\/runtime\/bin\/claude/);
   assert.match(evaluate, /--permission-mode bypassPermissions/);
   assert.match(evaluate, /--model sonnet/);
@@ -168,6 +170,10 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /evaluator-failure\.txt/);
   assert.match(evaluate, /pkill -TERM -u packeval/);
   assert.match(evaluate, /pkill -KILL -u packeval/);
+  assert.match(evaluate, /pkill -TERM -u packproxy -f pack-evaluator-proxy\.mjs/);
+  assert.match(evaluate, /pkill -KILL -u packproxy -f pack-evaluator-proxy\.mjs/);
+  assert.match(evaluate, /pgrep -u packproxy -f pack-evaluator-proxy\.mjs/);
+  assert.match(evaluate, /proxy-termination-failure\.txt/);
   assert.match(evaluate, /EVALUATOR_PROCESSES_STOPPED=true/);
   assert.match(evaluate, /process-termination-failure\.txt/);
   assert.match(evaluate, /RESULT_BYTES=.*du -sb \/opt\/pack-evaluator\/results/);
@@ -189,6 +195,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy request budget exhausted/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy token has expired/);
+  assert.match(EVALUATOR_PROXY, /response\.once\('close', abortUpstream\)/);
 });
 
 test('extracted evaluator preflight is valid bounded bash', () => {
@@ -203,6 +210,7 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /exitCode: \$exitCode/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /if ! printf '%s\\n' 'Reply with exactly PACK_EVALUATOR_READY/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/agent-preflight-diagnostics\.json/);
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/proxy-activity\.ndjson/);
 });
 
 test('evaluator preflight retries only bounded transient or unknown command failures', () => {
@@ -306,6 +314,7 @@ test('evaluate emits bounded progress and checkpoints cancellation-safe evidence
 
 test('planning is bounded to three artifact scenarios and CLI release is immutable', () => {
   const plan = section('  plan:', '  evaluate:');
+  assert.match(plan, /permission-contents: read/);
   assert.match(plan, /scenario-queue --limit 3/);
   assert.match(plan, /requiredArtifacts \| length >= 1/);
   assert.match(plan, /\(\.scenarios \| length\) > 0 or \.source == "signals"/);

--- a/scripts/tests/pack-evaluator-proxy.test.mjs
+++ b/scripts/tests/pack-evaluator-proxy.test.mjs
@@ -1,6 +1,6 @@
 import { after, before, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer } from 'node:http';
+import { createServer, request as httpRequest } from 'node:http';
 import { once } from 'node:events';
 import { createPackEvaluatorProxy } from '../pack-evaluator-proxy.mjs';
 
@@ -85,7 +85,11 @@ test('replaces local credentials with the bounded upstream credential', async ()
   assert.match(observed.body, /gpt-5\.5/);
   assert.equal(response.headers.has('set-cookie'), false);
   assert.equal(JSON.parse(observed.body).max_output_tokens, 65536);
-  assert.deepEqual(activities.slice(-2).map((activity) => activity.phase), ['started', 'completed']);
+  assert.deepEqual(
+    activities.slice(-3).map((activity) => activity.phase),
+    ['started', 'response', 'completed']
+  );
+  assert.equal(activities.at(-2).statusClass, 200);
 });
 
 test('rejects models and token requests outside the evaluator budget', async () => {
@@ -143,4 +147,43 @@ test('enforces request, concurrency, and TTL limits', async () => {
   });
   assert.equal(expired.status, 403);
   await new Promise((resolve) => limited.close(resolve));
+});
+
+test('aborts an in-flight upstream request when the evaluator disconnects', async () => {
+  let markStarted;
+  let markAborted;
+  const started = new Promise((resolve) => { markStarted = resolve; });
+  const aborted = new Promise((resolve) => { markAborted = resolve; });
+  const hangingFetch = (_url, init) => new Promise((_resolve, reject) => {
+    markStarted();
+    init.signal.addEventListener('abort', () => {
+      markAborted();
+      reject(new Error('aborted by downstream disconnect'));
+    }, { once: true });
+  });
+  const abortingProxy = createPackEvaluatorProxy({
+    localToken: LOCAL_TOKEN,
+    upstreamKey: UPSTREAM_KEY,
+    upstreamBaseUrl: upstreamUrl,
+    fetchImpl: hangingFetch,
+    requestTimeoutMs: 60_000,
+  });
+  abortingProxy.listen(0, '127.0.0.1');
+  await once(abortingProxy, 'listening');
+  const request = httpRequest({
+    host: '127.0.0.1',
+    port: abortingProxy.address().port,
+    path: '/v1/responses',
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${LOCAL_TOKEN}`,
+      'content-type': 'application/json',
+    },
+  });
+  request.on('error', () => {});
+  request.end(JSON.stringify({ model: 'gpt-5.5', input: 'hang' }));
+  await started;
+  request.destroy();
+  await aborted;
+  await new Promise((resolve) => abortingProxy.close(resolve));
 });


### PR DESCRIPTION
## Summary
- align the read-only model preflight budget with real provider latency by raising the fixed timeout from 60s to 180s
- abort upstream inference when the evaluator client disconnects, preventing timed-out requests from accumulating
- persist only safe proxy phase and HTTP status-class diagnostics
- verify packproxy termination and make the Plan GitHub App token explicitly contents-read-only

## Production evidence
Run 29469620698 exhausted both 60-second Claude preflight attempts with zero stdout/stderr. Retry cleanup and final cleanup passed; scenario evaluation never began and Persist/Publish were skipped.

## Verification
- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-evaluator-proxy.test.mjs scripts/tests/pack-production.test.mjs scripts/tests/pack-evaluator-cleanup-linux.test.mjs
- bash -n scripts/pack-evaluator-preflight.sh
- git diff --check

37 tests passed; 2 Linux-only tests skipped on macOS.