### PR TITLE
fix(cache): close catalog recovery by generation

### DIFF
--- a/.github/actions/invalidate-cache/action.yml
+++ b/.github/actions/invalidate-cache/action.yml
@@ -51,6 +51,9 @@ outputs:
   failed_count:
     description: 'Number of cache items that failed invalidation'
     value: ${{ steps.invalidate.outputs.failed_count }}
+  list_version_bumped:
+    description: 'Whether every applicable successful batch proved a list-generation bump'
+    value: ${{ steps.invalidate.outputs.list_version_bumped }}
 
 runs:
   using: composite
@@ -107,6 +110,7 @@ runs:
           echo "total_count=0" >> "$GITHUB_OUTPUT"
           echo "success_count=0" >> "$GITHUB_OUTPUT"
           echo "failed_count=0" >> "$GITHUB_OUTPUT"
+          echo "list_version_bumped=false" >> "$GITHUB_OUTPUT"
           if [ "$FAIL_ON_ERROR" = "true" ]; then
             echo "::error::Cache invalidation secret is empty"
             exit 1
@@ -143,6 +147,7 @@ runs:
           echo "No items to invalidate"
           echo "success_count=0" >> "$GITHUB_OUTPUT"
           echo "failed_count=0" >> "$GITHUB_OUTPUT"
+          echo "list_version_bumped=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
@@ -194,6 +199,7 @@ runs:
                 and (.invalidated.total | type == "number")
                 and (.invalidated.api | type == "number")
                 and (.invalidated.artifacts | type == "number")
