### PR TITLE
fix(pack): enable scoped bwrap user namespaces

### DIFF
--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           # Content finalization must use the same immutable nonce-aware v4 CLI
           # contract as evaluation and persistence.
-          version: '2.13.0'
-          minimum-version: '2.13.0'
+          version: '2.13.1'
+          minimum-version: '2.13.1'
           require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli

--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           # Content finalization must use the same immutable nonce-aware v4 CLI
           # contract as evaluation and persistence.
-          version: '2.13.1'
-          minimum-version: '2.13.1'
+          version: '2.13.2'
+          minimum-version: '2.13.2'
           require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.13.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.13.1'
 
 jobs:
   contract_smoke_only:
@@ -257,7 +257,7 @@ jobs:
     if: needs.plan.outputs.has_scenarios == 'true'
     # GitHub-hosted runners are single-use VMs. The evaluator never reuses the
     # persistent OAuth HOME or sibling workspaces from our self-hosted pool.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 330
     steps:
       - name: Checkout immutable skills and orchestrator
@@ -359,7 +359,8 @@ jobs:
       - name: Install evaluator runtimes before secrets are available
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends bubblewrap ffmpeg poppler-utils ripgrep
+          sudo apt-get install --yes --no-install-recommends \
+            apparmor bubblewrap ffmpeg poppler-utils ripgrep util-linux
           sudo install -d -o root -g root -m 0755 \
             /opt/pack-evaluator \
             /opt/pack-evaluator/runtime
@@ -455,6 +456,13 @@ jobs:
             | sudo tee /opt/pack-evaluator/codex-home/config.toml >/dev/null
           sudo chown root:root /opt/pack-evaluator/codex-home/config.toml
           sudo chmod 0444 /opt/pack-evaluator/codex-home/config.toml
+
+      - name: Configure and prove scoped bubblewrap user namespaces before secrets
+        run: |
+          set -euo pipefail
+          sudo env \
+            PACK_EVALUATOR_OUTER_WORKSPACE="$GITHUB_WORKSPACE" \
+            "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/configure-pack-evaluator-bwrap.sh"
 
       # The real Helm credential exists only in this runner-owned shell and the
       # separate packproxy process. Agent commands run as a different, non-sudo
@@ -671,49 +679,6 @@ jobs:
               > "$GITHUB_WORKSPACE/pack-diagnostics/preflight-failure.txt"
             exit 1
           fi
-
-          # Match the Skillstore agent sandbox contract before any model CLI
-          # is allowed to run. The fresh PID namespace must hide the proxy's
-          # parent process, and the empty mount root must not expose evaluator
-          # orchestration code, immutable inputs, results, or the checkout.
-          sudo -u packeval env -i \
-            /usr/bin/bwrap \
-              --die-with-parent \
-              --new-session \
-              --unshare-pid \
-              --unshare-ipc \
-              --unshare-uts \
-              --tmpfs / \
-              --proc /proc \
-              --dev /dev \
-              --dir /opt \
-              --dir /opt/pack-evaluator \
-              --ro-bind /opt/pack-evaluator/runtime /opt/pack-evaluator/runtime \
-              --dir /usr \
-              --ro-bind /usr /usr \
-              --symlink usr/bin /bin \
-              --symlink usr/lib /lib \
-              --symlink usr/lib64 /lib64 \
-              --dir /home \
-              --dir /home/packeval \
-              --bind /home/packeval /home/packeval \
-              --dir /tmp \
-              --bind /home/packeval/tmp /tmp \
-              --setenv HOME /home/packeval \
-              --setenv TMPDIR /tmp \
-              --setenv PATH /opt/pack-evaluator/runtime/bin:/usr/bin:/bin \
-              --setenv PROXY_PID "$PROXY_PID" \
-              --setenv OUTER_WORKSPACE "$GITHUB_WORKSPACE" \
-              /usr/bin/bash -c '
-                set -euo pipefail
-                test -x /opt/pack-evaluator/runtime/bin/node
-                ! test -e /opt/pack-evaluator/bin
-                ! test -e /opt/pack-evaluator/lib
-                ! test -e /opt/pack-evaluator/input
-                ! test -e /opt/pack-evaluator/results
-                ! test -e "$OUTER_WORKSPACE"
-                ! test -e "/proc/$PROXY_PID"
-              '
 
           # Two single-request contract probes (Messages and Responses) prove
           # the Helm key/model/route contract before any expensive agent run.

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.13.1'
+  PACK_PRODUCTION_CLI_VERSION: '2.13.2'
 
 jobs:
   contract_smoke_only:

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -1,0 +1,75 @@
+name: Test Pack Evaluator Bubblewrap
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/generate-packs.yml'
+      - '.github/workflows/test-pack-evaluator-bwrap.yml'
+      - 'scripts/configure-pack-evaluator-bwrap.sh'
+      - 'scripts/pack-evaluator-bwrap.apparmor'
+      - 'scripts/pack-evaluator-preflight.sh'
+      - 'scripts/tests/generate-packs-workflow.test.mjs'
+      - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/generate-packs.yml'
+      - '.github/workflows/test-pack-evaluator-bwrap.yml'
+      - 'scripts/configure-pack-evaluator-bwrap.sh'
+      - 'scripts/pack-evaluator-bwrap.apparmor'
+      - 'scripts/pack-evaluator-preflight.sh'
+      - 'scripts/tests/generate-packs-workflow.test.mjs'
+      - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-pack-evaluator-bwrap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  userns:
+    name: Prove scoped bwrap user namespace
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout immutable helper
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
+
+      - name: Install bubblewrap and prepare disposable runtime
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends apparmor bubblewrap util-linux
+          sudo useradd --create-home --home-dir /home/packeval --shell /bin/bash packeval
+          NODE_SOURCE=$(command -v node)
+          test -x "$NODE_SOURCE"
+          sudo install -d -o root -g root -m 0755 \
+            /opt/pack-evaluator \
+            /opt/pack-evaluator/runtime \
+            /opt/pack-evaluator/runtime/bin
+          sudo install -o root -g root -m 0555 \
+            "$NODE_SOURCE" /opt/pack-evaluator/runtime/bin/node
+          sudo install -d -o packeval -g packeval -m 0700 /home/packeval/tmp
+          sudo install -d -o root -g root -m 1777 /opt/pack-evaluator/codex-home
+          sudo chown root:root \
+            scripts/configure-pack-evaluator-bwrap.sh \
+            scripts/pack-evaluator-bwrap.apparmor
+          sudo chmod 0555 scripts/configure-pack-evaluator-bwrap.sh
+          sudo chmod 0444 scripts/pack-evaluator-bwrap.apparmor
+
+      - name: Configure scoped AppArmor policy and prove the real sandbox
+        run: |
+          set -euo pipefail
+          sudo env \
+            PACK_EVALUATOR_OUTER_WORKSPACE="$GITHUB_WORKSPACE" \
+            "$GITHUB_WORKSPACE/scripts/configure-pack-evaluator-bwrap.sh"

