### PR TITLE
fix(pack): harden evaluator preflight and egress

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -360,7 +360,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
-            apparmor bubblewrap ffmpeg poppler-utils ripgrep util-linux
+            apparmor bubblewrap ffmpeg iptables poppler-utils ripgrep util-linux
           sudo install -d -o root -g root -m 0755 \
             /opt/pack-evaluator \
             /opt/pack-evaluator/runtime
@@ -463,6 +463,35 @@ jobs:
           sudo env \
             PACK_EVALUATOR_OUTER_WORKSPACE="$GITHUB_WORKSPACE" \
             "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/configure-pack-evaluator-bwrap.sh"
+
+      - name: Restrict and prove evaluator egress before secrets
+        run: |
+          set -euo pipefail
+          sudo "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/configure-pack-evaluator-egress.sh"
+          IPV4_REJECT_BEFORE=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          IPV6_REJECT_BEFORE=$(sudo ip6tables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          test -n "$IPV4_REJECT_BEFORE"
+          test -n "$IPV6_REJECT_BEFORE"
+          sudo -u packeval env -i PATH=/usr/bin:/bin bash -ceu '
+            for blocked in \
+              http://1.1.1.1 \
+              http://169.254.169.254/latest/meta-data/ \
+              http://127.0.0.1:18764 \
+              http://[::1]:18765; do
+              if curl --noproxy "*" --connect-timeout 1 --max-time 2 "$blocked" >/dev/null 2>&1; then
+                echo "Evaluator egress unexpectedly reached a blocked target" >&2
+                exit 1
+              fi
+            done
+          '
+          IPV4_REJECT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          IPV6_REJECT_AFTER=$(sudo ip6tables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          test "$IPV4_REJECT_AFTER" -gt "$IPV4_REJECT_BEFORE"
+          test "$IPV6_REJECT_AFTER" -gt "$IPV6_REJECT_BEFORE"
 
       # The real Helm credential exists only in this runner-owned shell and the
       # separate packproxy process. Agent commands run as a different, non-sudo
@@ -733,7 +762,7 @@ jobs:
             if [ "$PREFLIGHT_RC" -ne 0 ]; then
               PREFLIGHT_DIAGNOSTICS="$GITHUB_WORKSPACE/pack-diagnostics/agent-preflight-diagnostics.json"
               DIAGNOSTIC_SHA256=$(sha256sum "$PREFLIGHT_DIAGNOSTICS" | awk '{print $1}')
-              PREFLIGHT_CLASS=$(jq -r '
+              PREFLIGHT_REASON=$(jq -r '
                 [.claude.errorClass, .codex.errorClass]
                 | if index("deterministic_http") then "deterministic_http"
                   elif index("timeout") then "timeout"
@@ -746,16 +775,15 @@ jobs:
               ' "$PREFLIGHT_DIAGNOSTICS")
               jq -n \
                 --arg stage agent_preflight \
-                --arg reason "$PREFLIGHT_CLASS" \
+                --arg reason "$PREFLIGHT_REASON" \
                 --arg status "$PREFLIGHT_STATUS" \
-                --arg errorCategory "$PREFLIGHT_CLASS" \
                 --arg diagnosticSha256 "$DIAGNOSTIC_SHA256" \
                 '{
                   schemaVersion: "marketplace.pack-production-infrastructure-failure/v1",
                   stage: $stage,
                   reason: $reason,
                   status: (if $status == "" then null else ($status | tonumber) end),
-                  errorCategory: $errorCategory,
+                  errorCategory: null,
                   diagnosticSha256: $diagnosticSha256
                 }' > "$INFRASTRUCTURE_FAILURE_FILE"
             fi

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -6,10 +6,14 @@ on:
       - '.github/workflows/generate-packs.yml'
       - '.github/workflows/test-pack-evaluator-bwrap.yml'
       - 'scripts/configure-pack-evaluator-bwrap.sh'
+      - 'scripts/configure-pack-evaluator-egress.sh'
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
+      - 'scripts/pack-evaluator-preflight-mock.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
+      - 'scripts/tests/pack-evaluator-egress.test.mjs'
+      - 'scripts/tests/pack-evaluator-preflight-mock.test.mjs'
   push:
     branches:
       - main
@@ -17,10 +21,14 @@ on:
       - '.github/workflows/generate-packs.yml'
       - '.github/workflows/test-pack-evaluator-bwrap.yml'
       - 'scripts/configure-pack-evaluator-bwrap.sh'
+      - 'scripts/configure-pack-evaluator-egress.sh'
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
+      - 'scripts/pack-evaluator-preflight-mock.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
+      - 'scripts/tests/pack-evaluator-egress.test.mjs'
+      - 'scripts/tests/pack-evaluator-preflight-mock.test.mjs'
   workflow_dispatch:
 
 permissions:
@@ -45,11 +53,11 @@ jobs:
           clean: true
           persist-credentials: false
 
-      - name: Install bubblewrap and prepare disposable runtime
+      - name: Install bubblewrap and pinned evaluator CLIs
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends apparmor bubblewrap util-linux
+          sudo apt-get install --yes --no-install-recommends apparmor bubblewrap iptables util-linux
           sudo useradd --create-home --home-dir /home/packeval --shell /bin/bash packeval
           NODE_SOURCE=$(command -v node)
           test -x "$NODE_SOURCE"
@@ -57,15 +65,43 @@ jobs:
             /opt/pack-evaluator \
             /opt/pack-evaluator/runtime \
             /opt/pack-evaluator/runtime/bin
+          sudo npm install --global --prefix /opt/pack-evaluator/runtime \
+            @anthropic-ai/claude-code@2.1.210 \
+            @openai/codex@0.139.0
           sudo install -o root -g root -m 0555 \
             "$NODE_SOURCE" /opt/pack-evaluator/runtime/bin/node
+          sudo chown -R root:root /opt/pack-evaluator/runtime
+          sudo chmod -R a=rX /opt/pack-evaluator/runtime
           sudo install -d -o packeval -g packeval -m 0700 /home/packeval/tmp
           sudo install -d -o root -g root -m 1777 /opt/pack-evaluator/codex-home
+          sudo install -d -o packeval -g packeval -m 0700 \
+            /opt/pack-evaluator/codex-home/log \
+            /opt/pack-evaluator/codex-home/sessions
+          printf '%s\n' \
+            'model_provider = "pack_evaluator_proxy"' \
+            '[model_providers.pack_evaluator_proxy]' \
+            'name = "Job-local Pack evaluator proxy"' \
+            'base_url = "http://127.0.0.1:18765/v1"' \
+            'env_key = "PACK_EVALUATOR_PROXY_TOKEN"' \
+            'wire_api = "responses"' \
+            'supports_websockets = false' \
+            | sudo tee /opt/pack-evaluator/codex-home/config.toml >/dev/null
+          sudo chown root:root /opt/pack-evaluator/codex-home/config.toml
+          sudo chmod 0444 /opt/pack-evaluator/codex-home/config.toml
           sudo chown root:root \
             scripts/configure-pack-evaluator-bwrap.sh \
-            scripts/pack-evaluator-bwrap.apparmor
-          sudo chmod 0555 scripts/configure-pack-evaluator-bwrap.sh
+            scripts/configure-pack-evaluator-egress.sh \
+            scripts/pack-evaluator-bwrap.apparmor \
+            scripts/pack-evaluator-preflight.sh \
+            scripts/pack-evaluator-preflight-mock.mjs
+          sudo chmod 0555 \
+            scripts/configure-pack-evaluator-bwrap.sh \
+            scripts/configure-pack-evaluator-egress.sh \
+            scripts/pack-evaluator-preflight.sh \
+            scripts/pack-evaluator-preflight-mock.mjs
           sudo chmod 0444 scripts/pack-evaluator-bwrap.apparmor
+          test "$(/opt/pack-evaluator/runtime/bin/claude --version | awk '{print $1}')" = '2.1.210'
+          test "$(/opt/pack-evaluator/runtime/bin/codex --version | awk '{print $2}')" = '0.139.0'
 
       - name: Configure scoped AppArmor policy and prove the real sandbox
         run: |
@@ -73,3 +109,95 @@ jobs:
           sudo env \
             PACK_EVALUATOR_OUTER_WORKSPACE="$GITHUB_WORKSPACE" \
             "$GITHUB_WORKSPACE/scripts/configure-pack-evaluator-bwrap.sh"
+
+      - name: Restrict and prove evaluator egress
+        run: |
+          set -euo pipefail
+          sudo "$GITHUB_WORKSPACE/scripts/configure-pack-evaluator-egress.sh"
+          sudo "$GITHUB_WORKSPACE/scripts/configure-pack-evaluator-egress.sh"
+          IPV4_REJECT_BEFORE=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          IPV6_REJECT_BEFORE=$(sudo ip6tables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          sudo -u packeval env -i PATH=/usr/bin:/bin bash -ceu '
+            for blocked in \
+              http://1.1.1.1 \
+              http://169.254.169.254/latest/meta-data/ \
+              http://127.0.0.1:18764 \
+              http://[::1]:18765; do
+              ! curl --noproxy "*" --connect-timeout 1 --max-time 2 "$blocked" >/dev/null 2>&1
+            done
+          '
+          IPV4_REJECT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          IPV6_REJECT_AFTER=$(sudo ip6tables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "REJECT" {print $1}')
+          test "$IPV4_REJECT_AFTER" -gt "$IPV4_REJECT_BEFORE"
+          test "$IPV6_REJECT_AFTER" -gt "$IPV6_REJECT_BEFORE"
+
+      - name: Run both pinned CLIs through the production preflight sandbox
+        run: |
+          set -euo pipefail
+          LOCAL_TOKEN=local-preflight-token-longer-than-thirty-two-bytes
+          ACTIVITY_FILE="$RUNNER_TEMP/pack-preflight-activity.ndjson"
+          MOCK_LOG="$RUNNER_TEMP/pack-preflight-mock.log"
+          DIAGNOSTICS_DIR="$RUNNER_TEMP/pack-preflight-diagnostics"
+          install -d -m 0700 "$DIAGNOSTICS_DIR"
+          install -m 0600 /dev/null "$ACTIVITY_FILE"
+          install -m 0600 /dev/null "$MOCK_LOG"
+          env -i \
+            PATH=/opt/pack-evaluator/runtime/bin:/usr/bin:/bin \
+            PACK_EVALUATOR_LOCAL_TOKEN="$LOCAL_TOKEN" \
+            PACK_EVALUATOR_PROXY_PORT=18765 \
+            PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
+            /opt/pack-evaluator/runtime/bin/node \
+              "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight-mock.mjs" \
+              >"$MOCK_LOG" 2>&1 &
+          MOCK_PID=$!
+          cleanup() {
+            kill "$MOCK_PID" 2>/dev/null || true
+            wait "$MOCK_PID" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          READY=false
+          for _ in $(seq 1 30); do
+            if curl --fail --silent \
+              -H "Authorization: Bearer $LOCAL_TOKEN" \
+              http://127.0.0.1:18765/healthz >/dev/null; then
+              READY=true
+              break
+            fi
+            sleep 0.2
+          done
+          test "$READY" = true
+          IPV4_ACCEPT_BEFORE=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "ACCEPT" {print $1}')
+          env -i \
+            PATH=/usr/bin:/bin \
+            PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
+            PACK_DIAGNOSTICS_DIR="$DIAGNOSTICS_DIR" \
+            PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
+            bash "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight.sh"
+          IPV4_ACCEPT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
+            | awk '$3 == "ACCEPT" {print $1}')
+          test "$IPV4_ACCEPT_AFTER" -gt "$IPV4_ACCEPT_BEFORE"
+          jq -e '
+            .claude.outcome == "passed"
+            and .claude.errorClass == "none"
+            and .codex.outcome == "passed"
+            and .codex.errorClass == "none"
+            and .cleanup.outcome == "passed"
+          ' "$DIAGNOSTICS_DIR/agent-preflight-diagnostics.json" >/dev/null
+          jq -se '
+            [ .[] | select(.phase == "response" and .status == 200) | .path ] as $paths
+            | ($paths | index("/v1/messages")) != null
+            and ($paths | index("/v1/responses")) != null
+          ' "$DIAGNOSTICS_DIR/proxy-activity.ndjson" >/dev/null
+          if rg -F \
+            -e "$LOCAL_TOKEN" \
+            -e 'Reply with exactly' \
+            -e 'PACK_EVALUATOR_READY' \
+            "$DIAGNOSTICS_DIR"; then
+            echo 'Preflight diagnostics retained forbidden raw content' >&2
+            exit 1
+          fi

--- a/scripts/configure-pack-evaluator-egress.sh
+++ b/scripts/configure-pack-evaluator-egress.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EVALUATOR_USER=packeval
+readonly IPV4_CHAIN=PACK_EVALUATOR_EGRESS
+readonly IPV6_CHAIN=PACK_EVALUATOR_EGRESS
+readonly IPV4_GUARD_CHAIN=PACK_EVALUATOR_GUARD
+readonly IPV6_GUARD_CHAIN=PACK_EVALUATOR_GUARD
+readonly PROXY_ADDRESS=127.0.0.1
+readonly PROXY_PORT=18765
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  echo 'Pack evaluator egress configuration must run as root' >&2
+  exit 1
+fi
+
+for command_name in getent iptables ip6tables; do
+  command -v "$command_name" >/dev/null
+done
+
+readonly EVALUATOR_UID="$(id -u "$EVALUATOR_USER")"
+test "$EVALUATOR_UID" -gt 0
+
+remove_output_jumps() {
+  local tool="$1"
+  local chain="$2"
+  while "$tool" -w 5 -C OUTPUT \
+    -m owner --uid-owner "$EVALUATOR_UID" -j "$chain" 2>/dev/null; do
+    "$tool" -w 5 -D OUTPUT \
+      -m owner --uid-owner "$EVALUATOR_UID" -j "$chain"
+  done
+}
+
+prepare_guard() {
+  local tool="$1"
+  local chain="$2"
+  shift 2
+  if "$tool" -w 5 -S "$chain" >/dev/null 2>&1; then
+    local rule_count
+    rule_count=$("$tool" -w 5 -S "$chain" | awk '$1 == "-A" {count += 1} END {print count + 0}')
+    test "$rule_count" -eq 1
+    "$tool" -w 5 -C "$chain" "$@"
+  else
+    "$tool" -w 5 -N "$chain"
+    "$tool" -w 5 -A "$chain" "$@"
+  fi
+  "$tool" -w 5 -I OUTPUT 1 \
+    -m owner --uid-owner "$EVALUATOR_UID" -j "$chain"
+}
+
+finish_guard() {
+  local tool="$1"
+  local chain="$2"
+  remove_output_jumps "$tool" "$chain"
+  "$tool" -w 5 -F "$chain"
+  "$tool" -w 5 -X "$chain"
+}
+
+# Install fail-closed guards before touching either referenced policy chain.
+# If this script is interrupted, a guard remains and blocks packeval egress.
+prepare_guard iptables "$IPV4_GUARD_CHAIN" \
+  -j REJECT --reject-with icmp-admin-prohibited
+prepare_guard ip6tables "$IPV6_GUARD_CHAIN" \
+  -j REJECT --reject-with icmp6-adm-prohibited
+
+iptables -w 5 -N "$IPV4_CHAIN" 2>/dev/null || true
+iptables -w 5 -F "$IPV4_CHAIN"
+iptables -w 5 -A "$IPV4_CHAIN" \
+  -p tcp -d "$PROXY_ADDRESS/32" --dport "$PROXY_PORT" -j ACCEPT
+iptables -w 5 -A "$IPV4_CHAIN" -j REJECT --reject-with icmp-admin-prohibited
+remove_output_jumps iptables "$IPV4_CHAIN"
+iptables -w 5 -I OUTPUT 1 \
+  -m owner --uid-owner "$EVALUATOR_UID" -j "$IPV4_CHAIN"
+
+ip6tables -w 5 -N "$IPV6_CHAIN" 2>/dev/null || true
+ip6tables -w 5 -F "$IPV6_CHAIN"
+ip6tables -w 5 -A "$IPV6_CHAIN" -j REJECT --reject-with icmp6-adm-prohibited
+remove_output_jumps ip6tables "$IPV6_CHAIN"
+ip6tables -w 5 -I OUTPUT 1 \
+  -m owner --uid-owner "$EVALUATOR_UID" -j "$IPV6_CHAIN"
+
+iptables -w 5 -C "$IPV4_CHAIN" \
+  -p tcp -d "$PROXY_ADDRESS/32" --dport "$PROXY_PORT" -j ACCEPT
+iptables -w 5 -C "$IPV4_CHAIN" -j REJECT --reject-with icmp-admin-prohibited
+ip6tables -w 5 -C "$IPV6_CHAIN" -j REJECT --reject-with icmp6-adm-prohibited
+
+finish_guard iptables "$IPV4_GUARD_CHAIN"
+finish_guard ip6tables "$IPV6_GUARD_CHAIN"
+
+echo "Pack evaluator egress restricted to ${PROXY_ADDRESS}:${PROXY_PORT}"

--- a/scripts/pack-evaluator-preflight-mock.mjs
+++ b/scripts/pack-evaluator-preflight-mock.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import { timingSafeEqual } from 'node:crypto';
+import { appendFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { pathToFileURL } from 'node:url';
+
+const READY_TEXT = 'PACK_EVALUATOR_READY';
+const MAX_REQUEST_BYTES = 1024 * 1024;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sameToken(actual, expected) {
+  const left = Buffer.from(actual || '');
+  const right = Buffer.from(expected || '');
+  return left.length === right.length && left.length > 0 && timingSafeEqual(left, right);
+}
+
+function requestToken(request) {
+  const authorization = request.headers.authorization;
+  if (authorization?.startsWith('Bearer ')) return authorization.slice('Bearer '.length);
+  const apiKey = request.headers['x-api-key'];
+  return Array.isArray(apiKey) ? apiKey[0] : apiKey;
+}
+
+function json(response, status, body) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(`${JSON.stringify(body)}\n`);
+}
+
+function sse(response, events) {
+  response.writeHead(200, {
+    'cache-control': 'no-store',
+    'content-type': 'text/event-stream; charset=utf-8',
+  });
+  for (const event of events) {
+    response.write(`event: ${event.type}\n`);
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
+  }
+  response.end();
+}
+
+async function requestJson(request) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of request) {
+    bytes += chunk.length;
+    if (bytes > MAX_REQUEST_BYTES) fail('mock preflight request exceeded 1 MiB');
+    chunks.push(chunk);
+  }
+  const body = Buffer.concat(chunks);
+  const value = JSON.parse(body.toString('utf8'));
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail('mock preflight request must be a JSON object');
+  }
+  return { value, bytes: body.length };
+}
+
+function messageObject(model, content, stopReason) {
+  return {
+    id: 'msg_pack_preflight_mock',
+    type: 'message',
+    role: 'assistant',
+    model,
+    content,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: content.length > 0 ? 1 : 0 },
+  };
+}
+
+function messagesEvents(model) {
+  return [
+    { type: 'message_start', message: messageObject(model, [], null) },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: READY_TEXT },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 1 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function responseItem() {
+  return {
+    id: 'msg_pack_preflight_mock',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: READY_TEXT, annotations: [] }],
+  };
+}
+
+function responsesEvents() {
+  const id = 'resp_pack_preflight_mock';
+  const item = responseItem();
+  return [
+    { type: 'response.created', response: { id } },
+    { type: 'response.output_item.added', output_index: 0, item: { ...item, content: [] } },
+    {
+      type: 'response.content_part.added',
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: 'output_text', text: '', annotations: [] },
+    },
+    {
+      type: 'response.output_text.delta',
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      delta: READY_TEXT,
+    },
+    {
+      type: 'response.output_text.done',
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      text: READY_TEXT,
+    },
+    {
+      type: 'response.content_part.done',
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      part: item.content[0],
+    },
+    { type: 'response.output_item.done', output_index: 0, item },
+    {
+      type: 'response.completed',
+      response: {
+        id,
+        status: 'completed',
+        output: [item],
+        usage: {
+          input_tokens: 1,
+          input_tokens_details: null,
+          output_tokens: 1,
+          output_tokens_details: null,
+          total_tokens: 2,
+        },
+      },
+    },
+  ];
+}
+
+export function createPackEvaluatorPreflightMock({ localToken, onActivity = () => {} }) {
+  if (typeof localToken !== 'string' || localToken.length < 32) {
+    fail('PACK_EVALUATOR_LOCAL_TOKEN must be at least 32 characters');
+  }
+  let requestNumber = 0;
+  return createServer(async (request, response) => {
+    const path = new URL(request.url || '/', 'http://127.0.0.1').pathname;
+    if (!sameToken(requestToken(request), localToken)) {
+      onActivity({ phase: 'rejected', path, status: 401 });
+      json(response, 401, { error: 'invalid local mock token' });
+      return;
+    }
+    if (request.method === 'GET' && path === '/healthz') {
+      json(response, 200, { ok: true });
+      return;
+    }
+    if (request.method !== 'POST') {
+      onActivity({ phase: 'rejected', path, status: 405 });
+      json(response, 405, { error: 'method not allowed' });
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = await requestJson(request);
+    } catch {
+      onActivity({ phase: 'response', path, status: 400 });
+      json(response, 400, { error: 'invalid mock request' });
+      return;
+    }
+    requestNumber += 1;
+    const model = typeof parsed.value.model === 'string' ? parsed.value.model : null;
+    const activity = {
+      phase: 'response',
+      requestNumber,
+      path,
+      model,
+      requestBytes: parsed.bytes,
+      stream: parsed.value.stream === true,
+      status: 200,
+    };
+
+    if (path === '/v1/messages/count_tokens') {
+      onActivity(activity);
+      json(response, 200, { input_tokens: 1 });
+      return;
+    }
+    if (path === '/v1/messages') {
+      onActivity(activity);
+      if (parsed.value.stream === true) {
+        sse(response, messagesEvents(model || 'sonnet'));
+      } else {
+        json(response, 200, messageObject(model || 'sonnet', [{ type: 'text', text: READY_TEXT }], 'end_turn'));
+      }
+      return;
+    }
+    if (path === '/v1/responses') {
+      onActivity(activity);
+      if (parsed.value.stream === true) {
+        sse(response, responsesEvents());
+      } else {
+        json(response, 200, responsesEvents().at(-1).response);
+      }
+      return;
+    }
+    if (path === '/v1/responses/compact') {
+      onActivity(activity);
+      json(response, 200, { output: [], usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 } });
+      return;
+    }
+
+    onActivity({ ...activity, status: 403 });
+    json(response, 403, { error: 'endpoint not allowed by preflight mock' });
+  });
+}
+
+export async function startPackEvaluatorPreflightMock(environment = process.env) {
+  const port = Number(environment.PACK_EVALUATOR_PROXY_PORT || '18765');
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) fail('invalid mock proxy port');
+  const activityFile = environment.PACK_EVALUATOR_ACTIVITY_FILE;
+  const server = createPackEvaluatorPreflightMock({
+    localToken: environment.PACK_EVALUATOR_LOCAL_TOKEN,
+    onActivity: activityFile
+      ? (activity) => appendFileSync(
+        activityFile,
+        `${JSON.stringify({ at: Date.now(), ...activity })}\n`,
+        { mode: 0o600 },
+      )
+      : undefined,
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+  process.stderr.write(`Pack evaluator preflight mock listening on 127.0.0.1:${port}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  startPackEvaluatorPreflightMock().catch((error) => {
+    process.stderr.write(`Pack evaluator preflight mock failed: ${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -53,6 +53,7 @@ readonly -a AGENT_BWRAP=(
   --setenv CI true
   --setenv NO_COLOR 1
   --setenv NO_PROXY 127.0.0.1,localhost
+  --chdir /home/packeval
 )
 
 CLAUDE_STDOUT=$(mktemp)
@@ -65,27 +66,34 @@ cleanup_files() {
 trap cleanup_files EXIT
 
 classify_error() {
-  local file="$1"
-  local exit_code="$2"
-  local fatal_http_status="${3:-}"
-  local retryable_http_status="${4:-}"
-  if [ -n "$fatal_http_status" ]; then
+  local stdout_file="$1"
+  local stderr_file="$2"
+  local outcome="$3"
+  local exit_code="$4"
+  local fatal_http_status="${5:-}"
+  local retryable_http_status="${6:-}"
+  if [ "$outcome" = "passed" ]; then
+    printf 'none\n'
+  elif [ -n "$fatal_http_status" ]; then
     printf 'deterministic_http\n'
   elif [ -n "$retryable_http_status" ]; then
     printf 'retryable_http\n'
-  elif grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' "$file"; then
+  elif grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' \
+    "$stdout_file" "$stderr_file"; then
     printf 'state_storage\n'
-  elif grep -Eqi '401|403|unauthoriz|authentication|api key' "$file"; then
+  elif grep -Eqi '401|403|unauthoriz|authentication|api key|not logged in|please run /login' \
+    "$stdout_file" "$stderr_file"; then
     printf 'authentication\n'
-  elif grep -Eqi '404|model.*not found|unsupported model' "$file"; then
+  elif grep -Eqi '404|model.*not found|unsupported model' "$stdout_file" "$stderr_file"; then
     printf 'model_route\n'
-  elif grep -Eqi 'unknown argument|unexpected argument|usage:' "$file"; then
+  elif grep -Eqi 'unknown argument|unexpected argument|usage:' "$stdout_file" "$stderr_file"; then
     printf 'cli_arguments\n'
-  elif [ "$exit_code" -eq 124 ] || grep -Eqi 'timed out|timeout' "$file"; then
+  elif [ "$exit_code" -eq 124 ] || grep -Eqi 'timed out|timeout' "$stdout_file" "$stderr_file"; then
     printf 'timeout\n'
-  elif grep -Eqi 'error sending request|failed to send request|connection (reset|refused|closed|aborted)|transport.*(closed|error)|unexpected (eof|end of file)|temporary failure in name resolution|dns.*temporary|tls.*(handshake|temporary)|http[^0-9]*(408|429|502|503|504)|status( code)?[^0-9]*(408|429|502|503|504)' "$file"; then
+  elif grep -Eqi 'error sending request|failed to send request|connection (reset|refused|closed|aborted)|transport.*(closed|error)|unexpected (eof|end of file)|temporary failure in name resolution|dns.*temporary|tls.*(handshake|temporary)|http[^0-9]*(408|429|502|503|504)|status( code)?[^0-9]*(408|429|502|503|504)' \
+    "$stdout_file" "$stderr_file"; then
     printf 'upstream_transport\n'
-  elif [ -s "$file" ] || [ "$exit_code" -ne 0 ]; then
+  elif [ -s "$stdout_file" ] || [ -s "$stderr_file" ] || [ "$exit_code" -ne 0 ]; then
     printf 'unknown\n'
   else
     printf 'none\n'
@@ -222,7 +230,8 @@ for ATTEMPT in 1 2; do
   STDOUT_SHA256=$(sha256sum "$CLAUDE_STDOUT" | awk '{print $1}')
   STDERR_SHA256=$(sha256sum "$CLAUDE_STDERR" | awk '{print $1}')
   CLAUDE_ERROR_CLASS=$(classify_error \
-    "$CLAUDE_STDERR" "$CLAUDE_EXIT_CODE" "$CLAUDE_FATAL_HTTP_STATUS" "$CLAUDE_RETRYABLE_HTTP_STATUS")
+    "$CLAUDE_STDOUT" "$CLAUDE_STDERR" "$CLAUDE_OUTCOME" "$CLAUDE_EXIT_CODE" \
+    "$CLAUDE_FATAL_HTTP_STATUS" "$CLAUDE_RETRYABLE_HTTP_STATUS")
   CLAUDE_ATTEMPTS=$(jq -c \
     --argjson attempt "$ATTEMPT" \
     --arg outcome "$CLAUDE_OUTCOME" \
@@ -313,7 +322,8 @@ if [ "$CLAUDE_OUTCOME" = "passed" ]; then
     STDOUT_SHA256=$(sha256sum "$CODEX_STDOUT" | awk '{print $1}')
     STDERR_SHA256=$(sha256sum "$CODEX_STDERR" | awk '{print $1}')
     CODEX_ERROR_CLASS=$(classify_error \
-      "$CODEX_STDERR" "$CODEX_EXIT_CODE" "$CODEX_FATAL_HTTP_STATUS" "$CODEX_RETRYABLE_HTTP_STATUS")
+      "$CODEX_STDOUT" "$CODEX_STDERR" "$CODEX_OUTCOME" "$CODEX_EXIT_CODE" \
+      "$CODEX_FATAL_HTTP_STATUS" "$CODEX_RETRYABLE_HTTP_STATUS")
     CODEX_ATTEMPTS=$(jq -c \
       --argjson attempt "$ATTEMPT" \
       --arg outcome "$CODEX_OUTCOME" \

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -207,10 +207,11 @@ export function normalizeInfrastructureFailure(value) {
   if (!INFRASTRUCTURE_FAILURE_REASONS.has(value.reason)) {
     fail(`Unsupported infrastructure failure reason: ${value.reason}`);
   }
-  const diagnosticSha256 = value.diagnosticSha256 == null
-    ? null
-    : safeActivityToken(value.diagnosticSha256, 64);
-  if (diagnosticSha256 != null && !/^[0-9a-f]{64}$/.test(diagnosticSha256)) {
+  const diagnosticSha256 = value.diagnosticSha256 == null ? null : value.diagnosticSha256;
+  if (
+    diagnosticSha256 != null
+    && (typeof diagnosticSha256 !== 'string' || !/^[0-9a-f]{64}$/.test(diagnosticSha256))
+  ) {
     fail('Infrastructure diagnostic hash is invalid');
   }
   const status = value.status == null ? null : Number(value.status);

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -88,7 +89,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /@openai\/codex@0\.139\.0/);
   assert.match(
     evaluate,
-    /apt-get install --yes --no-install-recommends[\s\\]+apparmor bubblewrap ffmpeg poppler-utils ripgrep util-linux/,
+    /apt-get install --yes --no-install-recommends[\s\\]+apparmor bubblewrap ffmpeg iptables poppler-utils ripgrep util-linux/,
   );
   assert.match(evaluate, /test "\$\(command -v bwrap\)" = \/usr\/bin\/bwrap/);
   assert.match(evaluate, /command -v ffprobe/);
@@ -198,6 +199,11 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.doesNotMatch(evaluate, /connect\|connection\|transport\|request/);
   assert.match(evaluate, /SKILLSTORE_AGENTS=codex,claude/);
   assert.match(evaluate, /agent-preflight-diagnostics\.json/);
+  assert.match(evaluate, /PREFLIGHT_REASON=\$\(jq -r/);
+  assert.match(evaluate, /--arg reason "\$PREFLIGHT_REASON"/);
+  assert.match(evaluate, /errorCategory: null/);
+  assert.doesNotMatch(evaluate, /PREFLIGHT_ERROR_CATEGORY=/);
+  assert.doesNotMatch(evaluate, /--arg errorCategory "\$PREFLIGHT_REASON"/);
   assert.match(evaluate, /CLAUDE_OUTCOME=invalid_response/);
   assert.match(evaluate, /CODEX_OUTCOME=invalid_response/);
   assert.match(evaluate, /classify_error\(\)/);
@@ -295,10 +301,72 @@ test('extracted evaluator preflight is valid bounded bash', () => {
     /--unshare-all\s+--share-net\s+--unshare-user\s+--disable-userns\s+--cap-drop ALL/,
   );
   assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \/run/);
+  assert.match(EVALUATOR_PREFLIGHT, /--chdir \/home\/packeval/);
   assert.match(EVALUATOR_PREFLIGHT, /--ro-bind \/opt\/pack-evaluator\/runtime \/opt\/pack-evaluator\/runtime/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--ro-bind \/ \//);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--(?:ro-)?bind \/opt\/pack-evaluator\/(?:bin|lib|input|results)/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /GITHUB_WORKSPACE/);
+});
+
+test('evaluator preflight classifies both output streams without retaining their text', () => {
+  const start = EVALUATOR_PREFLIGHT.indexOf('classify_error() {');
+  const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
+  assert.ok(start >= 0 && end > start, 'error classifier must be extractable');
+  const classifier = EVALUATOR_PREFLIGHT.slice(start, end + 3);
+  const directory = mkdtempSync(join(tmpdir(), 'pack-preflight-classifier-'));
+  const stdout = join(directory, 'stdout');
+  const stderr = join(directory, 'stderr');
+
+  const classify = ({ stdoutText = '', stderrText = '', outcome, exitCode, fatal = '', retryable = '' }) => {
+    writeFileSync(stdout, stdoutText);
+    writeFileSync(stderr, stderrText);
+    return spawnSync(
+      'bash',
+      [
+        '-c',
+        `${classifier}\nclassify_error "$1" "$2" "$3" "$4" "$5" "$6"`,
+        'classifier',
+        stdout,
+        stderr,
+        outcome,
+        String(exitCode),
+        fatal,
+        retryable,
+      ],
+      { encoding: 'utf8' },
+    );
+  };
+
+  assert.equal(classify({
+    stdoutText: 'Not logged in. Please run /login.',
+    outcome: 'command_failed',
+    exitCode: 1,
+  }).stdout.trim(), 'authentication');
+  assert.equal(classify({
+    stderrText: 'unable to open session database',
+    outcome: 'command_failed',
+    exitCode: 1,
+  }).stdout.trim(), 'state_storage');
+  assert.equal(classify({
+    stdoutText: 'PACK_EVALUATOR_READY\n',
+    outcome: 'passed',
+    exitCode: 0,
+  }).stdout.trim(), 'none');
+  assert.equal(classify({
+    stdoutText: 'unexpected model response',
+    outcome: 'invalid_response',
+    exitCode: 0,
+  }).stdout.trim(), 'unknown');
+  assert.equal(classify({
+    outcome: 'command_failed',
+    exitCode: 1,
+    fatal: '401',
+  }).stdout.trim(), 'deterministic_http');
+  assert.equal(classify({
+    outcome: 'command_failed',
+    exitCode: 1,
+    retryable: '503',
+  }).stdout.trim(), 'retryable_http');
 });
 
 test('evaluator preflight retries only an exact bounded HTTP failure once', () => {

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -103,9 +103,15 @@ test('hosted proof is pinned, secret-free, and invokes the production helper', (
   assert.match(HOSTED_CI, /timeout-minutes: 10/);
   assert.match(HOSTED_CI, /permissions:\n  contents: read/);
   assert.match(HOSTED_CI, /persist-credentials: false/);
-  assert.match(HOSTED_CI, /apt-get install --yes --no-install-recommends apparmor bubblewrap util-linux/);
+  assert.match(HOSTED_CI, /apt-get install --yes --no-install-recommends apparmor bubblewrap iptables util-linux/);
+  assert.match(HOSTED_CI, /@anthropic-ai\/claude-code@2\.1\.210/);
+  assert.match(HOSTED_CI, /@openai\/codex@0\.139\.0/);
   assert.match(HOSTED_CI, /useradd --create-home --home-dir \/home\/packeval/);
   assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/runtime\/bin\/node/);
   assert.match(HOSTED_CI, /scripts\/configure-pack-evaluator-bwrap\.sh/);
+  assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight-mock\.mjs/);
+  assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight\.sh/);
+  assert.match(HOSTED_CI, /\.claude\.outcome == "passed"/);
+  assert.match(HOSTED_CI, /\.codex\.outcome == "passed"/);
   assert.doesNotMatch(HOSTED_CI, /secrets\.|pull_request_target|self-hosted/);
 });

--- a/scripts/tests/pack-evaluator-egress.test.mjs
+++ b/scripts/tests/pack-evaluator-egress.test.mjs
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const HELPER_PATH = join(REPO_ROOT, 'scripts/configure-pack-evaluator-egress.sh');
+const HELPER = readFileSync(HELPER_PATH, 'utf8');
+const PRODUCTION = readFileSync(join(REPO_ROOT, '.github/workflows/generate-packs.yml'), 'utf8');
+const HOSTED = readFileSync(join(REPO_ROOT, '.github/workflows/test-pack-evaluator-bwrap.yml'), 'utf8');
+
+test('egress helper is bounded to one UID, one IPv4 address, and one TCP port', () => {
+  const syntax = spawnSync('bash', ['-n', HELPER_PATH], { encoding: 'utf8' });
+  assert.equal(syntax.status, 0, syntax.stderr);
+  assert.match(HELPER, /EVALUATOR_USER=packeval/);
+  assert.match(HELPER, /PROXY_ADDRESS=127\.0\.0\.1/);
+  assert.match(HELPER, /PROXY_PORT=18765/);
+  assert.match(HELPER, /-m owner --uid-owner "\$EVALUATOR_UID"/);
+  assert.match(HELPER, /prepare_guard iptables "\$IPV4_GUARD_CHAIN"/);
+  assert.match(HELPER, /prepare_guard ip6tables "\$IPV6_GUARD_CHAIN"/);
+  assert.match(HELPER, /-p tcp -d "\$PROXY_ADDRESS\/32" --dport "\$PROXY_PORT" -j ACCEPT/);
+  assert.match(HELPER, /iptables .* -j REJECT --reject-with icmp-admin-prohibited/);
+  assert.match(HELPER, /ip6tables .* -j REJECT --reject-with icmp6-adm-prohibited/);
+  assert.doesNotMatch(HELPER, /-P OUTPUT|--flush|\s-F OUTPUT|ACCEPT.*0\.0\.0\.0|ACCEPT.*::\/0/);
+  const guardIndex = HELPER.indexOf('prepare_guard iptables');
+  const flushIndex = HELPER.indexOf('iptables -w 5 -F "$IPV4_CHAIN"');
+  const policyJumpIndex = HELPER.indexOf('iptables -w 5 -I OUTPUT 1');
+  const guardRemovalIndex = HELPER.indexOf('finish_guard iptables');
+  assert.ok(guardIndex > 0 && guardIndex < flushIndex);
+  assert.ok(flushIndex < policyJumpIndex && policyJumpIndex < guardRemovalIndex);
+});
+
+test('production installs and proves egress restrictions before the only Helm secret step', () => {
+  const evaluateStart = PRODUCTION.indexOf('  evaluate:');
+  const persistStart = PRODUCTION.indexOf('  persist:', evaluateStart);
+  const evaluate = PRODUCTION.slice(evaluateStart, persistStart);
+  const helperIndex = evaluate.indexOf('configure-pack-evaluator-egress.sh');
+  const secretIndex = evaluate.indexOf('PACK_EVALUATOR_HELM_API_KEY: ${{ secrets.PACK_EVALUATOR_HELM_API_KEY }}');
+  assert.match(evaluate, /apparmor bubblewrap ffmpeg iptables poppler-utils ripgrep util-linux/);
+  assert.ok(helperIndex > 0 && helperIndex < secretIndex);
+  assert.match(evaluate, /169\.254\.169\.254/);
+  assert.match(evaluate, /127\.0\.0\.1:18764/);
+  assert.match(evaluate, /\[::1\]:18765/);
+  assert.match(evaluate, /IPV4_REJECT_AFTER.*-gt.*IPV4_REJECT_BEFORE/);
+  assert.match(evaluate, /IPV6_REJECT_AFTER.*-gt.*IPV6_REJECT_BEFORE/);
+});
+
+test('hosted proof applies the same helper before real pinned CLI preflight', () => {
+  const helperIndex = HOSTED.indexOf('configure-pack-evaluator-egress.sh');
+  const preflightIndex = HOSTED.indexOf('bash "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight.sh"');
+  assert.ok(helperIndex > 0 && helperIndex < preflightIndex);
+  assert.match(HOSTED, /169\.254\.169\.254/);
+  assert.match(HOSTED, /127\.0\.0\.1:18764/);
+  assert.match(HOSTED, /\[::1\]:18765/);
+  assert.match(HOSTED, /IPV4_ACCEPT_AFTER.*-gt.*IPV4_ACCEPT_BEFORE/);
+  assert.equal((HOSTED.match(/configure-pack-evaluator-egress\.sh"/g) ?? []).length >= 2, true);
+  assert.match(HOSTED, /\/v1\/messages/);
+  assert.match(HOSTED, /\/v1\/responses/);
+});

--- a/scripts/tests/pack-evaluator-preflight-mock.test.mjs
+++ b/scripts/tests/pack-evaluator-preflight-mock.test.mjs
@@ -1,0 +1,76 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createPackEvaluatorPreflightMock } from '../pack-evaluator-preflight-mock.mjs';
+
+const LOCAL_TOKEN = 'local-preflight-token-longer-than-thirty-two-bytes';
+let server;
+let baseUrl;
+let activities;
+
+before(async () => {
+  activities = [];
+  server = createPackEvaluatorPreflightMock({
+    localToken: LOCAL_TOKEN,
+    onActivity: (activity) => activities.push(activity),
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('mock requires the local token and exposes only a local health check', async () => {
+  assert.equal((await fetch(`${baseUrl}/healthz`)).status, 401);
+  const response = await fetch(`${baseUrl}/healthz`, {
+    headers: { authorization: `Bearer ${LOCAL_TOKEN}` },
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+});
+
+test('mock serves protocol-complete Messages and Responses streams without retaining bodies', async () => {
+  const headers = {
+    authorization: `Bearer ${LOCAL_TOKEN}`,
+    'content-type': 'application/json',
+  };
+  const messages = await fetch(`${baseUrl}/v1/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: 'sonnet',
+      stream: true,
+      messages: [{ role: 'user', content: 'sensitive mock prompt' }],
+    }),
+  });
+  assert.equal(messages.status, 200);
+  assert.match(messages.headers.get('content-type'), /^text\/event-stream/);
+  assert.match(await messages.text(), /message_stop/);
+
+  const responses = await fetch(`${baseUrl}/v1/responses`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: 'gpt-5.5', stream: true, input: 'sensitive mock prompt' }),
+  });
+  assert.equal(responses.status, 200);
+  const responseBody = await responses.text();
+  assert.match(responseBody, /response\.output_text\.delta/);
+  assert.match(responseBody, /response\.completed/);
+
+  assert.deepEqual(
+    activities.filter((activity) => activity.status === 200).map(({ path, model, stream }) => ({
+      path,
+      model,
+      stream,
+    })),
+    [
+      { path: '/v1/messages', model: 'sonnet', stream: true },
+      { path: '/v1/responses', model: 'gpt-5.5', stream: true },
+    ],
+  );
+  const serialized = JSON.stringify(activities);
+  assert.doesNotMatch(serialized, /sensitive mock prompt|local-preflight-token|PACK_EVALUATOR_READY/);
+});

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -492,6 +492,14 @@ test('infrastructure audit reports retain only bounded operational evidence', ()
     stage: 'evaluation',
     reason: 'invented',
   }), /Unsupported infrastructure failure reason/);
+  for (const diagnosticSha256 of ['a'.repeat(65), `${'a'.repeat(63)} `, 42]) {
+    assert.throws(() => normalizeInfrastructureFailure({
+      schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
+      stage: 'agent_preflight',
+      reason: 'preflight_failed',
+      diagnosticSha256,
+    }), /Infrastructure diagnostic hash is invalid/);
+  }
 });
 
 test('safe CLI evidence hard-caps error digests per category and in total', () => {
@@ -955,11 +963,10 @@ exit 99
   writeFileSync(planFile, `${JSON.stringify(immutableProductionPlan(report.scenario))}\n`);
   writeFileSync(failureFile, `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
-    stage: 'contract_smoke',
-    reason: 'deterministic_http',
-    status: 400,
-    path: '/v1/messages',
-    model: 'claude-sonnet-5',
+    stage: 'agent_preflight',
+    reason: 'preflight_failed',
+    status: null,
+    errorCategory: null,
     diagnosticSha256: 'a'.repeat(64),
   })}\n`);
   const result = spawnSync(process.execPath, [
@@ -986,13 +993,13 @@ exit 99
   assert.equal(audit.candidate, null);
   assert.deepEqual(audit.evidence.cliReport.infrastructureFailure, {
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
-    stage: 'contract_smoke',
-    reason: 'deterministic_http',
-    status: 400,
+    stage: 'agent_preflight',
+    reason: 'preflight_failed',
+    status: null,
     errorCategory: null,
     diagnosticSha256: 'a'.repeat(64),
-    pathSha256: createHash('sha256').update('/v1/messages').digest('hex'),
-    modelSha256: createHash('sha256').update('claude-sonnet-5').digest('hex'),
+    pathSha256: null,
+    modelSha256: null,
   });
 
   const replayResultsDir = join(directory, 'replay-results');


### PR DESCRIPTION
Summary:
- run both pinned evaluator CLIs in the real hosted Ubuntu bwrap sandbox against a secret-free localhost mock
- restore the missing sandbox working directory and classify stdout plus stderr without retaining raw output
- separate infrastructure reason from error category and validate diagnostic hashes fail-closed
- restrict packeval egress to 127.0.0.1:18765 with repeat-safe IPv4 and IPv6 guard chains

Validation:
- CI=true targeted Node tests: 59 passed, 1 Linux-only skip
- bash syntax checks passed
- git diff --check passed
- independent runtime, reliability, and SRE reviews completed

Safety:
- no production database access
- no production workflow dispatch in this PR
- automatic Pack publication remains disabled