### PR TITLE
fix(pack): gate contract smoke on protocol

### DIFF
--- a/scripts/pack-evaluator-contract-smoke.mjs
+++ b/scripts/pack-evaluator-contract-smoke.mjs
@@ -11,6 +11,7 @@ const REQUIRED_PROTOCOL_CHECKS = [
   'firstEventValid',
   'textDeltaSeen',
   'completed',
+  'errorFree',
 ];
 
 function fail(message) {
@@ -136,6 +137,7 @@ function outputTextDiagnostics(text) {
 
 function validateMessagesEvents(events) {
   const firstEventValid = events[0]?.type === 'message_start';
+  const errorFree = events.every((event) => event.type !== 'error');
   const deltas = events.filter((event) => (
     event.type === 'content_block_delta'
     && event.data?.delta?.type === 'text_delta'
@@ -146,12 +148,14 @@ function validateMessagesEvents(events) {
   return {
     firstEventValid,
     completed,
+    errorFree,
     ...outputTextDiagnostics(text),
   };
 }
 
 function validateResponsesEvents(events) {
   const firstEventValid = events[0]?.type === 'response.created';
+  const errorFree = events.every((event) => event.type !== 'error');
   const deltas = events.filter((event) => (
     event.type === 'response.output_text.delta'
     && typeof event.data?.delta === 'string'
@@ -161,6 +165,7 @@ function validateResponsesEvents(events) {
   return {
     firstEventValid,
     completed,
+    errorFree,
     ...outputTextDiagnostics(text),
   };
 }
@@ -226,6 +231,7 @@ async function runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs 
     firstEventValid: false,
     textDeltaSeen: false,
     completed: false,
+    errorFree: false,
     textMatches: false,
     outputTextBytes: 0,
     outputTextSha256: null,

--- a/scripts/pack-evaluator-contract-smoke.mjs
+++ b/scripts/pack-evaluator-contract-smoke.mjs
@@ -5,6 +5,13 @@ import { writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const MAX_RESPONSE_BYTES = 1024 * 1024;
+const EXPECTED_RESPONSE_TEXT = 'PACK_EVALUATOR_READY';
+const REQUIRED_PROTOCOL_CHECKS = [
+  'contentTypeValid',
+  'firstEventValid',
+  'textDeltaSeen',
+  'completed',
+];
 
 function fail(message) {
   throw new Error(message);
@@ -117,6 +124,16 @@ function sseEvents(body) {
   return events;
 }
 
+function outputTextDiagnostics(text) {
+  const normalized = text.trim();
+  return {
+    textDeltaSeen: normalized.length > 0,
+    textMatches: normalized === EXPECTED_RESPONSE_TEXT,
+    outputTextBytes: Buffer.byteLength(normalized),
+    outputTextSha256: normalized ? sha256(normalized) : null,
+  };
+}
+
 function validateMessagesEvents(events) {
   const firstEventValid = events[0]?.type === 'message_start';
   const deltas = events.filter((event) => (
@@ -125,12 +142,11 @@ function validateMessagesEvents(events) {
     && typeof event.data.delta.text === 'string'
   ));
   const completed = events.some((event) => event.type === 'message_stop');
-  const text = deltas.map((event) => event.data.delta.text).join('').trim();
+  const text = deltas.map((event) => event.data.delta.text).join('');
   return {
     firstEventValid,
-    textDeltaSeen: deltas.length > 0,
     completed,
-    textMatches: text === 'PACK_EVALUATOR_READY',
+    ...outputTextDiagnostics(text),
   };
 }
 
@@ -141,12 +157,11 @@ function validateResponsesEvents(events) {
     && typeof event.data?.delta === 'string'
   ));
   const completed = events.some((event) => event.type === 'response.completed');
-  const text = deltas.map((event) => event.data.delta).join('').trim();
+  const text = deltas.map((event) => event.data.delta).join('');
   return {
     firstEventValid,
-    textDeltaSeen: deltas.length > 0,
     completed,
-    textMatches: text === 'PACK_EVALUATOR_READY',
+    ...outputTextDiagnostics(text),
   };
 }
 
@@ -212,6 +227,8 @@ async function runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs 
     textDeltaSeen: false,
     completed: false,
     textMatches: false,
+    outputTextBytes: 0,
+    outputTextSha256: null,
   };
   let eventCount = 0;
   if (response?.ok) {
@@ -226,7 +243,7 @@ async function runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs 
       protocol = { ...protocol, malformed: true };
     }
   }
-  const validResponse = Object.values(protocol).every((value) => value === true);
+  const validResponse = REQUIRED_PROTOCOL_CHECKS.every((check) => protocol[check] === true);
   return {
     name: contract.name,
     outcome: transportError

--- a/scripts/tests/pack-evaluator-contract-smoke.test.mjs
+++ b/scripts/tests/pack-evaluator-contract-smoke.test.mjs
@@ -11,6 +11,28 @@ function sse(events) {
   )).join('\n\n')}\n\n`;
 }
 
+function messagesEvents(text = 'PACK_EVALUATOR_READY', { completed = true } = {}) {
+  return [
+    { type: 'message_start', data: { message: { id: 'msg_safe' } } },
+    { type: 'content_block_delta', data: { delta: { type: 'text_delta', text } } },
+    ...(completed ? [{ type: 'message_stop', data: {} }] : []),
+  ];
+}
+
+function responsesEvents(text = 'PACK_EVALUATOR_READY', { completed = true } = {}) {
+  return [
+    { type: 'response.created', data: { response: { id: 'resp_safe' } } },
+    { type: 'response.output_text.delta', data: { delta: text } },
+    ...(completed ? [{ type: 'response.completed', data: { response: { id: 'resp_safe' } } }] : []),
+  ];
+}
+
+function contractSse(url, { messagesText, responsesText, responsesCompleted = true } = {}) {
+  return String(url).endsWith('/v1/messages')
+    ? sse(messagesEvents(messagesText))
+    : sse(responsesEvents(responsesText, { completed: responsesCompleted }));
+}
+
 test('contract smoke makes one bounded request for Messages and Responses before evaluation', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
@@ -21,19 +43,7 @@ test('contract smoke makes one bounded request for Messages and Responses before
     diagnosticsFile,
     fetchImpl: async (url, init) => {
       calls.push({ url: String(url), init });
-      const response = String(url).endsWith('/v1/messages')
-        ? sse([
-          { type: 'message_start', data: { message: { id: 'msg_safe' } } },
-          { type: 'content_block_delta', data: { delta: { type: 'text_delta', text: 'PACK_EVALUATOR_' } } },
-          { type: 'content_block_delta', data: { delta: { type: 'text_delta', text: 'READY' } } },
-          { type: 'message_stop', data: {} },
-        ])
-        : sse([
-          { type: 'response.created', data: { response: { id: 'resp_safe' } } },
-          { type: 'response.output_text.delta', data: { delta: 'PACK_EVALUATOR_' } },
-          { type: 'response.output_text.delta', data: { delta: 'READY' } },
-          { type: 'response.completed', data: { response: { id: 'resp_safe' } } },
-        ]);
+      const response = contractSse(url);
       return new Response(response, {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
@@ -64,8 +74,73 @@ test('contract smoke makes one bounded request for Messages and Responses before
   assert.doesNotMatch(persisted, /PACK_EVALUATOR_READY|job-local-secret|Reply with exactly/);
 });
 
-test('contract smoke still sends exactly two probes after an HTTP error without persisting its body', async () => {
-  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-error-'));
+test('generated text mismatch is redacted diagnostics and not a protocol failure for either contract', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-content-'));
+  const diagnosticsFile = join(directory, 'contract-smoke.json');
+  let calls = 0;
+  const diagnostics = await runContractSmoke({
+    proxyUrl: 'http://127.0.0.1:18765',
+    token: 'job-local-secret',
+    diagnosticsFile,
+    fetchImpl: async (url) => {
+      calls += 1;
+      return new Response(contractSse(url, {
+        messagesText: 'Messages route is ready.',
+        responsesText: 'Responses route is ready.',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+      });
+    },
+  });
+  assert.equal(calls, 2);
+  assert.equal(diagnostics.outcome, 'passed');
+  for (const contract of diagnostics.contracts) {
+    assert.equal(contract.outcome, 'passed');
+    assert.equal(contract.protocol.textDeltaSeen, true);
+    assert.equal(contract.protocol.textMatches, false);
+    assert.ok(contract.protocol.outputTextBytes > 0);
+    assert.match(contract.protocol.outputTextSha256, /^[a-f0-9]{64}$/);
+  }
+  const persisted = readFileSync(diagnosticsFile, 'utf8');
+  assert.doesNotMatch(persisted, /Messages route is ready|Responses route is ready|job-local-secret/);
+});
+
+for (const emptyContract of ['messages', 'responses']) {
+  test(`empty ${emptyContract} text delta remains a protocol failure`, async () => {
+    const directory = mkdtempSync(join(tmpdir(), `pack-contract-smoke-empty-${emptyContract}-`));
+    const diagnosticsFile = join(directory, 'contract-smoke.json');
+    let calls = 0;
+    await assert.rejects(
+      runContractSmoke({
+        proxyUrl: 'http://127.0.0.1:18765',
+        token: 'job-local-secret',
+        diagnosticsFile,
+        fetchImpl: async (url) => {
+          calls += 1;
+          return new Response(contractSse(url, {
+            messagesText: emptyContract === 'messages' ? '  \n' : undefined,
+            responsesText: emptyContract === 'responses' ? '\t' : undefined,
+          }), {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          });
+        },
+      }),
+      new RegExp(`contract=(?:claude_messages|codex_responses) outcome=invalid_response status=200`),
+    );
+    assert.equal(calls, 2);
+    const persisted = JSON.parse(readFileSync(diagnosticsFile, 'utf8'));
+    const failed = persisted.contracts.find((contract) => contract.outcome === 'invalid_response');
+    assert.equal(failed.name, emptyContract === 'messages' ? 'claude_messages' : 'codex_responses');
+    assert.equal(failed.protocol.textDeltaSeen, false);
+    assert.equal(failed.protocol.outputTextBytes, 0);
+    assert.equal(failed.protocol.outputTextSha256, null);
+  });
+}
+
+test('HTTP 200 JSON is not accepted as an SSE protocol response', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-json-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   let calls = 0;
   await assert.rejects(
@@ -75,14 +150,117 @@ test('contract smoke still sends exactly two probes after an HTTP error without 
       diagnosticsFile,
       fetchImpl: async () => {
         calls += 1;
-        return new Response('{"error":{"message":"private upstream detail"}}', { status: 422 });
+        return new Response('{"status":"ok"}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
       },
     }),
-    /contract=claude_messages outcome=http_failed status=422/,
+    /contract=claude_messages outcome=invalid_response status=200/,
+  );
+  assert.equal(calls, 2);
+  const persisted = JSON.parse(readFileSync(diagnosticsFile, 'utf8'));
+  assert.equal(persisted.contracts[0].protocol.contentTypeValid, false);
+});
+
+test('malformed SSE JSON remains a protocol failure', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-malformed-'));
+  const diagnosticsFile = join(directory, 'contract-smoke.json');
+  let calls = 0;
+  await assert.rejects(
+    runContractSmoke({
+      proxyUrl: 'http://127.0.0.1:18765',
+      token: 'job-local-secret',
+      diagnosticsFile,
+      fetchImpl: async (url) => {
+        calls += 1;
+        const body = String(url).endsWith('/v1/messages')
+          ? 'event: message_start\ndata: {not-json}\n\n'
+          : contractSse(url);
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    }),
+    /contract=claude_messages outcome=invalid_response status=200/,
+  );
+  assert.equal(calls, 2);
+  const persisted = JSON.parse(readFileSync(diagnosticsFile, 'utf8'));
+  assert.equal(persisted.contracts[0].protocol.malformed, true);
+});
+
+test('wrong first SSE event remains a protocol failure', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-first-event-'));
+  const diagnosticsFile = join(directory, 'contract-smoke.json');
+  await assert.rejects(
+    runContractSmoke({
+      proxyUrl: 'http://127.0.0.1:18765',
+      token: 'job-local-secret',
+      diagnosticsFile,
+      fetchImpl: async (url) => {
+        const body = String(url).endsWith('/v1/messages')
+          ? sse([
+            { type: 'content_block_delta', data: { delta: { type: 'text_delta', text: 'ready' } } },
+            { type: 'message_start', data: { message: { id: 'msg_safe' } } },
+            { type: 'message_stop', data: {} },
+          ])
+          : contractSse(url);
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    }),
+    /contract=claude_messages outcome=invalid_response status=200/,
+  );
+  const persisted = JSON.parse(readFileSync(diagnosticsFile, 'utf8'));
+  assert.equal(persisted.contracts[0].protocol.firstEventValid, false);
+});
+
+test('missing completion SSE event remains a protocol failure', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-completed-'));
+  const diagnosticsFile = join(directory, 'contract-smoke.json');
+  await assert.rejects(
+    runContractSmoke({
+      proxyUrl: 'http://127.0.0.1:18765',
+      token: 'job-local-secret',
+      diagnosticsFile,
+      fetchImpl: async (url) => new Response(contractSse(url, {
+        responsesCompleted: !String(url).endsWith('/v1/responses'),
+      }), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    }),
+    /contract=codex_responses outcome=invalid_response status=200/,
+  );
+  const persisted = JSON.parse(readFileSync(diagnosticsFile, 'utf8'));
+  assert.equal(persisted.contracts[1].protocol.completed, false);
+});
+
+test('contract smoke still sends exactly two probes after an HTTP error without persisting its body', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-error-'));
+  const diagnosticsFile = join(directory, 'contract-smoke.json');
+  let calls = 0;
+  await assert.rejects(
+    runContractSmoke({
+      proxyUrl: 'http://127.0.0.1:18765',
+      token: 'job-local-secret',
+      diagnosticsFile,
+      fetchImpl: async (url) => {
+        calls += 1;
+        return new Response('{"error":{"message":"private upstream detail"}}', {
+          status: String(url).endsWith('/v1/messages') ? 400 : 404,
+        });
+      },
+    }),
+    /contract=claude_messages outcome=http_failed status=400/,
   );
   assert.equal(calls, 2);
   const persisted = readFileSync(diagnosticsFile, 'utf8');
-  assert.match(persisted, /"status": 422/);
+  assert.match(persisted, /"status": 400/);
+  assert.match(persisted, /"status": 404/);
   assert.match(persisted, /"errorCategory": "other"/);
   assert.match(persisted, /"errorMessageSha256": "[a-f0-9]{64}"/);
   assert.doesNotMatch(persisted, /private upstream detail|job-local-secret/);

--- a/scripts/tests/pack-evaluator-contract-smoke.test.mjs
+++ b/scripts/tests/pack-evaluator-contract-smoke.test.mjs
@@ -139,6 +139,47 @@ for (const emptyContract of ['messages', 'responses']) {
   });
 }
 
+for (const errorContract of ['messages', 'responses']) {
+  test(`${errorContract} error SSE event remains a protocol failure`, async () => {
+    const directory = mkdtempSync(join(tmpdir(), `pack-contract-smoke-error-event-${errorContract}-`));
+    const diagnosticsFile = join(directory, 'contract-smoke.json');
+    let calls = 0;
+    await assert.rejects(
+      runContractSmoke({
+        proxyUrl: 'http://127.0.0.1:18765',
+        token: 'job-local-secret',
+        diagnosticsFile,
+        fetchImpl: async (url) => {
+          calls += 1;
+          const isMessages = String(url).endsWith('/v1/messages');
+          const events = isMessages ? messagesEvents() : responsesEvents();
+          if ((isMessages ? 'messages' : 'responses') === errorContract) {
+            events.splice(-1, 0, {
+              type: 'error',
+              data: { error: { message: 'private upstream stream error' } },
+            });
+          }
+          return new Response(sse(events), {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          });
+        },
+      }),
+      /contract=(?:claude_messages|codex_responses) outcome=invalid_response status=200/,
+    );
+    assert.equal(calls, 2);
+    const persistedText = readFileSync(diagnosticsFile, 'utf8');
+    const persisted = JSON.parse(persistedText);
+    const failed = persisted.contracts.find((contract) => contract.outcome === 'invalid_response');
+    assert.equal(failed.name, errorContract === 'messages' ? 'claude_messages' : 'codex_responses');
+    assert.equal(failed.protocol.firstEventValid, true);
+    assert.equal(failed.protocol.textDeltaSeen, true);
+    assert.equal(failed.protocol.completed, true);
+    assert.equal(failed.protocol.errorFree, false);
+    assert.doesNotMatch(persistedText, /private upstream stream error/);
+  });
+}
+
 test('HTTP 200 JSON is not accepted as an SSE protocol response', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-json-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');


### PR DESCRIPTION
## Summary

- gate the Messages and Responses probes only on explicit SSE protocol requirements
- require non-empty generated text while keeping exact text matching as redacted diagnostics
- persist only output byte counts and SHA-256 hashes, never generated text
- prove HTTP, content-type, malformed SSE, ordering, empty output, and completion failures remain blocking

## Why

The bounded smoke run returned HTTP 200 and a valid Responses SSE lifecycle, but failed only because generated text did not exactly equal the requested marker. Exact generative content is not a stable transport or protocol contract.

## Verification

- CI=true node --test scripts/tests/pack-evaluator-contract-smoke.test.mjs scripts/tests/generate-packs-workflow.test.mjs
- Ruby YAML syntax parse for .github/workflows/generate-packs.yml
- node --check for the smoke script and its tests
- git diff --check

No Helm or model endpoint was called during this change.