--- a/scripts/configure-pack-evaluator-bwrap.sh
+++ b/scripts/configure-pack-evaluator-bwrap.sh
@@ -119,12 +119,19 @@ runuser -u "$EVALUATOR_USER" -- \
     --ro-bind-try /sbin /sbin \
     --ro-bind-try /lib /lib \
     --ro-bind-try /lib64 /lib64 \
+    --ro-bind-try /opt/google/chrome /opt/google/chrome \
+    --ro-bind-try /etc/alternatives /etc/alternatives \
     --ro-bind-try /etc/ca-certificates /etc/ca-certificates \
+    --ro-bind-try /etc/fonts /etc/fonts \
     --ro-bind-try /etc/group /etc/group \
     --ro-bind-try /etc/hosts /etc/hosts \
     --ro-bind-try /etc/localtime /etc/localtime \
+    --ro-bind-try /etc/magic /etc/magic \
+    --ro-bind-try /etc/magic.mime /etc/magic.mime \
+    --ro-bind-try /etc/mime.types /etc/mime.types \
     --ro-bind-try /etc/nsswitch.conf /etc/nsswitch.conf \
     --ro-bind-try /etc/passwd /etc/passwd \
+    --ro-bind-try /etc/pki /etc/pki \
     --ro-bind-try /etc/resolv.conf /etc/resolv.conf \
     --ro-bind-try /etc/ssl /etc/ssl \
     --bind "$EVALUATOR_HOME" "$EVALUATOR_HOME" \

