### PR TITLE
feat(packs): add protected v4 manual publishing

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: false
       auto_publish:
-        description: 'Request auto-publish; repository rollout gate must also be enabled'
+        description: 'Record an auto-publish request for audit only; v4 publication is hard-disabled'
         type: boolean
         default: false
 
@@ -1061,8 +1061,9 @@ jobs:
         env:
           SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
           PACK_PRODUCTION_AUTOMATION_KEY: ${{ secrets.PACK_PRODUCTION_AUTOMATION_KEY }}
-          # Fail closed until the hardened evaluator-container canary passes and
-          # PACK_PRODUCTION_AUTO_PUBLISH_ENABLED is explicitly enabled.
+          # Audit the requested state only. pack-production.mjs hard-stops every
+          # v4 generation at review_pending; only the protected manual workflow
+          # can publish.
           AUTO_PUBLISH: ${{ vars.PACK_PRODUCTION_AUTO_PUBLISH_ENABLED == 'true' && (github.event_name == 'schedule' || inputs.auto_publish) && 'true' || 'false' }}
         run: |
           node marketplace-finalize/scripts/pack-production.mjs finalize \

--- a/.github/workflows/pack-review.yml
+++ b/.github/workflows/pack-review.yml
@@ -29,6 +29,13 @@ jobs:
               console.log(`Not a recognized command: ${comment.substring(0, 50)}`);
               return;
             }
+            // Usage guides can contain an immutable Pack-production DAG marker.
+            // The legacy callback cannot prove or preserve that binding, so it
+            // may never accept an inline guide replacement for any Pack.
+            if (comment.startsWith('/approve') && /(?:^|\s)--guide(?:\s|=)/.test(comment)) {
+              core.setFailed('/approve --guide is disabled; immutable usage guides must use a binding-aware API');
+              return;
+            }
 
             const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
@@ -41,6 +48,14 @@ jobs:
             }
 
             const issueBody = context.payload.issue.body;
+            const isPackProductionV4 = /Pack Production Generation|Generation ID|skillstore\.pack-evaluation\/v4/i.test(issueBody);
+            if (
+              isPackProductionV4
+              && ['/generate', '/approve', '/regenerate'].some((command) => comment.startsWith(command))
+            ) {
+              core.setFailed('Pack Production v4 can only be published by the generation-bound production workflow');
+              return;
+            }
 
             // Extract pack ID from issue body. Tolerate legacy Plugin ID rows
             // from issues opened before the product rename.