+                and ($type == "releases" or .invalidated.listVersionBumped == true)
                 and ($invalidateArtifacts or .invalidated.artifacts == 0)
                 and ($invalidateDependentPacks or ((.closure.dependentPacks.all // []) | length) == 0)' \
               "$response_file" >/dev/null; then
@@ -348,6 +354,11 @@ runs:
         echo "✅ Complete: $SUCCESS succeeded, $FAILED failed"
         echo "success_count=$SUCCESS" >> "$GITHUB_OUTPUT"
         echo "failed_count=$FAILED" >> "$GITHUB_OUTPUT"
+        if [ "$CONTENT_TYPE" = "releases" ]; then
+          echo "list_version_bumped=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "list_version_bumped=true" >> "$GITHUB_OUTPUT"
+        fi
 
         if [ "$INTERNAL_FAILURE" -gt 0 ]; then
           echo "::error::Cache invalidation workers did not produce trustworthy completion evidence"

--- a/.github/workflows/recover-score-cache-closure.yml
+++ b/.github/workflows/recover-score-cache-closure.yml
@@ -327,14 +327,27 @@ jobs:
           count=$(sed '/^$/d' "$target" | sort -u | wc -l | tr -d ' ')
           test "$count" -gt 0
           test "$(jq -r '.scores | length' "$expected")" -eq "$count"
+          invalidation_target="$RUNNER_TEMP/cache-invalidation-slugs.txt"
+          if [ "$SCOPE" = approved-catalog-cache ]; then
+            # The deployed Skill detail v6 / recommendation v3 / page-build
+            # generations make every old per-Skill key unreachable. One exact
+            # invalidation still bumps the shared Skill-list generation without
+            # issuing millions of redundant KV deletes for the full catalog.
+            awk 'NF { print; exit }' "$target" > "$invalidation_target"
+          else
+            cp "$target" "$invalidation_target"
+          fi
+          invalidation_count=$(sed '/^$/d' "$invalidation_target" | sort -u | wc -l | tr -d ' ')
+          test "$invalidation_count" -gt 0
           echo "slug_count=$count" >> "$GITHUB_OUTPUT"
+          echo "invalidation_count=$invalidation_count" >> "$GITHUB_OUTPUT"
 
       - name: Invalidate selected score API entries
         id: invalidate
         uses: ./.github/actions/invalidate-cache
         with:
           type: skills
-          slugs-file: ${{ runner.temp }}/cache-closure-slugs.txt
+          slugs-file: ${{ runner.temp }}/cache-invalidation-slugs.txt
           site-url: https://skillstore.io
           secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           batch-size: '30'
@@ -345,8 +358,9 @@ jobs:
 
       - name: Require exact invalidation count
         env:
-          EXPECTED: ${{ steps.selected.outputs.slug_count }}
+          EXPECTED: ${{ steps.selected.outputs.invalidation_count }}
           FAILED: ${{ steps.invalidate.outputs.failed_count }}
+          LIST_VERSION_BUMPED: ${{ steps.invalidate.outputs.list_version_bumped }}
           SUCCEEDED: ${{ steps.invalidate.outputs.success_count }}
           TOTAL: ${{ steps.invalidate.outputs.total_count }}
         run: |
@@ -354,6 +368,7 @@ jobs:
           test "$TOTAL" -eq "$EXPECTED"
           test "$SUCCEEDED" -eq "$EXPECTED"
           test "$FAILED" -eq 0
+          test "$LIST_VERSION_BUMPED" = true
 
       - name: Verify every production cache readback
         id: readback
@@ -362,28 +377,34 @@ jobs:
             --expected-score-evidence "$RUNNER_TEMP/cache-closure-expected-score-evidence.json" \
             --evidence "$RUNNER_TEMP/cache-readback.json" \
             --site-url https://skillstore.io \
-            --concurrency 8 \
+            --expected-cache-version v6 \
+            --concurrency 16 \
             --attempts 3 \
             --timeout-ms 30000
 
       - name: Write closure evidence
         if: always()
         env:
+          INVALIDATION_COUNT: ${{ steps.selected.outputs.invalidation_count || 'unknown' }}
+          LIST_VERSION_BUMPED: ${{ steps.invalidate.outputs.list_version_bumped || 'unknown' }}
           REMAINING: ${{ steps.selected.outputs.remaining_score_failures || 'unknown' }}
           SLUG_COUNT: ${{ steps.selected.outputs.slug_count || 'unknown' }}
         run: |
           evidence="$RUNNER_TEMP/score-cache-recovery-evidence"
           mkdir -p "$evidence"
           cp "$RUNNER_TEMP/cache-closure-slugs.txt" "$evidence/selected-slugs.txt" 2>/dev/null || true
+          cp "$RUNNER_TEMP/cache-invalidation-slugs.txt" "$evidence/invalidation-slugs.txt" 2>/dev/null || true
           cp "$RUNNER_TEMP/cache-closure-expected-score-evidence.json" "$evidence/expected-score-evidence.json" 2>/dev/null || true
           cp "$RUNNER_TEMP/cache-readback.json" "$evidence/cache-readback.json" 2>/dev/null || true
           cp "$RUNNER_TEMP/score-cache-recovery-result/before-score-evidence.json" "$evidence/before-score-evidence.json" 2>/dev/null || true
           cp "$RUNNER_TEMP/score-cache-recovery-result/run-boundary.txt" "$evidence/run-boundary.txt" 2>/dev/null || true
           cp "$RUNNER_TEMP/score-cache-recovery-result/score-write-evidence.json" "$evidence/score-write-evidence.json" 2>/dev/null || true
           jq -n --arg scope "${{ needs.plan.outputs.scope }}" --arg slugCount "$SLUG_COUNT" \
+            --arg invalidationCount "$INVALIDATION_COUNT" \
+            --arg listVersionBumped "$LIST_VERSION_BUMPED" \
             --arg remainingScoreFailures "$REMAINING" --arg invalidation "${{ steps.invalidate.outcome }}" \
             --arg readback "${{ steps.readback.outcome }}" \
-            '{schemaVersion:1,scope:$scope,slugCount:$slugCount,remainingScoreFailures:$remainingScoreFailures,invalidation:$invalidation,readback:$readback}' \
+            '{schemaVersion:1,scope:$scope,slugCount:$slugCount,invalidationCount:$invalidationCount,listVersionBumped:$listVersionBumped,remainingScoreFailures:$remainingScoreFailures,invalidation:$invalidation,readback:$readback}' \
             > "$evidence/summary.json"
 
       - name: Upload closure evidence
@@ -414,6 +435,8 @@ jobs:
             echo "- Scope: ${{ needs.plan.outputs.scope }}"
             echo "- Planned slugs: ${{ needs.plan.outputs.slug_count }}"
             echo "- Cache-closed slugs: ${{ steps.selected.outputs.slug_count || 'unknown' }}"
+            echo "- List-generation invalidation slugs: ${{ steps.selected.outputs.invalidation_count || 'unknown' }}"
+            echo "- Skill list generation bumped: ${{ steps.invalidate.outputs.list_version_bumped || 'unknown' }}"
             echo "- Remaining score failures: ${{ steps.selected.outputs.remaining_score_failures || 'unknown' }}"
             echo "- Invalidation: ${{ steps.invalidate.outcome }}"
             echo "- Production readback: ${{ steps.readback.outcome }}"

--- a/scripts/score-cache-closure.mjs
+++ b/scripts/score-cache-closure.mjs
@@ -297,12 +297,16 @@ function firstReadCanClose(read) {
 export async function verifyCacheReadback({
   attempts = 3,
   concurrency = 8,
+  expectedCacheVersion,
   fetchImpl = fetch,
   siteUrl = 'https://skillstore.io',
   expectedScores,
   timeoutMs = 30_000,
 }) {
   if (!Array.isArray(expectedScores)) fail('expected score evidence must be an array');
+  if (expectedCacheVersion !== undefined && !/^v[1-9][0-9]*$/.test(expectedCacheVersion)) {
+    fail('expected cache version must have the form vN');
+  }
   const normalized = normalizeSlugs(expectedScores.map((item) => item?.slug));
   if (normalized.length !== expectedScores.length) fail('expected score evidence contains duplicate slugs');
   const expectedBySlug = new Map(expectedScores.map((item) => [item.slug, item]));
@@ -316,6 +320,14 @@ export async function verifyCacheReadback({
       try {
         const first = await readSkill(fetchImpl, siteUrl, slug, timeoutMs);
         const second = await readSkill(fetchImpl, siteUrl, slug, timeoutMs);
+        if (
+          expectedCacheVersion !== undefined &&
+          (first.version !== expectedCacheVersion || second.version !== expectedCacheVersion)
+        ) {
+          fail(
+            `${slug} cache version was ${first.version}/${second.version}; expected ${expectedCacheVersion}`
+          );
+        }
         if (!firstReadCanClose(first)) {
           fail(`${slug} first read was ${first.cache || 'missing'}+${first.write || 'missing'}`);
         }
@@ -450,6 +462,7 @@ async function main() {
     const evidence = await verifyCacheReadback({
       attempts: positiveInteger(readOption(args, '--attempts', { fallback: '3' }), 'attempts', 5),
       concurrency: positiveInteger(readOption(args, '--concurrency', { fallback: '8' }), 'concurrency', 16),
+      expectedCacheVersion: readOption(args, '--expected-cache-version'),
       siteUrl: readOption(args, '--site-url', { fallback: 'https://skillstore.io' }),
       expectedScores,
       timeoutMs: positiveInteger(readOption(args, '--timeout-ms', { fallback: '30000' }), 'timeout-ms', 120_000),

--- a/scripts/tests/score-cache-closure.test.mjs
+++ b/scripts/tests/score-cache-closure.test.mjs
@@ -204,19 +204,37 @@ test('production readback requires a closed first read and a stable HIT+SKIPPED 
     })),
     attempts: 1,
     concurrency: 2,
+    expectedCacheVersion: 'v6',
     fetchImpl: async (url) => {
       const slug = String(url).split('/').at(-1);
       const count = (calls.get(slug) || 0) + 1;
       calls.set(slug, count);
       return cachedResponse(slug, count === 1
-        ? { cache: 'MISS', write: 'STORED' }
-        : { cache: 'HIT', write: 'SKIPPED' });
+        ? { cache: 'MISS', version: 'v6', write: 'STORED' }
+        : { cache: 'HIT', version: 'v6', write: 'SKIPPED' });
     },
   });
   assert.equal(evidence.failures.length, 0);
   assert.equal(evidence.slugCount, 2);
   assert.deepEqual(evidence.builds, ['build-a']);
   assert.deepEqual(Object.fromEntries(calls), { alpha: 2, beta: 2 });
+});
+
+test('readback rejects a stable cache generation that is not the required version', async () => {
+  const evidence = await verifyCacheReadback({
+    expectedScores: [{
+      slug: 'alpha', qualityScore: 88, qualityTier: 'silver',
+      calculatedAt: '2026-07-15T12:00:00+00:00', snapshotId: '11111111-1111-4111-8111-111111111111',
+    }],
+    attempts: 1,
+    concurrency: 1,
+    expectedCacheVersion: 'v6',
+    fetchImpl: async () => cachedResponse('alpha', {
+      cache: 'HIT', version: 'v5', write: 'SKIPPED',
+    }),
+  });
+  assert.equal(evidence.failures.length, 1);
+  assert.match(evidence.failures[0].error, /cache version was v5\/v5; expected v6/);
 });
 
 test('readback records unstable cache identity as a failure', async () => {
@@ -323,7 +341,16 @@ test('manual recovery is file-backed, fixed-CLI, bounded, and red on any remaini
   assert.match(RECOVERY, /group: production-skill-score-writes/);
   assert.match(RECOVERY, /--concurrency "\$\{\{ inputs\.score_concurrency \}\}"/);
   assert.match(RECOVERY, /Invalidate selected score API entries/);
+  assert.match(RECOVERY, /awk 'NF \{ print; exit \}' "\$target" > "\$invalidation_target"/);
+  assert.match(RECOVERY, /slugs-file: \$\{\{ runner\.temp \}\}\/cache-invalidation-slugs\.txt/);
+  assert.match(RECOVERY, /EXPECTED: \$\{\{ steps\.selected\.outputs\.invalidation_count \}\}/);
+  assert.match(RECOVERY, /test "\$LIST_VERSION_BUMPED" = true/);
+  assert.match(RECOVERY, /invalidationCount:\$invalidationCount/);
+  assert.match(RECOVERY, /listVersionBumped:\$listVersionBumped/);
+  assert.match(RECOVERY, /List-generation invalidation slugs:/);
   assert.match(RECOVERY, /batch-size: '30'\n\s+concurrency: \$\{\{ needs\.plan\.outputs\.scope == 'approved-catalog-cache' && '4' \|\| '1' \}\}/);
+  assert.match(RECOVERY, /--expected-cache-version v6/);
+  assert.match(RECOVERY, /--concurrency 16/);
   assert.match(RECOVERY, /Require complete score and cache recovery/);
   assert.match(RECOVERY, /freeze-score-evidence/);
   assert.match(RECOVERY, /before-score-evidence\.json/);
@@ -359,6 +386,8 @@ test('shared invalidation action preserves score-only closure flags and validate
   assert.match(INVALIDATE_ACTION, /invalidateArtifacts: \$invalidateArtifacts/);
   assert.match(INVALIDATE_ACTION, /invalidateDependentPacks: \$invalidateDependentPacks/);
   assert.match(INVALIDATE_ACTION, /Cache invalidation response violated the requested closure contract/);
+  assert.match(INVALIDATE_ACTION, /\.invalidated\.listVersionBumped == true/);
+  assert.match(INVALIDATE_ACTION, /list_version_bumped=true/);
   assert.match(INVALIDATE_ACTION, /--max-time 90/);
   assert.match(INVALIDATE_ACTION, /local max_attempts=4/);
   assert.match(INVALIDATE_ACTION, /concurrency:[\s\S]*default: '1'/);


### PR DESCRIPTION
## Summary
- keep the full 5,295-Skill frozen score/readback closure
- use one exact Skill invalidation to prove a global list-generation bump after the Skillstore v6/v3 namespace deployment
- require `listVersionBumped=true` and record it in closure evidence
- require every production readback to use `x-kv-version=v6`
- raise bounded readback concurrency from 8 to 16

## Safety
- non-approved recovery scopes retain full successful-slug invalidation
- artifact and dependent-Pack invalidation remain disabled for score recovery
- ZIP, download, install, NPX, MCP, and Pack detail namespaces are untouched

## Verification
- `CI=true node --check scripts/score-cache-closure.mjs`
- `CI=true node --test scripts/tests/score-cache-closure.test.mjs scripts/tests/recalculate-scores.test.mjs` (40/40)
- strict independent review: no remaining findings
- rebased on latest `origin/main` before push