--- a/scripts/configure-pack-evaluator-bwrap.sh
+++ b/scripts/configure-pack-evaluator-bwrap.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+readonly BWRAP=/usr/bin/bwrap
+readonly APPARMOR_PARSER=/usr/sbin/apparmor_parser
+readonly APPARMOR_PROFILES=/sys/kernel/security/apparmor/profiles
+readonly PROFILE_NAME=pack-production-bwrap
+readonly PROFILE_TARGET=/etc/apparmor.d/pack-production-bwrap
+readonly EVALUATOR_USER=packeval
+readonly EVALUATOR_HOME=/home/packeval
+readonly EVALUATOR_TMP=/home/packeval/tmp
+readonly RUNTIME_ROOT=/opt/pack-evaluator/runtime
+readonly CODEX_HOME=/opt/pack-evaluator/codex-home
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly PROFILE_SOURCE="$SCRIPT_DIR/pack-evaluator-bwrap.apparmor"
+
+: "${PACK_EVALUATOR_OUTER_WORKSPACE:?PACK_EVALUATOR_OUTER_WORKSPACE is required}"
+
+diagnose_failure() {
+  local exit_code=$?
+  trap - ERR
+  echo '::error::Pack evaluator bubblewrap/AppArmor preflight failed' >&2
+  /usr/sbin/sysctl \
+    kernel.apparmor_restrict_unprivileged_userns \
+    kernel.apparmor_restrict_unprivileged_unconfined \
+    user.max_user_namespaces 2>/dev/null >&2 || true
+  /usr/bin/dmesg 2>/dev/null \
+    | /usr/bin/grep -Ei 'apparmor="DENIED"|userns|uid_map' \
+    | /usr/bin/tail -50 >&2 || true
+  exit "$exit_code"
+}
+trap diagnose_failure ERR
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  echo 'Pack evaluator bubblewrap configuration must run as root' >&2
+  exit 1
+fi
+
+# Pin the kernel/security contract alongside the workflow's Ubuntu image.
+source /etc/os-release
+test "${ID:-}:${VERSION_ID:-}" = 'ubuntu:24.04'
+test "$(cat /sys/module/apparmor/parameters/enabled)" = 'Y'
+test -x "$APPARMOR_PARSER"
+test -r "$APPARMOR_PROFILES"
+test -x "$BWRAP"
+test "$("$BWRAP" --version)" = 'bubblewrap 0.9.0'
+test "$(stat -c '%U:%G' "$BWRAP")" = 'root:root'
+test -r "$PROFILE_SOURCE"
+test "$(stat -c '%U:%G' "$PROFILE_SOURCE")" = 'root:root'
+test "$(stat -c '%U:%G' "${BASH_SOURCE[0]}")" = 'root:root'
+test -d "$PACK_EVALUATOR_OUTER_WORKSPACE"
+test "${PACK_EVALUATOR_OUTER_WORKSPACE#/}" != "$PACK_EVALUATOR_OUTER_WORKSPACE"
+id "$EVALUATOR_USER" >/dev/null
+if runuser -u "$EVALUATOR_USER" -- test -w "$BWRAP"; then
+  echo 'Evaluator user can modify the bubblewrap executable' >&2
+  exit 1
+fi
+if runuser -u "$EVALUATOR_USER" -- test -w "$PROFILE_SOURCE"; then
+  echo 'Evaluator user can modify the AppArmor profile source' >&2
+  exit 1
+fi
+if runuser -u "$EVALUATOR_USER" -- test -w "${BASH_SOURCE[0]}"; then
+  echo 'Evaluator user can modify the root helper' >&2
+  exit 1
+fi
+test -d "$EVALUATOR_HOME"
+test -d "$EVALUATOR_TMP"
+test -x "$RUNTIME_ROOT/bin/node"
+test -d "$CODEX_HOME"
+
+readonly RESTRICTED_USERNS_BEFORE="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)"
+readonly MAX_USER_NAMESPACES="$(sysctl -n user.max_user_namespaces)"
+test "$RESTRICTED_USERNS_BEFORE" = '1'
+test "$MAX_USER_NAMESPACES" -gt 0
+
+# This is the path-scoped mitigation recommended by Ubuntu. Never lower the
+# host-wide unprivileged-user-namespace restriction for the whole runner.
+install -o root -g root -m 0644 "$PROFILE_SOURCE" "$PROFILE_TARGET"
+"$APPARMOR_PARSER" -Q "$PROFILE_TARGET"
+"$APPARMOR_PARSER" -r "$PROFILE_TARGET"
+grep -F "$PROFILE_NAME " "$APPARMOR_PROFILES" >/dev/null
+test "$(stat -c '%U:%G:%a' "$PROFILE_TARGET")" = 'root:root:644'
+test "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)" = '1'
+
+# Prove the host-wide restriction was not disabled: an unprofiled executable
+# still cannot create and map an unprivileged user namespace.
+if runuser -u "$EVALUATOR_USER" -- \
+  env -i /usr/bin/unshare --user --map-root-user /usr/bin/true \
+  >/dev/null 2>&1; then
+  echo 'Unprofiled user namespace creation unexpectedly succeeded' >&2
+  exit 1
+fi
+
+readonly EVALUATOR_UID="$(id -u "$EVALUATOR_USER")"
+readonly HOST_NET_NAMESPACE="$(readlink /proc/self/ns/net)"
+readonly HOST_PID="$$"
+
+# Match the Skillstore executor's namespace/capability contract. --disable-userns
+# creates a second user namespace after setup, preventing the Agent from making
+# another user namespace and rearranging the mount tree from inside the sandbox.
+runuser -u "$EVALUATOR_USER" -- \
+  env -i \
+  "$BWRAP" \
+    --die-with-parent \
+    --new-session \
+    --unshare-all \
+    --share-net \
+    --disable-userns \
+    --cap-drop ALL \
+    --tmpfs / \
+    --proc /proc \
+    --dev /dev \
+    --tmpfs /run \
+    --ro-bind "$RUNTIME_ROOT" "$RUNTIME_ROOT" \
+    --ro-bind-try /usr /usr \
+    --ro-bind-try /bin /bin \
+    --ro-bind-try /sbin /sbin \
+    --ro-bind-try /lib /lib \
+    --ro-bind-try /lib64 /lib64 \
+    --ro-bind-try /etc/ca-certificates /etc/ca-certificates \
+    --ro-bind-try /etc/group /etc/group \
+    --ro-bind-try /etc/hosts /etc/hosts \
+    --ro-bind-try /etc/localtime /etc/localtime \
+    --ro-bind-try /etc/nsswitch.conf /etc/nsswitch.conf \
+    --ro-bind-try /etc/passwd /etc/passwd \
+    --ro-bind-try /etc/resolv.conf /etc/resolv.conf \
+    --ro-bind-try /etc/ssl /etc/ssl \
+    --bind "$EVALUATOR_HOME" "$EVALUATOR_HOME" \
+    --bind "$EVALUATOR_TMP" /tmp \
+    --bind "$CODEX_HOME" "$CODEX_HOME" \
+    --setenv HOME "$EVALUATOR_HOME" \
+    --setenv TMPDIR /tmp \
+    --setenv CODEX_HOME "$CODEX_HOME" \
+    --setenv PATH "$RUNTIME_ROOT/bin:/usr/bin:/bin" \
+    --setenv EXPECTED_UID "$EVALUATOR_UID" \
+    --setenv EXPECTED_NET_NAMESPACE "$HOST_NET_NAMESPACE" \
+    --setenv OUTER_WORKSPACE "$PACK_EVALUATOR_OUTER_WORKSPACE" \
+    --setenv OUTER_PID "$HOST_PID" \
+    --chdir "$EVALUATOR_HOME" \
+    -- \
+    /usr/bin/bash -ceu '
+      test "$(id -u)" = "$EXPECTED_UID"
+      read -r namespace_uid parent_uid map_length < /proc/self/uid_map
+      test "$namespace_uid:$parent_uid:$map_length" = "$EXPECTED_UID:0:1"
+      awk '\''
+        $1 ~ /^Cap(Inh|Prm|Eff|Bnd|Amb):$/ {
+          seen += 1
+          if ($2 !~ /^0+$/) exit 1
+        }
+        END { if (seen != 5) exit 1 }
+      '\'' /proc/self/status
+      test -x /opt/pack-evaluator/runtime/bin/node
+      /opt/pack-evaluator/runtime/bin/node --version >/dev/null
+      ! test -w /opt/pack-evaluator/runtime
+      ! test -e /opt/pack-evaluator/bin
+      ! test -e /opt/pack-evaluator/lib
+      ! test -e /opt/pack-evaluator/input
+      ! test -e /opt/pack-evaluator/results
+      test "$(readlink /proc/self/ns/net)" = "$EXPECTED_NET_NAMESPACE"
+      ! test -e "$OUTER_WORKSPACE"
+      ! test -e "/proc/$OUTER_PID"
+      ! env | grep -Eq "SUPABASE|HELM|GITHUB_TOKEN|GH_TOKEN|APP_PRIVATE_KEY|CALLBACK"
+      if /usr/bin/unshare --user /usr/bin/true 2>/dev/null; then
+        exit 1
+      fi
+    '
+
+test "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)" = '1'
+echo 'Pack evaluator bubblewrap/AppArmor preflight passed'