@@ -59,12 +74,10 @@ jobs:
               payload = { packId };
             } else if (comment.startsWith('/approve')) {
               event = 'approve';
-              // Parse optional modifications
-              const guideMatch = comment.match(/--guide\s+"([^"]+)"/);
               payload = {
                 packId,
                 approvedBy: context.actor,
-                modifiedGuide: guideMatch ? guideMatch[1] : null
+                modifiedGuide: null
               };
             } else if (comment.startsWith('/regenerate')) {
               event = 'regenerate';

--- a/.github/workflows/publish-pack-production-v4.yml
+++ b/.github/workflows/publish-pack-production-v4.yml
@@ -1,0 +1,292 @@
+name: Publish Pack Production v4
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: 'Successful Generate Pack run that ended in review_pending'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: publish-pack-production-v4
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare immutable generation approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      generation_id: ${{ steps.approval.outputs.generation_id }}
+      pack_slug: ${{ steps.approval.outputs.pack_slug }}
+      source_sha: ${{ steps.approval.outputs.source_sha }}
+      binding_digest: ${{ steps.approval.outputs.binding_digest }}
+      score: ${{ steps.approval.outputs.score }}
+    steps:
+      - name: Checkout the manual publisher from main
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
+          sparse-checkout: scripts/pack-production-manual-publish.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Require main and a disabled automatic publish gate
+        env:
+          AUTO_PUBLISH_ENABLED: ${{ vars.PACK_PRODUCTION_AUTO_PUBLISH_ENABLED }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          if [ "${AUTO_PUBLISH_ENABLED:-false}" = true ]; then
+            echo '::error::Manual publication is forbidden while PACK_PRODUCTION_AUTO_PUBLISH_ENABLED=true'
+            exit 1
+          fi
+
+      - name: Resolve the exact source run and final artifact
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]{5,19}$ ]]; then
+            echo '::error::source_run_id must be a GitHub Actions run id'
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/pack-manual-source"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$RUNNER_TEMP/pack-manual-source/source-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/generate-packs.yml" \
+            > "$RUNNER_TEMP/pack-manual-source/workflow.json"
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?name=pack-production-final&per_page=100" \
+            --slurp | jq -e '
+              [.[].artifacts[] | select(.name == "pack-production-final")] as $artifacts |
+              if ($artifacts | length) == 1 then $artifacts[0]
+              else error("expected one exact pack-production-final artifact") end
+            ' > "$RUNNER_TEMP/pack-manual-source/artifact.json"
+          ARTIFACT_ID=$(jq -er '
+            select(.expired == false) |
+            select(.digest | test("^sha256:[0-9a-f]{64}$")) |
+            select(.size_in_bytes > 0 and .size_in_bytes <= 33554432) |
+            .id
+          ' "$RUNNER_TEMP/pack-manual-source/artifact.json")
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download, authenticate, and bound the source artifact ZIP
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.source.outputs.artifact_id }}
+        run: |
+          set -euo pipefail
+          EXPECTED=$(jq -er '.digest | sub("^sha256:"; "")' \
+            "$RUNNER_TEMP/pack-manual-source/artifact.json")
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            > "$RUNNER_TEMP/pack-manual-source/source-artifact.zip"
+          ACTUAL=$(sha256sum "$RUNNER_TEMP/pack-manual-source/source-artifact.zip" | awk '{print $1}')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo '::error::pack-production-final artifact digest mismatch'
+            exit 1
+          fi
+          COMPRESSED_BYTES=$(stat -c '%s' "$RUNNER_TEMP/pack-manual-source/source-artifact.zip")
+          METADATA_BYTES=$(jq -er '.size_in_bytes' "$RUNNER_TEMP/pack-manual-source/artifact.json")
+          if [ "$COMPRESSED_BYTES" -ne "$METADATA_BYTES" ] || [ "$COMPRESSED_BYTES" -gt 33554432 ]; then
+            echo '::error::pack-production-final compressed size is invalid or exceeds 32 MiB'
+            exit 1
+          fi
+          ZIP_TOTALS=$(LC_ALL=C zipinfo -t "$RUNNER_TEMP/pack-manual-source/source-artifact.zip")
+          ENTRY_COUNT=$(awk '{print $1}' <<<"$ZIP_TOTALS")
+          UNCOMPRESSED_BYTES=$(awk '{print $3}' <<<"$ZIP_TOTALS")
+          if ! [[ "$ENTRY_COUNT" =~ ^[0-9]+$ && "$UNCOMPRESSED_BYTES" =~ ^[0-9]+$ ]]; then
+            echo '::error::pack-production-final ZIP totals are invalid'
+            exit 1
+          fi
+          if [ "$ENTRY_COUNT" -lt 1 ] || [ "$ENTRY_COUNT" -gt 1024 ]; then
+            echo '::error::pack-production-final entry count exceeds 1024'
+            exit 1
+          fi
+          if [ "$UNCOMPRESSED_BYTES" -lt 1 ] || [ "$UNCOMPRESSED_BYTES" -gt 134217728 ]; then
+            echo '::error::pack-production-final uncompressed size exceeds 128 MiB'
+            exit 1
+          fi
+          if unzip -Z1 "$RUNNER_TEMP/pack-manual-source/source-artifact.zip" \
+            | grep -Eq '(^/|(^|/)\.\.(/|$)|\\)'; then
+            echo '::error::pack-production-final contains an unsafe ZIP path'
+            exit 1
+          fi
+          rm -rf "$RUNNER_TEMP/pack-production-final"
+          mkdir -p "$RUNNER_TEMP/pack-production-final"
+          unzip -q "$RUNNER_TEMP/pack-manual-source/source-artifact.zip" \
+            -d "$RUNNER_TEMP/pack-production-final"
+          if [ -n "$(find "$RUNNER_TEMP/pack-production-final" -type l -print -quit)" ]; then
+            echo '::error::pack-production-final contains a symbolic link'
+            exit 1
+          fi
+
+      - name: Validate generation, nonce, source SHA, quality, and binding
+        id: approval
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/pack-manual-ready"
+          node scripts/pack-production-manual-publish.mjs prepare \
+            --source-dir "$RUNNER_TEMP/pack-production-final" \
+            --source-run-id "$SOURCE_RUN_ID" \
+            --source-run-file "$RUNNER_TEMP/pack-manual-source/source-run.json" \
+            --workflow-file "$RUNNER_TEMP/pack-manual-source/workflow.json" \
+            --artifact-file "$RUNNER_TEMP/pack-manual-source/artifact.json" \
+            --output "$RUNNER_TEMP/pack-manual-ready/approval.json" \
+            > "$RUNNER_TEMP/pack-manual-ready/prepare-result.json"
+          jq -e --arg run "$SOURCE_RUN_ID" '.sourceRunId == $run' \
+            "$RUNNER_TEMP/pack-manual-ready/prepare-result.json" >/dev/null
+          echo "generation_id=$(jq -r .generationId "$RUNNER_TEMP/pack-manual-ready/prepare-result.json")" >> "$GITHUB_OUTPUT"
+          echo "pack_slug=$(jq -r .packSlug "$RUNNER_TEMP/pack-manual-ready/prepare-result.json")" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$(jq -r .sourceSha "$RUNNER_TEMP/pack-manual-ready/prepare-result.json")" >> "$GITHUB_OUTPUT"
+          echo "binding_digest=$(jq -r .bindingDigest "$RUNNER_TEMP/pack-manual-ready/prepare-result.json")" >> "$GITHUB_OUTPUT"
+          echo "score=$(jq -r .score "$RUNNER_TEMP/pack-manual-ready/prepare-result.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize the approval request without the nonce
+        run: |
+          {
+            echo '## Pack Production v4 manual approval'
+            echo
+            echo "- Source run: \`${{ inputs.source_run_id }}\`"
+            echo "- Source SHA: \`${{ steps.approval.outputs.source_sha }}\`"
+            echo "- Generation: \`${{ steps.approval.outputs.generation_id }}\`"
+            echo "- Pack: \`${{ steps.approval.outputs.pack_slug }}\`"
+            echo "- Binding: \`${{ steps.approval.outputs.binding_digest }}\`"
+            echo "- Evaluation score: \`${{ steps.approval.outputs.score }}\`"
+            echo '- Quality override: **forbidden**'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable approval handoff
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-manual-approval
+          path: ${{ runner.temp }}/pack-manual-ready/approval.json
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+  publish:
+    name: Publish and prove the exact generation
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment:
+      name: production
+    steps:
+      - name: Checkout the manual publisher from main
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
+          sparse-checkout: scripts/pack-production-manual-publish.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Download the reviewed immutable approval handoff
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-manual-approval
+          path: ${{ runner.temp }}/pack-manual-ready
+
+      - name: Publish through the nonce-bound manual API
+        id: publish
+        env:
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          PACK_PRODUCTION_MANUAL_PUBLISH_KEY: ${{ secrets.PACK_PRODUCTION_MANUAL_PUBLISH_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/pack-manual-release"
+          node scripts/pack-production-manual-publish.mjs publish \
+            --approval "$RUNNER_TEMP/pack-manual-ready/approval.json" \
+            --api-url "$SKILLSTORE_API_URL" \
+            --token "$PACK_PRODUCTION_MANUAL_PUBLISH_KEY" \
+            --output "$RUNNER_TEMP/pack-manual-release/publish-result.json" \
+            > "$RUNNER_TEMP/pack-manual-release/publish-command.json"
+          PACK_SLUG=$(jq -er .packSlug "$RUNNER_TEMP/pack-manual-release/publish-result.json")
+          echo "pack_slug=$PACK_SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Verify page, API, signatures, binding, and every file hash
+        id: public_readback
+        continue-on-error: true
+        env:
+          PACK_PUBLIC_URL: https://skillstore.io
+        run: |
+          set -euo pipefail
+          node scripts/pack-production-manual-publish.mjs public-readback \
+            --approval "$RUNNER_TEMP/pack-manual-ready/approval.json" \
+            --publish-result "$RUNNER_TEMP/pack-manual-release/publish-result.json" \
+            --public-url "$PACK_PUBLIC_URL" \
+            --attempts 10 \
+            --poll-seconds 30 \
+            --output "$RUNNER_TEMP/pack-manual-release/public-readback.json" \
+            > "$RUNNER_TEMP/pack-manual-release/public-readback-command.json"
+
+      - name: Install the real Pack with the public Linux CLI
+        id: cli_readback
+        continue-on-error: true
+        env:
+          PACK_SLUG: ${{ steps.publish.outputs.pack_slug }}
+          HOME: ${{ runner.temp }}/pack-cli-home
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/pack-cli-home/.npm
+          NPM_CONFIG_UPDATE_NOTIFIER: 'false'
+          NO_COLOR: '1'
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME" "$RUNNER_TEMP/pack-cli-work"
+          cd "$RUNNER_TEMP/pack-cli-work"
+          npx --yes skillstore@0.1.9 add "@$PACK_SLUG" --agent codex --overwrite
+          npx --yes skillstore@0.1.9 check --json \
+            > "$RUNNER_TEMP/pack-manual-release/cli-check.json"
+          jq -e '.errors == [] and .updates == [] and (.upToDate | type == "array")' \
+            "$RUNNER_TEMP/pack-manual-release/cli-check.json" >/dev/null
+
+      - name: Record generation production readback only after every proof
+        if: always() && steps.publish.outcome == 'success'
+        env:
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          PACK_PRODUCTION_MANUAL_PUBLISH_KEY: ${{ secrets.PACK_PRODUCTION_MANUAL_PUBLISH_KEY }}
+          PUBLIC_READBACK_OUTCOME: ${{ steps.public_readback.outcome }}
+          CLI_READBACK_OUTCOME: ${{ steps.cli_readback.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$PUBLIC_READBACK_OUTCOME" = success ] && [ "$CLI_READBACK_OUTCOME" = success ]; then
+            STATUS=succeeded
+            ERROR_MESSAGE=''
+          else
+            STATUS=failed
+            ERROR_MESSAGE="public_readback=$PUBLIC_READBACK_OUTCOME; cli_readback=$CLI_READBACK_OUTCOME"
+          fi
+          node scripts/pack-production-manual-publish.mjs complete \
+            --approval "$RUNNER_TEMP/pack-manual-ready/approval.json" \
+            --api-url "$SKILLSTORE_API_URL" \
+            --token "$PACK_PRODUCTION_MANUAL_PUBLISH_KEY" \
+            --status "$STATUS" \
+            --error "${ERROR_MESSAGE:-none}" \
+            --public-readback "$RUNNER_TEMP/pack-manual-release/public-readback.json" \
+            --cli-check "$RUNNER_TEMP/pack-manual-release/cli-check.json" \
+            --output "$RUNNER_TEMP/pack-manual-release/final-release.json"
+
+      - name: Upload manual publication evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-production-manual-release
+          path: ${{ runner.temp }}/pack-manual-release/
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -10,6 +10,8 @@ on:
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
+      - "scripts/pack-production.mjs"
+      - "scripts/pack-production-manual-publish.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
@@ -21,6 +23,9 @@ on:
       - ".github/workflows/scrape-skills-sh.yml"
       - ".github/workflows/recalculate-scores.yml"
       - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/workflows/generate-packs.yml"
+      - ".github/workflows/pack-review.yml"
+      - ".github/workflows/publish-pack-production-v4.yml"
       - ".github/actions/invalidate-cache/action.yml"
       - ".github/workflows/test-recalculate-scores.yml"
   push:
@@ -32,6 +37,8 @@ on:
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/invalidate-cache.sh"
       - "scripts/plan-cache-invalidation.mjs"
+      - "scripts/pack-production.mjs"
+      - "scripts/pack-production-manual-publish.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
@@ -43,6 +50,9 @@ on:
       - ".github/workflows/scrape-skills-sh.yml"
       - ".github/workflows/recalculate-scores.yml"
       - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/workflows/generate-packs.yml"
+      - ".github/workflows/pack-review.yml"
+      - ".github/workflows/publish-pack-production-v4.yml"
       - ".github/actions/invalidate-cache/action.yml"
   workflow_dispatch:
 
@@ -83,4 +93,5 @@ jobs:
           node --check scripts/resolve-manual-skills.mjs
           node --check scripts/plan-cache-invalidation.mjs
           node --check scripts/score-cache-closure.mjs
+          node --check scripts/pack-production-manual-publish.mjs
           CI=true node --test scripts/tests/*.test.mjs

--- a/scripts/pack-production-manual-publish.mjs
+++ b/scripts/pack-production-manual-publish.mjs
@@ -1,0 +1,956 @@
+#!/usr/bin/env node
+
+import { createHash, createPublicKey, verify as verifySignature } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APPROVAL_SCHEMA = 'marketplace.pack-production-manual-approval/v1';
+const PUBLIC_READBACK_SCHEMA = 'marketplace.pack-production-public-readback/v1';
+const RELEASE_SCHEMA = 'marketplace.pack-production-manual-release/v1';
+const API_READBACK_SCHEMA = 'skillstore.pack-production-readback/v1';
+const API_READBACK_EVIDENCE_SCHEMA = 'skillstore.pack-production-readback-evidence/v1';
+const REPOSITORY = 'aiskillstore/marketplace';
+const WORKFLOW_NAME = 'Generate Pack';
+const WORKFLOW_PATH = '.github/workflows/generate-packs.yml';
+const SOURCE_ARTIFACT_NAME = 'pack-production-final';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const SHA1_RE = /^[0-9a-f]{40}$/;
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,78}[a-z0-9])?$/;
+const MAX_PUBLIC_ARTIFACT_FILES = 512;
+const MAX_PUBLIC_ARTIFACT_BYTES = 256 * 1024 * 1024;
+const MAX_SINGLE_FILE_BYTES = 32 * 1024 * 1024;
+const MAX_JSON_BYTES = 16 * 1024 * 1024;
+const ARTIFACT_DOWNLOAD_CONCURRENCY = 4;
+const TRUSTED_SIGNING_KEY = Object.freeze({
+  keyId: 'EP0Myk7rTk_J0RdG1fvpkP',
+  publicKeyX: '2tbC6eNY4T9sx4Pvuo_NwHlXGyWWz95WAtHyHUTqzs8',
+});
+const RETRYABLE_PUBLIC_STATUSES = new Set([404, 409, 425, 429]);
+
+export class RetryablePublicReadbackError extends Error {}
+
+function isRetryablePublicStatus(status) {
+  return RETRYABLE_PUBLIC_STATUSES.has(status) || (status >= 500 && status <= 599);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = { command };
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith('--')) fail(`Unexpected argument: ${token}`);
+    const key = token.slice(2);
+    const value = rest[index + 1];
+    if (value == null || value.startsWith('--')) fail(`Missing value for --${key}`);
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function required(args, key) {
+  const value = args[key];
+  if (typeof value !== 'string' || value.length === 0) fail(`Missing --${key}`);
+  return value;
+}
+
+function normalizeForJson(value) {
+  if (Array.isArray(value)) return value.map(normalizeForJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entry]) => [key, normalizeForJson(entry)]));
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(normalizeForJson(value));
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function readJson(path) {
+  let raw;
+  try {
+    raw = await readFile(path);
+  } catch (cause) {
+    fail(`Unable to read ${path}: ${cause.message}`);
+  }
+  if (raw.length > MAX_JSON_BYTES) fail(`${path} exceeds the JSON size limit`);
+  try {
+    return { raw, value: JSON.parse(raw.toString('utf8')) };
+  } catch {
+    fail(`${path} is not valid JSON`);
+  }
+}
+
+async function writeJson(path, value) {
+  await mkdir(resolve(path, '..'), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function exactString(value, name, pattern) {
+  if (typeof value !== 'string' || !pattern.test(value)) fail(`${name} is invalid`);
+  return value;
+}
+
+function exactInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1) fail(`${name} is invalid`);
+  return value;
+}
+
+function exactSourceRun(sourceRun, workflow, artifact, requestedRunId) {
+  const runId = exactInteger(sourceRun?.id, 'source run id');
+  if (String(runId) !== requestedRunId) fail('Source run id differs from workflow_dispatch input');
+  if (
+    sourceRun.name !== WORKFLOW_NAME
+    || sourceRun.path !== WORKFLOW_PATH
+    || sourceRun.repository?.full_name !== REPOSITORY
+    || sourceRun.status !== 'completed'
+    || sourceRun.conclusion !== 'success'
+    || sourceRun.head_branch !== 'main'
+    || !['schedule', 'workflow_dispatch'].includes(sourceRun.event)
+  ) fail('Source run is not a successful main Generate Pack execution');
+  const headSha = exactString(sourceRun.head_sha, 'source run head SHA', SHA1_RE);
+  const runAttempt = exactInteger(sourceRun.run_attempt, 'source run attempt');
+  if (
+    workflow?.name !== WORKFLOW_NAME
+    || workflow?.path !== WORKFLOW_PATH
+    || workflow?.state !== 'active'
+    || exactInteger(workflow?.id, 'workflow id') !== sourceRun.workflow_id
+  ) fail('Generate Pack workflow identity is not exact and active');
+  if (
+    artifact?.name !== SOURCE_ARTIFACT_NAME
+    || artifact?.expired !== false
+    || !Number.isSafeInteger(artifact?.size_in_bytes)
+    || artifact.size_in_bytes < 1
+    || artifact.size_in_bytes > 32 * 1024 * 1024
+    || artifact?.workflow_run?.id !== runId
+    || artifact?.workflow_run?.head_sha !== headSha
+  ) fail('Source artifact is not bound to the exact Generate Pack run');
+  const digest = exactString(artifact.digest, 'source artifact digest', /^sha256:[0-9a-f]{64}$/);
+  return {
+    repository: REPOSITORY,
+    runId: String(runId),
+    runAttempt,
+    runUrl: sourceRun.html_url,
+    event: sourceRun.event,
+    headSha,
+    workflowId: workflow.id,
+    workflowPath: WORKFLOW_PATH,
+    artifactId: exactInteger(artifact.id, 'source artifact id'),
+    artifactName: SOURCE_ARTIFACT_NAME,
+    artifactDigest: digest,
+  };
+}
+
+function exactSkillBindings(evaluation) {
+  const manifest = evaluation?.candidate?.manifest;
+  const dag = manifest?.executionDag;
+  if (
+    !dag
+    || dag.schemaVersion !== 'skillstore.pack-execution-dag/v1'
+    || !SHA256_RE.test(dag.workflowDigest ?? '')
+    || !SHA256_RE.test(dag.bindingDigest ?? '')
+    || dag.usageGuideMarker !== `<!-- skillstore-execution-binding:${dag.bindingDigest} -->`
+    || !Array.isArray(manifest.skills)
+    || !Array.isArray(dag.skillBindings)
+    || manifest.skills.length < 2
+    || dag.skillBindings.length !== manifest.skills.length
+  ) fail('Candidate execution DAG or ordered Skill binding is incomplete');
+  const skills = dag.skillBindings.map((binding, index) => {
+    if (
+      binding?.canonicalId !== manifest.skills[index]
+      || !SLUG_RE.test(binding?.canonicalId ?? '')
+      || typeof binding?.version !== 'string'
+      || binding.version.length === 0
+      || !SHA256_RE.test(binding?.contentHash ?? '')
+      || !Array.isArray(binding?.slotIds)
+      || binding.slotIds.length === 0
+    ) fail(`Candidate Skill binding ${index + 1} is incomplete or out of order`);
+    return {
+      canonicalId: binding.canonicalId,
+      version: binding.version,
+      contentHash: binding.contentHash,
+      slotIds: [...binding.slotIds],
+    };
+  });
+  return { manifest, dag, skills };
+}
+
+function exactCandidate(persisted, finalResult, source) {
+  const selected = persisted?.selected;
+  if (!selected || !UUID_RE.test(selected.generationId ?? '')) {
+    fail('Persist summary did not select a valid generation');
+  }
+  if (
+    !selected.pack?.id
+    || !SLUG_RE.test(selected.pack?.slug ?? '')
+    || selected.autoPublishEligible !== true
+    || selected.comparisonOf != null
+    || selected.enrichment?.content !== 'dispatched'
+    || !UUID_RE.test(selected.enrichment?.contentDispatchNonce ?? '')
+  ) fail('Selected candidate is not eligible for non-override manual publication');
+  const candidates = (persisted.persisted ?? []).filter(
+    (item) => item?.request?.generationId === selected.generationId && item?.auditOnly === false,
+  );
+  if (candidates.length !== 1) fail('Persist summary does not contain one exact selected candidate');
+  const persistedCandidate = candidates[0];
+  const evaluation = persistedCandidate.request;
+  if (
+    evaluation?.schemaVersion !== 'skillstore.pack-evaluation/v4'
+    || evaluation?.outcome !== 'candidate_ready'
+    || evaluation.generationId !== selected.generationId
+    || evaluation.workflow?.repository !== REPOSITORY
+    || evaluation.workflow?.runId !== source.runId
+    || evaluation.workflow?.runAttempt !== source.runAttempt
+    || evaluation.workflow?.commitSha !== source.headSha
+    || !SHA256_RE.test(evaluation.evidenceDigest ?? '')
+    || !SLUG_RE.test(evaluation.scenario?.slug ?? '')
+    || persistedCandidate.response?.data?.generationId !== selected.generationId
+    || persistedCandidate.response?.data?.pack?.id !== selected.pack.id
+    || persistedCandidate.response?.data?.pack?.slug !== selected.pack.slug
+    || persistedCandidate.response?.data?.enrichment?.contentDispatchNonce
+      !== selected.enrichment.contentDispatchNonce
+  ) fail('Selected v4 evaluation differs from persisted source run evidence');
+  const { evidenceDigest: _evidenceDigest, ...unsignedEvaluation } = evaluation;
+  if (sha256(canonicalJson(unsignedEvaluation)) !== evaluation.evidenceDigest) {
+    fail('Selected v4 evaluation evidence digest is invalid');
+  }
+  const { manifest, dag, skills } = exactSkillBindings(evaluation);
+  const fitness = evaluation.candidate?.fitness;
+  const score = Number(fitness?.score);
+  if (
+    fitness?.passed !== true
+    || !Number.isFinite(score)
+    || score < 8
+    || !Array.isArray(manifest.riskFlags)
+    || manifest.riskFlags.length !== 0
+    || !fitness?.bestSingle
+    || !Array.isArray(fitness.bestSingle.competitors)
+    || !Array.isArray(fitness?.ablation)
+    || fitness?.evaluationSuite?.executed !== true
+    || fitness?.usageProvenance?.deterministic !== true
+    || !Array.isArray(fitness?.errors)
+    || fitness.errors.length !== 0
+  ) fail('Manual publication cannot override v4 quality, risk, or evaluation gates');
+  if (
+    finalResult?.outcome !== 'review_pending'
+    || finalResult?.generationId !== selected.generationId
+    || finalResult?.pack?.id !== selected.pack.id
+    || finalResult?.pack?.slug !== selected.pack.slug
+    || finalResult?.reason !== 'automatic publish was disabled for this run'
+    || finalResult?.publicationMode !== 'manual_only'
+  ) fail('Final artifact is not an auto-publish-disabled review_pending generation');
+  return { selected, evaluation, dag, skills, score };
+}
+
+export function buildManualApproval({ sourceRun, workflow, artifact, persisted, finalResult, requestedRunId, hashes }) {
+  const source = exactSourceRun(sourceRun, workflow, artifact, requestedRunId);
+  const candidate = exactCandidate(persisted, finalResult, source);
+  const unsigned = {
+    schemaVersion: APPROVAL_SCHEMA,
+    preparedAt: new Date().toISOString(),
+    source,
+    generationId: candidate.selected.generationId,
+    contentDispatchNonce: candidate.selected.enrichment.contentDispatchNonce,
+    pack: {
+      id: candidate.selected.pack.id,
+      stagingSlug: candidate.selected.pack.slug,
+      publicSlug: candidate.evaluation.scenario.slug,
+    },
+    evaluation: {
+      schemaVersion: candidate.evaluation.schemaVersion,
+      evidenceDigest: candidate.evaluation.evidenceDigest,
+      sha256: sha256(canonicalJson(candidate.evaluation)),
+      score: candidate.score,
+    },
+    executionBinding: {
+      schemaVersion: 'skillstore.pack-execution-binding/v1',
+      generationId: candidate.evaluation.generationId,
+      evidenceDigest: candidate.evaluation.evidenceDigest,
+      executionDag: candidate.dag,
+      workflowDigest: candidate.dag.workflowDigest,
+      bindingDigest: candidate.dag.bindingDigest,
+      usageGuideMarker: candidate.dag.usageGuideMarker,
+      marketplaceCommitSha: candidate.evaluation.workflow.commitSha,
+      skills: candidate.skills,
+    },
+    skills: candidate.skills.map((skill) => ({
+      slug: skill.canonicalId,
+      version: skill.version,
+      contentHash: skill.contentHash,
+    })),
+    sourceFiles: hashes,
+  };
+  return { ...unsigned, handoffDigest: sha256(canonicalJson(unsigned)) };
+}
+
+export function validateManualApproval(approval) {
+  if (!approval || approval.schemaVersion !== APPROVAL_SCHEMA) fail('Manual approval schema is invalid');
+  const { handoffDigest, ...unsigned } = approval;
+  if (!SHA256_RE.test(handoffDigest ?? '') || sha256(canonicalJson(unsigned)) !== handoffDigest) {
+    fail('Manual approval handoff digest is invalid');
+  }
+  if (
+    approval.source?.repository !== REPOSITORY
+    || approval.source?.workflowPath !== WORKFLOW_PATH
+    || approval.source?.artifactName !== SOURCE_ARTIFACT_NAME
+    || !/^sha256:[0-9a-f]{64}$/.test(approval.source?.artifactDigest ?? '')
+    || !SHA256_RE.test(approval.sourceFiles?.persistSummarySha256 ?? '')
+    || !SHA256_RE.test(approval.sourceFiles?.finalResultSha256 ?? '')
+    || !Number.isFinite(approval.evaluation?.score)
+    || approval.evaluation.score < 8
+    || !UUID_RE.test(approval.generationId ?? '')
+    || !UUID_RE.test(approval.contentDispatchNonce ?? '')
+    || !SLUG_RE.test(approval.pack?.stagingSlug ?? '')
+    || !SLUG_RE.test(approval.pack?.publicSlug ?? '')
+    || approval.executionBinding?.generationId !== approval.generationId
+    || approval.executionBinding?.bindingDigest
+      !== approval.executionBinding?.executionDag?.bindingDigest
+    || !Array.isArray(approval.skills)
+    || approval.skills.length < 2
+    || canonicalJson(approval.skills) !== canonicalJson(
+      approval.executionBinding?.skills?.map((skill) => ({
+        slug: skill.canonicalId,
+        version: skill.version,
+        contentHash: skill.contentHash,
+      })),
+    )
+  ) fail('Manual approval binding is internally inconsistent');
+  return approval;
+}
+
+async function prepare(args) {
+  const sourceDir = resolve(required(args, 'source-dir'));
+  const output = resolve(required(args, 'output'));
+  const requestedRunId = required(args, 'source-run-id');
+  if (!/^[1-9][0-9]{5,19}$/.test(requestedRunId)) fail('Invalid --source-run-id');
+  const [sourceRunFile, workflowFile, artifactFile, persistedFile, finalFile] = await Promise.all([
+    readJson(resolve(required(args, 'source-run-file'))),
+    readJson(resolve(required(args, 'workflow-file'))),
+    readJson(resolve(required(args, 'artifact-file'))),
+    readJson(resolve(sourceDir, 'persist-summary.json')),
+    readJson(resolve(sourceDir, 'final-result.json')),
+  ]);
+  const approval = buildManualApproval({
+    sourceRun: sourceRunFile.value,
+    workflow: workflowFile.value,
+    artifact: artifactFile.value,
+    persisted: persistedFile.value,
+    finalResult: finalFile.value,
+    requestedRunId,
+    hashes: {
+      persistSummarySha256: sha256(persistedFile.raw),
+      finalResultSha256: sha256(finalFile.raw),
+    },
+  });
+  await writeJson(output, approval);
+  process.stdout.write(`${JSON.stringify({
+    generationId: approval.generationId,
+    packSlug: approval.pack.publicSlug,
+    stagingSlug: approval.pack.stagingSlug,
+    sourceRunId: approval.source.runId,
+    sourceSha: approval.source.headSha,
+    bindingDigest: approval.executionBinding.bindingDigest,
+    score: approval.evaluation.score,
+    handoffDigest: approval.handoffDigest,
+  })}\n`);
+}
+
+async function requestJson(url, options = {}, fetchImpl = fetch) {
+  const { retryPublicStatus = false, ...fetchOptions } = options;
+  const response = await fetchImpl(url, {
+    ...fetchOptions,
+    signal: fetchOptions.signal ?? AbortSignal.timeout(30_000),
+    headers: { Accept: 'application/json', ...(fetchOptions.headers ?? {}) },
+  });
+  if (!response.ok && retryPublicStatus === true && isRetryablePublicStatus(response.status)) {
+    throw new RetryablePublicReadbackError(`${url} returned HTTP ${response.status}`);
+  }
+  const raw = Buffer.from(await response.arrayBuffer());
+  if (raw.length > MAX_JSON_BYTES) fail(`${url} returned oversized JSON`);
+  const text = raw.toString('utf8');
+  if (!response.ok) {
+    const message = `${url} returned HTTP ${response.status}: ${text.slice(0, 500)}`;
+    fail(message);
+  }
+  let body = null;
+  if (text) {
+    try { body = JSON.parse(text); } catch { fail(`${url} returned invalid JSON`); }
+  }
+  return body;
+}
+
+function apiBase(value, name) {
+  let url;
+  try { url = new URL(value); } catch { fail(`${name} is invalid`); }
+  if (
+    url.protocol !== 'https:'
+    || url.username
+    || url.password
+    || url.pathname !== '/'
+    || url.search
+    || url.hash
+  ) {
+    fail(`${name} must be a credential-free HTTPS origin`);
+  }
+  return url.origin;
+}
+
+export function validateGenerationReadback(readback, approval) {
+  const attempt = readback?.attempt ?? readback;
+  const pack = readback?.pack ?? null;
+  const evidence = attempt?.evidence;
+  if (
+    attempt?.generation_id !== approval.generationId
+    || attempt?.pack_id !== approval.pack.id
+    || attempt?.content_dispatch_nonce !== approval.contentDispatchNonce
+    || attempt?.evidence_digest !== approval.evaluation.evidenceDigest
+    || attempt?.workflow_repository !== REPOSITORY
+    || String(attempt?.workflow_run_id) !== approval.source.runId
+    || attempt?.workflow_run_attempt !== approval.source.runAttempt
+    || evidence?.generationId !== approval.generationId
+    || evidence?.evidenceDigest !== approval.evaluation.evidenceDigest
+    || evidence?.workflow?.commitSha !== approval.source.headSha
+    || canonicalJson(evidence?.candidate?.manifest?.executionDag)
+      !== canonicalJson(approval.executionBinding.executionDag)
+  ) fail('Authenticated generation readback differs from the immutable approval');
+  if (attempt.outcome === 'review_pending') {
+    if (
+      attempt.pack_slug !== approval.pack.stagingSlug
+      || pack?.id !== approval.pack.id
+      || pack?.slug !== approval.pack.stagingSlug
+      || !['generated', 'pending_review'].includes(pack?.review_status)
+    ) fail('review_pending generation no longer points at the approved staging Pack');
+    return { outcome: 'review_pending', publicSlug: null };
+  }
+  if (attempt.outcome === 'published') {
+    if (
+      attempt.pack_slug !== approval.pack.publicSlug
+      || pack?.id !== approval.pack.id
+      || pack?.slug !== approval.pack.publicSlug
+      || pack?.review_status !== 'approved'
+    ) fail('Published generation no longer points at the approved public Pack');
+    return { outcome: 'published', publicSlug: pack.slug };
+  }
+  fail(`Generation outcome ${String(attempt?.outcome)} cannot be manually published`);
+}
+
+export async function publishManualApproval(approval, { apiUrl, token, fetchImpl = fetch }) {
+  validateManualApproval(approval);
+  if (typeof token !== 'string' || token.length < 16) fail('Manual publish token is missing');
+  const base = apiBase(apiUrl, 'Skillstore API URL');
+  const body = {
+    generationId: approval.generationId,
+    contentDispatchNonce: approval.contentDispatchNonce,
+    publishMode: 'manual',
+    sourceRunId: approval.source.runId,
+  };
+  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+  const readGeneration = async () => {
+    const response = await requestJson(
+      `${base}/api/automation/packs/production/${encodeURIComponent(approval.generationId)}`,
+      { headers },
+      fetchImpl,
+    );
+    return validateGenerationReadback(response?.data, approval);
+  };
+  const before = await readGeneration();
+  let data;
+  let replayed = false;
+  if (before.outcome === 'published') {
+    data = {
+      slug: before.publicSlug,
+      reviewStatus: 'approved',
+      generationId: approval.generationId,
+      contentDispatchNonce: approval.contentDispatchNonce,
+      sourceRunId: approval.source.runId,
+    };
+    replayed = true;
+  } else {
+    let response;
+    try {
+      response = await requestJson(
+        `${base}/api/automation/packs/${encodeURIComponent(approval.pack.stagingSlug)}/publish`,
+        { method: 'POST', headers, body: JSON.stringify(body) },
+        fetchImpl,
+      );
+    } catch (cause) {
+      // A publish can commit while its HTTP response is lost. Re-read the exact
+      // generation before deciding whether a rerun is safe.
+      const recovered = await readGeneration().catch(() => null);
+      if (recovered?.outcome !== 'published') throw cause;
+      response = { data: {
+        slug: recovered.publicSlug,
+        reviewStatus: 'approved',
+        generationId: approval.generationId,
+        contentDispatchNonce: approval.contentDispatchNonce,
+        sourceRunId: approval.source.runId,
+      } };
+      replayed = true;
+    }
+    data = response?.data;
+  }
+  if (
+    data?.slug !== approval.pack.publicSlug
+    || (data.reviewStatus ?? data.review_status) !== 'approved'
+    || data?.generationId !== approval.generationId
+    || data?.contentDispatchNonce !== approval.contentDispatchNonce
+    || String(data?.sourceRunId) !== approval.source.runId
+  ) fail('Manual publish response did not echo the exact generation, nonce, run, and Pack binding');
+  const after = await readGeneration();
+  if (after.outcome !== 'published' || after.publicSlug !== data.slug) {
+    fail('Generation did not become exactly published after the manual publish request');
+  }
+  return {
+    schemaVersion: 'marketplace.pack-production-manual-publish/v1',
+    publishedAt: new Date().toISOString(),
+    approvalDigest: approval.handoffDigest,
+    generationId: approval.generationId,
+    sourceRunId: approval.source.runId,
+    packSlug: data.slug,
+    reviewStatus: 'approved',
+    replayed,
+  };
+}
+
+async function publish(args) {
+  const approval = validateManualApproval((await readJson(resolve(required(args, 'approval')))).value);
+  const result = await publishManualApproval(approval, {
+    apiUrl: required(args, 'api-url'),
+    token: required(args, 'token'),
+  });
+  await writeJson(resolve(required(args, 'output')), result);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function validatePublicPack(pack, approval) {
+  const mismatches = [];
+  if (pack?.id !== approval.pack.id) mismatches.push('Pack id differs from approval');
+  if (pack?.slug !== approval.pack.publicSlug) mismatches.push('Pack slug differs from approval');
+  if (pack?.reviewStatus !== 'approved') mismatches.push('Pack is not publicly approved');
+  if (canonicalJson(pack?.executionBinding) !== canonicalJson(approval.executionBinding)) {
+    mismatches.push('Pack execution binding differs from approval');
+  }
+  if (typeof pack?.usageGuide !== 'string' || !pack.usageGuide.includes(approval.executionBinding.usageGuideMarker)) {
+    mismatches.push('Pack usage guide lost the DAG binding marker');
+  }
+  const skills = Array.isArray(pack?.skills) ? pack.skills.map((skill) => ({
+    slug: skill?.slug,
+    version: skill?.version,
+    contentHash: skill?.contentHash,
+  })) : [];
+  if (canonicalJson(skills) !== canonicalJson(approval.skills)) {
+    mismatches.push('Pack ordered Skill identities differ from approval');
+  }
+  if (mismatches.length > 0) fail(mismatches.join('; '));
+}
+
+function decodeBase64Url(value) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]+$/.test(value)) fail('Signature is not base64url');
+  return Buffer.from(value, 'base64url');
+}
+
+export function verifyCanonicalEd25519(signed, signature, trustedSigningKey = TRUSTED_SIGNING_KEY) {
+  if (
+    signature?.algorithm !== 'Ed25519'
+    || typeof signature?.keyId !== 'string'
+    || signature.keyId.length === 0
+    || signature?.publicKeyJwk?.kty !== 'OKP'
+    || signature?.publicKeyJwk?.crv !== 'Ed25519'
+    || typeof signature.publicKeyJwk.x !== 'string'
+  ) fail('Ed25519 signature metadata is invalid');
+  if (
+    signature.keyId !== trustedSigningKey?.keyId
+    || signature.publicKeyJwk.x !== trustedSigningKey?.publicKeyX
+  ) fail('Ed25519 signature key is not the trusted production key');
+  let verified = false;
+  try {
+    verified = verifySignature(
+      null,
+      Buffer.from(canonicalJson(signed)),
+      createPublicKey({ key: signature.publicKeyJwk, format: 'jwk' }),
+      decodeBase64Url(signature.value),
+    );
+  } catch {
+    verified = false;
+  }
+  if (!verified) fail('Ed25519 signature verification failed');
+  return true;
+}
+
+function installSkillProjection(skills) {
+  return (skills ?? []).map((skill) => ({
+    slug: skill?.slug,
+    version: skill?.version,
+    contentHash: skill?.contentHash,
+  }));
+}
+
+export function validateSignedInstallContracts(
+  manifest,
+  lockfile,
+  approval,
+  publicBase,
+  trustedSigningKey = TRUSTED_SIGNING_KEY,
+) {
+  const expectedManifestUrl = `${publicBase}/api/packs/${encodeURIComponent(approval.pack.publicSlug)}/manifest`;
+  if (manifest?.schemaVersion !== '2.0' || manifest?.signed?.kind !== 'pack') {
+    fail('Signed Pack manifest envelope is invalid');
+  }
+  verifyCanonicalEd25519(manifest.signed, manifest.signature, trustedSigningKey);
+  for (const field of ['kind', 'version', 'generatedAt', 'pack', 'executionBinding', 'skills', 'lockfile']) {
+    if (canonicalJson(manifest[field]) !== canonicalJson(manifest.signed[field])) {
+      fail(`Manifest flattened ${field} differs from its signed payload`);
+    }
+  }
+  if (
+    manifest.signed.pack?.slug !== approval.pack.publicSlug
+    || manifest.signed.pack?.visibility !== 'public'
+    || canonicalJson(manifest.signed.executionBinding) !== canonicalJson(approval.executionBinding)
+    || canonicalJson(installSkillProjection(manifest.signed.skills)) !== canonicalJson(approval.skills)
+    || canonicalJson(installSkillProjection(manifest.signed.lockfile?.skills)) !== canonicalJson(approval.skills)
+    || canonicalJson(manifest.signed.lockfile?.executionBinding) !== canonicalJson(approval.executionBinding)
+    || manifest.signed.lockfile?.source?.manifestUrl !== expectedManifestUrl
+  ) fail('Signed Pack manifest differs from the approved execution binding');
+  manifest.signed.skills.forEach((skill, index) => {
+    const manifestLockSkill = manifest.signed.lockfile.skills[index];
+    if (
+      canonicalJson(skill.artifact) !== canonicalJson(manifestLockSkill?.artifact)
+      || skill.contentHash !== manifestLockSkill?.contentHash
+    ) fail(`Manifest lockfile artifact differs for ${skill.slug}`);
+  });
+  const { signature, ...lockfileBody } = lockfile ?? {};
+  verifyCanonicalEd25519(lockfileBody, signature, trustedSigningKey);
+  if (
+    lockfileBody.manifestUrl !== expectedManifestUrl
+    || lockfileBody.source?.manifestUrl !== expectedManifestUrl
+    || canonicalJson(lockfileBody.executionBinding) !== canonicalJson(approval.executionBinding)
+    || canonicalJson(installSkillProjection(lockfileBody.skills)) !== canonicalJson(approval.skills)
+  ) fail('Independently signed Pack lockfile differs from the approved execution binding');
+  manifest.signed.lockfile.skills.forEach((skill, index) => {
+    if (canonicalJson(skill.artifact) !== canonicalJson(lockfileBody.skills[index]?.artifact)) {
+      fail(`Standalone lockfile artifact differs for ${skill.slug}`);
+    }
+  });
+  if (
+    signature.keyId !== manifest.signature.keyId
+    || canonicalJson(signature.publicKeyJwk) !== canonicalJson(manifest.signature.publicKeyJwk)
+  ) fail('Manifest and lockfile were signed by different keys');
+  return manifest.signed.skills.flatMap((skill) => {
+    const artifact = skill?.artifact;
+    if (
+      artifact?.type !== 'skill-files'
+      || artifact?.source?.type !== 'github'
+      || artifact?.source?.owner !== 'aiskillstore'
+      || artifact?.source?.repo !== 'marketplace'
+      || !SHA1_RE.test(artifact?.source?.commit ?? '')
+      || !Array.isArray(artifact?.files)
+      || artifact.files.length === 0
+    ) fail(`Signed artifact for ${skill?.slug ?? 'unknown Skill'} is invalid`);
+    const seen = new Set();
+    const files = artifact.files.map((file) => {
+      if (
+        typeof file?.path !== 'string'
+        || file.path.length === 0
+        || file.path.startsWith('/')
+        || file.path.split('/').includes('..')
+        || seen.has(file.path)
+        || typeof file?.url !== 'string'
+        || !file.url.startsWith('https://')
+        || !SHA256_RE.test(file?.sha256 ?? '')
+        || !Number.isSafeInteger(file?.bytes)
+        || file.bytes < 0
+        || file.bytes > MAX_SINGLE_FILE_BYTES
+      ) fail(`Signed artifact file for ${skill.slug} is invalid`);
+      seen.add(file.path);
+      return { skill: skill.slug, ...file };
+    });
+    const skillMd = artifact.files.find((file) => file.path === 'SKILL.md') ?? artifact.files[0];
+    if (skill.contentHash !== skillMd.sha256) fail(`Signed contentHash differs for ${skill.slug}`);
+    if (skill.downloadUrl !== skillMd.url) fail(`Signed downloadUrl differs for ${skill.slug}`);
+    const aggregate = sha256(canonicalJson(artifact.files.map(({ path, sha256: fileSha256 }) => ({
+      path,
+      sha256: fileSha256,
+    }))));
+    if (artifact.sha256 !== aggregate) fail(`Signed artifact aggregate differs for ${skill.slug}`);
+    return files;
+  });
+}
+
+async function fetchResponse(url, options, fetchImpl) {
+  return fetchImpl(url, { ...options, signal: options?.signal ?? AbortSignal.timeout(30_000) });
+}
+
+async function verifyArtifactFiles(files, fetchImpl) {
+  if (files.length > MAX_PUBLIC_ARTIFACT_FILES) fail('Signed Pack exceeds the public artifact file limit');
+  const expectedBytes = files.reduce((total, file) => total + file.bytes, 0);
+  if (expectedBytes > MAX_PUBLIC_ARTIFACT_BYTES) fail('Signed Pack exceeds the public artifact byte limit');
+  const results = new Array(files.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < files.length) {
+      const index = cursor;
+      cursor += 1;
+      const file = files[index];
+      const response = await fetchResponse(file.url, { headers: { Accept: 'application/octet-stream' } }, fetchImpl);
+      if (!response.ok) fail(`Artifact download returned HTTP ${response.status}: ${file.skill}/${file.path}`);
+      const bytes = Buffer.from(await response.arrayBuffer());
+      const digest = sha256(bytes);
+      if (bytes.length !== file.bytes || digest !== file.sha256) {
+        fail(`Artifact download hash/size mismatch: ${file.skill}/${file.path}`);
+      }
+      results[index] = { skill: file.skill, path: file.path, bytes: bytes.length, sha256: digest, url: file.url };
+    }
+  };
+  await Promise.all(Array.from(
+    { length: Math.min(ARTIFACT_DOWNLOAD_CONCURRENCY, files.length) },
+    () => worker(),
+  ));
+  return results;
+}
+
+export async function verifyPublicProduction(approval, {
+  publicUrl,
+  fetchImpl = fetch,
+  trustedSigningKey = TRUSTED_SIGNING_KEY,
+}) {
+  validateManualApproval(approval);
+  const base = apiBase(publicUrl, 'public Skillstore URL');
+  const slug = encodeURIComponent(approval.pack.publicSlug);
+  const packBody = await requestJson(`${base}/api/packs/${slug}?lang=en`, {
+    headers: { 'Cache-Control': 'no-cache' },
+    retryPublicStatus: true,
+  }, fetchImpl);
+  validatePublicPack(packBody?.data, approval);
+  const page = await fetchResponse(`${base}/packs/${slug}`, {
+    headers: { Accept: 'text/html', 'Cache-Control': 'no-cache' },
+  }, fetchImpl);
+  if (!page.ok) {
+    const message = `Public Pack page returned HTTP ${page.status}`;
+    if (isRetryablePublicStatus(page.status)) throw new RetryablePublicReadbackError(message);
+    fail(message);
+  }
+  const manifest = await requestJson(`${base}/api/packs/${slug}/manifest`, {
+    headers: { 'Cache-Control': 'no-cache' },
+    retryPublicStatus: true,
+  }, fetchImpl);
+  const lockfile = await requestJson(`${base}/api/packs/${slug}/lockfile`, {
+    headers: { 'Cache-Control': 'no-cache' },
+    retryPublicStatus: true,
+  }, fetchImpl);
+  const files = validateSignedInstallContracts(manifest, lockfile, approval, base, trustedSigningKey);
+  const downloads = await verifyArtifactFiles(files, fetchImpl);
+  const unsigned = {
+    schemaVersion: PUBLIC_READBACK_SCHEMA,
+    checkedAt: new Date().toISOString(),
+    approvalDigest: approval.handoffDigest,
+    generationId: approval.generationId,
+    packSlug: approval.pack.publicSlug,
+    publicBase: base,
+    pageStatus: page.status,
+    manifest: {
+      keyId: manifest.signature.keyId,
+      bindingDigest: manifest.signed.executionBinding.bindingDigest,
+      skillCount: manifest.signed.skills.length,
+      sha256: sha256(canonicalJson(manifest)),
+    },
+    lockfile: {
+      keyId: lockfile.signature.keyId,
+      skillCount: lockfile.skills.length,
+      sha256: sha256(canonicalJson(lockfile)),
+    },
+    downloads,
+  };
+  return { ...unsigned, readbackDigest: sha256(canonicalJson(unsigned)) };
+}
+
+async function publicReadback(args) {
+  const approval = validateManualApproval((await readJson(resolve(required(args, 'approval')))).value);
+  const publishResult = (await readJson(resolve(required(args, 'publish-result')))).value;
+  if (
+    publishResult?.approvalDigest !== approval.handoffDigest
+    || publishResult?.generationId !== approval.generationId
+    || publishResult?.packSlug !== approval.pack.publicSlug
+    || publishResult?.reviewStatus !== 'approved'
+  ) fail('Publish result differs from the approved handoff');
+  const attempts = Number(args.attempts ?? '10');
+  const pollSeconds = Number(args['poll-seconds'] ?? '30');
+  if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 10) fail('Invalid --attempts');
+  if (!Number.isSafeInteger(pollSeconds) || pollSeconds < 1 || pollSeconds > 60) fail('Invalid --poll-seconds');
+  let result;
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      result = await verifyPublicProduction(approval, { publicUrl: required(args, 'public-url') });
+      break;
+    } catch (cause) {
+      if (!(cause instanceof RetryablePublicReadbackError)) throw cause;
+      lastError = cause;
+      if (attempt < attempts) await new Promise((resolveWait) => setTimeout(resolveWait, pollSeconds * 1000));
+    }
+  }
+  if (!result) throw lastError;
+  await writeJson(resolve(required(args, 'output')), result);
+  process.stdout.write(`${JSON.stringify({
+    generationId: result.generationId,
+    packSlug: result.packSlug,
+    pageStatus: result.pageStatus,
+    skillCount: result.manifest.skillCount,
+    fileCount: result.downloads.length,
+    readbackDigest: result.readbackDigest,
+  })}\n`);
+}
+
+export function validateCliCheck(report, approval) {
+  if (!Array.isArray(report?.errors) || report.errors.length !== 0) fail('skillstore check reported errors');
+  if (!Array.isArray(report?.updates) || report.updates.length !== 0) fail('skillstore check reported unexpected updates');
+  if (!Array.isArray(report?.upToDate)) fail('skillstore check omitted upToDate');
+  for (const skill of approval.skills) {
+    if (!report.upToDate.includes(skill.slug)) fail(`skillstore check omitted ${skill.slug}`);
+  }
+  return true;
+}
+
+export async function recordReadback(
+  base,
+  token,
+  approval,
+  status,
+  errorMessage,
+  evidence,
+  fetchImpl = fetch,
+) {
+  const response = await requestJson(`${base}/api/automation/packs/production/${encodeURIComponent(approval.generationId)}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      schemaVersion: API_READBACK_SCHEMA,
+      status,
+      packSlug: approval.pack.publicSlug,
+      checkedAt: new Date().toISOString(),
+      error: errorMessage,
+      evidence,
+    }),
+  }, fetchImpl);
+  const attempt = response?.data;
+  if (
+    attempt?.generation_id !== approval.generationId
+    || attempt?.pack_id !== approval.pack.id
+    || attempt?.pack_slug !== approval.pack.publicSlug
+    || attempt?.content_dispatch_nonce !== approval.contentDispatchNonce
+    || attempt?.outcome !== 'published'
+    || attempt?.production_readback_status !== status
+    || (status === 'succeeded' && attempt?.production_readback_error != null)
+    || (status === 'failed' && attempt?.production_readback_error !== errorMessage)
+    || canonicalJson(attempt?.production_readback_evidence ?? null) !== canonicalJson(evidence)
+  ) fail('Production readback record did not preserve the exact published generation');
+  return attempt;
+}
+
+async function complete(args) {
+  const approval = validateManualApproval((await readJson(resolve(required(args, 'approval')))).value);
+  const token = required(args, 'token');
+  const base = apiBase(required(args, 'api-url'), 'Skillstore API URL');
+  const status = required(args, 'status');
+  const output = resolve(required(args, 'output'));
+  if (!['succeeded', 'failed'].includes(status)) fail('Invalid --status');
+  if (status === 'failed') {
+    const message = required(args, 'error').slice(0, 500);
+    await recordReadback(base, token, approval, 'failed', message, null);
+    const result = {
+      schemaVersion: RELEASE_SCHEMA,
+      outcome: 'readback_failed',
+      generationId: approval.generationId,
+      packSlug: approval.pack.publicSlug,
+      error: message,
+    };
+    await writeJson(output, result);
+    fail(message);
+  }
+  let readbackDigest;
+  try {
+    const publicReadback = (await readJson(resolve(required(args, 'public-readback')))).value;
+    const readbackUnsigned = { ...publicReadback };
+    readbackDigest = readbackUnsigned.readbackDigest;
+    delete readbackUnsigned.readbackDigest;
+    if (
+      publicReadback?.schemaVersion !== PUBLIC_READBACK_SCHEMA
+      || publicReadback?.approvalDigest !== approval.handoffDigest
+      || publicReadback?.generationId !== approval.generationId
+      || publicReadback?.packSlug !== approval.pack.publicSlug
+      || !SHA256_RE.test(readbackDigest ?? '')
+      || sha256(canonicalJson(readbackUnsigned)) !== readbackDigest
+    ) fail('Public production readback evidence is invalid');
+    const cliCheck = (await readJson(resolve(required(args, 'cli-check')))).value;
+    validateCliCheck(cliCheck, approval);
+    const readbackEvidence = {
+      schemaVersion: API_READBACK_EVIDENCE_SCHEMA,
+      sourceRunId: approval.source.runId,
+      generationId: approval.generationId,
+      contentDispatchNonce: approval.contentDispatchNonce,
+      bindingDigest: approval.executionBinding.bindingDigest,
+      manifestDigest: publicReadback.manifest.sha256,
+      lockfileDigest: publicReadback.lockfile.sha256,
+      fileCount: publicReadback.downloads.length,
+      cliPackage: 'skillstore@0.1.9',
+      cliCheck: 'passed',
+    };
+    await recordReadback(base, token, approval, 'succeeded', null, readbackEvidence);
+  } catch (cause) {
+    const message = `completion validation failed: ${cause instanceof Error ? cause.message : String(cause)}`.slice(0, 500);
+    await recordReadback(base, token, approval, 'failed', message, null).catch(() => {});
+    await writeJson(output, {
+      schemaVersion: RELEASE_SCHEMA,
+      outcome: 'readback_failed',
+      generationId: approval.generationId,
+      packSlug: approval.pack.publicSlug,
+      error: message,
+    });
+    throw cause;
+  }
+  const result = {
+    schemaVersion: RELEASE_SCHEMA,
+    outcome: 'published',
+    generationId: approval.generationId,
+    sourceRunId: approval.source.runId,
+    packSlug: approval.pack.publicSlug,
+    bindingDigest: approval.executionBinding.bindingDigest,
+    publicReadbackDigest: readbackDigest,
+    cliPackage: 'skillstore@0.1.9',
+    cliAgent: 'codex',
+    readbackPassed: true,
+  };
+  await writeJson(output, result);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  switch (args.command) {
+    case 'prepare': return prepare(args);
+    case 'publish': return publish(args);
+    case 'public-readback': return publicReadback(args);
+    case 'complete': return complete(args);
+    default:
+      fail('Usage: pack-production-manual-publish.mjs <prepare|publish|public-readback|complete> [options]');
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack ?? error.message ?? String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -11,7 +11,6 @@ import { fileURLToPath } from 'node:url';
 const CLI_SCHEMA = 'pack-generation-evaluation/v2';
 const API_SCHEMA = 'skillstore.pack-evaluation/v4';
 const STATUS_SCHEMA = 'skillstore.pack-production-status/v1';
-const READBACK_SCHEMA = 'skillstore.pack-production-readback/v1';
 const SLO_SCHEMA = 'marketplace.pack-production-slo/v1';
 const VERIFICATION_SCHEMA = 'marketplace.pack-production-evaluation-verification/v1';
 const INFRASTRUCTURE_FAILURE_SCHEMA = 'marketplace.pack-production-infrastructure-failure/v1';
@@ -2503,6 +2502,20 @@ function wait(milliseconds) {
   return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
 }
 
+export function buildHardDisabledReviewPendingResult(selected, autoPublishRequested) {
+  if (!selected?.generationId || !selected?.pack?.id || !selected?.pack?.slug) {
+    fail('Hard-disabled automatic publication requires an exact selected generation and Pack');
+  }
+  return {
+    outcome: 'review_pending',
+    generationId: selected.generationId,
+    pack: selected.pack,
+    reason: 'automatic publish was disabled for this run',
+    autoPublishRequested: autoPublishRequested === true,
+    publicationMode: 'manual_only',
+  };
+}
+
 async function finalize(args) {
   const resultsDir = resolve(required(args, 'results-dir'));
   const persisted = await readJson(resolve(resultsDir, 'persist-summary.json'));
@@ -2581,78 +2594,11 @@ async function finalize(args) {
     translationStatus: 'succeeded',
     error: null,
   });
-  const autoPublishEnabled = (args['auto-publish'] ?? 'true') === 'true';
-  if (!autoPublishEnabled || !selected.autoPublishEligible || selected.comparisonOf) {
-    const result = {
-      outcome: 'review_pending',
-      generationId,
-      pack: selected.pack,
-      reason: selected.comparisonOf
-        ? 'comparison candidates require human review'
-        : !autoPublishEnabled
-          ? 'automatic publish was disabled for this run'
-          : 'candidate did not meet the automatic publish gate',
-    };
-    await writeJson(resolve(resultsDir, 'final-result.json'), result);
-    process.stdout.write(`${JSON.stringify(result)}\n`);
-    return;
-  }
-
-  const publish = await apiRequest(
-    `${base}/api/automation/packs/${encodeURIComponent(selected.pack.slug)}/publish`,
-    token,
-    { method: 'POST', body: JSON.stringify({ generationId }) },
-  );
-  const publicSlug = publish?.data?.slug;
-  if (!publicSlug) fail('Publish response did not include the public slug');
-  const expectedPublicPack = buildPublicReadbackExpectation(persisted, selected, publicSlug);
-
-  let publicPack = null;
-  let readbackMismatches = [];
-  for (let attemptNumber = 1; attemptNumber <= 10; attemptNumber += 1) {
-    try {
-      const readback = await readExactPublicPack(base, expectedPublicPack);
-      publicPack = readback.pack;
-      readbackMismatches = readback.mismatches;
-      if (publicPack) break;
-    } catch (cause) {
-      // Production cache/readback may lag; retry within the bounded window.
-      readbackMismatches = [cause instanceof Error ? cause.message : String(cause)];
-    }
-    if (attemptNumber < 10) await wait(30_000);
-  }
-  const checkedAt = new Date().toISOString();
-  if (!publicPack) {
-    const readbackError = `exact public Pack readback failed: ${readbackMismatches.join('; ') || 'no matching Pack returned'}`;
-    await apiRequest(`${base}/api/automation/packs/production/${generationId}`, token, {
-      method: 'POST',
-      body: JSON.stringify({
-        schemaVersion: READBACK_SCHEMA,
-        status: 'failed',
-        packSlug: publicSlug,
-        checkedAt,
-        error: readbackError,
-      }),
-    }).catch(() => {});
-    fail(`Published pack ${publicSlug} failed production readback: ${readbackError}`);
-  }
-
-  await apiRequest(`${base}/api/automation/packs/production/${generationId}`, token, {
-    method: 'POST',
-    body: JSON.stringify({
-      schemaVersion: READBACK_SCHEMA,
-      status: 'succeeded',
-      packSlug: publicSlug,
-      checkedAt,
-      error: null,
-    }),
-  });
-  const result = {
-    outcome: 'published',
-    generationId,
-    pack: { id: publicPack.id, slug: publicSlug, skillCount: publicPack.skills.length },
-    readbackPassed: true,
-  };
+  // Automatic publication is hard-disabled in code. A true request is retained
+  // as audit evidence but cannot cross the review_pending boundary; the only v4
+  // publisher is the Environment-protected generation-bound manual workflow.
+  const autoPublishRequested = (args['auto-publish'] ?? 'false') === 'true';
+  const result = buildHardDisabledReviewPendingResult(selected, autoPublishRequested);
   await writeJson(resolve(resultsDir, 'final-result.json'), result);
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -558,7 +558,13 @@ test('trusted phases use the Automation API and retain full evidence for 90 days
   assert.match(finalize, /--poll-seconds 60/);
   assert.match(finalize, /--max-poll-seconds 180/);
   assert.match(PACK_PRODUCTION, /nextPollSeconds = Math\.min\(maxPollSeconds, nextPollSeconds \* 2\)/);
-  assert.match(PACK_PRODUCTION, /attemptNumber <= 10/);
+  assert.match(PACK_PRODUCTION, /buildHardDisabledReviewPendingResult/);
+  assert.match(PACK_PRODUCTION, /publicationMode: 'manual_only'/);
+  const finalizeImplementation = PACK_PRODUCTION.slice(
+    PACK_PRODUCTION.indexOf('async function finalize(args)'),
+    PACK_PRODUCTION.indexOf('async function reportSlo(args)'),
+  );
+  assert.doesNotMatch(finalizeImplementation, /\/api\/automation\/packs\/[^\n]+\/publish/);
   assert.match(WORKFLOW, /auto_publish:[\s\S]*?default: false/);
   assert.match(PACK_PRODUCTION, /skillstore\.pack-evaluation\/v4/);
   assert.match(PACK_PRODUCTION, /candidate_ready evidence is incomplete; persistence and enrichment are forbidden/);

--- a/scripts/tests/pack-production-manual-publish.test.mjs
+++ b/scripts/tests/pack-production-manual-publish.test.mjs
@@ -1,0 +1,472 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildManualApproval,
+  canonicalJson,
+  publishManualApproval,
+  recordReadback,
+  RetryablePublicReadbackError,
+  validateCliCheck,
+  validateGenerationReadback,
+  validateManualApproval,
+  validateSignedInstallContracts,
+  verifyCanonicalEd25519,
+  verifyPublicProduction,
+} from '../pack-production-manual-publish.mjs';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const GENERATION_ID = 'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0';
+const NONCE = '11111111-1111-4111-8111-111111111111';
+const RUN_ID = '123456789';
+const SOURCE_SHA = 'a'.repeat(40);
+const ARTIFACT_DIGEST = `sha256:${'b'.repeat(64)}`;
+const SKILL_CONTENTS = [Buffer.from('# Skill one\n'), Buffer.from('# Skill two\n')];
+
+function hash(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function fixture() {
+  const evaluation = JSON.parse(readFileSync(
+    join(REPO_ROOT, 'scripts/tests/fixtures/pack-production-evaluation-v4.golden.json'),
+    'utf8',
+  ));
+  evaluation.workflow.runId = RUN_ID;
+  evaluation.workflow.runAttempt = 1;
+  evaluation.workflow.commitSha = SOURCE_SHA;
+  evaluation.candidate.manifest.executionDag.skillBindings.forEach((binding, index) => {
+    binding.contentHash = hash(SKILL_CONTENTS[index]);
+  });
+  const { evidenceDigest: _evidenceDigest, ...unsignedEvaluation } = evaluation;
+  evaluation.evidenceDigest = hash(canonicalJson(unsignedEvaluation));
+  const stagingSlug = 'monthly-sales-excel-workbook-staging';
+  const selected = {
+    generationId: GENERATION_ID,
+    pack: { id: 'pack-123', slug: stagingSlug },
+    enrichment: { content: 'dispatched', translation: 'not_applicable', contentDispatchNonce: NONCE },
+    autoPublishEligible: true,
+    comparisonOf: null,
+  };
+  const persisted = {
+    schemaVersion: 'marketplace.pack-production-persist/v1',
+    selected,
+    persisted: [{
+      file: '01-excel-dashboard.evaluation.json',
+      request: evaluation,
+      response: {
+        data: {
+          generationId: GENERATION_ID,
+          pack: selected.pack,
+          enrichment: { contentDispatchNonce: NONCE },
+        },
+      },
+      auditOnly: false,
+      persistedRemotely: true,
+    }],
+  };
+  const finalResult = {
+    outcome: 'review_pending',
+    generationId: GENERATION_ID,
+    pack: selected.pack,
+    reason: 'automatic publish was disabled for this run',
+    autoPublishRequested: false,
+    publicationMode: 'manual_only',
+  };
+  const sourceRun = {
+    id: Number(RUN_ID),
+    workflow_id: 303407323,
+    name: 'Generate Pack',
+    path: '.github/workflows/generate-packs.yml',
+    repository: { full_name: 'aiskillstore/marketplace' },
+    status: 'completed',
+    conclusion: 'success',
+    head_branch: 'main',
+    head_sha: SOURCE_SHA,
+    event: 'workflow_dispatch',
+    run_attempt: 1,
+    html_url: `https://github.com/aiskillstore/marketplace/actions/runs/${RUN_ID}`,
+  };
+  const workflow = {
+    id: 303407323,
+    name: 'Generate Pack',
+    path: '.github/workflows/generate-packs.yml',
+    state: 'active',
+  };
+  const artifact = {
+    id: 987654321,
+    name: 'pack-production-final',
+    expired: false,
+    size_in_bytes: 4096,
+    digest: ARTIFACT_DIGEST,
+    workflow_run: { id: Number(RUN_ID), head_sha: SOURCE_SHA },
+  };
+  const approval = buildManualApproval({
+    sourceRun,
+    workflow,
+    artifact,
+    persisted,
+    finalResult,
+    requestedRunId: RUN_ID,
+    hashes: { persistSummarySha256: 'c'.repeat(64), finalResultSha256: 'd'.repeat(64) },
+  });
+  return { evaluation, selected, persisted, finalResult, sourceRun, workflow, artifact, approval };
+}
+
+function generationReadback(approval, outcome) {
+  const published = outcome === 'published';
+  return {
+    attempt: {
+      generation_id: approval.generationId,
+      pack_id: approval.pack.id,
+      pack_slug: published ? approval.pack.publicSlug : approval.pack.stagingSlug,
+      content_dispatch_nonce: approval.contentDispatchNonce,
+      evidence_digest: approval.evaluation.evidenceDigest,
+      workflow_repository: 'aiskillstore/marketplace',
+      workflow_run_id: Number(approval.source.runId),
+      workflow_run_attempt: approval.source.runAttempt,
+      outcome,
+      evidence: {
+        generationId: approval.generationId,
+        evidenceDigest: approval.evaluation.evidenceDigest,
+        workflow: { commitSha: approval.source.headSha },
+        candidate: { manifest: { executionDag: approval.executionBinding.executionDag } },
+      },
+    },
+    pack: {
+      id: approval.pack.id,
+      slug: published ? approval.pack.publicSlug : approval.pack.stagingSlug,
+      review_status: published ? 'approved' : 'generated',
+    },
+  };
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function signatureFor(value, privateKey, publicJwk) {
+  return {
+    algorithm: 'Ed25519',
+    keyId: 'test-key',
+    publicKeyJwk: publicJwk,
+    signedAt: '2026-07-16T00:00:00.000Z',
+    value: sign(null, Buffer.from(canonicalJson(value)), privateKey).toString('base64url'),
+  };
+}
+
+function installContracts(approval) {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  const contents = SKILL_CONTENTS;
+  const skills = approval.skills.map((skill, index) => {
+    const digest = hash(contents[index]);
+    const artifactFiles = [{
+      path: 'SKILL.md',
+      url: `https://raw.example/${skill.slug}/SKILL.md`,
+      sha256: digest,
+      bytes: contents[index].length,
+    }];
+    return {
+      slug: skill.slug,
+      name: skill.slug,
+      version: skill.version,
+      authorVersion: skill.version,
+      skillstoreRevision: 1,
+      versionStatus: 'valid',
+      treeHash: `${index + 1}`.repeat(64),
+      downloadUrl: artifactFiles[0].url,
+      contentHash: skill.contentHash,
+      artifact: {
+        type: 'skill-files',
+        source: { type: 'github', owner: 'aiskillstore', repo: 'marketplace', ref: SOURCE_SHA, commit: SOURCE_SHA, path: `skills/${skill.slug}` },
+        files: artifactFiles,
+        sha256: hash(canonicalJson(artifactFiles.map(({ path, sha256 }) => ({ path, sha256 })))),
+      },
+    };
+  });
+  const lockfileBody = {
+    schemaVersion: '1.0',
+    generatedAt: '2026-07-16T00:00:00.000Z',
+    source: { manifestUrl: `https://skillstore.io/api/packs/${approval.pack.publicSlug}/manifest` },
+    executionBinding: approval.executionBinding,
+    skills: skills.map(({ downloadUrl: _downloadUrl, ...skill }) => skill),
+  };
+  const signed = {
+    kind: 'pack',
+    version: '1.0',
+    generatedAt: lockfileBody.generatedAt,
+    pack: { slug: approval.pack.publicSlug, name: 'Pack', version: '1.0.0', visibility: 'public' },
+    executionBinding: approval.executionBinding,
+    skills,
+    lockfile: lockfileBody,
+  };
+  const manifest = {
+    ...signed,
+    schemaVersion: '2.0',
+    signed,
+    signature: signatureFor(signed, privateKey, publicJwk),
+  };
+  const standaloneBody = {
+    ...lockfileBody,
+    manifestUrl: `https://skillstore.io/api/packs/${approval.pack.publicSlug}/manifest`,
+  };
+  const lockfile = {
+    ...standaloneBody,
+    signature: signatureFor(standaloneBody, privateKey, publicJwk),
+  };
+  return {
+    manifest,
+    lockfile,
+    contents,
+    trustedSigningKey: { keyId: 'test-key', publicKeyX: publicJwk.x },
+  };
+}
+
+test('prepare binds the exact successful run, nonce, staging/public slugs, quality, and DAG', () => {
+  const { approval } = fixture();
+  assert.equal(validateManualApproval(approval), approval);
+  assert.equal(approval.pack.stagingSlug, 'monthly-sales-excel-workbook-staging');
+  assert.equal(approval.pack.publicSlug, 'monthly-sales-excel-workbook');
+  assert.equal(approval.source.artifactDigest, ARTIFACT_DIGEST);
+  assert.equal(approval.evaluation.score, 8);
+  assert.equal(approval.skills.length, 2);
+  assert.equal(approval.executionBinding.bindingDigest, approval.executionBinding.executionDag.bindingDigest);
+});
+
+test('prepare rejects quality override, comparison, stale nonce, and source SHA drift', () => {
+  for (const mutate of [
+    (value) => { value.persisted.selected.autoPublishEligible = false; },
+    (value) => { value.persisted.selected.comparisonOf = 'other-pack'; },
+    (value) => { value.persisted.persisted[0].response.data.enrichment.contentDispatchNonce = '22222222-2222-4222-8222-222222222222'; },
+    (value) => { value.sourceRun.head_sha = 'f'.repeat(40); value.artifact.workflow_run.head_sha = 'f'.repeat(40); },
+    (value) => { value.artifact.size_in_bytes = 32 * 1024 * 1024 + 1; },
+    (value) => { value.persisted.persisted[0].request.candidate.fitness.score = 9; },
+    (value) => { delete value.finalResult.publicationMode; },
+  ]) {
+    const value = fixture();
+    mutate(value);
+    assert.throws(() => buildManualApproval({
+      ...value,
+      requestedRunId: RUN_ID,
+      hashes: { persistSummarySha256: 'c'.repeat(64), finalResultSha256: 'd'.repeat(64) },
+    }));
+  }
+});
+
+test('manual publish pre-reads the exact generation and sends only artifact-bound authority', async () => {
+  const { approval } = fixture();
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    if (calls.length === 1) return jsonResponse({ data: generationReadback(approval, 'review_pending') });
+    if (calls.length === 2) return jsonResponse({ data: {
+      slug: approval.pack.publicSlug,
+      reviewStatus: 'approved',
+      generationId: approval.generationId,
+      contentDispatchNonce: approval.contentDispatchNonce,
+      sourceRunId: approval.source.runId,
+    } });
+    return jsonResponse({ data: generationReadback(approval, 'published') });
+  };
+  const result = await publishManualApproval(approval, {
+    apiUrl: 'https://skillstore.example', token: 'manual-key-1234567890', fetchImpl,
+  });
+  assert.equal(result.replayed, false);
+  assert.equal(calls[0].options.method, undefined);
+  assert.match(calls[1].url, new RegExp(`/packs/${approval.pack.stagingSlug}/publish$`));
+  assert.deepEqual(JSON.parse(calls[1].options.body), {
+    generationId: approval.generationId,
+    contentDispatchNonce: approval.contentDispatchNonce,
+    publishMode: 'manual',
+    sourceRunId: approval.source.runId,
+  });
+  assert.equal(calls.length, 3);
+});
+
+test('manual publish safely replays an already-published exact generation without POST', async () => {
+  const { approval } = fixture();
+  const calls = [];
+  const result = await publishManualApproval(approval, {
+    apiUrl: 'https://skillstore.example',
+    token: 'manual-key-1234567890',
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ data: generationReadback(approval, 'published') });
+    },
+  });
+  assert.equal(result.replayed, true);
+  assert.equal(calls.length, 2);
+  assert.ok(calls.every((call) => call.options.method == null));
+});
+
+test('generation readback rejects evidence or nonce drift before publication', () => {
+  const { approval } = fixture();
+  const readback = generationReadback(approval, 'review_pending');
+  assert.equal(validateGenerationReadback(readback, approval).outcome, 'review_pending');
+  readback.attempt.content_dispatch_nonce = '22222222-2222-4222-8222-222222222222';
+  assert.throws(() => validateGenerationReadback(readback, approval), /immutable approval/);
+});
+
+test('production readback record must echo the exact published generation and status', async () => {
+  const { approval } = fixture();
+  const evidence = {
+    schemaVersion: 'skillstore.pack-production-readback-evidence/v1',
+    sourceRunId: approval.source.runId,
+    generationId: approval.generationId,
+    contentDispatchNonce: approval.contentDispatchNonce,
+    bindingDigest: approval.executionBinding.bindingDigest,
+    manifestDigest: '1'.repeat(64),
+    lockfileDigest: '2'.repeat(64),
+    fileCount: 2,
+    cliPackage: 'skillstore@0.1.9',
+    cliCheck: 'passed',
+  };
+  const attempt = {
+    ...generationReadback(approval, 'published').attempt,
+    production_readback_status: 'succeeded',
+    production_readback_error: null,
+    production_readback_evidence: evidence,
+  };
+  const recorded = await recordReadback(
+    'https://skillstore.example',
+    'manual-key-1234567890',
+    approval,
+    'succeeded',
+    null,
+    evidence,
+    async () => jsonResponse({ data: attempt }),
+  );
+  assert.equal(recorded.generation_id, approval.generationId);
+  await assert.rejects(
+    recordReadback(
+      'https://skillstore.example',
+      'manual-key-1234567890',
+      approval,
+      'succeeded',
+      null,
+      evidence,
+      async () => jsonResponse({ data: { ...attempt, pack_slug: 'wrong-pack' } }),
+    ),
+    /exact published generation/,
+  );
+});
+
+test('public proof verifies independent signatures, exact binding, every file hash, and CLI closure', async () => {
+  const { approval } = fixture();
+  const { manifest, lockfile, contents, trustedSigningKey } = installContracts(approval);
+  assert.equal(validateSignedInstallContracts(
+    manifest,
+    lockfile,
+    approval,
+    'https://skillstore.io',
+    trustedSigningKey,
+  ).length, 2);
+  const routes = new Map([
+    [`https://skillstore.io/api/packs/${approval.pack.publicSlug}?lang=en`, jsonResponse({ data: {
+      id: approval.pack.id,
+      slug: approval.pack.publicSlug,
+      reviewStatus: 'approved',
+      executionBinding: approval.executionBinding,
+      usageGuide: `# Guide\n${approval.executionBinding.usageGuideMarker}`,
+      skills: approval.skills,
+    } })],
+    [`https://skillstore.io/packs/${approval.pack.publicSlug}`, new Response('<html></html>', { status: 200 })],
+    [`https://skillstore.io/api/packs/${approval.pack.publicSlug}/manifest`, jsonResponse(manifest)],
+    [`https://skillstore.io/api/packs/${approval.pack.publicSlug}/lockfile`, jsonResponse(lockfile)],
+    [`https://raw.example/${approval.skills[0].slug}/SKILL.md`, new Response(contents[0])],
+    [`https://raw.example/${approval.skills[1].slug}/SKILL.md`, new Response(contents[1])],
+  ]);
+  const result = await verifyPublicProduction(approval, {
+    publicUrl: 'https://skillstore.io',
+    trustedSigningKey,
+    fetchImpl: async (url) => routes.get(url) ?? new Response('missing', { status: 404 }),
+  });
+  assert.equal(result.pageStatus, 200);
+  assert.equal(result.downloads.length, 2);
+  assert.equal(validateCliCheck({ errors: [], updates: [], upToDate: approval.skills.map((skill) => skill.slug) }, approval), true);
+  assert.throws(() => validateCliCheck({ errors: [], updates: [], upToDate: [] }, approval), /omitted/);
+});
+
+test('public HTTP 5xx with an HTML body is retryable before JSON parsing', async () => {
+  const { approval } = fixture();
+  await assert.rejects(
+    verifyPublicProduction(approval, {
+      publicUrl: 'https://skillstore.io',
+      fetchImpl: async () => new Response('<html>upstream unavailable</html>', { status: 503 }),
+    }),
+    (error) => error instanceof RetryablePublicReadbackError && /HTTP 503/.test(error.message),
+  );
+});
+
+test('signature verification fails closed on a changed signed payload', () => {
+  const { approval } = fixture();
+  const { manifest, trustedSigningKey } = installContracts(approval);
+  assert.equal(verifyCanonicalEd25519(manifest.signed, manifest.signature, trustedSigningKey), true);
+  assert.throws(
+    () => verifyCanonicalEd25519(manifest.signed, manifest.signature),
+    /trusted production key/,
+  );
+  assert.throws(
+    () => verifyCanonicalEd25519(
+      { ...manifest.signed, generatedAt: 'changed' },
+      manifest.signature,
+      trustedSigningKey,
+    ),
+    /verification failed/,
+  );
+});
+
+test('workflow has source-run-only input, two phases, environment gate, exact artifact id, and real Linux CLI', () => {
+  const workflow = readFileSync(join(REPO_ROOT, '.github/workflows/publish-pack-production-v4.yml'), 'utf8');
+  assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+source_run_id:/);
+  const inputs = workflow.slice(workflow.indexOf('    inputs:'), workflow.indexOf('\npermissions:'));
+  assert.doesNotMatch(inputs, /(?:content_dispatch_nonce|generation_id|pack_slug|binding_digest):/);
+  assert.match(workflow, /  prepare:/);
+  assert.match(workflow, /  publish:[\s\S]*needs: prepare/);
+  assert.match(workflow, /environment:\n\s+name: production/);
+  assert.match(workflow, /actions\/artifacts\/\$ARTIFACT_ID\/zip/);
+  const sourceArtifactSection = workflow.slice(
+    workflow.indexOf('      - name: Resolve the exact source run and final artifact'),
+    workflow.indexOf('      - name: Validate generation, nonce, source SHA, quality, and binding'),
+  );
+  assert.doesNotMatch(sourceArtifactSection, /actions\/download-artifact/);
+  assert.match(workflow, /source-artifact\.zip/);
+  assert.match(workflow, /artifact digest mismatch/);
+  assert.match(workflow, /compressed size is invalid or exceeds 32 MiB/);
+  assert.match(workflow, /entry count exceeds 1024/);
+  assert.match(workflow, /uncompressed size exceeds 128 MiB/);
+  assert.match(workflow, /contains an unsafe ZIP path/);
+  assert.match(workflow, /contains a symbolic link/);
+  assert.match(workflow, /PACK_PRODUCTION_AUTO_PUBLISH_ENABLED/);
+  assert.match(workflow, /PACK_PRODUCTION_MANUAL_PUBLISH_KEY/);
+  assert.match(workflow, /npx --yes skillstore@0\.1\.9 add "@\$PACK_SLUG" --agent codex --overwrite/);
+  assert.match(workflow, /npx --yes skillstore@0\.1\.9 check --json/);
+  assert.match(workflow, /public_readback=[^;]+; cli_readback=/);
+  const production = readFileSync(join(REPO_ROOT, 'scripts/pack-production.mjs'), 'utf8');
+  const finalize = production.slice(
+    production.indexOf('async function finalize(args)'),
+    production.indexOf('async function reportSlo(args)'),
+  );
+  assert.match(finalize, /buildHardDisabledReviewPendingResult/);
+  assert.match(finalize, /autoPublishRequested/);
+  assert.doesNotMatch(finalize, /\/api\/automation\/packs\/[^\n]+\/publish/);
+  assert.doesNotMatch(finalize, /outcome: 'published'/);
+});
+
+test('legacy Pack review refuses guide replacement and marked v4 generation commands', () => {
+  const workflow = readFileSync(join(REPO_ROOT, '.github/workflows/pack-review.yml'), 'utf8');
+  assert.match(workflow, /\/approve --guide is disabled/);
+  assert.match(workflow, /isPackProductionV4/);
+  assert.match(workflow, /Pack Production v4 can only be published by the generation-bound production workflow/);
+  assert.doesNotMatch(workflow, /const guideMatch =/);
+  assert.match(workflow, /modifiedGuide: null/);
+});

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 import {
   allocateScenarioBudgetMs,
   buildApiEvaluation,
+  buildHardDisabledReviewPendingResult,
   buildInfrastructureCliReport,
   buildPublicReadbackExpectation,
   buildSafeCliEvidence,
@@ -43,6 +44,22 @@ import {
 const PACK_PRODUCTION = fileURLToPath(new URL('../pack-production.mjs', import.meta.url));
 const PACK_PRODUCTION_URL = new URL('../pack-production.mjs', import.meta.url).href;
 const V4_GOLDEN = fileURLToPath(new URL('./fixtures/pack-production-evaluation-v4.golden.json', import.meta.url));
+
+test('automatic publication is hard-disabled even when explicitly requested', () => {
+  const selected = {
+    generationId: 'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0',
+    pack: { id: 'pack-123', slug: 'staging-pack' },
+  };
+  assert.deepEqual(buildHardDisabledReviewPendingResult(selected, true), {
+    outcome: 'review_pending',
+    generationId: selected.generationId,
+    pack: selected.pack,
+    reason: 'automatic publish was disabled for this run',
+    autoPublishRequested: true,
+    publicationMode: 'manual_only',
+  });
+  assert.equal(buildHardDisabledReviewPendingResult(selected, false).autoPublishRequested, false);
+});
 
 export function cliReport() {
   const summary = {


### PR DESCRIPTION
## Summary
- add a two-phase source-run-bound manual Pack publication workflow behind the production Environment
- derive generation, nonce, source SHA, Pack slug, and DAG binding only from the immutable final artifact
- verify artifact ZIP digest and resource bounds before safe extraction
- pin and verify the production Ed25519 key, manifest, lockfile, execution binding, every file hash, and a real Linux skillstore@0.1.9 install/check
- record bounded production proof only after every public/install check succeeds
- block legacy guide replacement and v4 review commands
- hard-disable automatic publication even when requested; all v4 generations stop at review_pending

## Verification
- 61 passed / 1 Linux-only skipped under CI=true
- four Workflow YAML files parsed successfully
- Node syntax and git diff --check passed
- live GitHub Artifact API ZIP digest behavior verified

## Rollout dependency
Merge only after the Skillstore v2 publication/readback migration and API are live and PACK_PRODUCTION_MANUAL_PUBLISH_KEY is provisioned in both Skillstore production and the GitHub production Environment.
