### PR TITLE
feat(workflow): prove exact Pack executor boundary

### DIFF
--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           # Content finalization must use the same immutable nonce-aware v4 CLI
           # contract as evaluation and persistence.
-          version: '2.14.1'
-          minimum-version: '2.14.1'
+          version: '2.14.2'
+          minimum-version: '2.14.2'
           require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli

--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           # Content finalization must use the same immutable nonce-aware v4 CLI
           # contract as evaluation and persistence.
-          version: '2.14.0'
-          minimum-version: '2.14.0'
+          version: '2.14.1'
+          minimum-version: '2.14.1'
           require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli

--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           # Content finalization must use the same immutable nonce-aware v4 CLI
           # contract as evaluation and persistence.
-          version: '2.13.2'
-          minimum-version: '2.13.2'
+          version: '2.14.0'
+          minimum-version: '2.14.0'
           require-checksum: 'true'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
@@ -63,7 +63,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
           CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
-          # Binding-aware CLI 2.13 uses this narrow Automation endpoint only
+          # Binding-aware CLI 2.14 uses this narrow Automation endpoint only
           # when GENERATION_ID is present. It must not direct-write a generated
           # production guide with the service-role client.
           SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.2'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.13.2'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
@@ -758,6 +758,8 @@ jobs:
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
             PACK_DIAGNOSTICS_DIR="$GITHUB_WORKSPACE/pack-diagnostics" \
             PACK_EVALUATOR_ACTIVITY_FILE="$PROXY_ACTIVITY" \
+            PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="$GITHUB_SHA" \
+            PACK_EVALUATOR_CLI_SHA256="$(jq -r '.sha256' "$GITHUB_WORKSPACE/pack-production-input/cli-identity.json")" \
             bash "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-evaluator-preflight.sh"
             PREFLIGHT_RC=$?
             set -e