--- a/scripts/configure-pack-evaluator-bwrap.sh
+++ b/scripts/configure-pack-evaluator-bwrap.sh
@@ -106,6 +106,7 @@ runuser -u "$EVALUATOR_USER" -- \
     --new-session \
     --unshare-all \
     --share-net \
+    --unshare-user \
     --disable-userns \
     --cap-drop ALL \
     --tmpfs / \

--- a/scripts/pack-evaluator-bwrap.apparmor
+++ b/scripts/pack-evaluator-bwrap.apparmor
@@ -1,0 +1,9 @@
+abi <abi/4.0>,
+include <tunables/global>
+
+# Ubuntu 24.04 restricts unprivileged user namespaces by default. Grant only
+# the root-owned bubblewrap executable the userns permission it needs to build
+# the evaluator sandbox; keep the host-wide restriction enabled.
+profile pack-production-bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+}

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -14,12 +14,14 @@ readonly -a AGENT_BWRAP=(
   "$BWRAP"
   --die-with-parent
   --new-session
-  --unshare-pid
-  --unshare-ipc
-  --unshare-uts
+  --unshare-all
+  --share-net
+  --disable-userns
+  --cap-drop ALL
   --tmpfs /
   --proc /proc
   --dev /dev
+  --tmpfs /run
   --dir /opt
   --dir /opt/pack-evaluator
   --ro-bind /opt/pack-evaluator/runtime /opt/pack-evaluator/runtime

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -16,6 +16,7 @@ readonly -a AGENT_BWRAP=(
   --new-session
   --unshare-all
   --share-net
+  --unshare-user
   --disable-userns
   --cap-drop ALL
   --tmpfs /

--- a/scripts/tests/fixtures/README.md
+++ b/scripts/tests/fixtures/README.md
@@ -12,4 +12,4 @@ Marketplace-only fixture update is a release blocker, not backward
 compatibility.
 
 The Generate Pack and content workflows are pinned to the immutable,
-checksum-verified CLI 2.13.1 release that owns this v4 contract.
+checksum-verified CLI 2.13.2 release that owns this v4 contract.

--- a/scripts/tests/fixtures/README.md
+++ b/scripts/tests/fixtures/README.md
@@ -12,4 +12,4 @@ Marketplace-only fixture update is a release blocker, not backward
 compatibility.
 
 The Generate Pack and content workflows are pinned to the immutable,
-checksum-verified CLI 2.13.0 release that owns this v4 contract.
+checksum-verified CLI 2.13.1 release that owns this v4 contract.

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -269,7 +269,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=\/opt\/pack-evaluator\/runtime/);
   assert.match(
     evaluate,
-    /--unshare-all\s+--share-net\s+--disable-userns\s+--cap-drop ALL/,
+    /--unshare-all\s+--share-net\s+--unshare-user\s+--disable-userns\s+--cap-drop ALL/,
   );
   assert.match(evaluate, /! test -r "\/proc\/\$PROXY_PID\/environ"/);
   assert.doesNotMatch(evaluate, /PATH=\/opt\/pack-evaluator\/runtime\/bin:\/opt\/pack-evaluator\/bin/);
@@ -292,7 +292,7 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \//);
   assert.match(
     EVALUATOR_PREFLIGHT,
-    /--unshare-all\s+--share-net\s+--disable-userns\s+--cap-drop ALL/,
+    /--unshare-all\s+--share-net\s+--unshare-user\s+--disable-userns\s+--cap-drop ALL/,
   );
   assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \/run/);
   assert.match(EVALUATOR_PREFLIGHT, /--ro-bind \/opt\/pack-evaluator\/runtime \/opt\/pack-evaluator\/runtime/);
