### PR TITLE
fix(pack): align Claude output token budget

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -26,6 +26,8 @@ env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
   PACK_PRODUCTION_CLI_VERSION: '2.13.2'
+  # One cap feeds the local proxy and every Claude CLI process.
+  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 jobs:
   contract_smoke_only:
@@ -634,7 +636,7 @@ jobs:
             PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5.5 \
             PACK_EVALUATOR_MAX_REQUESTS=256 \
             PACK_EVALUATOR_MAX_CONCURRENT=4 \
-            PACK_EVALUATOR_MAX_OUTPUT_TOKENS=16384 \
+            PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
             PACK_EVALUATOR_TTL_MS=14400000 \
             PACK_EVALUATOR_REQUEST_TIMEOUT_MS=600000 \
             PACK_EVALUATOR_ACTIVITY_FILE="$PROXY_ACTIVITY" \
@@ -773,17 +775,45 @@ jobs:
                 | map(.fatalHttpStatus // .retryableHttpStatus)
                 | map(select(. != null)) | last // empty
               ' "$PREFLIGHT_DIAGNOSTICS")
+              PREFLIGHT_ERROR_CATEGORY=$(sudo jq -rs '
+                [
+                  .[]
+                  | select(
+                      .phase == "response"
+                      and (.status | type) == "number"
+                      and .status >= 400 and .status < 500
+                      and (.status != 408 and .status != 425 and .status != 429)
+                    )
+                ]
+                | last as $activity
+                | [
+                    "unknown_model_or_lane",
+                    "unsupported_parameter",
+                    "authentication_failed",
+                    "context_length_exceeded",
+                    "malformed_request",
+                    "other",
+                    "request_body_too_large",
+                    "model_not_allowed",
+                    "invalid_output_token_limit"
+                  ] as $allowed
+                | if $activity != null and ($allowed | index($activity.errorCategory)) != null
+                  then $activity.errorCategory
+                  else empty
+                  end
+              ' "$PROXY_ACTIVITY" 2>/dev/null || true)
               jq -n \
                 --arg stage agent_preflight \
                 --arg reason "$PREFLIGHT_REASON" \
                 --arg status "$PREFLIGHT_STATUS" \
+                --arg errorCategory "$PREFLIGHT_ERROR_CATEGORY" \
                 --arg diagnosticSha256 "$DIAGNOSTIC_SHA256" \
                 '{
                   schemaVersion: "marketplace.pack-production-infrastructure-failure/v1",
                   stage: $stage,
                   reason: $reason,
                   status: (if $status == "" then null else ($status | tonumber) end),
-                  errorCategory: null,
+                  errorCategory: (if $errorCategory == "" then null else $errorCategory end),
                   diagnosticSha256: $diagnosticSha256
                 }' > "$INFRASTRUCTURE_FAILURE_FILE"
             fi
@@ -808,13 +838,14 @@ jobs:
             NO_COLOR=1 \
             SKILLSTORE_AGENTS=codex,claude \
             SKILLSTORE_AGENT_ENV_MODE=strict \
-            SKILLSTORE_AGENT_ENV_ALLOWLIST=CODEX_HOME,PACK_EVALUATOR_PROXY_TOKEN,PACK_EVALUATOR_CHROMIUM_PATH,ANTHROPIC_BASE_URL,ANTHROPIC_AUTH_TOKEN,NO_PROXY,SKILLSTORE_AGENT_SANDBOX_MODE,SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT \
+            SKILLSTORE_AGENT_ENV_ALLOWLIST=CODEX_HOME,PACK_EVALUATOR_PROXY_TOKEN,PACK_EVALUATOR_CHROMIUM_PATH,ANTHROPIC_BASE_URL,ANTHROPIC_AUTH_TOKEN,CLAUDE_CODE_MAX_OUTPUT_TOKENS,NO_PROXY,SKILLSTORE_AGENT_SANDBOX_MODE,SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT \
             SKILLSTORE_AGENT_SANDBOX_MODE=bwrap \
             SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=/opt/pack-evaluator/runtime \
             PACK_EVALUATOR_CHROMIUM_PATH=/usr/bin/google-chrome \
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
             ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
             ANTHROPIC_AUTH_TOKEN="$LOCAL_TOKEN" \
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
             NO_PROXY=127.0.0.1,localhost \
             timeout --signal=TERM --kill-after=30s 4h \
             prlimit --nproc=256:256 --as=6442450944:6442450944 -- \

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -34,6 +34,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
+
 concurrency:
   group: test-pack-evaluator-bwrap-${{ github.ref }}
   cancel-in-progress: true
@@ -177,6 +180,7 @@ jobs:
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
             PACK_DIAGNOSTICS_DIR="$DIAGNOSTICS_DIR" \
             PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
+            PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
             bash "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight.sh"
           IPV4_ACCEPT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
             | awk '$3 == "ACCEPT" {print $1}')