@@ -765,16 +767,12 @@ jobs:
               PREFLIGHT_DIAGNOSTICS="$GITHUB_WORKSPACE/pack-diagnostics/agent-preflight-diagnostics.json"
               DIAGNOSTIC_SHA256=$(sha256sum "$PREFLIGHT_DIAGNOSTICS" | awk '{print $1}')
               PREFLIGHT_REASON=$(jq -r '
-                [.claude.errorClass, .codex.errorClass]
-                | if index("deterministic_http") then "deterministic_http"
-                  elif index("timeout") then "timeout"
-                  else "preflight_failed" end
+                if .errorClass == "deterministic_http" then "deterministic_http"
+                elif .errorClass == "timeout" then "timeout"
+                else "preflight_failed" end
               ' "$PREFLIGHT_DIAGNOSTICS")
-              PREFLIGHT_STATUS=$(jq -r '
-                [.claude.attempts[], .codex.attempts[]]
-                | map(.fatalHttpStatus // .retryableHttpStatus)
-                | map(select(. != null)) | last // empty
-              ' "$PREFLIGHT_DIAGNOSTICS")
+              PREFLIGHT_STATUS=$(jq -r '.http.fatalStatus // .http.retryableStatus // empty' \
+                "$PREFLIGHT_DIAGNOSTICS")
               PREFLIGHT_ERROR_CATEGORY=$(sudo jq -rs '
                 [
                   .[]

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -39,7 +39,7 @@ permissions:
   contents: read
 
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 concurrency:

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -10,10 +10,12 @@ on:
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
       - 'scripts/pack-evaluator-preflight-mock.mjs'
+      - 'scripts/pack-production.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
       - 'scripts/tests/pack-evaluator-egress.test.mjs'
       - 'scripts/tests/pack-evaluator-preflight-mock.test.mjs'
+      - 'scripts/tests/pack-production.test.mjs'
   push:
     branches:
       - main
@@ -25,16 +27,19 @@ on:
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
       - 'scripts/pack-evaluator-preflight-mock.mjs'
+      - 'scripts/pack-production.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
       - 'scripts/tests/pack-evaluator-egress.test.mjs'
       - 'scripts/tests/pack-evaluator-preflight-mock.test.mjs'
+      - 'scripts/tests/pack-production.test.mjs'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 env:
+  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 concurrency:
@@ -42,8 +47,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  contract:
+    name: Validate secret-free preflight contracts
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout immutable contracts
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          filter: ''
+          clean: true
+          persist-credentials: false
+
+      - name: Run bounded contract tests
+        run: |
+          CI=true node --test \
+            scripts/tests/generate-packs-workflow.test.mjs \
+            scripts/tests/pack-evaluator-bwrap-userns.test.mjs \
+            scripts/tests/pack-evaluator-preflight-mock.test.mjs \
+            scripts/tests/pack-production.test.mjs
+
   userns:
     name: Prove scoped bwrap user namespace
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -56,7 +85,17 @@ jobs:
           clean: true
           persist-credentials: false
 
+      - name: Generate read-only Skillstore release token
+        id: cli-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: skillstore
+          permission-contents: read
+
       - name: Install bubblewrap and pinned evaluator CLIs
+        id: runtimes
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -67,13 +106,24 @@ jobs:
           test -x "$NODE_SOURCE"
           sudo install -d -o root -g root -m 0755 \
             /opt/pack-evaluator \
+            /opt/pack-evaluator/bin \
+            /opt/pack-evaluator/lib \
             /opt/pack-evaluator/runtime \
-            /opt/pack-evaluator/runtime/bin
+            /opt/pack-evaluator/runtime/bin \
+            /opt/pack-evaluator/generations
           sudo npm install --global --prefix /opt/pack-evaluator/runtime \
             @anthropic-ai/claude-code@2.1.210 \
             @openai/codex@0.139.0
           sudo install -o root -g root -m 0555 \
-            "$NODE_SOURCE" /opt/pack-evaluator/runtime/bin/node
+            "$NODE_SOURCE" \
+            /opt/pack-evaluator/bin/node
+          sudo install -o root -g root -m 0555 \
+            "$NODE_SOURCE" \
+            /opt/pack-evaluator/runtime/bin/node
+          sudo install -o root -g root -m 0444 \
+            scripts/pack-production.mjs \
+            /opt/pack-evaluator/lib/pack-production.mjs
+          sudo chmod 0711 /opt/pack-evaluator/generations
           sudo chown -R root:root /opt/pack-evaluator/runtime
           sudo chmod -R a=rX /opt/pack-evaluator/runtime
           sudo install -d -o packeval -g packeval -m 0700 /home/packeval/tmp
@@ -97,15 +147,37 @@ jobs:
             scripts/configure-pack-evaluator-egress.sh \
             scripts/pack-evaluator-bwrap.apparmor \
             scripts/pack-evaluator-preflight.sh \
-            scripts/pack-evaluator-preflight-mock.mjs
+            scripts/pack-evaluator-preflight-mock.mjs \
+            scripts/pack-production.mjs
           sudo chmod 0555 \
             scripts/configure-pack-evaluator-bwrap.sh \
             scripts/configure-pack-evaluator-egress.sh \
             scripts/pack-evaluator-preflight.sh \
             scripts/pack-evaluator-preflight-mock.mjs
+          sudo chmod 0444 scripts/pack-production.mjs
           sudo chmod 0444 scripts/pack-evaluator-bwrap.apparmor
           test "$(/opt/pack-evaluator/runtime/bin/claude --version | awk '{print $1}')" = '2.1.210'
           test "$(/opt/pack-evaluator/runtime/bin/codex --version | awk '{print $2}')" = '0.139.0'
+
+      - name: Download the checksum-verified Skillstore CLI
+        id: cli
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          minimum-version: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
+          require-checksum: 'true'
+          token: ${{ steps.cli-app-token.outputs.token }}
+
+      - name: Install the verified CLI into the production path
+        env:
+          CLI: ${{ steps.cli.outputs.cli-path }}
+          CLI_SHA256: ${{ steps.cli.outputs.cli-sha256 }}
+        run: |
+          set -euo pipefail
+          test "$(sha256sum "$CLI" | awk '{print $1}')" = "$CLI_SHA256"
+          sudo install -o root -g root -m 0555 "$CLI" /opt/pack-evaluator/bin/skillstore-cli
+          test "$(/opt/pack-evaluator/bin/skillstore-cli --version | grep -Eo '[0-9]+([.][0-9]+){2}' | head -n1)" = \
+            "$PACK_PRODUCTION_CLI_VERSION"
 
       - name: Configure scoped AppArmor policy and prove the real sandbox
         run: |
@@ -140,6 +212,8 @@ jobs:
           test "$IPV6_REJECT_AFTER" -gt "$IPV6_REJECT_BEFORE"
 
       - name: Run both pinned CLIs through the production preflight sandbox
+        env:
+          CLI_SHA256: ${{ steps.cli.outputs.cli-sha256 }}
         run: |
           set -euo pipefail
           LOCAL_TOKEN=local-preflight-token-longer-than-thirty-two-bytes
@@ -154,6 +228,7 @@ jobs:
             PACK_EVALUATOR_LOCAL_TOKEN="$LOCAL_TOKEN" \
             PACK_EVALUATOR_PROXY_PORT=18765 \
             PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
+            PACK_EVALUATOR_PREFLIGHT_MODE=pack-verify \
             /opt/pack-evaluator/runtime/bin/node \
               "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight-mock.mjs" \
               >"$MOCK_LOG" 2>&1 &
@@ -182,15 +257,50 @@ jobs:
             PACK_DIAGNOSTICS_DIR="$DIAGNOSTICS_DIR" \
             PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
             PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
+            PACK_PRODUCTION_CLI_VERSION="$PACK_PRODUCTION_CLI_VERSION" \
+            PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="$GITHUB_SHA" \
+            PACK_EVALUATOR_CLI_SHA256="$CLI_SHA256" \
             bash "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight.sh"
           IPV4_ACCEPT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
             | awk '$3 == "ACCEPT" {print $1}')
           test "$IPV4_ACCEPT_AFTER" -gt "$IPV4_ACCEPT_BEFORE"
           jq -e '
-            .claude.outcome == "passed"
-            and .claude.errorClass == "none"
-            and .codex.outcome == "passed"
-            and .codex.errorClass == "none"
+            .schemaVersion == "marketplace.pack-executor-preflight/v1"
+            and .mode == "pack-production-node-uid-nested-bwrap"
+            and .outcome == "passed"
+            and .errorClass == "none"
+            and .outerExecution.exitCode == 0
+            and .outerExecution.signal == null
+            and .outerExecution.timedOut == false
+            and .outerExecution.stalled == false
+            and .outerExecution.outputExceeded == false
+            and .runnerTraceEvidence.schemaVersion == "marketplace.pack-executor-trace-evidence/v1"
+            and .runnerTraceEvidence.deterministic == true
+            and .runnerTraceEvidence.traceCount == 1
+            and .runnerTraceEvidence.eventCount == 2
+            and (.runnerTraceEvidence.bindingDigest | test("^[0-9a-f]{64}$"))
+            and (.commandAttempts | length) == 1
+            and .commandAttempts[0].attempt == 1
+            and .commandAttempts[0].recovered == false
+            and .commandAttempts[0].outerExecution == .outerExecution
+            and .commandAttempts[0].agentExecutionEvidence == .agentExecutionEvidence
+            and .proofBinding.marketplaceCommitSha == env.GITHUB_SHA
+            and .proofBinding.cliVersion == env.PACK_PRODUCTION_CLI_VERSION
+            and .proofBinding.cliSha256 == env.CLI_SHA256
+            and (.agentExecutionEvidence | length) == 2
+            and all(.agentExecutionEvidence[];
+              .succeeded == true
+              and (.attempts | length) == 1
+              and all(.attempts[];
+                .sandboxed == true
+                and .outcome == "succeeded"
+                and .failureCategory == "none"
+                and .exitCode == 0
+                and .signal == null
+              )
+            )
+            and .http.messages200 >= 2
+            and .http.responses200 >= 1
             and .cleanup.outcome == "passed"
           ' "$DIAGNOSTICS_DIR/agent-preflight-diagnostics.json" >/dev/null
           jq -se '
@@ -200,13 +310,23 @@ jobs:
           ' "$DIAGNOSTICS_DIR/proxy-activity.ndjson" >/dev/null
           jq -se '
             [ .[] | select(.phase == "response" and .status == 200 and .path == "/v1/messages") ]
-            | length > 0 and all(.[]; .maxTokens == 16384)
+            | length >= 2 and all(.[]; .maxTokens == 16384)
           ' "$DIAGNOSTICS_DIR/proxy-activity.ndjson" >/dev/null
           if rg -F \
             -e "$LOCAL_TOKEN" \
             -e 'Reply with exactly' \
             -e 'PACK_EVALUATOR_READY' \
+            -e 'executor path healthy' \
             "$DIAGNOSTICS_DIR"; then
             echo 'Preflight diagnostics retained forbidden raw content' >&2
             exit 1
           fi
+
+      - name: Upload commit- and checksum-bound proof
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pack-executor-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pack-preflight-diagnostics
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -39,7 +39,7 @@ permissions:
   contents: read
 
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.2'
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 concurrency:

--- a/scripts/pack-evaluator-preflight-mock.mjs
+++ b/scripts/pack-evaluator-preflight-mock.mjs
@@ -234,7 +234,9 @@ export function createPackEvaluatorPreflightMock({
     fail('PACK_EVALUATOR_LOCAL_TOKEN must be at least 32 characters');
   }
   let requestNumber = 0;
-  let messagesRequestNumber = 0;
+  let bootstrapMessagesRequestSeen = false;
+  let skillToolRequestSeen = false;
+  let skillToolResultsSeen = false;
   return createServer(async (request, response) => {
     const path = new URL(request.url || '/', 'http://127.0.0.1').pathname;
     if (!sameToken(requestToken(request), localToken)) {
@@ -286,32 +288,56 @@ export function createPackEvaluatorPreflightMock({
       return;
     }
     if (path === '/v1/messages') {
-      messagesRequestNumber += 1;
       if (preflightSkillIds.length > 0) {
-        if (messagesRequestNumber === 1 && !hasSkillTool(parsed.value)) {
-          onActivity({ ...activity, status: 400, toolNames: safeToolNames(parsed.value) });
-          json(response, 400, { error: 'Skill tool is required by Pack preflight' });
+        if (!skillToolRequestSeen && !hasSkillTool(parsed.value)) {
+          if (bootstrapMessagesRequestSeen) {
+            onActivity({ ...activity, status: 400, protocolStage: 'bootstrap_budget' });
+            json(response, 400, { error: 'Pack preflight exceeded the Messages bootstrap budget' });
+            return;
+          }
+          // Claude Code 2.1.210 issues one tool-less Messages bootstrap call
+          // with a clean HOME before it loads project Skills. A successful
+          // bootstrap is not proof: the preflight closure still requires the
+          // later ordered Skill tool-use/results and runner-owned trace.
+          bootstrapMessagesRequestSeen = true;
+          onActivity({
+            ...activity,
+            protocolStage: 'bootstrap',
+            toolNames: safeToolNames(parsed.value),
+          });
+          if (parsed.value.stream === true) sse(response, messagesEvents(model || 'sonnet'));
+          else json(response, 200, messageObject(model || 'sonnet', [], 'end_turn'));
           return;
         }
-        if (messagesRequestNumber === 2 && !hasExactToolResults(parsed.value, preflightSkillIds.length)) {
-          onActivity({ ...activity, status: 400 });
+        if (!skillToolRequestSeen) {
+          skillToolRequestSeen = true;
+          onActivity({ ...activity, protocolStage: 'skill_request' });
+          if (parsed.value.stream === true) {
+            sse(response, messagesToolUseEvents(model || 'sonnet', preflightSkillIds));
+          } else {
+            json(response, 400, { error: 'Pack preflight requires streaming Skill tool use' });
+          }
+          return;
+        }
+        if (!skillToolResultsSeen && !hasExactToolResults(parsed.value, preflightSkillIds.length)) {
+          onActivity({ ...activity, status: 400, protocolStage: 'tool_results' });
           json(response, 400, { error: 'Pack preflight tool results were incomplete' });
           return;
         }
-        if (messagesRequestNumber > 2) {
-          onActivity({ ...activity, status: 400 });
+        if (skillToolResultsSeen) {
+          onActivity({ ...activity, status: 400, protocolStage: 'complete' });
           json(response, 400, { error: 'Pack preflight exceeded the Messages request budget' });
           return;
         }
+        skillToolResultsSeen = true;
+        onActivity({ ...activity, protocolStage: 'tool_results' });
+        if (parsed.value.stream === true) sse(response, messagesEvents(model || 'sonnet'));
+        else json(response, 200, messageObject(model || 'sonnet', [{ type: 'text', text: READY_TEXT }], 'end_turn'));
+        return;
       }
       onActivity(activity);
       if (parsed.value.stream === true) {
-        sse(
-          response,
-          preflightSkillIds.length > 0 && messagesRequestNumber === 1
-            ? messagesToolUseEvents(model || 'sonnet', preflightSkillIds)
-            : messagesEvents(model || 'sonnet'),
-        );
+        sse(response, messagesEvents(model || 'sonnet'));
       } else {
         json(response, 200, messageObject(model || 'sonnet', [{ type: 'text', text: READY_TEXT }], 'end_turn'));
       }

--- a/scripts/pack-evaluator-preflight-mock.mjs
+++ b/scripts/pack-evaluator-preflight-mock.mjs
@@ -6,6 +6,19 @@ import { createServer } from 'node:http';
 import { pathToFileURL } from 'node:url';
 
 const READY_TEXT = 'PACK_EVALUATOR_READY';
+const PREFLIGHT_SKILL_IDS = [
+  'pack-executor-preflight-a',
+  'pack-executor-preflight-b',
+];
+const VERIFY_JUDGE_TEXT = JSON.stringify({
+  used_skill: true,
+  used_skills: PREFLIGHT_SKILL_IDS,
+  task_completed: true,
+  env_blocked: false,
+  score: 10,
+  reason: 'executor path healthy',
+  issues: [],
+});
 const MAX_REQUEST_BYTES = 1024 * 1024;
 
 function fail(message) {
@@ -94,18 +107,65 @@ function messagesEvents(model) {
   ];
 }
 
-function responseItem() {
+function messagesToolUseEvents(model, skillIds) {
+  const events = [
+    { type: 'message_start', message: messageObject(model, [], null) },
+  ];
+  skillIds.forEach((skill, index) => {
+    events.push({
+      type: 'content_block_start',
+      index,
+      content_block: {
+        type: 'tool_use',
+        id: `toolu_pack_preflight_${index + 1}`,
+        name: 'Skill',
+        input: {},
+      },
+    });
+    events.push({
+      type: 'content_block_delta',
+      index,
+      delta: { type: 'input_json_delta', partial_json: JSON.stringify({ skill }) },
+    });
+    events.push({ type: 'content_block_stop', index });
+  });
+  events.push({
+    type: 'message_delta',
+    delta: { stop_reason: 'tool_use', stop_sequence: null },
+    usage: { output_tokens: 1 },
+  });
+  events.push({ type: 'message_stop' });
+  return events;
+}
+
+function hasSkillTool(value) {
+  return Array.isArray(value.tools) && value.tools.some((tool) => tool?.name === 'Skill');
+}
+
+function hasExactToolResults(value, expectedCount) {
+  if (!Array.isArray(value.messages) || value.messages.length === 0) return false;
+  const last = value.messages.at(-1);
+  if (last?.role !== 'user' || !Array.isArray(last.content)) return false;
+  const resultIds = last.content
+    .filter((block) => block?.type === 'tool_result')
+    .map((block) => block.tool_use_id);
+  return resultIds.length === expectedCount && resultIds.every(
+    (id, index) => id === `toolu_pack_preflight_${index + 1}`,
+  );
+}
+
+function responseItem(outputText) {
   return {
     id: 'msg_pack_preflight_mock',
     type: 'message',
     role: 'assistant',
-    content: [{ type: 'output_text', text: READY_TEXT, annotations: [] }],
+    content: [{ type: 'output_text', text: outputText, annotations: [] }],
   };
 }
 
-function responsesEvents() {
+function responsesEvents(outputText) {
   const id = 'resp_pack_preflight_mock';
-  const item = responseItem();
+  const item = responseItem(outputText);
   return [
     { type: 'response.created', response: { id } },
     { type: 'response.output_item.added', output_index: 0, item: { ...item, content: [] } },
@@ -121,14 +181,14 @@ function responsesEvents() {
       item_id: item.id,
       output_index: 0,
       content_index: 0,
-      delta: READY_TEXT,
+      delta: outputText,
     },
     {
       type: 'response.output_text.done',
       item_id: item.id,
       output_index: 0,
       content_index: 0,
-      text: READY_TEXT,
+      text: outputText,
     },
     {
       type: 'response.content_part.done',
@@ -156,11 +216,17 @@ function responsesEvents() {
   ];
 }
 
-export function createPackEvaluatorPreflightMock({ localToken, onActivity = () => {} }) {
+export function createPackEvaluatorPreflightMock({
+  localToken,
+  onActivity = () => {},
+  responsesOutput = READY_TEXT,
+  preflightSkillIds = [],
+}) {
   if (typeof localToken !== 'string' || localToken.length < 32) {
     fail('PACK_EVALUATOR_LOCAL_TOKEN must be at least 32 characters');
   }
   let requestNumber = 0;
+  let messagesRequestNumber = 0;
   return createServer(async (request, response) => {
     const path = new URL(request.url || '/', 'http://127.0.0.1').pathname;
     if (!sameToken(requestToken(request), localToken)) {
@@ -212,9 +278,32 @@ export function createPackEvaluatorPreflightMock({ localToken, onActivity = () =
       return;
     }
     if (path === '/v1/messages') {
+      messagesRequestNumber += 1;
+      if (preflightSkillIds.length > 0) {
+        if (messagesRequestNumber === 1 && !hasSkillTool(parsed.value)) {
+          onActivity({ ...activity, status: 400 });
+          json(response, 400, { error: 'Skill tool is required by Pack preflight' });
+          return;
+        }
+        if (messagesRequestNumber === 2 && !hasExactToolResults(parsed.value, preflightSkillIds.length)) {
+          onActivity({ ...activity, status: 400 });
+          json(response, 400, { error: 'Pack preflight tool results were incomplete' });
+          return;
+        }
+        if (messagesRequestNumber > 2) {
+          onActivity({ ...activity, status: 400 });
+          json(response, 400, { error: 'Pack preflight exceeded the Messages request budget' });
+          return;
+        }
+      }
       onActivity(activity);
       if (parsed.value.stream === true) {
-        sse(response, messagesEvents(model || 'sonnet'));
+        sse(
+          response,
+          preflightSkillIds.length > 0 && messagesRequestNumber === 1
+            ? messagesToolUseEvents(model || 'sonnet', preflightSkillIds)
+            : messagesEvents(model || 'sonnet'),
+        );
       } else {
         json(response, 200, messageObject(model || 'sonnet', [{ type: 'text', text: READY_TEXT }], 'end_turn'));
       }
@@ -223,9 +312,9 @@ export function createPackEvaluatorPreflightMock({ localToken, onActivity = () =
     if (path === '/v1/responses') {
       onActivity(activity);
       if (parsed.value.stream === true) {
-        sse(response, responsesEvents());
+        sse(response, responsesEvents(responsesOutput));
       } else {
-        json(response, 200, responsesEvents().at(-1).response);
+        json(response, 200, responsesEvents(responsesOutput).at(-1).response);
       }
       return;
     }
@@ -246,6 +335,12 @@ export async function startPackEvaluatorPreflightMock(environment = process.env)
   const activityFile = environment.PACK_EVALUATOR_ACTIVITY_FILE;
   const server = createPackEvaluatorPreflightMock({
     localToken: environment.PACK_EVALUATOR_LOCAL_TOKEN,
+    responsesOutput: ['verify', 'pack-verify'].includes(environment.PACK_EVALUATOR_PREFLIGHT_MODE)
+      ? VERIFY_JUDGE_TEXT
+      : READY_TEXT,
+    preflightSkillIds: environment.PACK_EVALUATOR_PREFLIGHT_MODE === 'pack-verify'
+      ? PREFLIGHT_SKILL_IDS
+      : [],
     onActivity: activityFile
       ? (activity) => appendFileSync(
         activityFile,

--- a/scripts/pack-evaluator-preflight-mock.mjs
+++ b/scripts/pack-evaluator-preflight-mock.mjs
@@ -142,6 +142,14 @@ function hasSkillTool(value) {
   return Array.isArray(value.tools) && value.tools.some((tool) => tool?.name === 'Skill');
 }
 
+function safeToolNames(value) {
+  if (!Array.isArray(value.tools)) return [];
+  return value.tools
+    .map((tool) => tool?.name)
+    .filter((name) => typeof name === 'string' && /^[A-Za-z0-9_.:-]{1,96}$/.test(name))
+    .slice(0, 64);
+}
+
 function hasExactToolResults(value, expectedCount) {
   if (!Array.isArray(value.messages) || value.messages.length === 0) return false;
   const last = value.messages.at(-1);
@@ -281,7 +289,7 @@ export function createPackEvaluatorPreflightMock({
       messagesRequestNumber += 1;
       if (preflightSkillIds.length > 0) {
         if (messagesRequestNumber === 1 && !hasSkillTool(parsed.value)) {
-          onActivity({ ...activity, status: 400 });
+          onActivity({ ...activity, status: 400, toolNames: safeToolNames(parsed.value) });
           json(response, 400, { error: 'Skill tool is required by Pack preflight' });
           return;
         }

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -4,122 +4,75 @@ set -euo pipefail
 : "${PACK_EVALUATOR_PROXY_TOKEN:?PACK_EVALUATOR_PROXY_TOKEN is required}"
 : "${PACK_DIAGNOSTICS_DIR:?PACK_DIAGNOSTICS_DIR is required}"
 : "${PACK_EVALUATOR_MAX_OUTPUT_TOKENS:?PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required}"
+: "${PACK_PRODUCTION_CLI_VERSION:?PACK_PRODUCTION_CLI_VERSION is required}"
 if ! [[ "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" =~ ^[1-9][0-9]*$ ]]; then
   echo 'PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer' >&2
   exit 1
 fi
-readonly PACK_EVALUATOR_MAX_OUTPUT_TOKENS
-readonly PREFLIGHT_TIMEOUT_SECONDS=180
-readonly BWRAP=/usr/bin/bwrap
-[ -x "$BWRAP" ] || { echo 'bubblewrap is required for evaluator preflight' >&2; exit 1; }
+: "${PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA:?PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA is required}"
+: "${PACK_EVALUATOR_CLI_SHA256:?PACK_EVALUATOR_CLI_SHA256 is required}"
+if ! [[ "$PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA must be a lowercase Git commit SHA' >&2
+  exit 1
+fi
+if ! [[ "$PACK_EVALUATOR_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo 'PACK_EVALUATOR_CLI_SHA256 must be a lowercase SHA-256' >&2
+  exit 1
+fi
 
-# Empty-root, fresh-PID sandbox for the two real CLI preflights. It deliberately
-# mounts the agent runtime and writable identity state but none of the evaluator
-# CLI/orchestrator/input/results trees or the GitHub workspace.
-readonly -a AGENT_BWRAP=(
-  "$BWRAP"
-  --die-with-parent
-  --new-session
-  --unshare-all
-  --share-net
-  --unshare-user
-  --disable-userns
-  --cap-drop ALL
-  --tmpfs /
-  --proc /proc
-  --dev /dev
-  --tmpfs /run
-  --dir /opt
-  --dir /opt/pack-evaluator
-  --ro-bind /opt/pack-evaluator/runtime /opt/pack-evaluator/runtime
-  --dir /opt/pack-evaluator/codex-home
-  --bind /opt/pack-evaluator/codex-home /opt/pack-evaluator/codex-home
-  --dir /usr
-  --ro-bind /usr /usr
-  --symlink usr/bin /bin
-  --symlink usr/lib /lib
-  --symlink usr/lib64 /lib64
-  --dir /etc
-  --ro-bind /etc/ssl /etc/ssl
-  --ro-bind /etc/ca-certificates /etc/ca-certificates
-  --ro-bind /etc/resolv.conf /etc/resolv.conf
-  --ro-bind /etc/hosts /etc/hosts
-  --ro-bind /etc/nsswitch.conf /etc/nsswitch.conf
-  --ro-bind /etc/passwd /etc/passwd
-  --ro-bind /etc/group /etc/group
-  --dir /home
-  --dir /home/packeval
-  --bind /home/packeval /home/packeval
-  --dir /tmp
-  --bind /home/packeval/tmp /tmp
-  --setenv HOME /home/packeval
-  --setenv CODEX_HOME /opt/pack-evaluator/codex-home
-  --setenv TMPDIR /tmp
-  --setenv PATH /opt/pack-evaluator/runtime/bin:/usr/bin:/bin
-  --setenv CI true
-  --setenv NO_COLOR 1
-  --setenv NO_PROXY 127.0.0.1,localhost
-  --chdir /home/packeval
-)
+readonly PREFLIGHT_TIMEOUT_SECONDS=420
+readonly AGENT_TIMEOUT_MS=180000
+readonly NODE=/opt/pack-evaluator/bin/node
+readonly CLI=/opt/pack-evaluator/bin/skillstore-cli
+readonly ORCHESTRATOR=/opt/pack-evaluator/lib/pack-production.mjs
+readonly RUNTIME_ROOT=/opt/pack-evaluator/generations
+readonly PREFLIGHT_GENERATION_ID=00000000-0000-4000-8000-000000000001
+readonly PREFLIGHT_ROOT=/home/packeval/tmp/skillstore-executor-preflight
+readonly PREFLIGHT_SKILL_A="$PREFLIGHT_ROOT/input/skill-a"
+readonly PREFLIGHT_SKILL_B="$PREFLIGHT_ROOT/input/skill-b"
+readonly PREFLIGHT_RAW="$PREFLIGHT_ROOT/raw"
+readonly PREFLIGHT_TASK='Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second. After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.'
+readonly CLI_STDOUT="$(mktemp)"
+readonly CLI_STDERR="$(mktemp)"
+readonly ACTIVITY_SLICE="$(mktemp)"
 
-CLAUDE_STDOUT=$(mktemp)
-CLAUDE_STDERR=$(mktemp)
-CODEX_STDOUT=$(mktemp)
-CODEX_STDERR=$(mktemp)
+for executable in "$NODE" "$CLI" /usr/bin/bwrap /usr/bin/jq /usr/bin/prlimit /usr/bin/setsid /usr/bin/sha256sum; do
+  [ -x "$executable" ] || { echo "Required evaluator executable is missing: $executable" >&2; exit 1; }
+done
+[ -r "$ORCHESTRATOR" ] || { echo 'Pack production orchestrator is missing' >&2; exit 1; }
+
 cleanup_files() {
-  rm -f "$CLAUDE_STDOUT" "$CLAUDE_STDERR" "$CODEX_STDOUT" "$CODEX_STDERR"
+  rm -f \
+    "$CLI_STDOUT" \
+    "$CLI_STDERR" \
+    "$ACTIVITY_SLICE" \
+    "${PREFLIGHT_SKILL_MD_A:-}" \
+    "${PREFLIGHT_SKILL_MD_B:-}"
+  sudo rm -rf "$PREFLIGHT_ROOT"
+  sudo rm -rf "$RUNTIME_ROOT/$PREFLIGHT_GENERATION_ID"
 }
 trap cleanup_files EXIT
 
-classify_error() {
-  local stdout_file="$1"
-  local stderr_file="$2"
-  local outcome="$3"
-  local exit_code="$4"
-  local fatal_http_status="${5:-}"
-  local retryable_http_status="${6:-}"
-  if [ "$outcome" = "passed" ]; then
-    printf 'none\n'
-  elif [ -n "$fatal_http_status" ]; then
-    printf 'deterministic_http\n'
-  elif [ -n "$retryable_http_status" ]; then
-    printf 'retryable_http\n'
-  elif grep -Eqi 'permission denied|read-only file system|unable to open.*database|failed to.*(state|log|session)' \
-    "$stdout_file" "$stderr_file"; then
-    printf 'state_storage\n'
-  elif grep -Eqi '401|403|unauthoriz|authentication|api key|not logged in|please run /login' \
-    "$stdout_file" "$stderr_file"; then
-    printf 'authentication\n'
-  elif grep -Eqi '404|model.*not found|unsupported model' "$stdout_file" "$stderr_file"; then
-    printf 'model_route\n'
-  elif grep -Eqi 'unknown argument|unexpected argument|usage:' "$stdout_file" "$stderr_file"; then
-    printf 'cli_arguments\n'
-  elif [ "$exit_code" -eq 124 ] || grep -Eqi 'timed out|timeout' "$stdout_file" "$stderr_file"; then
-    printf 'timeout\n'
-  elif grep -Eqi 'error sending request|failed to send request|connection (reset|refused|closed|aborted)|transport.*(closed|error)|unexpected (eof|end of file)|temporary failure in name resolution|dns.*temporary|tls.*(handshake|temporary)|http[^0-9]*(408|429|502|503|504)|status( code)?[^0-9]*(408|429|502|503|504)' \
-    "$stdout_file" "$stderr_file"; then
-    printf 'upstream_transport\n'
-  elif [ -s "$stdout_file" ] || [ -s "$stderr_file" ] || [ "$exit_code" -ne 0 ]; then
-    printf 'unknown\n'
-  else
-    printf 'none\n'
-  fi
-}
-
-# A preflight is read-only, isolated, and capped at two attempts. Only an exact
-# 408/425/429/5xx response receives one retry. Every other 4xx and failures with
-# no exact upstream status fail closed on the first attempt.
-should_retry_preflight() {
-  local outcome="$1"
-  local error_class="$2"
-  local attempt="$3"
-  if [ "$outcome" != "command_failed" ] || [ "$attempt" -ge 2 ]; then
+cleanup_processes() {
+  local probe_rc
+  sudo pkill -TERM -u packeval 2>/dev/null || true
+  for _ in $(seq 1 10); do
+    if ! sudo pgrep -u packeval >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+  sudo pkill -KILL -u packeval 2>/dev/null || true
+  sleep 0.1
+  if sudo pgrep -u packeval >/dev/null 2>&1; then
     return 1
+  else
+    probe_rc=$?
+    if [ "$probe_rc" -ne 1 ]; then
+      return 2
+    fi
   fi
-  case "$error_class" in
-    retryable_http) return 0 ;;
-    *) return 1 ;;
-  esac
+  return 0
 }
 
 activity_start_line() {
@@ -170,88 +123,327 @@ monitor_preflight_http() {
   done
 }
 
-cleanup_processes() {
-  local probe_rc
-  sudo pkill -TERM -u packeval 2>/dev/null || true
-  for _ in $(seq 1 10); do
-    if ! sudo pgrep -u packeval >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.1
-  done
-  sudo pkill -KILL -u packeval 2>/dev/null || true
-  sleep 0.1
-  if sudo pgrep -u packeval >/dev/null 2>&1; then
-    return 1
-  else
-    probe_rc=$?
-    if [ "$probe_rc" -ne 1 ]; then
-      return 2
-    fi
-  fi
-  return 0
+should_retry_preflight() {
+  local outcome="$1"
+  local error_class="$2"
+  local attempt="$3"
+  [ "$outcome" = 'command_failed' ] && \
+    [ "$error_class" = 'retryable_http' ] && \
+    [ "$attempt" -lt 2 ]
 }
 
-CLAUDE_OUTCOME=not_run
-CLAUDE_ERROR_CLASS=none
-CLAUDE_ATTEMPTS='[]'
+safe_execution_evidence() {
+  local source="$1"
+  jq -c '
+    def sha: type == "string" and test("^[0-9a-f]{64}$");
+    def category: . as $value |
+      [
+        "none", "spawn_spec", "spawn_error", "timeout", "signal",
+        "sandbox_runtime", "state_storage", "authentication", "model_route",
+        "cli_arguments", "upstream_transport", "trace_protocol",
+        "nonzero_exit", "empty_output"
+      ] | index($value) != null;
+    def spawn_code: . as $value |
+      $value == null or (["EACCES", "EAGAIN", "EMFILE", "ENFILE", "ENOENT", "ENOMEM", "EPERM", "OTHER"] | index($value) != null);
+    [
+      .agentExecutionEvidence[]?
+      | select(.phase == "run" or .phase == "judge")
+      | select(.run == 1 and (.succeeded | type) == "boolean")
+      | {
+          phase,
+          run,
+          succeeded,
+          attempts: [
+            .attempts[]?
+            | select(.schemaVersion == "skillstore.agent-execution-evidence/v1")
+            | select(.agent == "claude" or .agent == "codex" or .agent == "gemini")
+            | select((.attempt | type) == "number" and .attempt >= 1 and .attempt <= 3)
+            | select((.sandboxed | type) == "boolean")
+            | select(.outcome == "succeeded" or .outcome == "failed")
+            | select(.failureCategory | category)
+            | select(.spawnErrorCode | spawn_code)
+            | select(.exitCode == null or ((.exitCode | type) == "number" and .exitCode >= 0 and .exitCode <= 255))
+            | select(.signal == null or ((.signal | type) == "string" and (.signal | test("^SIG[A-Z0-9]{1,12}$"))))
+            | select((.durationMs | type) == "number" and .durationMs >= 0 and .durationMs <= 420000)
+            | select((.stdoutBytes | type) == "number" and .stdoutBytes >= 0 and .stdoutBytes <= 67108864)
+            | select((.stderrBytes | type) == "number" and .stderrBytes >= 0 and .stderrBytes <= 67108864)
+            | select(.stdoutSha256 | sha)
+            | select(.stderrSha256 | sha)
+            | {
+                schemaVersion,
+                agent,
+                attempt,
+                sandboxed,
+                outcome,
+                failureCategory,
+                spawnErrorCode,
+                exitCode,
+                signal,
+                durationMs,
+                stdoutBytes,
+                stderrBytes,
+                stdoutSha256,
+                stderrSha256
+              }
+          ]
+        }
+    ][0:8]
+  ' "$source" 2>/dev/null || printf '[]'
+}
+
+safe_runner_trace_evidence() {
+  local source="$1"
+  jq -c '
+    .runnerTraceEvidence as $trace
+    | if (
+        ($trace | type) == "object"
+        and $trace.schemaVersion == "marketplace.pack-executor-trace-evidence/v1"
+        and $trace.deterministic == true
+        and $trace.traceCount == 1
+        and $trace.eventCount == 2
+        and ($trace.bindingDigest | type) == "string"
+        and ($trace.bindingDigest | test("^[0-9a-f]{64}$"))
+      ) then $trace | {
+        schemaVersion,
+        deterministic,
+        traceCount,
+        eventCount,
+        bindingDigest
+      } else null end
+  ' "$source" 2>/dev/null || printf 'null\n'
+}
+
+safe_outer_execution() {
+  local source="$1"
+  jq -c '
+    .outerExecution as $outer
+    | if (
+        ($outer | type) == "object" and
+        ($outer.spawnErrorCode == null or (["EACCES", "EAGAIN", "EMFILE", "ENFILE", "ENOENT", "ENOMEM", "EPERM", "OTHER"] | index($outer.spawnErrorCode) != null)) and
+        ($outer.exitCode == null or (($outer.exitCode | type) == "number" and $outer.exitCode >= 0 and $outer.exitCode <= 255)) and
+        ($outer.signal == null or (($outer.signal | type) == "string" and ($outer.signal | test("^SIG[A-Z0-9]{1,12}$")))) and
+        (($outer.timedOut | type) == "boolean") and (($outer.stalled | type) == "boolean") and
+        (($outer.outputExceeded | type) == "boolean") and
+        (($outer.durationMs | type) == "number" and $outer.durationMs >= 0 and $outer.durationMs <= 430000) and
+        (($outer.stdoutBytes | type) == "number" and $outer.stdoutBytes >= 0 and $outer.stdoutBytes <= 16777216) and
+        (($outer.stderrBytes | type) == "number" and $outer.stderrBytes >= 0 and $outer.stderrBytes <= 16777216) and
+        (($outer.stdoutSha256 | type) == "string" and ($outer.stdoutSha256 | test("^[0-9a-f]{64}$"))) and
+        (($outer.stderrSha256 | type) == "string" and ($outer.stderrSha256 | test("^[0-9a-f]{64}$")))
+      ) then $outer | {
+        spawnErrorCode, exitCode, signal, timedOut, stalled, outputExceeded,
+        durationMs, stdoutBytes, stderrBytes, stdoutSha256, stderrSha256
+      } else {} end
+  ' "$source" 2>/dev/null || printf '{}\n'
+}
+
+append_command_attempt() {
+  local history="$1"
+  local record="$2"
+  jq -ce --argjson record "$record" '
+    if length >= 2 then error("preflight command attempt budget exceeded")
+    elif (
+      ($record.attempt | type) == "number" and $record.attempt >= 1 and $record.attempt <= 2
+      and ($record.outcome == "passed" or $record.outcome == "command_failed")
+      and ($record.errorClass | type) == "string" and ($record.errorClass | length) <= 64
+      and ($record.exitCode | type) == "number" and $record.exitCode >= 0 and $record.exitCode <= 255
+      and ($record.durationMs | type) == "number" and $record.durationMs >= 0 and $record.durationMs <= 430000
+      and ($record.stdoutBytes | type) == "number" and $record.stdoutBytes >= 0 and $record.stdoutBytes <= 16777216
+      and ($record.stderrBytes | type) == "number" and $record.stderrBytes >= 0 and $record.stderrBytes <= 16777216
+      and ($record.stdoutSha256 | type) == "string" and ($record.stdoutSha256 | test("^[0-9a-f]{64}$"))
+      and ($record.stderrSha256 | type) == "string" and ($record.stderrSha256 | test("^[0-9a-f]{64}$"))
+      and ($record.outerExecution | type) == "object"
+      and ($record.agentExecutionEvidence | type) == "array"
+      and ($record.agentExecutionEvidence | length) <= 8
+      and ($record.runnerTraceEvidence == null or ($record.runnerTraceEvidence | type) == "object")
+    ) then . + [{
+      attempt: $record.attempt,
+      outcome: $record.outcome,
+      errorClass: $record.errorClass,
+      exitCode: $record.exitCode,
+      durationMs: $record.durationMs,
+      stdoutBytes: $record.stdoutBytes,
+      stderrBytes: $record.stderrBytes,
+      stdoutSha256: $record.stdoutSha256,
+      stderrSha256: $record.stderrSha256,
+      outerExecution: $record.outerExecution,
+      agentExecutionEvidence: $record.agentExecutionEvidence,
+      runnerTraceEvidence: $record.runnerTraceEvidence
+    }]
+    else error("invalid bounded preflight command attempt")
+    end
+  ' <<< "$history"
+}
+
+mark_recovered_command_attempts() {
+  local history="$1"
+  local final_outcome="$2"
+  jq -ce --arg finalOutcome "$final_outcome" '
+    map(. + {
+      recovered: ($finalOutcome == "passed" and .outcome == "command_failed")
+    })
+  ' <<< "$history"
+}
+
+# The two synthetic Skills are immutable inputs for the exact verifyPack trace
+# path. They have no network/write instructions and live only in disposable HOME.
+sudo rm -rf "$PREFLIGHT_ROOT"
+sudo install -d -o packeval -g packeval -m 0700 "$PREFLIGHT_SKILL_A" "$PREFLIGHT_SKILL_B"
+sudo install -d -o root -g root -m 0700 "$PREFLIGHT_RAW"
+PREFLIGHT_SKILL_MD_A=$(mktemp)
+printf '%s\n' \
+  '---' \
+  'name: pack-executor-preflight-a' \
+  'description: Load first, then follow the evaluator task exactly.' \
+  '---' \
+  '' \
+  'Follow the evaluator task exactly. Do not inspect the host or call external tools.' \
+  > "$PREFLIGHT_SKILL_MD_A"
+PREFLIGHT_SKILL_MD_B=$(mktemp)
+printf '%s\n' \
+  '---' \
+  'name: pack-executor-preflight-b' \
+  'description: Load second, then return the exact marker requested by the evaluator.' \
+  '---' \
+  '' \
+  'Follow the evaluator task exactly. Do not inspect the host or call external tools.' \
+  > "$PREFLIGHT_SKILL_MD_B"
+sudo install -o packeval -g packeval -m 0444 \
+  "$PREFLIGHT_SKILL_MD_A" "$PREFLIGHT_SKILL_A/SKILL.md"
+sudo install -o packeval -g packeval -m 0444 \
+  "$PREFLIGHT_SKILL_MD_B" "$PREFLIGHT_SKILL_B/SKILL.md"
+rm -f "$PREFLIGHT_SKILL_MD_A" "$PREFLIGHT_SKILL_MD_B"
+
+COMMAND_ATTEMPTS='[]'
 RETRY_CLEANUP_OUTCOME=not_needed
+PREFLIGHT_OUTCOME=command_failed
+PREFLIGHT_ERROR_CLASS=unknown
+HTTP_FATAL_STATUS=''
+HTTP_RETRYABLE_STATUS=''
+FINAL_EXECUTION_EVIDENCE='[]'
+FINAL_RUNNER_TRACE_EVIDENCE='null'
+FINAL_OUTER_EXECUTION='{}'
+
 for ATTEMPT in 1 2; do
-  : > "$CLAUDE_STDOUT"
-  : > "$CLAUDE_STDERR"
+  : > "$CLI_STDOUT"
+  : > "$CLI_STDERR"
   STARTED_MS=$(date +%s%3N)
   ACTIVITY_START_LINE=$(activity_start_line)
   set +e
-  printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
-    sudo -u packeval env -i \
-      /usr/bin/timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
-      "${AGENT_BWRAP[@]}" \
-        --setenv ANTHROPIC_BASE_URL http://127.0.0.1:18765 \
-        --setenv ANTHROPIC_AUTH_TOKEN "$PACK_EVALUATOR_PROXY_TOKEN" \
-        --setenv CLAUDE_CODE_MAX_OUTPUT_TOKENS "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
-        /opt/pack-evaluator/runtime/bin/claude \
-        --print \
-        --output-format text \
-        --permission-mode bypassPermissions \
-        --model sonnet \
-        - \
-      > "$CLAUDE_STDOUT" \
-      2> "$CLAUDE_STDERR" &
-  CLAUDE_COMMAND_PID=$!
-  monitor_preflight_http "$CLAUDE_COMMAND_PID" "$ACTIVITY_START_LINE"
-  wait "$CLAUDE_COMMAND_PID"
-  CLAUDE_EXIT_CODE=$?
-  CLAUDE_FATAL_HTTP_STATUS="$HTTP_FATAL_STATUS"
-  CLAUDE_RETRYABLE_HTTP_STATUS="$HTTP_RETRYABLE_STATUS"
+  setsid sudo env -i \
+    PATH=/opt/pack-evaluator/runtime/bin:/usr/bin:/bin \
+    HOME=/home/packeval \
+    CODEX_HOME=/opt/pack-evaluator/codex-home \
+    TMPDIR=/home/packeval/tmp \
+    CI=true \
+    NO_COLOR=1 \
+    SKILLSTORE_AGENTS=codex,claude \
+    SKILLSTORE_AGENT_ENV_MODE=strict \
+    SKILLSTORE_AGENT_ENV_ALLOWLIST=CODEX_HOME,PACK_EVALUATOR_PROXY_TOKEN,PACK_EVALUATOR_CHROMIUM_PATH,ANTHROPIC_BASE_URL,ANTHROPIC_AUTH_TOKEN,CLAUDE_CODE_MAX_OUTPUT_TOKENS,NO_PROXY,SKILLSTORE_AGENT_SANDBOX_MODE,SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT \
+    SKILLSTORE_AGENT_SANDBOX_MODE=bwrap \
+    SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=/opt/pack-evaluator/runtime \
+    PACK_EVALUATOR_CHROMIUM_PATH=/usr/bin/google-chrome \
+    PACK_EVALUATOR_PROXY_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
+    ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
+    ANTHROPIC_AUTH_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
+    CLAUDE_CODE_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
+    NO_PROXY=127.0.0.1,localhost \
+    timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
+    prlimit --nproc=256:256 --as=6442450944:6442450944 -- \
+    "$NODE" "$ORCHESTRATOR" executor-preflight \
+    --cli "$CLI" \
+    --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
+    --skill-a "$PREFLIGHT_SKILL_A" \
+    --skill-b "$PREFLIGHT_SKILL_B" \
+    --results-dir "$PREFLIGHT_RAW" \
+    --evaluator-runtime-root "$RUNTIME_ROOT" \
+    --generation-id "$PREFLIGHT_GENERATION_ID" \
+    --evaluator-uid "$(id -u packeval)" \
+    --evaluator-gid "$(id -g packeval)" \
+    --task "$PREFLIGHT_TASK" \
+    --model sonnet \
+    --judge-model gpt-5.5 \
+    --agent-timeout-ms "$AGENT_TIMEOUT_MS" \
+    --timeout-ms 360000 \
+    --idle-timeout-ms 240000 \
+    --proxy-activity-file "$PACK_EVALUATOR_ACTIVITY_FILE" \
+    > "$CLI_STDOUT" 2> "$CLI_STDERR" &
+  COMMAND_PID=$!
+  monitor_preflight_http "$COMMAND_PID" "$ACTIVITY_START_LINE"
+  wait "$COMMAND_PID"
+  COMMAND_EXIT_CODE=$?
   set -e
-  if [ "$CLAUDE_EXIT_CODE" -ne 0 ]; then
-    CLAUDE_OUTCOME=command_failed
-  elif [ "$(tr -d '\r\n' < "$CLAUDE_STDOUT")" != 'PACK_EVALUATOR_READY' ]; then
-    CLAUDE_OUTCOME=invalid_response
-  else
-    CLAUDE_OUTCOME=passed
-  fi
+
   DURATION_MS=$(( $(date +%s%3N) - STARTED_MS ))
-  STDOUT_BYTES=$(wc -c < "$CLAUDE_STDOUT")
-  STDERR_BYTES=$(wc -c < "$CLAUDE_STDERR")
-  STDOUT_SHA256=$(sha256sum "$CLAUDE_STDOUT" | awk '{print $1}')
-  STDERR_SHA256=$(sha256sum "$CLAUDE_STDERR" | awk '{print $1}')
-  CLAUDE_ERROR_CLASS=$(classify_error \
-    "$CLAUDE_STDOUT" "$CLAUDE_STDERR" "$CLAUDE_OUTCOME" "$CLAUDE_EXIT_CODE" \
-    "$CLAUDE_FATAL_HTTP_STATUS" "$CLAUDE_RETRYABLE_HTTP_STATUS")
-  CLAUDE_ATTEMPTS=$(jq -c \
+  STDOUT_BYTES=$(wc -c < "$CLI_STDOUT")
+  STDERR_BYTES=$(wc -c < "$CLI_STDERR")
+  STDOUT_SHA256=$(sha256sum "$CLI_STDOUT" | awk '{print $1}')
+  STDERR_SHA256=$(sha256sum "$CLI_STDERR" | awk '{print $1}')
+  FINAL_EXECUTION_EVIDENCE=$(safe_execution_evidence "$CLI_STDOUT")
+  FINAL_RUNNER_TRACE_EVIDENCE=$(safe_runner_trace_evidence "$CLI_STDOUT")
+  FINAL_OUTER_EXECUTION=$(safe_outer_execution "$CLI_STDOUT")
+
+  if [ -n "$HTTP_FATAL_STATUS" ]; then
+    PREFLIGHT_ERROR_CLASS=deterministic_http
+  elif [ -n "$HTTP_RETRYABLE_STATUS" ]; then
+    PREFLIGHT_ERROR_CLASS=retryable_http
+  else
+    PREFLIGHT_ERROR_CLASS=$(jq -r '
+      [.[].attempts[]? | select(.outcome == "failed") | .failureCategory] | first // "unknown"
+    ' <<< "$FINAL_EXECUTION_EVIDENCE")
+  fi
+
+  if [ "$COMMAND_EXIT_CODE" -eq 0 ] && jq -e \
+    --argjson projected "$FINAL_EXECUTION_EVIDENCE" '
+    .schemaVersion == "marketplace.pack-executor-preflight/v1" and
+    .mode == "pack-production-node-uid-nested-bwrap" and
+    .outcome == "passed" and
+    .errorClass == "none" and
+    .outerExecution.exitCode == 0 and
+    .outerExecution.signal == null and
+    .outerExecution.timedOut == false and
+    .outerExecution.stalled == false and
+    .outerExecution.outputExceeded == false and
+    .verdictCount == 1 and .errorCount == 0 and
+    .cleanup.outcome == "passed" and
+    .runnerTraceEvidence == $runnerTrace and
+    $runnerTrace.schemaVersion == "marketplace.pack-executor-trace-evidence/v1" and
+    $runnerTrace.deterministic == true and
+    $runnerTrace.traceCount == 1 and
+    $runnerTrace.eventCount == 2 and
+    (.agentExecutionEvidence == $projected) and
+    ($projected | length) == 2 and
+    ($projected[0].phase == "run" and $projected[0].run == 1 and $projected[0].succeeded == true) and
+    ($projected[1].phase == "judge" and $projected[1].run == 1 and $projected[1].succeeded == true) and
+    ($projected[0].attempts | length) == 1 and
+    ($projected[1].attempts | length) == 1 and
+    ($projected[0].attempts[0].agent == "claude") and
+    ($projected[1].attempts[0].agent == "codex") and
+    all($projected[].attempts[];
+      .attempt == 1 and .sandboxed == true and .outcome == "succeeded" and
+      .failureCategory == "none" and .spawnErrorCode == null and
+      .exitCode == 0 and .signal == null
+    )
+  ' --argjson runnerTrace "$FINAL_RUNNER_TRACE_EVIDENCE" "$CLI_STDOUT" >/dev/null 2>&1; then
+    PREFLIGHT_OUTCOME=passed
+    PREFLIGHT_ERROR_CLASS=none
+  else
+    PREFLIGHT_OUTCOME=command_failed
+  fi
+
+  ATTEMPT_RECORD=$(jq -cn \
     --argjson attempt "$ATTEMPT" \
-    --arg outcome "$CLAUDE_OUTCOME" \
-    --arg errorClass "$CLAUDE_ERROR_CLASS" \
-    --argjson exitCode "$CLAUDE_EXIT_CODE" \
+    --arg outcome "$PREFLIGHT_OUTCOME" \
+    --arg errorClass "$PREFLIGHT_ERROR_CLASS" \
+    --argjson exitCode "$COMMAND_EXIT_CODE" \
     --argjson durationMs "$DURATION_MS" \
     --argjson stdoutBytes "$STDOUT_BYTES" \
     --argjson stderrBytes "$STDERR_BYTES" \
     --arg stdoutSha256 "$STDOUT_SHA256" \
     --arg stderrSha256 "$STDERR_SHA256" \
-    --arg fatalHttpStatus "$CLAUDE_FATAL_HTTP_STATUS" \
-    --arg retryableHttpStatus "$CLAUDE_RETRYABLE_HTTP_STATUS" \
-    '. + [{
+    --argjson outerExecution "$FINAL_OUTER_EXECUTION" \
+    --argjson agentExecutionEvidence "$FINAL_EXECUTION_EVIDENCE" \
+    --argjson runnerTraceEvidence "$FINAL_RUNNER_TRACE_EVIDENCE" \
+    '{
       attempt: $attempt,
       outcome: $outcome,
       errorClass: $errorClass,
@@ -261,200 +453,88 @@ for ATTEMPT in 1 2; do
       stderrBytes: $stderrBytes,
       stdoutSha256: $stdoutSha256,
       stderrSha256: $stderrSha256,
-      fatalHttpStatus: (if $fatalHttpStatus == "" then null else ($fatalHttpStatus | tonumber) end),
-      retryableHttpStatus: (if $retryableHttpStatus == "" then null else ($retryableHttpStatus | tonumber) end)
-    }]' <<< "$CLAUDE_ATTEMPTS")
-  if ! should_retry_preflight \
-    "$CLAUDE_OUTCOME" "$CLAUDE_ERROR_CLASS" "$ATTEMPT"; then
+      outerExecution: $outerExecution,
+      agentExecutionEvidence: $agentExecutionEvidence,
+      runnerTraceEvidence: $runnerTraceEvidence
+    }')
+  COMMAND_ATTEMPTS=$(append_command_attempt "$COMMAND_ATTEMPTS" "$ATTEMPT_RECORD")
+
+  if ! should_retry_preflight "$PREFLIGHT_OUTCOME" "$PREFLIGHT_ERROR_CLASS" "$ATTEMPT"; then
     break
   fi
   if cleanup_processes; then
     RETRY_CLEANUP_OUTCOME=passed
   else
     CLEANUP_RC=$?
-    if [ "$CLEANUP_RC" -eq 1 ]; then
-      RETRY_CLEANUP_OUTCOME=failed
-    else
-      RETRY_CLEANUP_OUTCOME=probe_failed
-    fi
+    RETRY_CLEANUP_OUTCOME=$([ "$CLEANUP_RC" -eq 1 ] && printf failed || printf probe_failed)
     break
   fi
   sleep 5
 done
-CODEX_OUTCOME=not_run
-CODEX_ERROR_CLASS=none
-CODEX_EXIT_CODE=-1
-CODEX_ATTEMPTS='[]'
-if [ "$CLAUDE_OUTCOME" = "passed" ]; then
-  # Only an exact 408/425/429/5xx response receives one bounded retry.
-  for ATTEMPT in 1 2; do
-    : > "$CODEX_STDOUT"
-    : > "$CODEX_STDERR"
-    STARTED_MS=$(date +%s%3N)
-    ACTIVITY_START_LINE=$(activity_start_line)
-    set +e
-    printf '%s\n' 'Reply with exactly PACK_EVALUATOR_READY and nothing else.' | \
-      sudo -u packeval env -i \
-        /usr/bin/timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
-        "${AGENT_BWRAP[@]}" \
-          --setenv PACK_EVALUATOR_PROXY_TOKEN "$PACK_EVALUATOR_PROXY_TOKEN" \
-          /opt/pack-evaluator/runtime/bin/codex \
-          exec \
-          --skip-git-repo-check \
-          --sandbox read-only \
-          --cd /home/packeval \
-          --ephemeral \
-          --color never \
-          -m gpt-5.5 \
-          - \
-        > "$CODEX_STDOUT" \
-        2> "$CODEX_STDERR" &
-    CODEX_COMMAND_PID=$!
-    monitor_preflight_http "$CODEX_COMMAND_PID" "$ACTIVITY_START_LINE"
-    wait "$CODEX_COMMAND_PID"
-    CODEX_EXIT_CODE=$?
-    CODEX_FATAL_HTTP_STATUS="$HTTP_FATAL_STATUS"
-    CODEX_RETRYABLE_HTTP_STATUS="$HTTP_RETRYABLE_STATUS"
-    set -e
-    if [ "$CODEX_EXIT_CODE" -ne 0 ]; then
-      CODEX_OUTCOME=command_failed
-    elif [ "$(tr -d '\r\n' < "$CODEX_STDOUT")" != 'PACK_EVALUATOR_READY' ]; then
-      CODEX_OUTCOME=invalid_response
-    else
-      CODEX_OUTCOME=passed
-    fi
-    DURATION_MS=$(( $(date +%s%3N) - STARTED_MS ))
-    STDOUT_BYTES=$(wc -c < "$CODEX_STDOUT")
-    STDERR_BYTES=$(wc -c < "$CODEX_STDERR")
-    STDOUT_SHA256=$(sha256sum "$CODEX_STDOUT" | awk '{print $1}')
-    STDERR_SHA256=$(sha256sum "$CODEX_STDERR" | awk '{print $1}')
-    CODEX_ERROR_CLASS=$(classify_error \
-      "$CODEX_STDOUT" "$CODEX_STDERR" "$CODEX_OUTCOME" "$CODEX_EXIT_CODE" \
-      "$CODEX_FATAL_HTTP_STATUS" "$CODEX_RETRYABLE_HTTP_STATUS")
-    CODEX_ATTEMPTS=$(jq -c \
-      --argjson attempt "$ATTEMPT" \
-      --arg outcome "$CODEX_OUTCOME" \
-      --arg errorClass "$CODEX_ERROR_CLASS" \
-      --argjson exitCode "$CODEX_EXIT_CODE" \
-      --argjson durationMs "$DURATION_MS" \
-      --argjson stdoutBytes "$STDOUT_BYTES" \
-      --argjson stderrBytes "$STDERR_BYTES" \
-      --arg stdoutSha256 "$STDOUT_SHA256" \
-      --arg stderrSha256 "$STDERR_SHA256" \
-      --arg fatalHttpStatus "$CODEX_FATAL_HTTP_STATUS" \
-      --arg retryableHttpStatus "$CODEX_RETRYABLE_HTTP_STATUS" \
-      '. + [{
-        attempt: $attempt,
-        outcome: $outcome,
-        errorClass: $errorClass,
-        exitCode: $exitCode,
-        durationMs: $durationMs,
-        stdoutBytes: $stdoutBytes,
-        stderrBytes: $stderrBytes,
-        stdoutSha256: $stdoutSha256,
-        stderrSha256: $stderrSha256,
-        fatalHttpStatus: (if $fatalHttpStatus == "" then null else ($fatalHttpStatus | tonumber) end),
-        retryableHttpStatus: (if $retryableHttpStatus == "" then null else ($retryableHttpStatus | tonumber) end)
-      }]' <<< "$CODEX_ATTEMPTS")
-    if ! should_retry_preflight \
-      "$CODEX_OUTCOME" "$CODEX_ERROR_CLASS" "$ATTEMPT"; then
-      break
-    fi
-    if cleanup_processes; then
-      RETRY_CLEANUP_OUTCOME=passed
-    else
-      CLEANUP_RC=$?
-      if [ "$CLEANUP_RC" -eq 1 ]; then
-        RETRY_CLEANUP_OUTCOME=failed
-      else
-        RETRY_CLEANUP_OUTCOME=probe_failed
-      fi
-      break
-    fi
-    sleep 5
-  done
-fi
 
-CLAUDE_STDOUT_BYTES=$(wc -c < "$CLAUDE_STDOUT")
-CLAUDE_STDERR_BYTES=$(wc -c < "$CLAUDE_STDERR")
-CLAUDE_STDOUT_SHA256=$(sha256sum "$CLAUDE_STDOUT" | awk '{print $1}')
-CLAUDE_STDERR_SHA256=$(sha256sum "$CLAUDE_STDERR" | awk '{print $1}')
-CODEX_STDOUT_BYTES=$(wc -c < "$CODEX_STDOUT")
-CODEX_STDERR_BYTES=$(wc -c < "$CODEX_STDERR")
-CODEX_STDOUT_SHA256=$(sha256sum "$CODEX_STDOUT" | awk '{print $1}')
-CODEX_STDERR_SHA256=$(sha256sum "$CODEX_STDERR" | awk '{print $1}')
+COMMAND_ATTEMPTS=$(mark_recovered_command_attempts "$COMMAND_ATTEMPTS" "$PREFLIGHT_OUTCOME")
 
 if cleanup_processes; then
   CLEANUP_OUTCOME=passed
 else
   CLEANUP_RC=$?
-  if [ "$CLEANUP_RC" -eq 1 ]; then
-    CLEANUP_OUTCOME=failed
-  else
-    CLEANUP_OUTCOME=probe_failed
-  fi
+  CLEANUP_OUTCOME=$([ "$CLEANUP_RC" -eq 1 ] && printf failed || printf probe_failed)
 fi
 
+if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
+  sudo tail -n "+$ACTIVITY_START_LINE" "$PACK_EVALUATOR_ACTIVITY_FILE" > "$ACTIVITY_SLICE" 2>/dev/null || true
+fi
+HTTP_EVIDENCE=$(jq -cs '
+  {
+    messages200: ([.[] | select(.phase == "response" and .path == "/v1/messages" and .status == 200)] | length),
+    responses200: ([.[] | select(.phase == "response" and .path == "/v1/responses" and .status == 200)] | length),
+    fatalStatus: ([.[] | select(.phase == "response" and (.status | type) == "number" and .status >= 400 and .status < 500 and .status != 408 and .status != 425 and .status != 429) | .status] | first // null),
+    retryableStatus: ([.[] | select(.phase == "response" and ((.status == 408) or (.status == 425) or (.status == 429) or (.status >= 500))) | .status] | last // null)
+  }
+' "$ACTIVITY_SLICE" 2>/dev/null || printf '{"messages200":0,"responses200":0,"fatalStatus":null,"retryableStatus":null}')
+
 jq -n \
-  --arg claudeOutcome "$CLAUDE_OUTCOME" \
-  --argjson claudeStdoutBytes "$CLAUDE_STDOUT_BYTES" \
-  --argjson claudeStderrBytes "$CLAUDE_STDERR_BYTES" \
-  --arg claudeStdoutSha256 "$CLAUDE_STDOUT_SHA256" \
-  --arg claudeStderrSha256 "$CLAUDE_STDERR_SHA256" \
-  --arg claudeErrorClass "$CLAUDE_ERROR_CLASS" \
-  --argjson claudeExitCode "$CLAUDE_EXIT_CODE" \
-  --argjson claudeAttempts "$CLAUDE_ATTEMPTS" \
-  --arg codexOutcome "$CODEX_OUTCOME" \
-  --argjson codexStdoutBytes "$CODEX_STDOUT_BYTES" \
-  --argjson codexStderrBytes "$CODEX_STDERR_BYTES" \
-  --arg codexStdoutSha256 "$CODEX_STDOUT_SHA256" \
-  --arg codexStderrSha256 "$CODEX_STDERR_SHA256" \
-  --arg codexErrorClass "$CODEX_ERROR_CLASS" \
-  --argjson codexExitCode "$CODEX_EXIT_CODE" \
-  --argjson codexAttempts "$CODEX_ATTEMPTS" \
+  --arg outcome "$PREFLIGHT_OUTCOME" \
+  --arg errorClass "$PREFLIGHT_ERROR_CLASS" \
+  --argjson commandAttempts "$COMMAND_ATTEMPTS" \
+  --argjson executionEvidence "$FINAL_EXECUTION_EVIDENCE" \
+  --argjson runnerTraceEvidence "$FINAL_RUNNER_TRACE_EVIDENCE" \
+  --argjson outerExecution "$FINAL_OUTER_EXECUTION" \
+  --argjson http "$HTTP_EVIDENCE" \
   --arg cleanupOutcome "$CLEANUP_OUTCOME" \
   --arg retryCleanupOutcome "$RETRY_CLEANUP_OUTCOME" \
+  --arg marketplaceCommitSha "$PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA" \
+  --arg cliVersion "$PACK_PRODUCTION_CLI_VERSION" \
+  --arg cliSha256 "$PACK_EVALUATOR_CLI_SHA256" \
   '{
-    claude: {
-      outcome: $claudeOutcome,
-      stdoutBytes: $claudeStdoutBytes,
-      stderrBytes: $claudeStderrBytes,
-      stdoutSha256: $claudeStdoutSha256,
-      stderrSha256: $claudeStderrSha256,
-      errorClass: $claudeErrorClass,
-      exitCode: $claudeExitCode,
-      attempts: $claudeAttempts
-    },
-    codex: {
-      outcome: $codexOutcome,
-      stdoutBytes: $codexStdoutBytes,
-      stderrBytes: $codexStderrBytes,
-      stdoutSha256: $codexStdoutSha256,
-      stderrSha256: $codexStderrSha256,
-      errorClass: $codexErrorClass,
-      exitCode: $codexExitCode,
-      attempts: $codexAttempts
-    },
-    cleanup: {
-      outcome: $cleanupOutcome,
-      retryOutcome: $retryCleanupOutcome
+    schemaVersion: "marketplace.pack-executor-preflight/v1",
+    mode: "pack-production-node-uid-nested-bwrap",
+    outcome: $outcome,
+    errorClass: $errorClass,
+    commandAttempts: $commandAttempts,
+    outerExecution: $outerExecution,
+    agentExecutionEvidence: $executionEvidence,
+    runnerTraceEvidence: $runnerTraceEvidence,
+    http: $http,
+    cleanup: { outcome: $cleanupOutcome, retryOutcome: $retryCleanupOutcome },
+    proofBinding: {
+      marketplaceCommitSha: $marketplaceCommitSha,
+      cliVersion: $cliVersion,
+      cliSha256: $cliSha256
     }
   }' > "$PACK_DIAGNOSTICS_DIR/agent-preflight-diagnostics.json"
 
-if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && \
-   sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
-  sudo cp "$PACK_EVALUATOR_ACTIVITY_FILE" \
-    "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
-  sudo chown "$(id -u):$(id -g)" \
-    "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
+if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
+  sudo cp "$PACK_EVALUATOR_ACTIVITY_FILE" "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
+  sudo chown "$(id -u):$(id -g)" "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
   chmod 0600 "$PACK_DIAGNOSTICS_DIR/proxy-activity.ndjson"
 fi
 
-if [ "$CLAUDE_OUTCOME" != "passed" ] || \
-   [ "$CODEX_OUTCOME" != "passed" ] || \
-   [ "$CLEANUP_OUTCOME" != "passed" ] || \
-   { [ "$RETRY_CLEANUP_OUTCOME" != "not_needed" ] && \
-     [ "$RETRY_CLEANUP_OUTCOME" != "passed" ]; }; then
-  echo "::error::Pack evaluator model preflight failed: claude=$CLAUDE_OUTCOME codex=$CODEX_OUTCOME cleanup=$CLEANUP_OUTCOME retry_cleanup=$RETRY_CLEANUP_OUTCOME"
+if [ "$PREFLIGHT_OUTCOME" != passed ] || \
+   [ "$CLEANUP_OUTCOME" != passed ] || \
+   { [ "$RETRY_CLEANUP_OUTCOME" != not_needed ] && [ "$RETRY_CLEANUP_OUTCOME" != passed ]; } || \
+   [ "$(jq -r '.messages200' <<< "$HTTP_EVIDENCE")" -lt 1 ] || \
+   [ "$(jq -r '.responses200' <<< "$HTTP_EVIDENCE")" -lt 1 ]; then
+  echo "::error::Pack evaluator same-path preflight failed: outcome=$PREFLIGHT_OUTCOME class=$PREFLIGHT_ERROR_CLASS cleanup=$CLEANUP_OUTCOME retry_cleanup=$RETRY_CLEANUP_OUTCOME"
   exit 1
 fi

--- a/scripts/pack-evaluator-proxy.mjs
+++ b/scripts/pack-evaluator-proxy.mjs
@@ -29,6 +29,7 @@ const STRIPPED_HEADERS = new Set([
 ]);
 const MAX_BODY_BYTES = 32 * 1024 * 1024;
 const MAX_ERROR_DIAGNOSTIC_BYTES = 64 * 1024;
+const MAX_AUTH_REJECTION_DIAGNOSTICS = 8;
 const TRACE_HEADERS = [
   'cf-ray',
   'request-id',
@@ -282,6 +283,7 @@ export function createPackEvaluatorProxy({
   let requestsStarted = 0;
   let activityRequestSequence = 0;
   let activeRequests = 0;
+  let authRejectionDiagnostics = 0;
   let circuitFailure = null;
   const recordActivity = (activity) => {
     try {
@@ -298,6 +300,17 @@ export function createPackEvaluatorProxy({
   return createServer(async (request, response) => {
     try {
       if (!sameToken(requestToken(request), localToken)) {
+        if (authRejectionDiagnostics < MAX_AUTH_REJECTION_DIAGNOSTICS) {
+          const rejectedPath = new URL(request.url || '/', 'http://127.0.0.1').pathname;
+          recordActivity({
+            phase: 'response',
+            requestNumber: ++activityRequestSequence,
+            path: ALLOWED_PATHS.has(rejectedPath) ? rejectedPath : 'not_allowed',
+            status: 401,
+            errorCategory: 'authentication_failed',
+          });
+          authRejectionDiagnostics += 1;
+        }
         json(response, 401, { error: 'invalid local proxy token' });
         return;
       }

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -17,6 +17,7 @@ const INFRASTRUCTURE_FAILURE_SCHEMA = 'marketplace.pack-production-infrastructur
 const CLI_EVIDENCE_SCHEMA = 'marketplace.pack-production-cli-evidence/v1';
 const CLI_ERROR_DIGESTS_PER_CATEGORY = 16;
 const CLI_ERROR_DIGESTS_TOTAL = 64;
+const CLI_AGENT_FAILURE_EVIDENCE_LIMIT = 64;
 const CLI_ERROR_ITEMS_PER_ARRAY = 256;
 const CLI_ERROR_ITEM_LIMIT_BYTES = 4096;
 const CANDIDATE_TECHNICAL_ERROR_CODES = Object.freeze({
@@ -31,6 +32,8 @@ const KNOWN_CLI_EXIT = new Map([
   ['infrastructure_failed', 30],
 ]);
 const EVALUATOR_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024;
+const EXECUTOR_PREFLIGHT_CLI_SCHEMA = 'skillstore.pack-executor-preflight/v1';
+const EXECUTOR_PREFLIGHT_TRACE_SCHEMA = 'marketplace.pack-executor-trace-evidence/v1';
 const EXPECTED_REPOSITORY = 'aiskillstore/marketplace';
 const EXPECTED_WORKFLOW = 'Generate Pack';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -1238,6 +1241,153 @@ function collectErrorStrings(value, captureRoot = false, result = [], path = 'CL
   return result;
 }
 
+const AGENT_FAILURE_CATEGORIES = new Set([
+  'none',
+  'spawn_spec',
+  'spawn_error',
+  'timeout',
+  'signal',
+  'sandbox_runtime',
+  'state_storage',
+  'authentication',
+  'model_route',
+  'cli_arguments',
+  'upstream_transport',
+  'trace_protocol',
+  'nonzero_exit',
+  'empty_output',
+]);
+const AGENT_SPAWN_ERROR_CODES = new Set([
+  'EACCES', 'EAGAIN', 'EMFILE', 'ENFILE', 'ENOENT', 'ENOMEM', 'EPERM', 'OTHER',
+]);
+
+function boundedAgentExecutionAttempt(value, path) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${path} must be an Agent execution evidence object`);
+  }
+  if (
+    value.schemaVersion !== 'skillstore.agent-execution-evidence/v1'
+    || !['claude', 'codex', 'gemini'].includes(value.agent)
+    || !Number.isSafeInteger(value.attempt) || value.attempt < 1 || value.attempt > 3
+    || typeof value.sandboxed !== 'boolean'
+    || !['succeeded', 'failed'].includes(value.outcome)
+    || !AGENT_FAILURE_CATEGORIES.has(value.failureCategory)
+    || (value.spawnErrorCode !== null && !AGENT_SPAWN_ERROR_CODES.has(value.spawnErrorCode))
+    || (value.exitCode !== null && (!Number.isSafeInteger(value.exitCode) || value.exitCode < 0 || value.exitCode > 255))
+    || (value.signal !== null && (typeof value.signal !== 'string' || !/^SIG[A-Z0-9]{1,12}$/.test(value.signal)))
+    || !Number.isSafeInteger(value.durationMs) || value.durationMs < 0 || value.durationMs > 1_200_000
+    || !Number.isSafeInteger(value.stdoutBytes) || value.stdoutBytes < 0 || value.stdoutBytes > EVALUATOR_OUTPUT_LIMIT_BYTES
+    || !Number.isSafeInteger(value.stderrBytes) || value.stderrBytes < 0 || value.stderrBytes > EVALUATOR_OUTPUT_LIMIT_BYTES
+    || typeof value.stdoutSha256 !== 'string' || !/^[0-9a-f]{64}$/.test(value.stdoutSha256)
+    || typeof value.stderrSha256 !== 'string' || !/^[0-9a-f]{64}$/.test(value.stderrSha256)
+  ) {
+    fail(`${path} is not bounded Agent execution evidence`);
+  }
+  return {
+    agent: value.agent,
+    attempt: value.attempt,
+    sandboxed: value.sandboxed,
+    outcome: value.outcome,
+    failureCategory: value.failureCategory,
+    spawnErrorCode: value.spawnErrorCode,
+    exitCode: value.exitCode,
+    signal: value.signal,
+    durationMs: value.durationMs,
+    stdoutBytes: value.stdoutBytes,
+    stderrBytes: value.stderrBytes,
+    stdoutSha256: value.stdoutSha256,
+    stderrSha256: value.stderrSha256,
+  };
+}
+
+function collectAgentExecutionInvocations(value, result = [], path = 'CLI report') {
+  const stack = [{ value, path, depth: 0 }];
+  let visitedNodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    visitedNodes += 1;
+    if (visitedNodes > 250_000) fail('CLI report exceeds the Agent evidence traversal node budget');
+    if (current.depth > 32) fail('CLI report exceeds the Agent evidence traversal depth budget');
+    if (Array.isArray(current.value)) {
+      if (current.value.length > 10_000) fail(`${current.path} exceeds the traversal container budget`);
+      for (let index = current.value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          value: current.value[index],
+          path: `${current.path}[${index}]`,
+          depth: current.depth + 1,
+        });
+      }
+      continue;
+    }
+    if (!current.value || typeof current.value !== 'object') continue;
+    const entries = Object.entries(current.value);
+    if (entries.length > 512) fail(`${current.path} exceeds the traversal object-key budget`);
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const [key, item] = entries[index];
+      if (key !== 'agentExecutionEvidence') {
+        stack.push({
+          value: item,
+          path: `${current.path}.${key}`,
+          depth: current.depth + 1,
+        });
+        continue;
+      }
+      const evidencePath = `${current.path}.${key}`;
+      if (!Array.isArray(item) || item.length > 20) {
+        fail(`${evidencePath} must be a bounded Agent invocation array`);
+      }
+      item.forEach((invocation, invocationIndex) => {
+        const invocationPath = `${evidencePath}[${invocationIndex}]`;
+        if (
+          !invocation || typeof invocation !== 'object' || Array.isArray(invocation)
+          || !['run', 'judge'].includes(invocation.phase)
+          || !Number.isSafeInteger(invocation.run) || invocation.run < 1 || invocation.run > 10
+          || typeof invocation.succeeded !== 'boolean'
+          || !Array.isArray(invocation.attempts) || invocation.attempts.length > 9
+        ) {
+          fail(`${invocationPath} must be bounded Agent invocation evidence`);
+        }
+        result.push({
+          phase: invocation.phase,
+          run: invocation.run,
+          succeeded: invocation.succeeded,
+          attempts: invocation.attempts.map((attempt, attemptIndex) =>
+            boundedAgentExecutionAttempt(attempt, `${invocationPath}.attempts[${attemptIndex}]`)
+          ),
+        });
+        if (result.length > 512) fail('CLI report exceeds the bounded Agent invocation count');
+      });
+    }
+  }
+  return result;
+}
+
+function safeAgentExecutionEvidence(raw) {
+  const invocations = collectAgentExecutionInvocations(raw);
+  const failedInvocations = invocations.filter((invocation) => !invocation.succeeded);
+  const failedAttempts = invocations.flatMap((invocation) =>
+    invocation.attempts
+      .filter((attempt) => attempt.outcome === 'failed')
+      .map((attempt) => ({
+        phase: invocation.phase,
+        run: invocation.run,
+        recovered: invocation.succeeded,
+        ...attempt,
+      }))
+  );
+  return {
+    schemaVersion: 'marketplace.pack-production-agent-execution-evidence/v1',
+    invocations: invocations.length,
+    attempts: invocations.reduce((count, invocation) => count + invocation.attempts.length, 0),
+    failedInvocations: failedInvocations.length,
+    failedAttempts: failedAttempts.length,
+    recoveredFailedAttempts: failedAttempts.filter((attempt) => attempt.recovered).length,
+    capturedFailures: Math.min(failedAttempts.length, CLI_AGENT_FAILURE_EVIDENCE_LIMIT),
+    truncated: failedAttempts.length > CLI_AGENT_FAILURE_EVIDENCE_LIMIT,
+    failures: failedAttempts.slice(0, CLI_AGENT_FAILURE_EVIDENCE_LIMIT),
+  };
+}
+
 function isoInstant(value, name) {
   if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
     fail(`${name} is not a canonical UTC instant`);
@@ -1309,6 +1459,7 @@ export function buildSafeCliEvidence(raw, context) {
       errorDigestsTruncated: capturedErrorDigests < totalErrors,
     },
     errorEvidence: categories,
+    agentExecutionEvidence: safeAgentExecutionEvidence(raw),
     infrastructureFailure: safeInfrastructureEvidence(raw.infrastructureFailure),
   };
 }
@@ -1351,6 +1502,17 @@ export function buildInfrastructureApiEvaluation({
       errorDigestsTruncated: false,
     },
     errorEvidence: [],
+    agentExecutionEvidence: {
+      schemaVersion: 'marketplace.pack-production-agent-execution-evidence/v1',
+      invocations: 0,
+      attempts: 0,
+      failedInvocations: 0,
+      failedAttempts: 0,
+      recoveredFailedAttempts: 0,
+      capturedFailures: 0,
+      truncated: false,
+      failures: [],
+    },
     infrastructureFailure: safeInfrastructureEvidence(normalizedFailure),
   };
   const unsigned = {
@@ -1656,6 +1818,263 @@ export function validateImmutableProductionPlan(plan, args) {
     || binding.scenarioId !== scenario.id
   ) fail('Immutable plan workflow binding differs from this workflow invocation');
   return scenario;
+}
+
+function safeSpawnErrorCode(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return AGENT_SPAWN_ERROR_CODES.has(value) ? value : 'OTHER';
+}
+
+export function projectExecutorPreflightEvidence(raw) {
+  return collectAgentExecutionInvocations(raw).map((invocation) => ({
+    ...invocation,
+    attempts: invocation.attempts.map((attempt) => ({
+      schemaVersion: 'skillstore.agent-execution-evidence/v1',
+      ...attempt,
+    })),
+  }));
+}
+
+function exactExecutorPreflightTraceEvidence(raw, expectedBindings) {
+  if (
+    raw?.schemaVersion !== EXECUTOR_PREFLIGHT_CLI_SCHEMA
+    || raw.outcome !== 'passed'
+    || canonicalJson(raw.bindings) !== canonicalJson(expectedBindings)
+    || raw.verification?.passed !== true
+    || raw.verification?.runs !== 1
+    || raw.verification?.verdictCount !== 1
+    || raw.verification?.errorCount !== 0
+    || raw.verification?.usedSkill !== true
+    || canonicalJson(raw.verification?.usedSkills) !== canonicalJson(
+      expectedBindings.map((binding) => binding.canonicalId)
+    )
+    || raw.verification?.taskCompleted !== true
+    || raw.verification?.envBlocked !== false
+    || !Number.isInteger(raw.verification?.score)
+    || raw.verification.score < 1
+    || raw.verification.score > 10
+    || !Array.isArray(raw.runnerUsageTraces)
+    || raw.runnerUsageTraces.length !== 1
+  ) return null;
+  const trace = raw.runnerUsageTraces[0];
+  if (
+    trace?.schemaVersion !== 'skillstore.runner-skill-trace/v1'
+    || trace.agent !== 'claude'
+    || trace.source !== 'claude-stream-json-v1'
+    || trace.deterministic !== true
+    || !Array.isArray(trace.events)
+    || trace.events.length !== expectedBindings.length
+  ) return null;
+  for (let index = 0; index < expectedBindings.length; index += 1) {
+    const event = trace.events[index];
+    const binding = expectedBindings[index];
+    if (
+      event?.sequence !== index + 1
+      || event.canonicalId !== binding.canonicalId
+      || event.contentHash !== binding.contentHash
+      || event.version !== binding.version
+    ) return null;
+  }
+  return {
+    schemaVersion: EXECUTOR_PREFLIGHT_TRACE_SCHEMA,
+    deterministic: true,
+    traceCount: 1,
+    eventCount: expectedBindings.length,
+    bindingDigest: sha256(canonicalJson(expectedBindings)),
+  };
+}
+
+function exactExecutorPreflightClosureFromEvidence(raw, invocations, expectedBindings) {
+  if (
+    !raw || typeof raw !== 'object' || Array.isArray(raw)
+  ) return null;
+  const runnerTraceEvidence = exactExecutorPreflightTraceEvidence(raw, expectedBindings);
+  if (!runnerTraceEvidence) return null;
+  if (invocations.length !== 2) return null;
+  const expected = [
+    { phase: 'run', agent: 'claude' },
+    { phase: 'judge', agent: 'codex' },
+  ];
+  for (let index = 0; index < expected.length; index += 1) {
+    const invocation = invocations[index];
+    const attempt = invocation?.attempts?.[0];
+    if (
+      invocation.phase !== expected[index].phase
+      || invocation.run !== 1
+      || invocation.succeeded !== true
+      || invocation.attempts.length !== 1
+      || attempt.agent !== expected[index].agent
+      || attempt.attempt !== 1
+      || attempt.sandboxed !== true
+      || attempt.outcome !== 'succeeded'
+      || attempt.failureCategory !== 'none'
+      || attempt.spawnErrorCode !== null
+      || attempt.exitCode !== 0
+      || attempt.signal !== null
+    ) return null;
+  }
+  return { agentExecutionEvidence: invocations, runnerTraceEvidence };
+}
+
+export function exactExecutorPreflightClosure(raw, expectedBindings) {
+  if (!Array.isArray(expectedBindings) || expectedBindings.length !== 2) return null;
+  const evidence = projectExecutorPreflightEvidence(raw);
+  return exactExecutorPreflightClosureFromEvidence(raw, evidence, expectedBindings);
+}
+
+export async function executorPreflight(args) {
+  const cli = resolve(required(args, 'cli'));
+  const expectedCliVersion = required(args, 'expected-cli-version');
+  if (cliVersion(cli) !== expectedCliVersion) fail('Executor preflight CLI version mismatch');
+  const skillDirectories = [
+    resolve(required(args, 'skill-a')),
+    resolve(required(args, 'skill-b')),
+  ];
+  if (skillDirectories[0] === skillDirectories[1]) fail('Executor preflight Skills must be distinct');
+  const expectedBindings = await Promise.all([
+    { canonicalId: 'pack-executor-preflight-a', directory: skillDirectories[0] },
+    { canonicalId: 'pack-executor-preflight-b', directory: skillDirectories[1] },
+  ].map(async ({ canonicalId, directory }) => ({
+    canonicalId,
+    contentHash: await sha256File(resolve(directory, 'SKILL.md')),
+    version: '1.0.0',
+  })));
+  const resultsDir = resolve(required(args, 'results-dir'));
+  const runtimeRoot = resolve(required(args, 'evaluator-runtime-root'));
+  const generationId = required(args, 'generation-id');
+  if (!UUID_RE.test(generationId)) fail('--generation-id must be a UUID');
+  const uid = positiveInteger(required(args, 'evaluator-uid'), 'evaluator-uid');
+  const gid = positiveInteger(required(args, 'evaluator-gid'), 'evaluator-gid');
+  const timeoutMs = positiveInteger(args['timeout-ms'], 'timeout-ms', 360_000);
+  const idleTimeoutMs = positiveInteger(args['idle-timeout-ms'], 'idle-timeout-ms', 240_000);
+  const agentTimeoutMs = positiveInteger(args['agent-timeout-ms'], 'agent-timeout-ms', 180_000);
+  const proxyActivityFile = args['proxy-activity-file']
+    ? resolve(args['proxy-activity-file'])
+    : null;
+  await mkdir(resultsDir, { recursive: true, mode: 0o700 });
+  const stdoutFile = resolve(resultsDir, 'executor-preflight.raw.json');
+  const stderrFile = resolve(resultsDir, 'executor-preflight.run.log');
+  const progressFile = resolve(resultsDir, 'executor-preflight.progress.ndjson');
+  const baseEnv = { ...process.env, SKILLSTORE_AGENT_ENV_MODE: 'strict' };
+  const startedAt = Date.now();
+  let runtime = null;
+  let processResult = null;
+  let processErrorCode = null;
+  let raw = null;
+  let closure = null;
+  let agentExecutionEvidence = [];
+  let cleanupOutcome = 'not_run';
+  try {
+    terminateEvaluatorProcesses(uid);
+    runtime = await prepareScenarioRuntime(runtimeRoot, generationId, uid, gid, baseEnv);
+    const manifestFile = resolve(runtime.cwd, 'pack-executor-preflight-manifest.json');
+    await writeFile(manifestFile, `${JSON.stringify({
+      schemaVersion: 'skillstore.pack-executor-preflight-manifest/v1',
+      task: args.task ?? [
+        'Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second.',
+        'After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.',
+      ].join(' '),
+      skills: expectedBindings.map((binding, index) => ({
+        directory: skillDirectories[index],
+        ...binding,
+      })),
+    })}\n`, { mode: 0o444 });
+    await chmod(manifestFile, 0o444);
+    processResult = await runEvaluatorProcess(cli, [
+      'pack', 'executor-preflight',
+      '--manifest', manifestFile,
+      '--model', args.model ?? 'sonnet',
+      '--judge-model', args['judge-model'] ?? 'gpt-5.5',
+      '--agent-timeout-ms', String(agentTimeoutMs),
+      '--agent-max-retries', '1',
+    ], {
+      cwd: runtime.cwd,
+      env: runtime.env,
+      uid,
+      gid,
+      stdoutFile,
+      stderrFile,
+      progressFile,
+      label: 'executor-preflight',
+      generationId,
+      timeoutMs,
+      idleTimeoutMs,
+      heartbeatMs: 30_000,
+      ...(proxyActivityFile ? { externalActivityFile: proxyActivityFile } : {}),
+      onProgress: () => {},
+    });
+    try {
+      raw = JSON.parse(await readFile(stdoutFile, 'utf8'));
+      agentExecutionEvidence = projectExecutorPreflightEvidence(raw);
+      closure = exactExecutorPreflightClosureFromEvidence(
+        raw,
+        agentExecutionEvidence,
+        expectedBindings,
+      );
+    } catch {
+      raw = null;
+      closure = null;
+      agentExecutionEvidence = [];
+    }
+  } catch (error) {
+    processErrorCode = safeSpawnErrorCode(error?.code);
+  } finally {
+    try {
+      terminateEvaluatorProcesses(uid);
+      cleanupOutcome = 'passed';
+    } catch {
+      cleanupOutcome = 'failed';
+    }
+  }
+
+  const firstFailedAttempt = agentExecutionEvidence
+    .flatMap((invocation) => invocation.attempts)
+    .find((attempt) => attempt.outcome === 'failed') ?? null;
+  let errorClass = 'none';
+  if (processResult?.deterministicHttpFailure) errorClass = 'deterministic_http';
+  else if (processResult?.timedOut) errorClass = 'timeout';
+  else if (processResult?.stalled) errorClass = 'stalled';
+  else if (processResult?.outputExceeded) errorClass = 'output_limit';
+  else if (processErrorCode) errorClass = 'spawn_error';
+  else if (firstFailedAttempt) errorClass = firstFailedAttempt.failureCategory;
+  else if (!closure || !processResult || processResult.status !== 0 || processResult.signal !== null) {
+    errorClass = 'invalid_report';
+  } else if (cleanupOutcome !== 'passed') errorClass = 'cleanup_failed';
+
+  const outcome = errorClass === 'none' ? 'passed' : 'command_failed';
+  const stdoutEvidence = await readFile(stdoutFile).catch(() => Buffer.alloc(0));
+  const stderrEvidence = await readFile(stderrFile).catch(() => Buffer.alloc(0));
+  const summary = {
+    schemaVersion: 'marketplace.pack-executor-preflight/v1',
+    mode: 'pack-production-node-uid-nested-bwrap',
+    outcome,
+    errorClass,
+    outerExecution: {
+      spawnErrorCode: processErrorCode,
+      exitCode: processResult?.status ?? null,
+      signal: processResult?.signal ?? null,
+      timedOut: processResult?.timedOut ?? false,
+      stalled: processResult?.stalled ?? false,
+      outputExceeded: processResult?.outputExceeded ?? false,
+      durationMs: Date.now() - startedAt,
+      stdoutBytes: stdoutEvidence.length,
+      stderrBytes: stderrEvidence.length,
+      stdoutSha256: sha256(stdoutEvidence),
+      stderrSha256: sha256(stderrEvidence),
+    },
+    agentExecutionEvidence,
+    runnerTraceEvidence: closure?.runnerTraceEvidence ?? null,
+    verdictCount: Number.isSafeInteger(raw?.verification?.verdictCount)
+      ? raw.verification.verdictCount
+      : 0,
+    errorCount: Number.isSafeInteger(raw?.verification?.errorCount)
+      ? raw.verification.errorCount
+      : null,
+    cleanup: { outcome: cleanupOutcome },
+  };
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+  if (outcome !== 'passed') process.exitCode = 1;
+  return summary;
 }
 
 async function evaluate(args) {
@@ -2619,6 +3038,8 @@ async function reportSlo(args) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   switch (args.command) {
+    case 'executor-preflight':
+      return executorPreflight(args);
     case 'evaluate':
       return evaluate(args);
     case 'verify':
@@ -2630,7 +3051,7 @@ async function main() {
     case 'slo':
       return reportSlo(args);
     default:
-      fail('Usage: pack-production.mjs <evaluate|verify|persist|finalize|slo> [options]');
+      fail('Usage: pack-production.mjs <executor-preflight|evaluate|verify|persist|finalize|slo> [options]');
   }
 }
 

--- a/scripts/tests/fixtures/README.md
+++ b/scripts/tests/fixtures/README.md
@@ -12,4 +12,4 @@ Marketplace-only fixture update is a release blocker, not backward
 compatibility.
 
 The Generate Pack and content workflows are pinned to the immutable,
-checksum-verified CLI 2.14.0 release that owns this v4 contract.
+checksum-verified CLI 2.14.1 release that owns this v4 contract.

--- a/scripts/tests/fixtures/README.md
+++ b/scripts/tests/fixtures/README.md
@@ -12,4 +12,4 @@ Marketplace-only fixture update is a release blocker, not backward
 compatibility.
 
 The Generate Pack and content workflows are pinned to the immutable,
-checksum-verified CLI 2.14.1 release that owns this v4 contract.
+checksum-verified CLI 2.14.2 release that owns this v4 contract.

--- a/scripts/tests/fixtures/README.md
+++ b/scripts/tests/fixtures/README.md
@@ -12,4 +12,4 @@ Marketplace-only fixture update is a release blocker, not backward
 compatibility.
 
 The Generate Pack and content workflows are pinned to the immutable,
-checksum-verified CLI 2.13.2 release that owns this v4 contract.
+checksum-verified CLI 2.14.0 release that owns this v4 contract.

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -346,7 +346,7 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
     encoding: 'utf8',
     env: {
       PATH: process.env.PATH,
-      PACK_PRODUCTION_CLI_VERSION: '2.14.1',
+      PACK_PRODUCTION_CLI_VERSION: '2.14.2',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
       PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
@@ -700,7 +700,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.1'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.2'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -795,8 +795,8 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.doesNotMatch(GENERATE_CONTENT, /Dispatch translation after content is complete/);
   assert.doesNotMatch(GENERATE_CONTENT, /event_type:\"translate-packs\"/);
   assert.match(GENERATE_CONTENT, /if \[ -n "\$GENERATION_ID" \]; then/);
-  assert.match(GENERATE_CONTENT, /version: '2\.14\.1'/);
-  assert.match(GENERATE_CONTENT, /minimum-version: '2\.14\.1'/);
+  assert.match(GENERATE_CONTENT, /version: '2\.14\.2'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.14\.2'/);
   assert.match(GENERATE_CONTENT, /bindingDigest/);
   assert.match(GENERATE_CONTENT, /usageGuideMarker/);
   assert.match(GENERATE_CONTENT, /github\.event\.client_payload\.contentDispatchNonce/);

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -172,17 +172,24 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
     /SKILLSTORE_AGENT_ENV_ALLOWLIST=.*CLAUDE_CODE_MAX_OUTPUT_TOKENS/,
   );
   assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required/);
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA is required/);
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_CLI_SHA256 is required/);
   assert.match(EVALUATOR_PREFLIGHT, /\^\[1-9\]\[0-9\]\*\$/);
   assert.match(
     EVALUATOR_PREFLIGHT,
-    /--setenv CLAUDE_CODE_MAX_OUTPUT_TOKENS "\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
   );
   assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"/);
-  assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\\]+bash .*pack-evaluator-preflight\.sh/);
+  assert.match(
+    evaluate,
+    /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\S]*PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="\$GITHUB_SHA"[\s\S]*bash .*pack-evaluator-preflight\.sh/,
+  );
+  assert.match(evaluate, /PACK_EVALUATOR_CLI_SHA256="\$\(jq -r '\.sha256'/);
   assert.match(evaluate, /sudo rm -f "\$PROXY_ACTIVITY"/);
   assert.match(evaluate, /Pack evaluator proxy did not become healthy within 30 seconds/);
   assert.match(evaluate, /proxy-diagnostics\.json/);
-  assert.match(evaluate, /Reply with exactly PACK_EVALUATOR_READY and nothing else/);
+  assert.match(evaluate, /pack-executor-preflight-a first and Skill pack-executor-preflight-b second/);
+  assert.match(evaluate, /PACK_EVALUATOR_READY and nothing else/);
   assert.match(evaluate, /pack-evaluator-contract-smoke\.mjs/);
   assert.match(evaluate, /PACK_EVALUATOR_CONTRACT_TIMEOUT_MS=30000/);
   assert.match(evaluate, /contract-smoke\.json/);
@@ -195,28 +202,30 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.equal((CONTRACT_SMOKE.match(/stream: true/g) ?? []).length, 2);
   assert.match(CONTRACT_SMOKE, /content_block_delta/);
   assert.match(CONTRACT_SMOKE, /response\.output_text\.delta/);
-  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_SECONDS=180/);
+  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_SECONDS=420/);
   assert.match(evaluate, /timeout --signal=TERM --kill-after=5s "\$\{PREFLIGHT_TIMEOUT_SECONDS\}s"/);
-  assert.match(evaluate, /\/opt\/pack-evaluator\/runtime\/bin\/claude/);
-  assert.match(evaluate, /--permission-mode bypassPermissions/);
+  assert.match(evaluate, /setsid sudo env -i/);
+  assert.match(evaluate, /"\$NODE" "\$ORCHESTRATOR" executor-preflight/);
+  assert.match(evaluate, /--skill-a "\$PREFLIGHT_SKILL_A"/);
+  assert.match(evaluate, /--skill-b "\$PREFLIGHT_SKILL_B"/);
+  assert.match(evaluate, /--evaluator-runtime-root "\$RUNTIME_ROOT"/);
+  assert.match(evaluate, /--evaluator-uid "\$\(id -u packeval\)"/);
+  assert.match(evaluate, /--evaluator-gid "\$\(id -g packeval\)"/);
   assert.match(evaluate, /--model sonnet/);
-  assert.match(evaluate, /\/opt\/pack-evaluator\/runtime\/bin\/codex/);
-  assert.match(evaluate, /exec\s+\\\n\s+--skip-git-repo-check/);
-  assert.match(evaluate, /--sandbox read-only/);
-  assert.match(evaluate, /--cd \/home\/packeval/);
-  assert.match(evaluate, /--ephemeral/);
-  assert.match(evaluate, /--color never/);
-  assert.match(evaluate, /-m gpt-5\.5/);
-  assert.match(evaluate, /CLAUDE_OUTCOME=command_failed/);
-  assert.match(evaluate, /CODEX_OUTCOME=command_failed/);
+  assert.match(evaluate, /--judge-model gpt-5\.5/);
+  assert.match(evaluate, /--agent-timeout-ms "\$AGENT_TIMEOUT_MS"/);
+  assert.match(evaluate, /--agent-max-retries 1/);
+  assert.match(evaluate, /PREFLIGHT_OUTCOME=command_failed/);
+  assert.match(evaluate, /PREFLIGHT_ERROR_CLASS=unknown/);
   assert.match(evaluate, /for ATTEMPT in 1 2/);
-  assert.match(evaluate, /should_retry_preflight[\s\\]+"\$CODEX_OUTCOME" "\$CODEX_ERROR_CLASS" "\$ATTEMPT"/);
-  assert.match(EVALUATOR_PREFLIGHT, /retryable_http\) return 0/);
-  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$attempt" -ge 2 \]/);
+  assert.match(evaluate, /should_retry_preflight "\$PREFLIGHT_OUTCOME" "\$PREFLIGHT_ERROR_CLASS" "\$ATTEMPT"/);
+  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$error_class" = 'retryable_http' \]/);
+  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$attempt" -lt 2 \]/);
   assert.match(evaluate, /cleanup_processes\(\)/);
   assert.match(evaluate, /RETRY_CLEANUP_OUTCOME=passed/);
   assert.match(evaluate, /sleep 5/);
-  assert.match(evaluate, /attempts: \$codexAttempts/);
+  assert.match(evaluate, /commandAttempts: \$commandAttempts/);
+  assert.match(evaluate, /agentExecutionEvidence: \$executionEvidence/);
   assert.match(evaluate, /durationMs: \$durationMs/);
   assert.doesNotMatch(evaluate, /connect\|connection\|transport\|request/);
   assert.match(evaluate, /SKILLSTORE_AGENTS=codex,claude/);
@@ -239,22 +248,15 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
     /errorCategory: \(if \$errorCategory == "" then null else \$errorCategory end\)/,
   );
   assert.doesNotMatch(evaluate, /--arg errorCategory "\$PREFLIGHT_REASON"/);
-  assert.match(evaluate, /CLAUDE_OUTCOME=invalid_response/);
-  assert.match(evaluate, /CODEX_OUTCOME=invalid_response/);
-  assert.match(evaluate, /classify_error\(\)/);
+  assert.match(evaluate, /safe_execution_evidence\(\)/);
   assert.match(evaluate, /state_storage/);
   assert.match(evaluate, /authentication/);
   assert.match(evaluate, /model_route/);
   assert.match(evaluate, /upstream_transport/);
-  assert.match(evaluate, /errorClass: \$claudeErrorClass/);
-  assert.match(evaluate, /errorClass: \$codexErrorClass/);
-  assert.match(evaluate, /claude:\s*\{/);
-  assert.match(evaluate, /codex:\s*\{/);
-  assert.match(evaluate, /cleanup:\s*\{[\s\S]*outcome: \$cleanupOutcome,[\s\S]*retryOutcome: \$retryCleanupOutcome/);
-  assert.match(evaluate, /CLEANUP_OUTCOME=failed/);
-  assert.match(evaluate, /CLEANUP_OUTCOME=probe_failed/);
+  assert.match(evaluate, /schemaVersion: "marketplace\.pack-executor-preflight\/v1"/);
+  assert.match(evaluate, /cleanup: \{ outcome: \$cleanupOutcome, retryOutcome: \$retryCleanupOutcome \}/);
+  assert.match(evaluate, /CLEANUP_OUTCOME=\$\(/);
   assert.match(evaluate, /CLEANUP_RC/);
-  assert.match(evaluate, /tr -d '\\r\\n'/);
   assert.doesNotMatch(evaluate, /SKILLSTORE_AGENTS: \$\{\{ vars\.SKILLSTORE_AGENTS \}\}/);
   assert.doesNotMatch(evaluate, /sed -E .*Bearer|proxy\.log|proxy-failure\.log/);
   assert.match(evaluate, /evaluator-failure\.txt/);
@@ -308,10 +310,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(maximumWireRequests + 64 <= 256);
   assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_MODE=bwrap/);
   assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=\/opt\/pack-evaluator\/runtime/);
-  assert.match(
-    evaluate,
-    /--unshare-all\s+--share-net\s+--unshare-user\s+--disable-userns\s+--cap-drop ALL/,
-  );
+  assert.match(evaluate, /SKILLSTORE_AGENT_SANDBOX_MODE=bwrap/);
   assert.match(evaluate, /! test -r "\/proc\/\$PROXY_PID\/environ"/);
   assert.doesNotMatch(evaluate, /PATH=\/opt\/pack-evaluator\/runtime\/bin:\/opt\/pack-evaluator\/bin/);
 });
@@ -320,26 +319,25 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   const result = spawnSync('bash', ['-n', EVALUATOR_PREFLIGHT_PATH], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
   assert.match(EVALUATOR_PREFLIGHT, /for ATTEMPT in 1 2/);
-  assert.match(EVALUATOR_PREFLIGHT, /CLAUDE_EXIT_CODE=\$\?/);
-  assert.match(EVALUATOR_PREFLIGHT, /CODEX_EXIT_CODE=\$\?/);
-  assert.match(EVALUATOR_PREFLIGHT, /"\$exit_code" -eq 124/);
-  assert.match(EVALUATOR_PREFLIGHT, /CLAUDE_ATTEMPTS=/);
-  assert.match(EVALUATOR_PREFLIGHT, /--argjson claudeAttempts/);
+  assert.match(EVALUATOR_PREFLIGHT, /COMMAND_EXIT_CODE=\$\?/);
+  assert.match(EVALUATOR_PREFLIGHT, /COMMAND_ATTEMPTS=/);
+  assert.match(EVALUATOR_PREFLIGHT, /--argjson commandAttempts/);
   assert.match(EVALUATOR_PREFLIGHT, /exitCode: \$exitCode/);
-  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /if ! printf '%s\\n' 'Reply with exactly PACK_EVALUATOR_READY/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/agent-preflight-diagnostics\.json/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/proxy-activity\.ndjson/);
-  assert.match(EVALUATOR_PREFLIGHT, /readonly -a AGENT_BWRAP=/);
-  assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \//);
-  assert.match(
-    EVALUATOR_PREFLIGHT,
-    /--unshare-all\s+--share-net\s+--unshare-user\s+--disable-userns\s+--cap-drop ALL/,
-  );
-  assert.match(EVALUATOR_PREFLIGHT, /--tmpfs \/run/);
-  assert.match(EVALUATOR_PREFLIGHT, /--chdir \/home\/packeval/);
-  assert.match(EVALUATOR_PREFLIGHT, /--ro-bind \/opt\/pack-evaluator\/runtime \/opt\/pack-evaluator\/runtime/);
-  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--ro-bind \/ \//);
-  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--(?:ro-)?bind \/opt\/pack-evaluator\/(?:bin|lib|input|results)/);
+  assert.match(EVALUATOR_PREFLIGHT, /setsid sudo env -i/);
+  assert.match(EVALUATOR_PREFLIGHT, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
+  assert.match(EVALUATOR_PREFLIGHT, /"\$NODE" "\$ORCHESTRATOR" executor-preflight/);
+  assert.match(EVALUATOR_PREFLIGHT, /--skill-a "\$PREFLIGHT_SKILL_A"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--skill-b "\$PREFLIGHT_SKILL_B"/);
+  assert.match(EVALUATOR_PREFLIGHT, /safe_runner_trace_evidence\(\)/);
+  assert.match(EVALUATOR_PREFLIGHT, /proofBinding:/);
+  assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_ENV_MODE=strict/);
+  assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_SANDBOX_MODE=bwrap/);
+  assert.match(EVALUATOR_PREFLIGHT, /safe_execution_evidence\(\)/);
+  assert.match(EVALUATOR_PREFLIGHT, /\]\[0:8\]/);
+  assert.match(EVALUATOR_PREFLIGHT, /spawnErrorCode/);
+  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /command:|arguments:|environment:|rawStdout|rawStderr/);
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /GITHUB_WORKSPACE/);
 });
 
@@ -348,6 +346,7 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
     encoding: 'utf8',
     env: {
       PATH: process.env.PATH,
+      PACK_PRODUCTION_CLI_VERSION: '2.14.0',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
       PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
@@ -387,65 +386,152 @@ test('preflight infrastructure evidence selects the last fatal response before c
   assert.equal(rejected.stdout, '');
 });
 
-test('evaluator preflight classifies both output streams without retaining their text', () => {
-  const start = EVALUATOR_PREFLIGHT.indexOf('classify_error() {');
+test('evaluator preflight projects only fixed execution evidence fields', () => {
+  const start = EVALUATOR_PREFLIGHT.indexOf('safe_execution_evidence() {');
   const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
-  assert.ok(start >= 0 && end > start, 'error classifier must be extractable');
-  const classifier = EVALUATOR_PREFLIGHT.slice(start, end + 3);
-  const directory = mkdtempSync(join(tmpdir(), 'pack-preflight-classifier-'));
-  const stdout = join(directory, 'stdout');
-  const stderr = join(directory, 'stderr');
+  assert.ok(start >= 0 && end > start, 'safe evidence projector must be extractable');
+  const projector = EVALUATOR_PREFLIGHT.slice(start, end + 3);
+  const directory = mkdtempSync(join(tmpdir(), 'pack-preflight-projector-'));
+  const report = join(directory, 'report.json');
+  writeFileSync(report, JSON.stringify({
+    agentExecutionEvidence: [{
+      phase: 'run',
+      run: 1,
+      succeeded: false,
+      privatePhaseField: 'raw prompt',
+      attempts: [{
+        schemaVersion: 'skillstore.agent-execution-evidence/v1',
+        agent: 'claude',
+        attempt: 1,
+        sandboxed: true,
+        outcome: 'failed',
+        failureCategory: 'spawn_error',
+        spawnErrorCode: 'EAGAIN',
+        exitCode: null,
+        signal: null,
+        durationMs: 10,
+        stdoutBytes: 0,
+        stderrBytes: 0,
+        stdoutSha256: 'a'.repeat(64),
+        stderrSha256: 'b'.repeat(64),
+        rawStderr: 'private path and token',
+      }],
+    }],
+    errors: ['private error'],
+    verdicts: [{ reason: 'private judge text' }],
+  }));
+  const projected = spawnSync(
+    'bash',
+    ['-c', `${projector}\nsafe_execution_evidence "$1"`, 'projector', report],
+    { encoding: 'utf8' },
+  );
+  assert.equal(projected.status, 0, projected.stderr);
+  const value = JSON.parse(projected.stdout);
+  assert.deepEqual(value[0].attempts[0], {
+    schemaVersion: 'skillstore.agent-execution-evidence/v1',
+    agent: 'claude',
+    attempt: 1,
+    sandboxed: true,
+    outcome: 'failed',
+    failureCategory: 'spawn_error',
+    spawnErrorCode: 'EAGAIN',
+    exitCode: null,
+    signal: null,
+    durationMs: 10,
+    stdoutBytes: 0,
+    stderrBytes: 0,
+    stdoutSha256: 'a'.repeat(64),
+    stderrSha256: 'b'.repeat(64),
+  });
+  assert.doesNotMatch(projected.stdout, /private|rawStderr|errors|verdicts/);
+});
 
-  const classify = ({ stdoutText = '', stderrText = '', outcome, exitCode, fatal = '', retryable = '' }) => {
-    writeFileSync(stdout, stdoutText);
-    writeFileSync(stderr, stderrText);
-    return spawnSync(
-      'bash',
-      [
-        '-c',
-        `${classifier}\nclassify_error "$1" "$2" "$3" "$4" "$5" "$6"`,
-        'classifier',
-        stdout,
-        stderr,
-        outcome,
-        String(exitCode),
-        fatal,
-        retryable,
-      ],
-      { encoding: 'utf8' },
-    );
+test('invalid trace and outer summaries project explicit JSON fallbacks', () => {
+  const extractFunction = (name) => {
+    const start = EVALUATOR_PREFLIGHT.indexOf(`${name}() {`);
+    const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
+    assert.ok(start >= 0 && end > start, `${name} must be extractable`);
+    return EVALUATOR_PREFLIGHT.slice(start, end + 3);
   };
+  const directory = mkdtempSync(join(tmpdir(), 'pack-preflight-invalid-projection-'));
+  const report = join(directory, 'report.json');
+  writeFileSync(report, JSON.stringify({
+    runnerTraceEvidence: { schemaVersion: 'attacker-schema', bindingDigest: 'private path' },
+    outerExecution: {
+      durationMs: 430001,
+      rawStderr: 'private process detail',
+    },
+  }));
+  const script = [
+    extractFunction('safe_runner_trace_evidence'),
+    extractFunction('safe_outer_execution'),
+    'trace=$(safe_runner_trace_evidence "$1")',
+    'outer=$(safe_outer_execution "$1")',
+    'jq -cn --argjson trace "$trace" --argjson outer "$outer" "{trace: \\$trace, outer: \\$outer}"',
+  ].join('\n');
+  const result = spawnSync('bash', ['-c', script, 'invalid-projection', report], { encoding: 'utf8' });
 
-  assert.equal(classify({
-    stdoutText: 'Not logged in. Please run /login.',
-    outcome: 'command_failed',
-    exitCode: 1,
-  }).stdout.trim(), 'authentication');
-  assert.equal(classify({
-    stderrText: 'unable to open session database',
-    outcome: 'command_failed',
-    exitCode: 1,
-  }).stdout.trim(), 'state_storage');
-  assert.equal(classify({
-    stdoutText: 'PACK_EVALUATOR_READY\n',
-    outcome: 'passed',
-    exitCode: 0,
-  }).stdout.trim(), 'none');
-  assert.equal(classify({
-    stdoutText: 'unexpected model response',
-    outcome: 'invalid_response',
-    exitCode: 0,
-  }).stdout.trim(), 'unknown');
-  assert.equal(classify({
-    outcome: 'command_failed',
-    exitCode: 1,
-    fatal: '401',
-  }).stdout.trim(), 'deterministic_http');
-  assert.equal(classify({
-    outcome: 'command_failed',
-    exitCode: 1,
-    retryable: '503',
-  }).stdout.trim(), 'retryable_http');
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { trace: null, outer: {} });
+  assert.doesNotMatch(result.stdout, /private|rawStderr|attacker/);
+});
+
+test('evaluator preflight retains bounded Agent evidence across an outer retry', () => {
+  const extractFunction = (name) => {
+    const start = EVALUATOR_PREFLIGHT.indexOf(`${name}() {`);
+    const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
+    assert.ok(start >= 0 && end > start, `${name} must be extractable`);
+    return EVALUATOR_PREFLIGHT.slice(start, end + 3);
+  };
+  const append = extractFunction('append_command_attempt');
+  const mark = extractFunction('mark_recovered_command_attempts');
+  const attempt = (number, outcome, errorClass, agentEvidence) => ({
+    attempt: number,
+    outcome,
+    errorClass,
+    exitCode: outcome === 'passed' ? 0 : 1,
+    durationMs: number === 1 ? 429000 : 10,
+    stdoutBytes: 1,
+    stderrBytes: 0,
+    stdoutSha256: 'a'.repeat(64),
+    stderrSha256: 'b'.repeat(64),
+    outerExecution: { exitCode: outcome === 'passed' ? 0 : 1 },
+    agentExecutionEvidence: agentEvidence,
+    rawSecret: 'must not survive',
+  });
+  const failedEvidence = [{
+    phase: 'run',
+    run: 1,
+    succeeded: false,
+    attempts: [{ spawnErrorCode: 'EAGAIN', failureCategory: 'spawn_error' }],
+  }];
+  const passedEvidence = [{
+    phase: 'run',
+    run: 1,
+    succeeded: true,
+    attempts: [{ spawnErrorCode: null, failureCategory: 'none' }],
+  }];
+  const script = [
+    append,
+    mark,
+    'history=\"[]\"',
+    'history=$(append_command_attempt \"$history\" \"$1\")',
+    'history=$(append_command_attempt \"$history\" \"$2\")',
+    'mark_recovered_command_attempts \"$history\" passed',
+  ].join('\n');
+  const result = spawnSync('bash', ['-c', script, 'retry-history',
+    JSON.stringify(attempt(1, 'command_failed', 'retryable_http', failedEvidence)),
+    JSON.stringify(attempt(2, 'passed', 'none', passedEvidence)),
+  ], { encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  const history = JSON.parse(result.stdout);
+  assert.equal(history.length, 2);
+  assert.equal(history[0].recovered, true);
+  assert.equal(history[0].durationMs, 429000);
+  assert.equal(history[0].agentExecutionEvidence[0].attempts[0].spawnErrorCode, 'EAGAIN');
+  assert.equal(history[1].recovered, false);
+  assert.doesNotMatch(result.stdout, /must not survive|rawSecret/);
 });
 
 test('evaluator preflight retries only an exact bounded HTTP failure once', () => {
@@ -614,7 +700,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.13\.2'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.0'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -709,8 +795,8 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.doesNotMatch(GENERATE_CONTENT, /Dispatch translation after content is complete/);
   assert.doesNotMatch(GENERATE_CONTENT, /event_type:\"translate-packs\"/);
   assert.match(GENERATE_CONTENT, /if \[ -n "\$GENERATION_ID" \]; then/);
-  assert.match(GENERATE_CONTENT, /version: '2\.13\.2'/);
-  assert.match(GENERATE_CONTENT, /minimum-version: '2\.13\.2'/);
+  assert.match(GENERATE_CONTENT, /version: '2\.14\.0'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.14\.0'/);
   assert.match(GENERATE_CONTENT, /bindingDigest/);
   assert.match(GENERATE_CONTENT, /usageGuideMarker/);
   assert.match(GENERATE_CONTENT, /github\.event\.client_payload\.contentDispatchNonce/);

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -346,7 +346,7 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
     encoding: 'utf8',
     env: {
       PATH: process.env.PATH,
-      PACK_PRODUCTION_CLI_VERSION: '2.14.0',
+      PACK_PRODUCTION_CLI_VERSION: '2.14.1',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
       PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
@@ -700,7 +700,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.0'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.1'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -795,8 +795,8 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.doesNotMatch(GENERATE_CONTENT, /Dispatch translation after content is complete/);
   assert.doesNotMatch(GENERATE_CONTENT, /event_type:\"translate-packs\"/);
   assert.match(GENERATE_CONTENT, /if \[ -n "\$GENERATION_ID" \]; then/);
-  assert.match(GENERATE_CONTENT, /version: '2\.14\.0'/);
-  assert.match(GENERATE_CONTENT, /minimum-version: '2\.14\.0'/);
+  assert.match(GENERATE_CONTENT, /version: '2\.14\.1'/);
+  assert.match(GENERATE_CONTENT, /minimum-version: '2\.14\.1'/);
   assert.match(GENERATE_CONTENT, /bindingDigest/);
   assert.match(GENERATE_CONTENT, /usageGuideMarker/);
   assert.match(GENERATE_CONTENT, /github\.event\.client_payload\.contentDispatchNonce/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -119,7 +119,7 @@ test('hosted proof is manually gated, read-only, pinned, and invokes the product
   assert.match(HOSTED_CI, /actions\/create-github-app-token@v3/);
   assert.match(HOSTED_CI, /repositories: skillstore/);
   assert.match(HOSTED_CI, /permission-contents: read/);
-  assert.match(HOSTED_CI, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.0'/);
+  assert.match(HOSTED_CI, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.1'/);
   assert.match(HOSTED_CI, /download-skillstore-cli/);
   assert.match(HOSTED_CI, /require-checksum: 'true'/);
   assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/bin\/skillstore-cli/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -119,7 +119,7 @@ test('hosted proof is manually gated, read-only, pinned, and invokes the product
   assert.match(HOSTED_CI, /actions\/create-github-app-token@v3/);
   assert.match(HOSTED_CI, /repositories: skillstore/);
   assert.match(HOSTED_CI, /permission-contents: read/);
-  assert.match(HOSTED_CI, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.1'/);
+  assert.match(HOSTED_CI, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.2'/);
   assert.match(HOSTED_CI, /download-skillstore-cli/);
   assert.match(HOSTED_CI, /require-checksum: 'true'/);
   assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/bin\/skillstore-cli/);

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -98,7 +98,7 @@ test('production configures and proves bwrap before the only Helm secret step', 
   assert.doesNotMatch(evaluate.slice(0, secretStepIndex), /secrets\./);
 });
 
-test('hosted proof is pinned, secret-free, and invokes the production helper', () => {
+test('hosted proof is manually gated, read-only, pinned, and invokes the production helper', () => {
   assert.match(HOSTED_CI, /runs-on: ubuntu-24\.04/);
   assert.match(HOSTED_CI, /timeout-minutes: 10/);
   assert.match(HOSTED_CI, /permissions:\n  contents: read/);
@@ -115,13 +115,29 @@ test('hosted proof is pinned, secret-free, and invokes the production helper', (
   assert.match(HOSTED_CI, /scripts\/configure-pack-evaluator-bwrap\.sh/);
   assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight-mock\.mjs/);
   assert.match(HOSTED_CI, /scripts\/pack-evaluator-preflight\.sh/);
+  assert.match(HOSTED_CI, /if: github\.event_name == 'workflow_dispatch'/);
+  assert.match(HOSTED_CI, /actions\/create-github-app-token@v3/);
+  assert.match(HOSTED_CI, /repositories: skillstore/);
+  assert.match(HOSTED_CI, /permission-contents: read/);
+  assert.match(HOSTED_CI, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.0'/);
+  assert.match(HOSTED_CI, /download-skillstore-cli/);
+  assert.match(HOSTED_CI, /require-checksum: 'true'/);
+  assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/bin\/skillstore-cli/);
   assert.match(HOSTED_CI, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'/);
   assert.match(
     HOSTED_CI,
     /PACK_EVALUATOR_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
   );
   assert.match(HOSTED_CI, /\.maxTokens == 16384/);
-  assert.match(HOSTED_CI, /\.claude\.outcome == "passed"/);
-  assert.match(HOSTED_CI, /\.codex\.outcome == "passed"/);
-  assert.doesNotMatch(HOSTED_CI, /secrets\.|pull_request_target|self-hosted/);
+  assert.match(HOSTED_CI, /\.schemaVersion == "marketplace\.pack-executor-preflight\/v1"/);
+  assert.match(HOSTED_CI, /\.mode == "pack-production-node-uid-nested-bwrap"/);
+  assert.match(HOSTED_CI, /\.outcome == "passed"/);
+  assert.match(HOSTED_CI, /\.agentExecutionEvidence \| length/);
+  assert.match(HOSTED_CI, /runnerTraceEvidence\.bindingDigest/);
+  assert.match(HOSTED_CI, /proofBinding\.marketplaceCommitSha == env\.GITHUB_SHA/);
+  assert.match(HOSTED_CI, /proofBinding\.cliSha256 == env\.CLI_SHA256/);
+  assert.match(HOSTED_CI, /Upload commit- and checksum-bound proof/);
+  assert.match(HOSTED_CI, /PACK_EVALUATOR_PREFLIGHT_MODE=pack-verify/);
+  assert.match(HOSTED_CI, /private-key: \$\{\{ secrets\.APP_PRIVATE_KEY \}\}/);
+  assert.doesNotMatch(HOSTED_CI, /pull_request_target|self-hosted|PACK_EVALUATOR_HELM_API_KEY|SUPABASE/);
 });

--- a/scripts/tests/pack-evaluator-preflight-mock.test.mjs
+++ b/scripts/tests/pack-evaluator-preflight-mock.test.mjs
@@ -191,7 +191,7 @@ test('Pack preflight mock requires two ordered Skill results before returning th
   }
 });
 
-test('Pack preflight rejection retains only bounded safe tool names', async () => {
+test('Pack preflight permits one bounded bootstrap without advancing the Skill protocol', async () => {
   const rejectedActivities = [];
   const packServer = createPackEvaluatorPreflightMock({
     localToken: LOCAL_TOKEN,
@@ -202,7 +202,7 @@ test('Pack preflight rejection retains only bounded safe tool names', async () =
   await once(packServer, 'listening');
   const url = `http://127.0.0.1:${packServer.address().port}`;
   try {
-    const response = await fetch(`${url}/v1/messages`, {
+    const bootstrap = await fetch(`${url}/v1/messages`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${LOCAL_TOKEN}`,
@@ -220,11 +220,69 @@ test('Pack preflight rejection retains only bounded safe tool names', async () =
         messages: [{ role: 'user', content: 'private Pack task' }],
       }),
     });
-    assert.equal(response.status, 400);
+    assert.equal(bootstrap.status, 200);
+    assert.match(await bootstrap.text(), /message_stop/);
+    assert.equal(rejectedActivities.at(-1)?.protocolStage, 'bootstrap');
     assert.deepEqual(rejectedActivities.at(-1)?.toolNames, ['Read', 'mcp__safe.tool-1']);
+
+    const skillRequest = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [{ role: 'user', content: 'private Pack task' }],
+      }),
+    });
+    assert.equal(skillRequest.status, 200);
+    assert.match(await skillRequest.text(), /toolu_pack_preflight_2/);
+
+    const toolResults = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'toolu_pack_preflight_1', content: 'private result' },
+            { type: 'tool_result', tool_use_id: 'toolu_pack_preflight_2', content: 'private result' },
+          ],
+        }],
+      }),
+    });
+    assert.equal(toolResults.status, 200);
+    assert.match(await toolResults.text(), /PACK_EVALUATOR_READY/);
+
+    const overBudget = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [],
+      }),
+    });
+    assert.equal(overBudget.status, 400);
     assert.doesNotMatch(
       JSON.stringify(rejectedActivities),
-      /private Pack task|sensitive schema|unsafe tool name|local-preflight-token/,
+      /private Pack task|private result|sensitive schema|unsafe tool name|local-preflight-token|PACK_EVALUATOR_READY/,
     );
   } finally {
     await new Promise((resolve) => packServer.close(resolve));

--- a/scripts/tests/pack-evaluator-preflight-mock.test.mjs
+++ b/scripts/tests/pack-evaluator-preflight-mock.test.mjs
@@ -190,3 +190,43 @@ test('Pack preflight mock requires two ordered Skill results before returning th
     await new Promise((resolve) => packServer.close(resolve));
   }
 });
+
+test('Pack preflight rejection retains only bounded safe tool names', async () => {
+  const rejectedActivities = [];
+  const packServer = createPackEvaluatorPreflightMock({
+    localToken: LOCAL_TOKEN,
+    preflightSkillIds: ['pack-executor-preflight-a', 'pack-executor-preflight-b'],
+    onActivity: (activity) => rejectedActivities.push(activity),
+  });
+  packServer.listen(0, '127.0.0.1');
+  await once(packServer, 'listening');
+  const url = `http://127.0.0.1:${packServer.address().port}`;
+  try {
+    const response = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [
+          { name: 'Read' },
+          { name: 'mcp__safe.tool-1' },
+          { name: 'unsafe tool name', input_schema: { private: 'sensitive schema' } },
+        ],
+        messages: [{ role: 'user', content: 'private Pack task' }],
+      }),
+    });
+    assert.equal(response.status, 400);
+    assert.deepEqual(rejectedActivities.at(-1)?.toolNames, ['Read', 'mcp__safe.tool-1']);
+    assert.doesNotMatch(
+      JSON.stringify(rejectedActivities),
+      /private Pack task|sensitive schema|unsafe tool name|local-preflight-token/,
+    );
+  } finally {
+    await new Promise((resolve) => packServer.close(resolve));
+  }
+});

--- a/scripts/tests/pack-evaluator-preflight-mock.test.mjs
+++ b/scripts/tests/pack-evaluator-preflight-mock.test.mjs
@@ -81,3 +81,112 @@ test('mock serves protocol-complete Messages and Responses streams without retai
   const serialized = JSON.stringify(activities);
   assert.doesNotMatch(serialized, /sensitive mock prompt|local-preflight-token|PACK_EVALUATOR_READY/);
 });
+
+test('verify mode can return the strict Codex judge schema required by skill verify', async () => {
+  const judgeText = JSON.stringify({
+    used_skill: false,
+    task_completed: true,
+    env_blocked: false,
+    score: 10,
+    reason: 'executor path healthy',
+    issues: [],
+  });
+  const verifyServer = createPackEvaluatorPreflightMock({
+    localToken: LOCAL_TOKEN,
+    responsesOutput: judgeText,
+  });
+  verifyServer.listen(0, '127.0.0.1');
+  await once(verifyServer, 'listening');
+  const url = `http://127.0.0.1:${verifyServer.address().port}`;
+  try {
+    const response = await fetch(`${url}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-5.5', stream: true, input: 'private judge prompt' }),
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(body, /response\.completed/);
+    assert.match(body, /used_skill/);
+    assert.match(body, /executor path healthy/);
+  } finally {
+    await new Promise((resolve) => verifyServer.close(resolve));
+  }
+});
+
+test('Pack preflight mock requires two ordered Skill results before returning the marker', async () => {
+  const skillIds = ['pack-executor-preflight-a', 'pack-executor-preflight-b'];
+  const packActivities = [];
+  const packServer = createPackEvaluatorPreflightMock({
+    localToken: LOCAL_TOKEN,
+    preflightSkillIds: skillIds,
+    onActivity: (activity) => packActivities.push(activity),
+  });
+  packServer.listen(0, '127.0.0.1');
+  await once(packServer, 'listening');
+  const url = `http://127.0.0.1:${packServer.address().port}`;
+  const headers = {
+    authorization: `Bearer ${LOCAL_TOKEN}`,
+    'content-type': 'application/json',
+  };
+  try {
+    const first = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [{ role: 'user', content: 'private Pack task' }],
+      }),
+    });
+    const firstBody = await first.text();
+    assert.equal(first.status, 200);
+    for (const skillId of skillIds) assert.match(firstBody, new RegExp(skillId));
+    assert.match(firstBody, /toolu_pack_preflight_1/);
+    assert.match(firstBody, /toolu_pack_preflight_2/);
+
+    const second = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'toolu_pack_preflight_1', content: 'private result' },
+            { type: 'tool_result', tool_use_id: 'toolu_pack_preflight_2', content: 'private result' },
+          ],
+        }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.match(await second.text(), /PACK_EVALUATOR_READY/);
+
+    const third = await fetch(`${url}/v1/messages`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: 'sonnet',
+        stream: true,
+        max_tokens: 16384,
+        tools: [{ name: 'Skill' }],
+        messages: [],
+      }),
+    });
+    assert.equal(third.status, 400);
+    assert.doesNotMatch(
+      JSON.stringify(packActivities),
+      /private Pack task|private result|local-preflight-token|PACK_EVALUATOR_READY/,
+    );
+  } finally {
+    await new Promise((resolve) => packServer.close(resolve));
+  }
+});

--- a/scripts/tests/pack-evaluator-proxy.test.mjs
+++ b/scripts/tests/pack-evaluator-proxy.test.mjs
@@ -62,7 +62,47 @@ test('requires the job-local token even for health checks', async () => {
     headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
   });
   assert.equal(response.status, 200);
-  assert.equal(activities.length, activityCount, 'unauthenticated probes must not emit fatal activity');
+  assert.deepEqual(activities.slice(activityCount), [
+    {
+      phase: 'response',
+      requestNumber: 1,
+      path: 'not_allowed',
+      status: 401,
+      errorCategory: 'authentication_failed',
+    },
+    {
+      phase: 'response',
+      requestNumber: 2,
+      path: '/v1/messages',
+      status: 401,
+      errorCategory: 'authentication_failed',
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(activities.slice(activityCount)), /local-token|authorization/i);
+});
+
+test('bounds unauthenticated activity diagnostics independently of request budget', async () => {
+  const rejected = [];
+  const boundedProxy = createPackEvaluatorProxy({
+    localToken: LOCAL_TOKEN,
+    upstreamKey: UPSTREAM_KEY,
+    upstreamBaseUrl: upstreamUrl,
+    onActivity: (activity) => rejected.push(activity),
+  });
+  boundedProxy.listen(0, '127.0.0.1');
+  await once(boundedProxy, 'listening');
+  const url = `http://127.0.0.1:${boundedProxy.address().port}`;
+  try {
+    for (let index = 0; index < 12; index += 1) {
+      assert.equal((await fetch(`${url}/v1/responses`)).status, 401);
+    }
+    assert.equal(rejected.length, 8);
+    assert.ok(rejected.every((entry) =>
+      entry.status === 401 && entry.errorCategory === 'authentication_failed'
+    ));
+  } finally {
+    await new Promise((resolve) => boundedProxy.close(resolve));
+  }
 });
 
 test('allows only the explicit inference endpoint allowlist', async () => {

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -82,7 +82,7 @@ function metadata() {
     },
     workflowSource: `name: Generate Pack
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.13.2'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
 jobs:
   evaluate:
     steps:
@@ -152,7 +152,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
       scenarioId: 'spreadsheet-audit',
     },
   });
-  json(join(planDir, 'cli-identity.json'), { version: '2.13.2', sha256: CLI_SHA });
+  json(join(planDir, 'cli-identity.json'), { version: '2.14.0', sha256: CLI_SHA });
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -327,7 +327,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
-        cliVersion: '2.13.2',
+        cliVersion: '2.14.0',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],
         reports: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID }],

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -82,7 +82,7 @@ function metadata() {
     },
     workflowSource: `name: Generate Pack
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.2'
 jobs:
   evaluate:
     steps:
@@ -152,7 +152,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
       scenarioId: 'spreadsheet-audit',
     },
   });
-  json(join(planDir, 'cli-identity.json'), { version: '2.14.1', sha256: CLI_SHA });
+  json(join(planDir, 'cli-identity.json'), { version: '2.14.2', sha256: CLI_SHA });
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -327,7 +327,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
-        cliVersion: '2.14.1',
+        cliVersion: '2.14.2',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],
         reports: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID }],

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -82,7 +82,7 @@ function metadata() {
     },
     workflowSource: `name: Generate Pack
 env:
-  PACK_PRODUCTION_CLI_VERSION: '2.14.0'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.1'
 jobs:
   evaluate:
     steps:
@@ -152,7 +152,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
       scenarioId: 'spreadsheet-audit',
     },
   });
-  json(join(planDir, 'cli-identity.json'), { version: '2.14.0', sha256: CLI_SHA });
+  json(join(planDir, 'cli-identity.json'), { version: '2.14.1', sha256: CLI_SHA });
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -327,7 +327,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
-        cliVersion: '2.14.0',
+        cliVersion: '2.14.1',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],
         reports: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID }],

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -28,11 +28,13 @@ import {
   buildSloResult,
   canonicalJson,
   deterministicHttpFailureFromActivity,
+  exactExecutorPreflightClosure,
   isSafeEvaluatorProgressLine,
   normalizeEvaluatorProgressLine,
   normalizeInfrastructureFailure,
   planTrustedPersistence,
   prepareScenarioRuntime,
+  projectExecutorPreflightEvidence,
   readExactPublicPack,
   runEvaluatorProcess,
   validateCandidateNullPersistResponse,
@@ -558,6 +560,242 @@ test('safe CLI evidence hard-caps error digests per category and in total', () =
   assert.equal(evidence.counts.errorDigestsTruncated, true);
   assert.ok(evidence.errorEvidence.every((entry) => entry.truncated));
   assert.doesNotMatch(JSON.stringify(evidence), /secret-/);
+});
+
+test('safe CLI evidence retains only bounded failed Agent process metadata', () => {
+  const report = cliReport();
+  report.slotEvaluations = [{
+    agentExecutionEvidence: [{
+      phase: 'run',
+      run: 1,
+      succeeded: false,
+      privateInvocation: 'private prompt',
+      attempts: [{
+        schemaVersion: 'skillstore.agent-execution-evidence/v1',
+        agent: 'claude',
+        attempt: 1,
+        sandboxed: true,
+        outcome: 'failed',
+        failureCategory: 'spawn_error',
+        spawnErrorCode: 'EAGAIN',
+        exitCode: null,
+        signal: null,
+        durationMs: 42,
+        stdoutBytes: 0,
+        stderrBytes: 0,
+        stdoutSha256: 'a'.repeat(64),
+        stderrSha256: 'b'.repeat(64),
+        rawStderr: 'secret child path',
+      }],
+    }],
+    errors: [],
+  }];
+
+  const evidence = buildSafeCliEvidence(report, context).agentExecutionEvidence;
+  assert.deepEqual(evidence, {
+    schemaVersion: 'marketplace.pack-production-agent-execution-evidence/v1',
+    invocations: 1,
+    attempts: 1,
+    failedInvocations: 1,
+    failedAttempts: 1,
+    recoveredFailedAttempts: 0,
+    capturedFailures: 1,
+    truncated: false,
+    failures: [{
+      phase: 'run',
+      run: 1,
+      recovered: false,
+      agent: 'claude',
+      attempt: 1,
+      sandboxed: true,
+      outcome: 'failed',
+      failureCategory: 'spawn_error',
+      spawnErrorCode: 'EAGAIN',
+      exitCode: null,
+      signal: null,
+      durationMs: 42,
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      stdoutSha256: 'a'.repeat(64),
+      stderrSha256: 'b'.repeat(64),
+    }],
+  });
+  assert.doesNotMatch(JSON.stringify(evidence), /private|secret|rawStderr/);
+});
+
+test('safe CLI evidence retains a failed attempt recovered by a later retry', () => {
+  const report = cliReport();
+  const attempt = (number, outcome, category, code) => ({
+    schemaVersion: 'skillstore.agent-execution-evidence/v1',
+    agent: 'claude',
+    attempt: number,
+    sandboxed: true,
+    outcome,
+    failureCategory: category,
+    spawnErrorCode: code,
+    exitCode: outcome === 'succeeded' ? 0 : null,
+    signal: null,
+    durationMs: 10,
+    stdoutBytes: outcome === 'succeeded' ? 5 : 0,
+    stderrBytes: 0,
+    stdoutSha256: 'a'.repeat(64),
+    stderrSha256: 'b'.repeat(64),
+  });
+  report.slotEvaluations = [{
+    agentExecutionEvidence: [{
+      phase: 'run',
+      run: 1,
+      succeeded: true,
+      attempts: [
+        attempt(1, 'failed', 'spawn_error', 'EAGAIN'),
+        attempt(2, 'succeeded', 'none', null),
+      ],
+    }],
+    errors: [],
+  }];
+
+  const evidence = buildSafeCliEvidence(report, context).agentExecutionEvidence;
+  assert.equal(evidence.failedInvocations, 0);
+  assert.equal(evidence.failedAttempts, 1);
+  assert.equal(evidence.recoveredFailedAttempts, 1);
+  const { schemaVersion: _schemaVersion, ...failedAttempt } = attempt(
+    1,
+    'failed',
+    'spawn_error',
+    'EAGAIN',
+  );
+  assert.deepEqual(evidence.failures[0], {
+    phase: 'run',
+    run: 1,
+    recovered: true,
+    ...failedAttempt,
+  });
+});
+
+test('Agent evidence traversal fails before descending past its depth budget', () => {
+  const report = cliReport();
+  let nested = {};
+  for (let depth = 0; depth < 40; depth += 1) nested = { nested };
+  report.extra = nested;
+  assert.throws(
+    () => buildSafeCliEvidence(report, context),
+    /traversal depth budget/,
+  );
+});
+
+test('executor preflight preserves the validated attempt schema for the shell projector', () => {
+  const bindings = [
+    { canonicalId: 'pack-executor-preflight-a', contentHash: '1'.repeat(64), version: '1.0.0' },
+    { canonicalId: 'pack-executor-preflight-b', contentHash: '2'.repeat(64), version: '1.0.0' },
+  ];
+  const attempt = (agent) => ({
+    schemaVersion: 'skillstore.agent-execution-evidence/v1',
+    agent,
+    attempt: 1,
+    sandboxed: true,
+    outcome: 'succeeded',
+    failureCategory: 'none',
+    spawnErrorCode: null,
+    exitCode: 0,
+    signal: null,
+    durationMs: 10,
+    stdoutBytes: 5,
+    stderrBytes: 0,
+    stdoutSha256: 'a'.repeat(64),
+    stderrSha256: 'b'.repeat(64),
+  });
+  const report = {
+    schemaVersion: 'skillstore.pack-executor-preflight/v1',
+    outcome: 'passed',
+    bindings,
+    verification: {
+      passed: true,
+      runs: 1,
+      medianScore: 10,
+      taskCompletedRate: 1,
+      verdictCount: 1,
+      errorCount: 0,
+      usedSkill: true,
+      usedSkills: bindings.map((binding) => binding.canonicalId),
+      taskCompleted: true,
+      envBlocked: false,
+      score: 10,
+    },
+    runnerUsageTraces: [{
+      schemaVersion: 'skillstore.runner-skill-trace/v1',
+      agent: 'claude',
+      source: 'claude-stream-json-v1',
+      deterministic: true,
+      events: bindings.map((binding, index) => ({ sequence: index + 1, ...binding })),
+    }],
+    agentExecutionEvidence: [
+      { phase: 'run', run: 1, succeeded: true, attempts: [attempt('claude')] },
+      { phase: 'judge', run: 1, succeeded: true, attempts: [attempt('codex')] },
+    ],
+  };
+  const closure = exactExecutorPreflightClosure(report, bindings);
+
+  assert.deepEqual(
+    closure.agentExecutionEvidence.map((invocation) => invocation.attempts[0].schemaVersion),
+    [
+      'skillstore.agent-execution-evidence/v1',
+      'skillstore.agent-execution-evidence/v1',
+    ],
+  );
+  assert.deepEqual(closure.runnerTraceEvidence, {
+    schemaVersion: 'marketplace.pack-executor-trace-evidence/v1',
+    deterministic: true,
+    traceCount: 1,
+    eventCount: 2,
+    bindingDigest: createHash('sha256').update(canonicalJson(bindings)).digest('hex'),
+  });
+
+  const wrongJudge = structuredClone(report);
+  wrongJudge.verification.usedSkills = [bindings[0].canonicalId];
+  assert.equal(exactExecutorPreflightClosure(wrongJudge, bindings), null);
+
+  const wrongTrace = structuredClone(report);
+  wrongTrace.runnerUsageTraces[0].events[1].contentHash = 'f'.repeat(64);
+  assert.equal(exactExecutorPreflightClosure(wrongTrace, bindings), null);
+});
+
+test('executor preflight retains bounded failed Agent evidence outside the pass closure', () => {
+  const report = {
+    errors: ['private failure text'],
+    verdicts: [],
+    agentExecutionEvidence: [{
+      phase: 'run',
+      run: 1,
+      succeeded: false,
+      privateInvocation: 'private prompt',
+      attempts: [{
+        schemaVersion: 'skillstore.agent-execution-evidence/v1',
+        agent: 'claude',
+        attempt: 1,
+        sandboxed: true,
+        outcome: 'failed',
+        failureCategory: 'spawn_error',
+        spawnErrorCode: 'EAGAIN',
+        exitCode: null,
+        signal: null,
+        durationMs: 10,
+        stdoutBytes: 0,
+        stderrBytes: 0,
+        stdoutSha256: 'a'.repeat(64),
+        stderrSha256: 'b'.repeat(64),
+        rawStderr: 'private process detail',
+      }],
+    }],
+  };
+
+  assert.equal(exactExecutorPreflightClosure(report, [
+    { canonicalId: 'pack-executor-preflight-a', contentHash: '1'.repeat(64), version: '1.0.0' },
+    { canonicalId: 'pack-executor-preflight-b', contentHash: '2'.repeat(64), version: '1.0.0' },
+  ]), null);
+  const evidence = projectExecutorPreflightEvidence(report);
+  assert.equal(evidence[0].attempts[0].spawnErrorCode, 'EAGAIN');
+  assert.equal(evidence[0].attempts[0].schemaVersion, 'skillstore.agent-execution-evidence/v1');
+  assert.doesNotMatch(JSON.stringify(evidence), /private|rawStderr|errors|verdicts/);
 });
 
 test('isolated scenario Codex home permits ephemeral state without weakening config', async (t) => {


### PR DESCRIPTION
## Summary
- replace the liveness-only preflight with the released CLI 2.14.0 two-Skill `verifyPack` path, exact identity bindings, Claude stream-json trace proof, and Codex Judge proof
- run the preflight under the production UID/GID, disposable HOME/TMP/CODEX_HOME, prlimit, nested bubblewrap, and bounded local proxy path
- retain fixed-field Agent failure evidence across CLI and outer retries without prompts, outputs, paths, arguments, environment, or credentials
- add stateful local mock coverage for two ordered Skill tool calls and strict Judge output
- bind hosted proof artifacts to the exact Marketplace commit SHA and released CLI checksum
- keep automatic publication hard-disabled and add no database-heavy workflow

## Verification
- `CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-evaluator-bwrap-userns.test.mjs scripts/tests/pack-evaluator-proxy.test.mjs scripts/tests/pack-evaluator-preflight-mock.test.mjs scripts/tests/pack-production.test.mjs scripts/tests/pack-production-cancellation-recovery.test.mjs` (90 passed, 1 Linux-only skip)
- `git diff --check`
- `bash -n scripts/pack-evaluator-preflight.sh`
- Node syntax checks for the orchestrator, mock, and proxy
- independent findings-only review: no remaining code-level P0/P1/P2

## Rollout gate
Do not treat ordinary PR checks as the real executor proof. Before merge, manually dispatch `test-pack-evaluator-bwrap.yml` against this exact branch SHA and verify the uploaded `proofBinding`. If squash changes the SHA, dispatch again on merged `main` before any production canary. Auto-publish remains off.