@@ -467,7 +467,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.13\.1'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.13\.2'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -556,8 +556,8 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.doesNotMatch(GENERATE_CONTENT, /Dispatch translation after content is complete/);
   assert.doesNotMatch(GENERATE_CONTENT, /event_type:\"translate-packs\"/);
   assert.match(GENERATE_CONTENT, /if \[ -n "\$GENERATION_ID" \]; then/);
-  assert.match(GENERATE_CONTENT, /version: '2\.13\.1'/);
-  assert.match(GENERATE_CONTENT, /minimum-version: '2\.13\.1'/);
+  assert.match(GENERATE_CONTENT, /version: '2\.13\.2'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.13\.2'/);
   assert.match(GENERATE_CONTENT, /bindingDigest/);
   assert.match(GENERATE_CONTENT, /usageGuideMarker/);
   assert.match(GENERATE_CONTENT, /github\.event\.client_payload\.contentDispatchNonce/);

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -83,10 +83,13 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(preflightCallLines.length >= 3);
   assert.ok(preflightCallLines.every((line) => line.endsWith(` ${continuation}`)));
   assert.ok(preflightCallLines.every((line) => !line.endsWith(` ${continuation}${continuation}`)));
-  assert.match(evaluate, /runs-on: ubuntu-latest/);
+  assert.match(evaluate, /runs-on: ubuntu-24\.04/);
   assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
   assert.match(evaluate, /@openai\/codex@0\.139\.0/);
-  assert.match(evaluate, /apt-get install --yes --no-install-recommends bubblewrap ffmpeg poppler-utils ripgrep/);
+  assert.match(
+    evaluate,
+    /apt-get install --yes --no-install-recommends[\s\\]+apparmor bubblewrap ffmpeg poppler-utils ripgrep util-linux/,
+  );
   assert.match(evaluate, /test "\$\(command -v bwrap\)" = \/usr\/bin\/bwrap/);
   assert.match(evaluate, /command -v ffprobe/);
   assert.match(evaluate, /command -v pdfinfo/);
@@ -264,9 +267,11 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(maximumWireRequests + 64 <= 256);
   assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_MODE=bwrap/);
   assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=\/opt\/pack-evaluator\/runtime/);