@@ -192,6 +196,10 @@ jobs:
             [ .[] | select(.phase == "response" and .status == 200) | .path ] as $paths
             | ($paths | index("/v1/messages")) != null
             and ($paths | index("/v1/responses")) != null
+          ' "$DIAGNOSTICS_DIR/proxy-activity.ndjson" >/dev/null
+          jq -se '
+            [ .[] | select(.phase == "response" and .status == 200 and .path == "/v1/messages") ]
+            | length > 0 and all(.[]; .maxTokens == 16384)
           ' "$DIAGNOSTICS_DIR/proxy-activity.ndjson" >/dev/null
           if rg -F \
             -e "$LOCAL_TOKEN" \

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends apparmor bubblewrap iptables util-linux
+          sudo apt-get install --yes --no-install-recommends apparmor bubblewrap iptables ripgrep util-linux
+          test "$(command -v rg)" = /usr/bin/rg
           sudo useradd --create-home --home-dir /home/packeval --shell /bin/bash packeval
           NODE_SOURCE=$(command -v node)
           test -x "$NODE_SOURCE"

--- a/scripts/pack-evaluator-preflight-mock.mjs
+++ b/scripts/pack-evaluator-preflight-mock.mjs
@@ -188,6 +188,11 @@ export function createPackEvaluatorPreflightMock({ localToken, onActivity = () =
     }
     requestNumber += 1;
     const model = typeof parsed.value.model === 'string' ? parsed.value.model : null;
+    const requestedMaxTokens = path === '/v1/messages'
+      ? parsed.value.max_tokens
+      : path === '/v1/responses'
+        ? parsed.value.max_output_tokens
+        : null;
     const activity = {
       phase: 'response',
       requestNumber,
@@ -195,6 +200,9 @@ export function createPackEvaluatorPreflightMock({ localToken, onActivity = () =
       model,
       requestBytes: parsed.bytes,
       stream: parsed.value.stream === true,
+      maxTokens: Number.isSafeInteger(requestedMaxTokens) && requestedMaxTokens > 0
+        ? requestedMaxTokens
+        : null,
       status: 200,
     };
 

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 : "${PACK_EVALUATOR_PROXY_TOKEN:?PACK_EVALUATOR_PROXY_TOKEN is required}"
 : "${PACK_DIAGNOSTICS_DIR:?PACK_DIAGNOSTICS_DIR is required}"
+: "${PACK_EVALUATOR_MAX_OUTPUT_TOKENS:?PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required}"
+if ! [[ "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" =~ ^[1-9][0-9]*$ ]]; then
+  echo 'PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer' >&2
+  exit 1
+fi
+readonly PACK_EVALUATOR_MAX_OUTPUT_TOKENS
 readonly PREFLIGHT_TIMEOUT_SECONDS=180
 readonly BWRAP=/usr/bin/bwrap
 [ -x "$BWRAP" ] || { echo 'bubblewrap is required for evaluator preflight' >&2; exit 1; }
@@ -202,6 +208,7 @@ for ATTEMPT in 1 2; do
       "${AGENT_BWRAP[@]}" \
         --setenv ANTHROPIC_BASE_URL http://127.0.0.1:18765 \
         --setenv ANTHROPIC_AUTH_TOKEN "$PACK_EVALUATOR_PROXY_TOKEN" \
+        --setenv CLAUDE_CODE_MAX_OUTPUT_TOKENS "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
         /opt/pack-evaluator/runtime/bin/claude \
         --print \
         --output-format text \

--- a/scripts/pack-evaluator-proxy.mjs
+++ b/scripts/pack-evaluator-proxy.mjs
@@ -48,9 +48,10 @@ function fail(message) {
   throw new Error(message);
 }
 
-function reject(message, status) {
+function reject(message, status, policyCategory) {
   const error = new Error(message);
   error.status = status;
+  if (policyCategory) error.policyCategory = policyCategory;
   throw error;
 }
 
@@ -171,7 +172,9 @@ async function requestBody(request) {
   let size = 0;
   for await (const chunk of request) {
     size += chunk.length;
-    if (size > MAX_BODY_BYTES) fail('request body exceeds 32 MiB');
+    if (size > MAX_BODY_BYTES) {
+      reject('request body exceeds 32 MiB', 400, 'request_body_too_large');
+    }
     chunks.push(chunk);
   }
   return Buffer.concat(chunks);
@@ -197,19 +200,21 @@ function boundedInferenceBody(body, pathname, allowedModels, maxOutputTokens) {
   try {
     payload = JSON.parse(body.toString('utf8'));
   } catch {
-    reject('inference request body must be valid JSON', 400);
+    reject('inference request body must be valid JSON', 400, 'malformed_request');
   }
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    reject('inference request body must be a JSON object', 400);
+    reject('inference request body must be a JSON object', 400, 'malformed_request');
   }
 
   const model = typeof payload.model === 'string' ? payload.model.trim() : '';
-  if (!model || !allowedModels.has(model)) reject(`model is not allowed: ${model || '(missing)'}`, 403);
+  if (!model || !allowedModels.has(model)) {
+    reject(`model is not allowed: ${model || '(missing)'}`, 403, 'model_not_allowed');
+  }
 
   for (const field of ['max_tokens', 'max_output_tokens']) {
     if (payload[field] == null) continue;
     if (!Number.isSafeInteger(payload[field]) || payload[field] < 1 || payload[field] > maxOutputTokens) {
-      reject(`${field} must be between 1 and ${maxOutputTokens}`, 400);
+      reject(`${field} must be between 1 and ${maxOutputTokens}`, 400, 'invalid_output_token_limit');
     }
   }
   if (pathname === '/v1/messages' && payload.max_tokens == null) payload.max_tokens = maxOutputTokens;
@@ -275,6 +280,7 @@ export function createPackEvaluatorProxy({
   const timeoutMs = positiveInteger(requestTimeoutMs, 'requestTimeoutMs', 10 * 60 * 1000);
   const expiresAt = Date.now() + lifetimeMs;
   let requestsStarted = 0;
+  let activityRequestSequence = 0;
   let activeRequests = 0;
   let circuitFailure = null;
   const recordActivity = (activity) => {
@@ -319,13 +325,29 @@ export function createPackEvaluatorProxy({
       }
 
       const target = new URL(`${incoming.pathname}${incoming.search}`, upstreamBase);
-      const incomingBody = await requestBody(request);
-      const bounded = boundedInferenceBody(
-        incomingBody,
-        incoming.pathname,
-        modelAllowlist,
-        outputTokenLimit,
-      );
+      const requestNumber = ++activityRequestSequence;
+      let incomingBody;
+      let bounded;
+      try {
+        incomingBody = await requestBody(request);
+        bounded = boundedInferenceBody(
+          incomingBody,
+          incoming.pathname,
+          modelAllowlist,
+          outputTokenLimit,
+        );
+      } catch (error) {
+        if ([400, 403].includes(error?.status) && error?.policyCategory) {
+          recordActivity({
+            phase: 'response',
+            requestNumber,
+            path: incoming.pathname,
+            status: error.status,
+            errorCategory: error.policyCategory,
+          });
+        }
+        throw error;
+      }
       const requestDiagnostics = {
         path: incoming.pathname,
         model: bounded.model,
@@ -335,7 +357,7 @@ export function createPackEvaluatorProxy({
       if (circuitFailure) {
         recordActivity({
           phase: 'circuit_open',
-          requestNumber: requestsStarted + 1,
+          requestNumber,
           ...requestDiagnostics,
           status: circuitFailure.status,
           originalRequestNumber: circuitFailure.requestNumber,
@@ -345,8 +367,7 @@ export function createPackEvaluatorProxy({
       }
       requestsStarted += 1;
       activeRequests += 1;
-      recordActivity({ phase: 'started', requestNumber: requestsStarted, ...requestDiagnostics });
-      const requestNumber = requestsStarted;
+      recordActivity({ phase: 'started', requestNumber, ...requestDiagnostics });
       const upstreamController = new AbortController();
       const upstreamTimeout = setTimeout(() => upstreamController.abort(), timeoutMs);
       const abortUpstream = () => {

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -185,6 +185,9 @@ const INFRASTRUCTURE_ERROR_CATEGORIES = new Set([
   'context_length_exceeded',
   'malformed_request',
   'other',
+  'request_body_too_large',
+  'model_not_allowed',
+  'invalid_output_token_limit',
 ]);
 const INTERRUPTED_SIGNALS = new Set(['SIGINT', 'SIGTERM', 'SIGHUP']);
 
@@ -284,14 +287,6 @@ export function deterministicHttpFailureFromActivity(contents) {
     if (!Number.isSafeInteger(status) || status < 400 || status >= 500 || [408, 425, 429].includes(status)) {
       continue;
     }
-    const errorCategories = new Set([
-      'unknown_model_or_lane',
-      'unsupported_parameter',
-      'authentication_failed',
-      'context_length_exceeded',
-      'malformed_request',
-      'other',
-    ]);
     return {
       status,
       path: safeActivityToken(activity.path),
@@ -300,7 +295,9 @@ export function deterministicHttpFailureFromActivity(contents) {
       errorType: safeActivityToken(activity.errorType),
       errorCode: safeActivityToken(activity.errorCode),
       errorParam: safeActivityToken(activity.errorParam),
-      errorCategory: errorCategories.has(activity.errorCategory) ? activity.errorCategory : null,
+      errorCategory: INFRASTRUCTURE_ERROR_CATEGORIES.has(activity.errorCategory)
+        ? activity.errorCategory
+        : null,
       errorMessageSha256: /^[a-f0-9]{64}$/.test(activity.errorMessageSha256 || '')
         ? activity.errorMessageSha256
         : null,

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -154,7 +154,29 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4\.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5\.5/);
   assert.match(evaluate, /PACK_EVALUATOR_MAX_REQUESTS=256/);
   assert.match(evaluate, /PACK_EVALUATOR_MAX_CONCURRENT=4/);
-  assert.match(evaluate, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS=16384/);
+  assert.equal(
+    (WORKFLOW.match(/^  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'$/gm) ?? []).length,
+    1,
+    'the production workflow must define one output-token cap',
+  );
+  assert.match(
+    evaluateWorkflow,
+    /PACK_EVALUATOR_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+  );
+  assert.match(
+    evaluateWorkflow,
+    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+  );
+  assert.match(
+    evaluateWorkflow,
+    /SKILLSTORE_AGENT_ENV_ALLOWLIST=.*CLAUDE_CODE_MAX_OUTPUT_TOKENS/,
+  );
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required/);
+  assert.match(EVALUATOR_PREFLIGHT, /\^\[1-9\]\[0-9\]\*\$/);
+  assert.match(
+    EVALUATOR_PREFLIGHT,
+    /--setenv CLAUDE_CODE_MAX_OUTPUT_TOKENS "\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+  );
   assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"/);
   assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\\]+bash .*pack-evaluator-preflight\.sh/);
   assert.match(evaluate, /sudo rm -f "\$PROXY_ACTIVITY"/);
@@ -201,8 +223,21 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /agent-preflight-diagnostics\.json/);
   assert.match(evaluate, /PREFLIGHT_REASON=\$\(jq -r/);
   assert.match(evaluate, /--arg reason "\$PREFLIGHT_REASON"/);
-  assert.match(evaluate, /errorCategory: null/);
-  assert.doesNotMatch(evaluate, /PREFLIGHT_ERROR_CATEGORY=/);
+  assert.match(evaluate, /PREFLIGHT_ERROR_CATEGORY=\$\(sudo jq -rs/);
+  assert.match(evaluate, /\.phase == "response"/);
+  assert.match(evaluate, /\| last as \$activity/);
+  for (const category of [
+    'request_body_too_large',
+    'model_not_allowed',
+    'invalid_output_token_limit',
+  ]) {
+    assert.match(evaluate, new RegExp(`"${category}"`));
+  }
+  assert.match(evaluate, /--arg errorCategory "\$PREFLIGHT_ERROR_CATEGORY"/);
+  assert.match(
+    evaluate,
+    /errorCategory: \(if \$errorCategory == "" then null else \$errorCategory end\)/,
+  );
   assert.doesNotMatch(evaluate, /--arg errorCategory "\$PREFLIGHT_REASON"/);
   assert.match(evaluate, /CLAUDE_OUTCOME=invalid_response/);
   assert.match(evaluate, /CODEX_OUTCOME=invalid_response/);
@@ -306,6 +341,50 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--ro-bind \/ \//);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--(?:ro-)?bind \/opt\/pack-evaluator\/(?:bin|lib|input|results)/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /GITHUB_WORKSPACE/);
+});
+
+test('evaluator preflight rejects a non-positive Claude output-token cap before execution', () => {
+  const result = spawnSync('bash', [EVALUATOR_PREFLIGHT_PATH], {
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH,
+      PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
+      PACK_DIAGNOSTICS_DIR: '/tmp',
+      PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
+    },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer/);
+});
+
+test('preflight infrastructure evidence selects the last fatal response before category allowlisting', () => {
+  const prefix = "PREFLIGHT_ERROR_CATEGORY=$(sudo jq -rs '\n";
+  const suffix = "\n              ' \"$PROXY_ACTIVITY\" 2>/dev/null || true)";
+  const start = WORKFLOW.indexOf(prefix);
+  assert.notEqual(start, -1);
+  const filterStart = start + prefix.length;
+  const end = WORKFLOW.indexOf(suffix, filterStart);
+  assert.notEqual(end, -1);
+  const filter = WORKFLOW.slice(filterStart, end);
+  const extract = (activities) => spawnSync('jq', ['-rs', filter], {
+    encoding: 'utf8',
+    input: `${activities.map((activity) => JSON.stringify(activity)).join('\n')}\n`,
+  });
+
+  const allowed = extract([
+    { phase: 'response', status: 403, errorCategory: 'model_not_allowed' },
+    { phase: 'response', status: 400, errorCategory: 'invalid_output_token_limit' },
+    { phase: 'response', status: 503, errorCategory: 'other' },
+  ]);
+  assert.equal(allowed.status, 0, allowed.stderr);
+  assert.equal(allowed.stdout.trim(), 'invalid_output_token_limit');
+
+  const rejected = extract([
+    { phase: 'response', status: 403, errorCategory: 'model_not_allowed' },
+    { phase: 'response', status: 400, errorCategory: 'attacker_supplied_category' },
+  ]);
+  assert.equal(rejected.status, 0, rejected.stderr);
+  assert.equal(rejected.stdout, '');
 });
 
 test('evaluator preflight classifies both output streams without retaining their text', () => {

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -111,6 +111,12 @@ test('hosted proof is pinned, secret-free, and invokes the production helper', (
   assert.match(HOSTED_CI, /scripts\/configure-pack-evaluator-bwrap\.sh/);
   assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight-mock\.mjs/);
   assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight\.sh/);
+  assert.match(HOSTED_CI, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'/);
+  assert.match(
+    HOSTED_CI,
+    /PACK_EVALUATOR_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+  );
+  assert.match(HOSTED_CI, /\.maxTokens == 16384/);
   assert.match(HOSTED_CI, /\.claude\.outcome == "passed"/);
   assert.match(HOSTED_CI, /\.codex\.outcome == "passed"/);
   assert.doesNotMatch(HOSTED_CI, /secrets\.|pull_request_target|self-hosted/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -103,7 +103,11 @@ test('hosted proof is pinned, secret-free, and invokes the production helper', (
   assert.match(HOSTED_CI, /timeout-minutes: 10/);
   assert.match(HOSTED_CI, /permissions:\n  contents: read/);
   assert.match(HOSTED_CI, /persist-credentials: false/);
-  assert.match(HOSTED_CI, /apt-get install --yes --no-install-recommends apparmor bubblewrap iptables util-linux/);
+  assert.match(
+    HOSTED_CI,
+    /apt-get install --yes --no-install-recommends apparmor bubblewrap iptables ripgrep util-linux/,
+  );
+  assert.match(HOSTED_CI, /test "\$\(command -v rg\)" = \/usr\/bin\/rg/);
   assert.match(HOSTED_CI, /@anthropic-ai\/claude-code@2\.1\.210/);
   assert.match(HOSTED_CI, /@openai\/codex@0\.139\.0/);
   assert.match(HOSTED_CI, /useradd --create-home --home-dir \/home\/packeval/);

--- a/scripts/tests/pack-evaluator-preflight-mock.test.mjs
+++ b/scripts/tests/pack-evaluator-preflight-mock.test.mjs
@@ -43,6 +43,7 @@ test('mock serves protocol-complete Messages and Responses streams without retai
     body: JSON.stringify({
       model: 'sonnet',
       stream: true,
+      max_tokens: 16384,
       messages: [{ role: 'user', content: 'sensitive mock prompt' }],
     }),
   });
@@ -53,7 +54,12 @@ test('mock serves protocol-complete Messages and Responses streams without retai
   const responses = await fetch(`${baseUrl}/v1/responses`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ model: 'gpt-5.5', stream: true, input: 'sensitive mock prompt' }),
+    body: JSON.stringify({
+      model: 'gpt-5.5',
+      stream: true,
+      max_output_tokens: 4096,
+      input: 'sensitive mock prompt',
+    }),
   });
   assert.equal(responses.status, 200);
   const responseBody = await responses.text();
@@ -61,14 +67,15 @@ test('mock serves protocol-complete Messages and Responses streams without retai
   assert.match(responseBody, /response\.completed/);
 
   assert.deepEqual(
-    activities.filter((activity) => activity.status === 200).map(({ path, model, stream }) => ({
+    activities.filter((activity) => activity.status === 200).map(({ path, model, stream, maxTokens }) => ({
       path,
       model,
       stream,
+      maxTokens,
     })),
     [
-      { path: '/v1/messages', model: 'sonnet', stream: true },
-      { path: '/v1/responses', model: 'gpt-5.5', stream: true },
+      { path: '/v1/messages', model: 'sonnet', stream: true, maxTokens: 16384 },
+      { path: '/v1/responses', model: 'gpt-5.5', stream: true, maxTokens: 4096 },
     ],
   );
   const serialized = JSON.stringify(activities);

--- a/scripts/tests/pack-evaluator-proxy.test.mjs
+++ b/scripts/tests/pack-evaluator-proxy.test.mjs
@@ -39,6 +39,7 @@ before(async () => {
     localToken: LOCAL_TOKEN,
     upstreamKey: UPSTREAM_KEY,
     upstreamBaseUrl: upstreamUrl,
+    maxOutputTokens: 16384,
     onActivity: (activity) => activities.push(activity),
   });
   proxy.listen(0, '127.0.0.1');
@@ -54,19 +55,29 @@ after(async () => {
 });
 
 test('requires the job-local token even for health checks', async () => {
+  const activityCount = activities.length;
   assert.equal((await fetch(`${proxyUrl}/healthz`)).status, 401);
+  assert.equal((await fetch(`${proxyUrl}/v1/messages`, { method: 'HEAD' })).status, 401);
   const response = await fetch(`${proxyUrl}/healthz`, {
     headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
   });
   assert.equal(response.status, 200);
+  assert.equal(activities.length, activityCount, 'unauthenticated probes must not emit fatal activity');
 });
 
 test('allows only the explicit inference endpoint allowlist', async () => {
+  const activityCount = activities.length;
   const response = await fetch(`${proxyUrl}/admin/api/keys`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
   });
   assert.equal(response.status, 403);
+  const head = await fetch(`${proxyUrl}/v1/messages`, {
+    method: 'HEAD',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
+  });
+  assert.equal(head.status, 403);
+  assert.equal(activities.length, activityCount, 'HEAD and non-inference probes must not emit fatal activity');
 });
 
 test('replaces local credentials with the bounded upstream credential', async () => {
@@ -87,7 +98,7 @@ test('replaces local credentials with the bounded upstream credential', async ()
   assert.equal(observed.apiKey, undefined);
   assert.match(observed.body, /gpt-5\.5/);
   assert.equal(response.headers.has('set-cookie'), false);
-  assert.equal(JSON.parse(observed.body).max_output_tokens, 65536);
+  assert.equal(JSON.parse(observed.body).max_output_tokens, 16384);
   assert.deepEqual(
     activities.slice(-3).map((activity) => activity.phase),
     ['started', 'response', 'completed']
@@ -193,7 +204,10 @@ test('records exact redacted upstream error diagnostics without response text or
   assert.equal(circuitResponse.status, 424);
   assert.equal(upstreamCalls, 1, 'a deterministic 4xx must open the circuit before another upstream call');
   assert.ok(redactedActivities.some((entry) => (
-    entry.phase === 'circuit_open' && entry.status === 422 && entry.originalRequestNumber === 1
+    entry.phase === 'circuit_open'
+    && entry.status === 422
+    && entry.originalRequestNumber === 1
+    && entry.requestNumber === 2
   )));
   await new Promise((resolve) => rejectingProxy.close(resolve));
 });
@@ -217,6 +231,7 @@ test('classifies upstream 400 causes into a fixed enum without retaining raw tex
 });
 
 test('rejects models and token requests outside the evaluator budget', async () => {
+  const activityStart = activities.length;
   const forbiddenModel = await fetch(`${proxyUrl}/v1/responses`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
@@ -228,10 +243,134 @@ test('rejects models and token requests outside the evaluator budget', async () 
   const excessiveTokens = await fetch(`${proxyUrl}/v1/messages`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
-    body: JSON.stringify({ model: 'sonnet', max_tokens: 65537, messages: [] }),
+    body: JSON.stringify({ model: 'sonnet', max_tokens: 16385, messages: [] }),
   });
   assert.equal(excessiveTokens.status, 400);
   assert.match((await excessiveTokens.json()).error, /max_tokens/);
+
+  const malformedBody = await fetch(`${proxyUrl}/v1/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: '{"sensitive request text":',
+  });
+  assert.equal(malformedBody.status, 400);
+
+  const policyActivities = activities.slice(activityStart);
+  assert.deepEqual(
+    policyActivities.map(({ phase, path, status, errorCategory }) => ({
+      phase,
+      path,
+      status,
+      errorCategory,
+    })),
+    [
+      {
+        phase: 'response',
+        path: '/v1/responses',
+        status: 403,
+        errorCategory: 'model_not_allowed',
+      },
+      {
+        phase: 'response',
+        path: '/v1/messages',
+        status: 400,
+        errorCategory: 'invalid_output_token_limit',
+      },
+      {
+        phase: 'response',
+        path: '/v1/messages',
+        status: 400,
+        errorCategory: 'malformed_request',
+      },
+    ],
+  );
+  for (const activity of policyActivities) {
+    assert.deepEqual(
+      Object.keys(activity).sort(),
+      ['errorCategory', 'path', 'phase', 'requestNumber', 'status'],
+    );
+  }
+  assert.deepEqual(
+    policyActivities.map((activity) => activity.requestNumber),
+    [
+      policyActivities[0].requestNumber,
+      policyActivities[0].requestNumber + 1,
+      policyActivities[0].requestNumber + 2,
+    ],
+    'consecutive local policy rejections must receive distinct monotonic identifiers',
+  );
+  assert.doesNotMatch(
+    JSON.stringify(policyActivities),
+    /gpt-unbounded|sensitive request text|local-token|upstream-secret/,
+  );
+
+  const authorized = await fetch(`${proxyUrl}/v1/responses`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'allowed after policy rejection' }),
+  });
+  assert.equal(authorized.status, 200);
+  const nextStarted = activities.slice(activityStart + policyActivities.length)
+    .find((activity) => activity.phase === 'started');
+  assert.equal(nextStarted.requestNumber, policyActivities.at(-1).requestNumber + 1);
+});
+
+test('policy rejections use monotonic activity ids without spending the forwarding budget', async () => {
+  const recorded = [];
+  let upstreamCalls = 0;
+  const bounded = createPackEvaluatorProxy({
+    localToken: LOCAL_TOKEN,
+    upstreamKey: UPSTREAM_KEY,
+    upstreamBaseUrl: upstreamUrl,
+    maxRequests: 1,
+    maxOutputTokens: 16384,
+    fetchImpl: async () => {
+      upstreamCalls += 1;
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+    onActivity: (activity) => recorded.push(activity),
+  });
+  bounded.listen(0, '127.0.0.1');
+  await once(bounded, 'listening');
+  const url = `http://127.0.0.1:${bounded.address().port}`;
+  const headers = { Authorization: `Bearer ${LOCAL_TOKEN}`, 'content-type': 'application/json' };
+
+  assert.equal((await fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: 'not-allowed', input: 'one' }),
+  })).status, 403);
+  assert.equal((await fetch(`${url}/v1/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: 'sonnet', max_tokens: 16385, messages: [] }),
+  })).status, 400);
+  assert.equal((await fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'forward exactly once' }),
+  })).status, 200);
+  assert.equal((await fetch(`${url}/v1/responses`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model: 'gpt-5.5', input: 'budget exhausted' }),
+  })).status, 429);
+
+  assert.equal(upstreamCalls, 1);
+  assert.deepEqual(
+    recorded.map(({ phase, requestNumber }) => ({ phase, requestNumber })),
+    [
+      { phase: 'response', requestNumber: 1 },
+      { phase: 'response', requestNumber: 2 },
+      { phase: 'started', requestNumber: 3 },
+      { phase: 'response', requestNumber: 3 },
+      { phase: 'completed', requestNumber: 3 },
+    ],
+  );
+  await new Promise((resolve) => bounded.close(resolve));
 });
 
 test('enforces request, concurrency, and TTL limits', async () => {

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -504,6 +504,19 @@ test('infrastructure audit reports retain only bounded operational evidence', ()
   assert.equal(evaluation.candidate, null);
   assert.equal(evaluation.outcome, 'infrastructure_failed');
   assert.match(evaluation.evidenceDigest, /^[0-9a-f]{64}$/);
+  for (const errorCategory of [
+    'request_body_too_large',
+    'model_not_allowed',
+    'invalid_output_token_limit',
+  ]) {
+    assert.equal(normalizeInfrastructureFailure({
+      schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
+      stage: 'agent_preflight',
+      reason: 'deterministic_http',
+      status: 400,
+      errorCategory,
+    }).errorCategory, errorCategory);
+  }
   assert.throws(() => normalizeInfrastructureFailure({
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
     stage: 'evaluation',
@@ -981,9 +994,9 @@ exit 99
   writeFileSync(failureFile, `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
     stage: 'agent_preflight',
-    reason: 'preflight_failed',
-    status: null,
-    errorCategory: null,
+    reason: 'deterministic_http',
+    status: 400,
+    errorCategory: 'invalid_output_token_limit',
     diagnosticSha256: 'a'.repeat(64),
   })}\n`);
   const result = spawnSync(process.execPath, [
@@ -1011,9 +1024,9 @@ exit 99
   assert.deepEqual(audit.evidence.cliReport.infrastructureFailure, {
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
     stage: 'agent_preflight',
-    reason: 'preflight_failed',
-    status: null,
-    errorCategory: null,
+    reason: 'deterministic_http',
+    status: 400,
+    errorCategory: 'invalid_output_token_limit',
     diagnosticSha256: 'a'.repeat(64),
     pathSha256: null,
     modelSha256: null,


### PR DESCRIPTION
## Root cause

Generate Pack run 29504488971 failed before evaluation because Claude Code 2.1.210 sends `max_tokens=64000`, while the job-local proxy hard cap is 16384. The proxy correctly rejected the request locally with HTTP 400 before Helm; both Helm Messages and Responses contract probes were HTTP 200.

The retained 66-byte stdout SHA-256 exactly matched:

`API Error: 400 {"error":"max_tokens must be between 1 and 16384"}`

## Fix

- define one 16384 output-token cap for the workflow
- pass it to the proxy, Claude preflight, and real strict agent environment
- keep the proxy fail-closed instead of raising the budget
- make the hosted pinned-Claude proof assert its real Messages `max_tokens`
- retain redacted local policy 400/403 categories in trusted infrastructure evidence
- give policy rejections unique monotonic activity IDs without spending the upstream request budget

## Verification

- real Claude 2.1.210 -> production proxy -> mock upstream succeeded with both Messages requests at `maxTokens=16384`
- `CI=true node --test` focused suite: 68 passed, 1 Linux-only skipped, 0 failed
- bash syntax, YAML parsing, and `git diff --check` passed

Auto-publish remains hard-disabled. No production DB migration is included.