-  assert.match(evaluate, /\/usr\/bin\/bwrap[\s\S]*--unshare-pid/);
-  assert.match(evaluate, /! test -e \/opt\/pack-evaluator\/lib/);
-  assert.match(evaluate, /! test -e "\/proc\/\$PROXY_PID"/);
+  assert.match(
+    evaluate,
+    /--unshare-all\s+--share-net\s+--disable-userns\s+--cap-drop ALL/,
+  );
+  assert.match(evaluate, /! test -r "\/proc\/\$PROXY_PID\/environ"/);
   assert.doesNotMatch(evaluate, /PATH=\/opt\/pack-evaluator\/runtime\/bin:\/opt\/pack-evaluator\/bin/);
 });
 
@@ -285,7 +290,11 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/proxy-activity\.ndjson/);
   assert.match(EVALUATOR_PREFLIGHT, /readonly -a AGENT_BWRAP=/);
   assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \//);
-  assert.match(EVALUATOR_PREFLIGHT, /--unshare-pid/);
+  assert.match(
+    EVALUATOR_PREFLIGHT,
+    /--unshare-all\s+--share-net\s+--disable-userns\s+--cap-drop ALL/,
+  );
+  assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \/run/);
   assert.match(EVALUATOR_PREFLIGHT, /--ro-bind \/opt\/pack-evaluator\/runtime \/opt\/pack-evaluator\/runtime/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--ro-bind \/ \//);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--(?:ro-)?bind \/opt\/pack-evaluator\/(?:bin|lib|input|results)/);
@@ -458,7 +467,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.13\.0'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.13\.1'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -547,8 +556,8 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.doesNotMatch(GENERATE_CONTENT, /Dispatch translation after content is complete/);
   assert.doesNotMatch(GENERATE_CONTENT, /event_type:\"translate-packs\"/);
   assert.match(GENERATE_CONTENT, /if \[ -n "\$GENERATION_ID" \]; then/);
-  assert.match(GENERATE_CONTENT, /version: '2\.13\.0'/);
-  assert.match(GENERATE_CONTENT, /minimum-version: '2\.13\.0'/);
+  assert.match(GENERATE_CONTENT, /version: '2\.13\.1'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.13\.1'/);
   assert.match(GENERATE_CONTENT, /bindingDigest/);
   assert.match(GENERATE_CONTENT, /usageGuideMarker/);
   assert.match(GENERATE_CONTENT, /github\.event\.client_payload\.contentDispatchNonce/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -54,7 +54,7 @@ test('root helper keeps the global restriction and loads only the scoped profile
 test('real probe matches the executor namespace contract and verifies its closure', () => {
   assert.match(
     HELPER,
-    /--unshare-all\s+\\\n\s+--share-net\s+\\\n\s+--disable-userns\s+\\\n\s+--cap-drop ALL/,
+    /--unshare-all\s+\\\n\s+--share-net\s+\\\n\s+--unshare-user\s+\\\n\s+--disable-userns\s+\\\n\s+--cap-drop ALL/,
   );
   for (const required of ['--tmpfs /', '--proc /proc', '--dev /dev', '--tmpfs /run']) {
     assert.match(HELPER, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -59,6 +59,16 @@ test('real probe matches the executor namespace contract and verifies its closur
   for (const required of ['--tmpfs /', '--proc /proc', '--dev /dev', '--tmpfs /run']) {
     assert.match(HELPER, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
+  for (const runtimePath of [
+    '/usr', '/bin', '/sbin', '/lib', '/lib64', '/opt/google/chrome',
+    '/etc/alternatives', '/etc/ca-certificates', '/etc/fonts', '/etc/group',
+    '/etc/hosts', '/etc/localtime', '/etc/magic', '/etc/magic.mime',
+    '/etc/mime.types', '/etc/nsswitch.conf', '/etc/passwd', '/etc/pki',
+    '/etc/resolv.conf', '/etc/ssl',
+  ]) {
+    const escaped = runtimePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(HELPER, new RegExp(`--ro-bind-try ${escaped} ${escaped}`));
+  }
   assert.match(HELPER, /\/proc\/self\/uid_map/);
   assert.match(HELPER, /\^Cap\(Inh\|Prm\|Eff\|Bnd\|Amb\):\$/);
   assert.match(HELPER, /test -x \/opt\/pack-evaluator\/runtime\/bin\/node/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const HELPER_PATH = join(REPO_ROOT, 'scripts/configure-pack-evaluator-bwrap.sh');
+const HELPER = readFileSync(HELPER_PATH, 'utf8');
+const PROFILE = readFileSync(
+  join(REPO_ROOT, 'scripts/pack-evaluator-bwrap.apparmor'),
+  'utf8',
+);
+const PRODUCTION = readFileSync(join(REPO_ROOT, '.github/workflows/generate-packs.yml'), 'utf8');
+const HOSTED_CI = readFileSync(
+  join(REPO_ROOT, '.github/workflows/test-pack-evaluator-bwrap.yml'),
+  'utf8',
+);
+
+function workflowSection(source, start, end) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing workflow section ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `missing workflow boundary ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+test('AppArmor policy grants userns only to the root-owned bwrap path', () => {
+  assert.match(PROFILE, /profile pack-production-bwrap \/usr\/bin\/bwrap flags=\(unconfined\) \{/);
+  assert.match(PROFILE, /^\s*userns,\s*$/m);
+  assert.doesNotMatch(PROFILE, /capability|network|mount|ptrace|signal|\/\*\*/);
+});
+
+test('root helper keeps the global restriction and loads only the scoped profile', () => {
+  const syntax = spawnSync('bash', ['-n', HELPER_PATH], { encoding: 'utf8' });
+  assert.equal(syntax.status, 0, syntax.stderr);
+  assert.match(HELPER, /EUID[\s\S]*-ne 0/);
+  assert.match(HELPER, /ubuntu:24\.04/);
+  assert.match(HELPER, /bubblewrap 0\.9\.0/);
+  assert.match(HELPER, /kernel\.apparmor_restrict_unprivileged_userns/);
+  assert.match(HELPER, /test "\$RESTRICTED_USERNS_BEFORE" = '1'/);
+  assert.match(HELPER, /test "\$\(sysctl -n kernel\.apparmor_restrict_unprivileged_userns\)" = '1'/);
+  assert.match(HELPER, /test "\$MAX_USER_NAMESPACES" -gt 0/);
+  assert.match(HELPER, /install -o root -g root -m 0644/);
+  assert.match(HELPER, /"\$APPARMOR_PARSER" -Q/);
+  assert.match(HELPER, /"\$APPARMOR_PARSER" -r/);
+  assert.match(HELPER, /Unprofiled user namespace creation unexpectedly succeeded/);
+  assert.doesNotMatch(HELPER, /sysctl\s+(?:-w\s+)?kernel\.apparmor_restrict_unprivileged_userns=0/);
+  assert.doesNotMatch(HELPER, /apparmor_restrict_unprivileged_userns\s*=\s*0/);
+});
+
+test('real probe matches the executor namespace contract and verifies its closure', () => {
+  assert.match(
+    HELPER,
+    /--unshare-all\s+\\\n\s+--share-net\s+\\\n\s+--disable-userns\s+\\\n\s+--cap-drop ALL/,
+  );
+  for (const required of ['--tmpfs /', '--proc /proc', '--dev /dev', '--tmpfs /run']) {
+    assert.match(HELPER, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(HELPER, /\/proc\/self\/uid_map/);
+  assert.match(HELPER, /\^Cap\(Inh\|Prm\|Eff\|Bnd\|Amb\):\$/);
+  assert.match(HELPER, /test -x \/opt\/pack-evaluator\/runtime\/bin\/node/);
+  assert.match(HELPER, /\/opt\/pack-evaluator\/runtime\/bin\/node --version/);
+  assert.match(HELPER, /! test -w \/opt\/pack-evaluator\/runtime/);
+  assert.match(HELPER, /! test -e \/opt\/pack-evaluator\/(?:bin|lib|input|results)/);
+  assert.match(HELPER, /! test -e "\$OUTER_WORKSPACE"/);
+  assert.match(HELPER, /! test -e "\/proc\/\$OUTER_PID"/);
+  assert.match(HELPER, /! env \| grep -Eq/);
+  assert.match(HELPER, /if \/usr\/bin\/unshare --user \/usr\/bin\/true/);
+  assert.doesNotMatch(HELPER, /--(?:ro-)?bind \/ \/|--dev-bind \/ \/|--cap-add/);
+});
+
+test('production configures and proves bwrap before the only Helm secret step', () => {
+  const evaluate = workflowSection(PRODUCTION, '  evaluate:', '  persist:');
+  const helperIndex = evaluate.indexOf('scripts/configure-pack-evaluator-bwrap.sh');
+  const helperInputIndex = evaluate.indexOf('PACK_EVALUATOR_OUTER_WORKSPACE="$GITHUB_WORKSPACE"');
+  const userIndex = evaluate.indexOf('useradd --create-home --home-dir /home/packeval');
+  const secretStepIndex = evaluate.indexOf('PACK_EVALUATOR_HELM_API_KEY: ${{ secrets.PACK_EVALUATOR_HELM_API_KEY }}');
+
+  assert.match(evaluate, /runs-on: ubuntu-24\.04/);
+  assert.ok(userIndex >= 0);
+  assert.ok(helperInputIndex > userIndex);
+  assert.ok(helperIndex > userIndex);
+  assert.ok(secretStepIndex > helperIndex);
+  assert.ok(helperIndex > helperInputIndex);
+  assert.doesNotMatch(evaluate.slice(0, secretStepIndex), /secrets\./);
+});
+
+test('hosted proof is pinned, secret-free, and invokes the production helper', () => {
+  assert.match(HOSTED_CI, /runs-on: ubuntu-24\.04/);
+  assert.match(HOSTED_CI, /timeout-minutes: 10/);
+  assert.match(HOSTED_CI, /permissions:\n  contents: read/);
+  assert.match(HOSTED_CI, /persist-credentials: false/);
+  assert.match(HOSTED_CI, /apt-get install --yes --no-install-recommends apparmor bubblewrap util-linux/);
+  assert.match(HOSTED_CI, /useradd --create-home --home-dir \/home\/packeval/);
+  assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/runtime\/bin\/node/);
+  assert.match(HOSTED_CI, /scripts\/configure-pack-evaluator-bwrap\.sh/);
+  assert.doesNotMatch(HOSTED_CI, /secrets\.|pull_request_target|self-hosted/);
+});

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -82,7 +82,7 @@ function metadata() {
     },
     workflowSource: `name: Generate Pack
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.13.1'
+  PACK_PRODUCTION_CLI_VERSION: '2.13.2'
 jobs:
   evaluate:
     steps:
@@ -152,7 +152,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
       scenarioId: 'spreadsheet-audit',
     },
   });
-  json(join(planDir, 'cli-identity.json'), { version: '2.13.1', sha256: CLI_SHA });
+  json(join(planDir, 'cli-identity.json'), { version: '2.13.2', sha256: CLI_SHA });
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -327,7 +327,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
-        cliVersion: '2.13.1',
+        cliVersion: '2.13.2',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],
         reports: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID }],

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -82,7 +82,7 @@ function metadata() {
     },
     workflowSource: `name: Generate Pack
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.13.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.13.1'
 jobs:
   evaluate:
     steps:
@@ -152,7 +152,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
       scenarioId: 'spreadsheet-audit',
     },
   });
-  json(join(planDir, 'cli-identity.json'), { version: '2.13.0', sha256: CLI_SHA });
+  json(join(planDir, 'cli-identity.json'), { version: '2.13.1', sha256: CLI_SHA });
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -327,7 +327,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
-        cliVersion: '2.13.0',
+        cliVersion: '2.13.1',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],
         reports: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID }],


### PR DESCRIPTION
## Summary

- configure the Ubuntu-recommended path-scoped AppArmor userns permission for the root-owned `/usr/bin/bwrap` binary
- run the real empty-root sandbox proof before any evaluator proxy or secret-bearing step
- align helper and Claude/Codex preflight ordering with CLI 2.13.2: `--unshare-all --share-net --unshare-user --disable-userns --cap-drop ALL`
- pin Evaluate to `ubuntu-24.04`, pin Pack production/content to CLI 2.13.2, and add a secret-free GitHub-hosted proof workflow

## Incident and dependency

- Failed production canary: [Marketplace run 29493286355](https://github.com/aiskillstore/marketplace/actions/runs/29493286355) stopped at `bwrap: setting up uid map: Permission denied` before the Messages/Responses smoke or any model work.
- The first hosted proof [run 29495115616](https://github.com/aiskillstore/marketplace/actions/runs/29495115616) then proved that bubblewrap 0.9.0 requires explicit `--unshare-user`; `--unshare-all` only enables the try variant and does not satisfy `--disable-userns`.
- Ubuntu 24.04 enables AppArmor restrictions for unprivileged user namespaces. Canonical recommends a per-application `flags=(unconfined) { userns, }` profile: [Ubuntu 24.04 release notes](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#heading--unprivileged-user-namespace-restrictions).
- [Skillstore PR #263](https://github.com/aiskillstore/skillstore/pull/263) introduced the `--disable-userns` hardening; this branch advances the immutable production pin to CLI 2.13.2 for the explicit-userns correction.

## Security invariants

- The helper requires `kernel.apparmor_restrict_unprivileged_userns=1` before and after loading the profile.
- There is no fallback that globally disables the AppArmor sysctl; an unprofiled `unshare` must still fail.
- The real probe validates nested `uid_map`, zero inherited/permitted/effective/bounding/ambient capabilities, immutable runtime, hidden checkout and host PID, sanitized environment, retained network namespace contract, and disabled nested user namespaces.
- The helper/profile source and bwrap executable must be root-owned and non-writable by `packeval`.

## Verification

- `CI=true node --test` targeted suite: 30/30 passed
- helper/preflight `bash -n`: passed
- 3 workflow YAML files parsed; 16 embedded Bash blocks passed `bash -n`
- `git diff --check`: passed

## Merge gates

- Do not merge until immutable CLI 2.13.2 is published with checksum assets.
- Do not merge until the secret-free `Test Pack Evaluator Bubblewrap / Prove scoped bwrap user namespace` check passes on a GitHub-hosted `ubuntu-24.04` runner. This is the runtime proof for bubblewrap 0.9.0 plus explicit userns disabling, including the nested `uid_map` assertion.
