### PR TITLE
fix: 修复提交分片产物聚合

### DIFF
--- a/.github/workflows/approve-submission.yml
+++ b/.github/workflows/approve-submission.yml
@@ -155,6 +155,26 @@ jobs:
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }' || echo "::warning::Failed to notify skillstore"
 
+      - name: Notify skillstore - Completed without PR
+        if: needs.process-skills.result == 'success' && needs.process-skills.outputs.outcome == 'no_op'
+        env:
+          REASON_CODE: ${{ needs.process-skills.outputs.outcome_reason }}
+        run: |
+          curl -sS -X POST "${{ secrets.SKILLSTORE_API_URL }}/api/submit/callback" \
+            -H "Authorization: Bearer ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+            -H "X-Skillstore-Callback: true" \
+            -d '{
+              "submission_id": "'"${{ env.SUBMISSION_ID }}"'",
+              "event": "completed",
+              "reason_code": "'"$REASON_CODE"'",
+              "processed_count": 0,
+              "approved_by": "'"${{ github.actor }}"'",
+              "workflow_run_id": ${{ github.run_id }},
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "::warning::Failed to notify skillstore"
+
       - name: Notify skillstore - Failed
         if: needs.process-skills.result == 'failure'
         env:

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -109,6 +109,25 @@ jobs:
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }' || echo "::warning::Failed to notify skillstore"
 
+      - name: Notify skillstore - Completed without PR
+        if: needs.process-skills.result == 'success' && needs.process-skills.outputs.outcome == 'no_op'
+        env:
+          REASON_CODE: ${{ needs.process-skills.outputs.outcome_reason }}
+        run: |
+          curl -sS -X POST "${{ secrets.SKILLSTORE_API_URL }}/api/submit/callback" \
+            -H "Authorization: Bearer ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+            -H "X-Skillstore-Callback: true" \
+            -d '{
+              "submission_id": "'"${{ env.SUBMISSION_ID }}"'",
+              "event": "completed",
+              "reason_code": "'"$REASON_CODE"'",
+              "processed_count": 0,
+              "workflow_run_id": ${{ github.run_id }},
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "::warning::Failed to notify skillstore"
+
       - name: Notify skillstore - Failed
         if: needs.process-skills.result == 'failure'
         run: |

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -54,6 +54,12 @@ on:
       highest_risk:
         description: 'Highest security risk level found'
         value: ${{ jobs.merge-and-create-pr.outputs.highest_risk }}
+      outcome:
+        description: 'Terminal outcome: pr_created or no_op'
+        value: ${{ jobs.merge-and-create-pr.outputs.outcome }}
+      outcome_reason:
+        description: 'Machine-readable terminal outcome reason'
+        value: ${{ jobs.merge-and-create-pr.outputs.outcome_reason }}
     secrets:
       APP_ID:
         required: true
@@ -270,10 +276,10 @@ jobs:
           MAX_SHARDS=${{ env.MAX_SHARDS }}
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "❌ No skills found"
-            echo 'matrix={"include":[]}' >> $GITHUB_OUTPUT
+            echo "No skills found; planning one explicit no-op shard"
+            echo 'matrix={"include":[{"shard":0,"slugs":""}]}' >> $GITHUB_OUTPUT
             echo "is_sharded=false" >> $GITHUB_OUTPUT
-            echo "shard_count=0" >> $GITHUB_OUTPUT
+            echo "shard_count=1" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -335,13 +341,13 @@ jobs:
     if: needs.discover-and-plan.outputs.shard_count != '0'
     runs-on: self-hosted
     timeout-minutes: 1440
-    continue-on-error: true
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(inputs.max_parallel) }}
       matrix: ${{ fromJSON(needs.discover-and-plan.outputs.matrix) }}
     steps:
       - name: Generate GitHub App Token
+        if: matrix.slugs != ''
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -355,6 +361,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Skillstore CLI
+        if: matrix.slugs != ''
         uses: ./.github/actions/download-skillstore-cli
         with:
           version: ${{ inputs.cli_version }}
@@ -369,98 +376,18 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SLUGS: ${{ matrix.slugs }}
+          MODEL: ${{ inputs.model }}
         run: |
           set -euo pipefail
-          echo "=== Shard ${{ matrix.shard }} ==="
-          SKILL_COUNT=$(echo "$SLUGS" | tr ',' '\n' | grep -c . || echo 0)
-          echo "Processing $SKILL_COUNT skill(s)"
-
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
-          rm -rf "$RESULT_DIR"
-          mkdir -p "$RESULT_DIR/pending"
-          LOG_FILE="$RESULT_DIR/process-output-${{ matrix.shard }}.log"
-
-          MODEL_FLAG=""
-          if [ -n "${{ inputs.model }}" ]; then
-            MODEL_FLAG="--model ${{ inputs.model }}"
-          fi
-
-          # First attempt
-          set +e
-          "$GITHUB_WORKSPACE/skillstore-cli" skill process "${{ needs.discover-and-plan.outputs.github_url }}" \
+          node scripts/process-submission-shard.mjs \
+            --cli "$GITHUB_WORKSPACE/skillstore-cli" \
+            --github-url "${{ needs.discover-and-plan.outputs.github_url }}" \
             --slugs "$SLUGS" \
-            --output "$RESULT_DIR" \
+            --result-dir "$RESULT_DIR" \
             --marketplace-repo "${{ github.repository }}" \
-            --skip-pr \
-            $MODEL_FLAG \
-            2>&1 | tee "$LOG_FILE"
-          FIRST_EXIT=$?
-          set -e
-
-          # Check for failed skills and retry
-          FAILED_SLUGS=""
-          for slug in $(echo "$SLUGS" | tr ',' '\n'); do
-            [ -z "$slug" ] && continue
-            FOUND=$(find "$RESULT_DIR/pending" -path "*/$slug/skill-report.json" 2>/dev/null | head -1)
-            if [ -z "$FOUND" ]; then
-              [ -n "$FAILED_SLUGS" ] && FAILED_SLUGS="$FAILED_SLUGS,"
-              FAILED_SLUGS="$FAILED_SLUGS$slug"
-            fi
-          done
-
-          # Retry failed skills once
-          if [ -n "$FAILED_SLUGS" ]; then
-            RETRY_COUNT=$(echo "$FAILED_SLUGS" | tr ',' '\n' | grep -c . || echo 0)
-            echo ""
-            echo "🔄 Retrying $RETRY_COUNT failed skill(s): $FAILED_SLUGS"
-            sleep 10
-
-            "$GITHUB_WORKSPACE/skillstore-cli" skill process "${{ needs.discover-and-plan.outputs.github_url }}" \
-              --slugs "$FAILED_SLUGS" \
-              --output "$RESULT_DIR" \
-              --marketplace-repo "${{ github.repository }}" \
-              --skip-pr \
-              $MODEL_FLAG \
-              2>&1 | tee -a "$LOG_FILE" || true
-          fi
-
-          # Collect final results
-          PROCESSED=0
-          ERRORS=0
-          HIGHEST_RISK="safe"
-          PROCESSED_SLUGS=""
-
-          for report in $(find "$RESULT_DIR/pending" -name "skill-report.json" 2>/dev/null); do
-            SLUG=$(jq -r '.meta.slug' "$report")
-            RISK=$(jq -r '.security_audit.risk_level // "unknown"' "$report")
-
-            PROCESSED_SLUGS="$PROCESSED_SLUGS,$SLUG"
-            PROCESSED=$((PROCESSED + 1))
-
-            case "$RISK" in
-              critical) HIGHEST_RISK="critical" ;;
-              high) [ "$HIGHEST_RISK" != "critical" ] && HIGHEST_RISK="high" ;;
-              medium) [ "$HIGHEST_RISK" = "safe" ] || [ "$HIGHEST_RISK" = "low" ] && HIGHEST_RISK="medium" ;;
-              low) [ "$HIGHEST_RISK" = "safe" ] && HIGHEST_RISK="low" ;;
-            esac
-          done
-
-          # Count remaining failures
-          for slug in $(echo "$SLUGS" | tr ',' '\n'); do
-            [ -z "$slug" ] && continue
-            FOUND=$(find "$RESULT_DIR/pending" -path "*/$slug/skill-report.json" 2>/dev/null | head -1)
-            [ -z "$FOUND" ] && ERRORS=$((ERRORS + 1))
-          done
-
-          PROCESSED_SLUGS=$(echo "$PROCESSED_SLUGS" | sed 's/^,//')
-
-          echo "processed=$PROCESSED" >> $GITHUB_OUTPUT
-          echo "errors=$ERRORS" >> $GITHUB_OUTPUT
-          echo "highest_risk=$HIGHEST_RISK" >> $GITHUB_OUTPUT
-          echo "processed_slugs=$PROCESSED_SLUGS" >> $GITHUB_OUTPUT
-
-          echo ""
-          echo "📊 Shard ${{ matrix.shard }}: $PROCESSED processed, $ERRORS errors, highest risk: $HIGHEST_RISK"
+            --shard-index "${{ matrix.shard }}" \
+            --model "$MODEL"
 
       - name: Create mode-preserving shard archive
         if: always()
@@ -470,12 +397,17 @@ jobs:
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
           LOG_FILE="$RESULT_DIR/process-output-${{ matrix.shard }}.log"
+          MANIFEST_FILE="$RESULT_DIR/shard-manifest.json"
           mkdir -p "$RESULT_DIR/pending"
           test -f "$LOG_FILE" || : > "$LOG_FILE"
+          test -f "$MANIFEST_FILE" || {
+            echo "::error::Shard process step did not produce a diagnostic manifest"
+            exit 1
+          }
           printf '%s\n' "$PLANNED_SLUGS" > "$RESULT_DIR/planned-slugs.csv"
           SHARD_ARCHIVE_NAME="process-shard-${{ github.run_attempt }}-${{ matrix.shard }}.tar.gz"
           tar -C "$RESULT_DIR" -czf "$RESULT_DIR/$SHARD_ARCHIVE_NAME" \
-            pending "$(basename "$LOG_FILE")" planned-slugs.csv
+            pending "$(basename "$LOG_FILE")" planned-slugs.csv shard-manifest.json
 
       - name: Upload shard results
         if: always()
@@ -485,6 +417,20 @@ jobs:
           path: /tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}/process-shard-${{ github.run_attempt }}-${{ matrix.shard }}.tar.gz
           if-no-files-found: error
           retention-days: 1
+
+      - name: Enforce shard terminal status
+        if: always()
+        env:
+          PLANNED_SLUGS: ${{ matrix.slugs }}
+        run: |
+          set -euo pipefail
+          RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
+          node scripts/submission-shard-contract.mjs \
+            --manifest "$RESULT_DIR/shard-manifest.json" \
+            --expected-index "${{ matrix.shard }}" \
+            --expected-slugs "$PLANNED_SLUGS" \
+            --pending-root "$RESULT_DIR/pending" \
+            --require-success
 
       - name: Cleanup isolated shard results
         if: always()
@@ -507,6 +453,8 @@ jobs:
       pr_url: ${{ steps.create_pr.outputs.pr_url }}
       processed_count: ${{ steps.create_pr.outputs.processed_count }}
       highest_risk: ${{ steps.create_pr.outputs.highest_risk }}
+      outcome: ${{ steps.create_pr.outputs.outcome }}
+      outcome_reason: ${{ steps.create_pr.outputs.outcome_reason }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -538,7 +486,7 @@ jobs:
           cleanup() {
             echo "🧹 Cleaning up temp directories..."
             rm -rf "$WORK_DIR" "$ARTIFACTS_DIR" "${ARTIFACTS_DIR}.approval-plan.json" \
-              "${ARTIFACTS_DIR}.plan-items.jsonl" "${ARTIFACTS_DIR}.merged" 2>/dev/null || true
+              "${ARTIFACTS_DIR}.summary.json" "${ARTIFACTS_DIR}.merged" 2>/dev/null || true
           }
           trap cleanup EXIT
 
@@ -556,80 +504,29 @@ jobs:
 
           echo "=== Resolving frozen results from all shards ==="
           APPROVAL_PLAN="${ARTIFACTS_DIR}.approval-plan.json"
-          PLAN_ITEMS="${ARTIFACTS_DIR}.plan-items.jsonl"
+          AGGREGATION_SUMMARY="${ARTIFACTS_DIR}.summary.json"
           MERGED_RESULTS="${ARTIFACTS_DIR}.merged"
-          mkdir -p "$MERGED_RESULTS"
-          : > "$PLAN_ITEMS"
-          mapfile -t SHARD_ARCHIVES < <(find "$ARTIFACTS_DIR" -type f \
-            -name 'process-shard-${{ github.run_attempt }}-*.tar.gz' | sort)
-          test "${#SHARD_ARCHIVES[@]}" -eq "${{ needs.discover-and-plan.outputs.shard_count }}" || {
-            echo "::error::Downloaded ${#SHARD_ARCHIVES[@]}/${{ needs.discover-and-plan.outputs.shard_count }} shard archive(s)"
-            exit 1
-          }
-          declare -A SEEN_SHARD_INDICES=()
-          for SHARD_ARCHIVE in "${SHARD_ARCHIVES[@]}"; do
-            SHARD_ARCHIVE_NAME="$(basename "$SHARD_ARCHIVE")"
-            SHARD_INDEX="${SHARD_ARCHIVE_NAME#process-shard-${{ github.run_attempt }}-}"
-            SHARD_INDEX="${SHARD_INDEX%.tar.gz}"
-            if [[ ! "$SHARD_INDEX" =~ ^[0-9]+$ ]] || [ -n "${SEEN_SHARD_INDICES[$SHARD_INDEX]+x}" ]; then
-              echo "::error::Missing or duplicate shard artifact index: $SHARD_ARCHIVE_NAME"
-              exit 1
-            fi
-            SEEN_SHARD_INDICES[$SHARD_INDEX]=1
-            SHARD_ROOT="${SHARD_ARCHIVE%.tar.gz}.extracted"
-            mkdir -p "$SHARD_ROOT"
-            tar -xzf "$SHARD_ARCHIVE" -C "$SHARD_ROOT" --no-same-owner
-            EXPECTED_SLUGS=$(jq -er --argjson shard "$SHARD_INDEX" \
-              '.include[] | select(.shard == $shard) | .slugs' <<< "$SHARD_MATRIX")
-            test "$(cat "$SHARD_ROOT/planned-slugs.csv")" = "$EXPECTED_SLUGS" || {
-              echo "::error::Shard $SHARD_INDEX planned slug evidence does not match the workflow matrix"
-              exit 1
-            }
-            SHARD_FILES="${SHARD_ARCHIVE}.files.txt"
-            SHARD_PLAN="${SHARD_ARCHIVE}.approval-plan.json"
-            find "$SHARD_ROOT/pending" \( -type f -o -type l \) -print 2>/dev/null \
-              | sed "s|^$SHARD_ROOT/||" > "$SHARD_FILES"
-            if [ ! -s "$SHARD_FILES" ]; then
-              echo "::warning::Shard $SHARD_INDEX produced no successful skills"
-              continue
-            fi
-            node scripts/resolve-approved-submission.mjs \
-              --repo-root "$SHARD_ROOT" \
-              --files "$SHARD_FILES" \
-              --output "$SHARD_PLAN" \
-              --allow-blocked
-            jq -en --arg planned "$EXPECTED_SLUGS" --slurpfile plan "$SHARD_PLAN" '
-              ($planned | split(",") | map(select(length > 0)) | unique) as $expected
-              | ($plan[0].skills | map(.pendingDir | split("/")[-1]) | unique) as $actual
-              | (($actual - $expected) | length) == 0
-            ' >/dev/null || {
-              echo "::error::Shard $SHARD_INDEX produced a skill outside its planned slug set"
-              exit 1
-            }
-            jq -c '.skills[]' "$SHARD_PLAN" >> "$PLAN_ITEMS"
-            while IFS= read -r pending_dir; do
-              test ! -e "$MERGED_RESULTS/$pending_dir" || {
-                echo "::error::Duplicate pending path across shards: $pending_dir"
-                exit 1
-              }
-              mkdir -p "$MERGED_RESULTS/$(dirname "$pending_dir")"
-              cp -R "$SHARD_ROOT/$pending_dir" "$MERGED_RESULTS/$pending_dir"
-            done < <(jq -r '.skills[].pendingDir' "$SHARD_PLAN")
-          done
-          if [ ! -s "$PLAN_ITEMS" ]; then
-            echo "No skills were successfully processed"
+          node scripts/aggregate-submission-shards.mjs \
+            --artifacts-dir "$ARTIFACTS_DIR" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --matrix-json "$SHARD_MATRIX" \
+            --expected-count "${{ needs.discover-and-plan.outputs.shard_count }}" \
+            --approval-plan "$APPROVAL_PLAN" \
+            --merged-results "$MERGED_RESULTS" \
+            --summary "$AGGREGATION_SUMMARY"
+
+          AGGREGATION_STATUS=$(jq -er '.status' "$AGGREGATION_SUMMARY")
+          AGGREGATION_REASON=$(jq -er '.reasonCode' "$AGGREGATION_SUMMARY")
+          if [ "$AGGREGATION_STATUS" = "no_op" ]; then
+            echo "Explicit legal no-op: $AGGREGATION_REASON"
             echo "has_results=false" >> "$GITHUB_OUTPUT"
+            echo "processed_count=0" >> "$GITHUB_OUTPUT"
+            echo "highest_risk=safe" >> "$GITHUB_OUTPUT"
+            echo "outcome=no_op" >> "$GITHUB_OUTPUT"
+            echo "outcome_reason=$AGGREGATION_REASON" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          jq -s '
-            if ([.[].pendingDir] | length) != ([.[].pendingDir] | unique | length)
-              then error("duplicate pending path across submission shards")
-            elif ([.[].targetDir] | length) != ([.[].targetDir] | unique | length)
-              then error("duplicate publication target across submission shards")
-            elif ([.[].reportSlug] | length) != ([.[].reportSlug] | unique | length)
-              then error("duplicate report slug across submission shards")
-            else {schemaVersion: 1, skills: sort_by(.pendingDir)} end
-          ' "$PLAN_ITEMS" > "$APPROVAL_PLAN"
+          test "$AGGREGATION_STATUS" = "has_results"
           mapfile -t SUBMISSION_PATHS < <(jq -r '.skills[].pendingDir' "$APPROVAL_PLAN")
           test "${#SUBMISSION_PATHS[@]}" -gt 0
 
@@ -672,23 +569,16 @@ jobs:
           PROCESSED_SKILLS="${PROCESSED_SKILLS#,}"
 
           TOTAL_ERRORS=0
-          for log in "$ARTIFACTS_DIR"/process-shard-${{ github.run_attempt }}-*.tar.gz.extracted/process-output-*.log; do
-            if [ -f "$log" ]; then
-              ERR_COUNT=$(grep -c "❌ error" "$log" 2>/dev/null) || ERR_COUNT=0
-              TOTAL_ERRORS=$((TOTAL_ERRORS + ERR_COUNT))
-            fi
-          done
 
           echo "📊 Merged Results:"
           echo "  Total processed: $PROCESSED_COUNT"
           echo "  Total errors: $TOTAL_ERRORS"
           echo "  Highest risk: $HIGHEST_RISK"
 
-          if [ "$PROCESSED_COUNT" -eq 0 ]; then
-            echo "::error::No skills were successfully processed"
-            echo "has_results=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          test "$PROCESSED_COUNT" -gt 0 || {
+            echo "::error::Validated non-no-op aggregate contains no skills"
+            exit 1
+          }
 
           echo "has_results=true" >> $GITHUB_OUTPUT
           echo "processed_count=$PROCESSED_COUNT" >> $GITHUB_OUTPUT
@@ -822,4 +712,6 @@ jobs:
           fi
 
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "outcome=pr_created" >> $GITHUB_OUTPUT
+          echo "outcome_reason=processed_all_planned" >> $GITHUB_OUTPUT
           echo "Created PR: $PR_URL"

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -473,7 +473,8 @@ jobs:
           mkdir -p "$RESULT_DIR/pending"
           test -f "$LOG_FILE" || : > "$LOG_FILE"
           printf '%s\n' "$PLANNED_SLUGS" > "$RESULT_DIR/planned-slugs.csv"
-          tar -C "$RESULT_DIR" -czf "$RESULT_DIR/shard-results.tar.gz" \
+          SHARD_ARCHIVE_NAME="process-shard-${{ github.run_attempt }}-${{ matrix.shard }}.tar.gz"
+          tar -C "$RESULT_DIR" -czf "$RESULT_DIR/$SHARD_ARCHIVE_NAME" \
             pending "$(basename "$LOG_FILE")" planned-slugs.csv
 
       - name: Upload shard results
@@ -481,7 +482,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: process-shard-${{ github.run_attempt }}-${{ matrix.shard }}
-          path: /tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}/shard-results.tar.gz
+          path: /tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}/process-shard-${{ github.run_attempt }}-${{ matrix.shard }}.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -541,6 +542,11 @@ jobs:
           }
           trap cleanup EXIT
 
+          if [ "${{ needs.process.result }}" != "success" ]; then
+            echo "::error::Shard processing did not complete successfully; refusing to aggregate"
+            exit 1
+          fi
+
           echo "📦 Cloning fresh repository to $WORK_DIR..."
           git clone --depth 1 "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" "$WORK_DIR"
           cd "$WORK_DIR"
@@ -554,29 +560,33 @@ jobs:
           MERGED_RESULTS="${ARTIFACTS_DIR}.merged"
           mkdir -p "$MERGED_RESULTS"
           : > "$PLAN_ITEMS"
-          mapfile -t SHARD_DIRS < <(find "$ARTIFACTS_DIR" -mindepth 1 -maxdepth 1 -type d \
-            -name 'process-shard-${{ github.run_attempt }}-*' | sort)
-          test "${#SHARD_DIRS[@]}" -eq "${{ needs.discover-and-plan.outputs.shard_count }}" || {
-            echo "::error::Downloaded ${#SHARD_DIRS[@]}/${{ needs.discover-and-plan.outputs.shard_count }} shard artifact(s)"
+          mapfile -t SHARD_ARCHIVES < <(find "$ARTIFACTS_DIR" -type f \
+            -name 'process-shard-${{ github.run_attempt }}-*.tar.gz' | sort)
+          test "${#SHARD_ARCHIVES[@]}" -eq "${{ needs.discover-and-plan.outputs.shard_count }}" || {
+            echo "::error::Downloaded ${#SHARD_ARCHIVES[@]}/${{ needs.discover-and-plan.outputs.shard_count }} shard archive(s)"
             exit 1
           }
-          for shard_dir in "${SHARD_DIRS[@]}"; do
-            test -d "$shard_dir" || continue
-            SHARD_ARCHIVE="$shard_dir/shard-results.tar.gz"
-            SHARD_ROOT="$shard_dir/extracted"
-            test -f "$SHARD_ARCHIVE"
+          declare -A SEEN_SHARD_INDICES=()
+          for SHARD_ARCHIVE in "${SHARD_ARCHIVES[@]}"; do
+            SHARD_ARCHIVE_NAME="$(basename "$SHARD_ARCHIVE")"
+            SHARD_INDEX="${SHARD_ARCHIVE_NAME#process-shard-${{ github.run_attempt }}-}"
+            SHARD_INDEX="${SHARD_INDEX%.tar.gz}"
+            if [[ ! "$SHARD_INDEX" =~ ^[0-9]+$ ]] || [ -n "${SEEN_SHARD_INDICES[$SHARD_INDEX]+x}" ]; then
+              echo "::error::Missing or duplicate shard artifact index: $SHARD_ARCHIVE_NAME"
+              exit 1
+            fi
+            SEEN_SHARD_INDICES[$SHARD_INDEX]=1
+            SHARD_ROOT="${SHARD_ARCHIVE%.tar.gz}.extracted"
             mkdir -p "$SHARD_ROOT"
             tar -xzf "$SHARD_ARCHIVE" -C "$SHARD_ROOT" --no-same-owner
-            SHARD_INDEX="${shard_dir##*-}"
-            [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]]
             EXPECTED_SLUGS=$(jq -er --argjson shard "$SHARD_INDEX" \
               '.include[] | select(.shard == $shard) | .slugs' <<< "$SHARD_MATRIX")
             test "$(cat "$SHARD_ROOT/planned-slugs.csv")" = "$EXPECTED_SLUGS" || {
               echo "::error::Shard $SHARD_INDEX planned slug evidence does not match the workflow matrix"
               exit 1
             }
-            SHARD_FILES="${shard_dir}.files.txt"
-            SHARD_PLAN="${shard_dir}.approval-plan.json"
+            SHARD_FILES="${SHARD_ARCHIVE}.files.txt"
+            SHARD_PLAN="${SHARD_ARCHIVE}.approval-plan.json"
             find "$SHARD_ROOT/pending" \( -type f -o -type l \) -print 2>/dev/null \
               | sed "s|^$SHARD_ROOT/||" > "$SHARD_FILES"
             if [ ! -s "$SHARD_FILES" ]; then
@@ -662,7 +672,7 @@ jobs:
           PROCESSED_SKILLS="${PROCESSED_SKILLS#,}"
 
           TOTAL_ERRORS=0
-          for log in "$ARTIFACTS_DIR"/process-shard-${{ github.run_attempt }}-*/extracted/process-output-*.log; do
+          for log in "$ARTIFACTS_DIR"/process-shard-${{ github.run_attempt }}-*.tar.gz.extracted/process-output-*.log; do
             if [ -f "$log" ]; then
               ERR_COUNT=$(grep -c "❌ error" "$log" 2>/dev/null) || ERR_COUNT=0
               TOTAL_ERRORS=$((TOTAL_ERRORS + ERR_COUNT))

--- a/scripts/aggregate-submission-shards.mjs
+++ b/scripts/aggregate-submission-shards.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resolveApprovedSubmission } from './resolve-approved-submission.mjs';
+import {
+  parseCanonicalShardIndex,
+  parseSlugCsv,
+  readAndValidateSubmissionShardManifest,
+} from './submission-shard-contract.mjs';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) fail(`missing required option ${name}`);
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function parseMatrix(json, expectedCount) {
+  let matrix;
+  try {
+    matrix = JSON.parse(json);
+  } catch (error) {
+    fail(`matrix is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!matrix || typeof matrix !== 'object' || !Array.isArray(matrix.include)) fail('matrix.include must be an array');
+  if (matrix.include.length !== expectedCount) {
+    fail(`matrix contains ${matrix.include.length} shard(s), expected ${expectedCount}`);
+  }
+  const entries = new Map();
+  for (const [position, entry] of matrix.include.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail(`matrix entry ${position} must be an object`);
+    if (typeof entry.shard !== 'number') fail(`matrix entry ${position} shard must be a canonical JSON integer`);
+    const shard = parseCanonicalShardIndex(entry.shard, `matrix entry ${position} shard`);
+    if (entries.has(shard)) fail(`matrix contains duplicate canonical shard index ${shard}`);
+    entries.set(shard, parseSlugCsv(entry.slugs, `matrix shard ${shard} slugs`));
+  }
+  return entries;
+}
+
+function collectFiles(root, predicate) {
+  const files = [];
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) fail(`artifact tree contains symlink ${path}`);
+      if (entry.isDirectory()) walk(path);
+      else if (entry.isFile() && predicate(path)) files.push(path);
+    }
+  }
+  walk(root);
+  return files;
+}
+
+function collectArchives(artifactsDir, runAttempt) {
+  const prefix = `process-shard-${runAttempt}-`;
+  return collectFiles(artifactsDir, (path) => {
+    const name = basename(path);
+    return name.startsWith(prefix) && name.endsWith('.tar.gz');
+  }).sort();
+}
+
+function parseArchiveIndex(path, runAttempt) {
+  const name = basename(path);
+  const prefix = `process-shard-${runAttempt}-`;
+  if (!name.startsWith(prefix) || !name.endsWith('.tar.gz')) fail(`unexpected shard archive name ${name}`);
+  const raw = name.slice(prefix.length, -'.tar.gz'.length);
+  return parseCanonicalShardIndex(raw, `archive index in ${name}`);
+}
+
+function assertSameIntegerSet(actual, expected, label) {
+  const left = [...actual].sort((a, b) => a - b);
+  const right = [...expected].sort((a, b) => a - b);
+  if (JSON.stringify(left) !== JSON.stringify(right)) {
+    fail(`${label}: expected [${right.join(',')}], found [${left.join(',')}]`);
+  }
+}
+
+function validateTarEntries(archive) {
+  const listed = spawnSync('tar', ['-tzf', archive], { encoding: 'utf8' });
+  if (listed.status !== 0) fail(`cannot list ${basename(archive)}: ${listed.stderr.trim()}`);
+  const entries = listed.stdout.split(/\r?\n/).filter(Boolean);
+  if (entries.length === 0) fail(`${basename(archive)} is empty`);
+  for (const entry of entries) {
+    const normalized = entry.startsWith('./') ? entry.slice(2) : entry;
+    if (
+      normalized.startsWith('/')
+      || normalized.includes('\\')
+      || normalized.split('/').some((segment) => segment === '..')
+    ) {
+      fail(`${basename(archive)} contains unsafe path ${JSON.stringify(entry)}`);
+    }
+  }
+}
+
+function extractArchive(archive) {
+  validateTarEntries(archive);
+  const root = `${archive}.extracted`;
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+  const extracted = spawnSync('tar', ['-xzf', archive, '-C', root], { encoding: 'utf8' });
+  if (extracted.status !== 0) fail(`cannot extract ${basename(archive)}: ${extracted.stderr.trim()}`);
+  collectFiles(root, () => false);
+  return root;
+}
+
+function relativePendingFiles(root) {
+  const pending = join(root, 'pending');
+  if (!existsSync(pending) || !lstatSync(pending).isDirectory()) fail('archive is missing pending/ directory');
+  return collectFiles(pending, () => true)
+    .map((path) => relative(root, path).split(sep).join('/'))
+    .sort();
+}
+
+function assertSameStringSet(actual, expected, label) {
+  const left = [...actual].sort((a, b) => a.localeCompare(b, 'en'));
+  const right = [...expected].sort((a, b) => a.localeCompare(b, 'en'));
+  if (JSON.stringify(left) !== JSON.stringify(right)) {
+    fail(`${label}: expected ${JSON.stringify(right)}, got ${JSON.stringify(left)}`);
+  }
+}
+
+function ensureInside(root, path, label) {
+  const relativePath = relative(root, path);
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`)) fail(`${label} escapes output root`);
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function aggregate(config) {
+  if (!existsSync(config.artifactsDir)) fail(`artifacts directory does not exist: ${config.artifactsDir}`);
+  const expectedCount = Number(config.expectedCount);
+  if (!Number.isSafeInteger(expectedCount) || expectedCount < 1) fail('--expected-count must be a positive integer');
+  const runAttempt = parseCanonicalShardIndex(config.runAttempt, 'run attempt');
+  const matrix = parseMatrix(config.matrixJson, expectedCount);
+  const archives = collectArchives(config.artifactsDir, runAttempt);
+  const byIndex = new Map();
+  for (const archive of archives) {
+    const index = parseArchiveIndex(archive, runAttempt);
+    if (byIndex.has(index)) fail(`duplicate canonical shard archive index ${index}`);
+    byIndex.set(index, archive);
+  }
+  assertSameIntegerSet(byIndex.keys(), matrix.keys(), 'found shard index set must equal expected matrix index set');
+
+  const shards = [];
+  const skills = [];
+  for (const index of [...matrix.keys()].sort((a, b) => a - b)) {
+    const archive = byIndex.get(index);
+    const root = extractArchive(archive);
+    const pendingRoot = join(root, 'pending');
+    const manifestPath = join(root, 'shard-manifest.json');
+    const manifest = readAndValidateSubmissionShardManifest(manifestPath, {
+      expectedIndex: index,
+      expectedPlanned: matrix.get(index),
+      pendingRoot,
+      requireSuccess: true,
+    });
+
+    let shardSkills = [];
+    if (manifest.reasonCode === 'processed_all_planned') {
+      const changedFiles = relativePendingFiles(root);
+      const plan = resolveApprovedSubmission({
+        repositoryRoot: root,
+        changedFiles,
+        allowBlocked: true,
+      });
+      shardSkills = plan.skills;
+      assertSameStringSet(
+        shardSkills.map(({ pendingDir }) => basename(pendingDir)),
+        manifest.succeeded,
+        `shard ${index} resolved plan does not match manifest succeeded slugs`,
+      );
+    } else if (manifest.reasonCode !== 'no_skills_planned') {
+      fail(`shard ${index} has unsupported successful reasonCode ${manifest.reasonCode}`);
+    }
+    shards.push({ index, manifest, root, skills: shardSkills });
+    skills.push(...shardSkills);
+  }
+
+  const uniqueFields = ['pendingDir', 'targetDir', 'reportSlug'];
+  for (const field of uniqueFields) {
+    const values = skills.map((skill) => skill[field]);
+    if (new Set(values).size !== values.length) fail(`duplicate ${field} across submission shards`);
+  }
+
+  rmSync(config.mergedResults, { recursive: true, force: true });
+  mkdirSync(config.mergedResults, { recursive: true });
+  for (const shard of shards) {
+    for (const skill of shard.skills) {
+      const source = resolve(shard.root, ...skill.pendingDir.split('/'));
+      const destination = resolve(config.mergedResults, ...skill.pendingDir.split('/'));
+      ensureInside(config.mergedResults, destination, skill.pendingDir);
+      if (existsSync(destination)) fail(`duplicate pending path across shards: ${skill.pendingDir}`);
+      mkdirSync(dirname(destination), { recursive: true });
+      cpSync(source, destination, { recursive: true, errorOnExist: true });
+    }
+  }
+
+  const plan = { schemaVersion: 1, skills: skills.sort((left, right) => left.pendingDir.localeCompare(right.pendingDir, 'en')) };
+  writeJson(config.approvalPlan, plan);
+  const shardIndices = [...matrix.keys()].sort((a, b) => a - b);
+  if (skills.length === 0) {
+    if (!shards.every(({ manifest }) => manifest.reasonCode === 'no_skills_planned')) {
+      fail('empty aggregate is only legal when every shard explicitly reports no_skills_planned');
+    }
+    writeJson(config.summary, {
+      schemaVersion: 1,
+      status: 'no_op',
+      reasonCode: 'no_skills_planned',
+      shardIndices,
+    });
+  } else {
+    writeJson(config.summary, {
+      schemaVersion: 1,
+      status: 'has_results',
+      reasonCode: 'processed_all_planned',
+      shardIndices,
+      processedCount: skills.length,
+    });
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const config = {
+    artifactsDir: option(args, '--artifacts-dir'),
+    runAttempt: option(args, '--run-attempt'),
+    matrixJson: option(args, '--matrix-json'),
+    expectedCount: option(args, '--expected-count'),
+    approvalPlan: option(args, '--approval-plan'),
+    mergedResults: option(args, '--merged-results'),
+    summary: option(args, '--summary'),
+  };
+  aggregate(config);
+  const summary = JSON.parse(readFileSync(config.summary, 'utf8'));
+  process.stdout.write(`Aggregated shards: ${summary.status} (${summary.reasonCode})\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Submission shard aggregation failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/process-submission-shard.mjs
+++ b/scripts/process-submission-shard.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import {
+  createWriteStream,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parseCanonicalShardIndex, parseSlugCsv } from './submission-shard-contract.mjs';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name, { required = true, defaultValue = null } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) fail(`missing required option ${name}`);
+    return defaultValue;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function writeManifest(path, manifest) {
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+}
+
+function collectReports(pendingRoot) {
+  const reports = [];
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) {
+        reports.push({ slug: null, path, invalid: 'symlink' });
+      } else if (entry.isDirectory()) {
+        walk(path);
+      } else if (entry.isFile() && entry.name === 'skill-report.json') {
+        reports.push({ slug: basename(dirname(path)), path, invalid: null });
+      }
+    }
+  }
+  walk(pendingRoot);
+  return reports;
+}
+
+function inspectResults(pendingRoot, planned) {
+  const reports = collectReports(pendingRoot);
+  const counts = new Map();
+  const invalid = [];
+  for (const report of reports) {
+    if (report.invalid !== null || report.slug === null) {
+      invalid.push(report.path);
+      continue;
+    }
+    counts.set(report.slug, (counts.get(report.slug) ?? 0) + 1);
+  }
+  const plannedSet = new Set(planned);
+  const succeeded = planned.filter((slug) => counts.get(slug) === 1);
+  const failed = planned.filter((slug) => counts.get(slug) !== 1);
+  const duplicates = planned.filter((slug) => (counts.get(slug) ?? 0) > 1);
+  const unexpected = [...counts.keys()].filter((slug) => !plannedSet.has(slug));
+  return { succeeded, failed, duplicates, unexpected, invalid };
+}
+
+function sleep(milliseconds) {
+  if (milliseconds <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function runCli({ cli, cliArgs, logPath, append }) {
+  return new Promise((resolve) => {
+    const log = createWriteStream(logPath, { flags: append ? 'a' : 'w', mode: 0o600 });
+    let settled = false;
+    let spawnError = null;
+    const child = spawn(cli, cliArgs, { env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const copy = (stream, destination) => {
+      stream.on('data', (chunk) => {
+        destination.write(chunk);
+        log.write(chunk);
+      });
+    };
+    copy(child.stdout, process.stdout);
+    copy(child.stderr, process.stderr);
+    child.on('error', (error) => {
+      spawnError = error;
+    });
+    child.on('close', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      log.end(() => resolve({
+        code: Number.isInteger(code) ? code : null,
+        signal: signal ?? null,
+        spawnError: spawnError?.message ?? null,
+      }));
+    });
+  });
+}
+
+function attemptStatus(execution, result) {
+  if (execution.signal !== null) return 'cancelled';
+  if (execution.spawnError !== null || execution.code !== 0 || result.failed.length > 0) return 'failed';
+  return 'succeeded';
+}
+
+function buildAttempt(number, requested, execution, result) {
+  return {
+    number,
+    phase: number === 1 ? 'first' : 'retry',
+    status: attemptStatus(execution, result),
+    exitCode: execution.code,
+    requested,
+    succeeded: requested.filter((slug) => result.succeeded.includes(slug)),
+    failed: requested.filter((slug) => !result.succeeded.includes(slug)),
+  };
+}
+
+async function processShard(config) {
+  const planned = parseSlugCsv(config.slugs, 'planned slugs');
+  const shardIndex = parseCanonicalShardIndex(config.shardIndex);
+  const pendingRoot = join(config.resultDir, 'pending');
+  const manifestPath = join(config.resultDir, 'shard-manifest.json');
+  const logPath = join(config.resultDir, `process-output-${shardIndex}.log`);
+
+  rmSync(config.resultDir, { recursive: true, force: true });
+  mkdirSync(pendingRoot, { recursive: true });
+
+  if (planned.length === 0) {
+    writeFileSync(logPath, 'No skills planned; explicit no-op.\n', { mode: 0o600 });
+    const manifest = {
+      schemaVersion: 1,
+      shardIndex,
+      status: 'succeeded',
+      reasonCode: 'no_skills_planned',
+      planned: [],
+      succeeded: [],
+      failed: [],
+      failureCategories: [],
+      attempts: [{
+        number: 1,
+        phase: 'first',
+        status: 'skipped',
+        exitCode: null,
+        requested: [],
+        succeeded: [],
+        failed: [],
+      }],
+    };
+    writeManifest(manifestPath, manifest);
+    return manifest;
+  }
+
+  const baseArgs = [
+    'skill', 'process', config.githubUrl,
+    '--slugs', planned.join(','),
+    '--output', config.resultDir,
+    '--marketplace-repo', config.marketplaceRepo,
+    '--skip-pr',
+  ];
+  if (config.model !== '') baseArgs.push('--model', config.model);
+
+  const firstExecution = await runCli({ cli: config.cli, cliArgs: baseArgs, logPath, append: false });
+  const firstResult = inspectResults(pendingRoot, planned);
+  const attempts = [buildAttempt(1, planned, firstExecution, firstResult)];
+
+  let terminalExecution = firstExecution;
+  let retryRequested = [];
+  if (attempts[0].status !== 'succeeded') {
+    retryRequested = firstResult.failed.length > 0 ? firstResult.failed : planned;
+    await sleep(config.retryDelayMs);
+    const retryArgs = [...baseArgs];
+    retryArgs[retryArgs.indexOf('--slugs') + 1] = retryRequested.join(',');
+    const retryExecution = await runCli({ cli: config.cli, cliArgs: retryArgs, logPath, append: true });
+    const retryResult = inspectResults(pendingRoot, planned);
+    attempts.push(buildAttempt(2, retryRequested, retryExecution, retryResult));
+    terminalExecution = retryExecution;
+  }
+
+  const finalResult = inspectResults(pendingRoot, planned);
+  const failureCategories = new Set();
+  if (terminalExecution.signal !== null) failureCategories.add('cancelled');
+  if (terminalExecution.spawnError !== null) failureCategories.add('cli_spawn_failed');
+  if (terminalExecution.code !== 0) failureCategories.add('cli_nonzero');
+  if (finalResult.failed.some((slug) => !finalResult.duplicates.includes(slug))) failureCategories.add('missing_result');
+  if (finalResult.duplicates.length > 0) failureCategories.add('duplicate_result');
+  if (finalResult.unexpected.length > 0) failureCategories.add('unexpected_result');
+  if (finalResult.invalid.length > 0) failureCategories.add('invalid_result');
+
+  const terminalAttemptSucceeded = attempts.at(-1).status === 'succeeded';
+  const succeeded = finalResult.succeeded;
+  const failed = finalResult.failed;
+  const status = terminalAttemptSucceeded
+    && succeeded.length === planned.length
+    && failed.length === 0
+    && finalResult.duplicates.length === 0
+    && finalResult.unexpected.length === 0
+    && finalResult.invalid.length === 0
+    ? 'succeeded'
+    : 'failed';
+  const manifest = {
+    schemaVersion: 1,
+    shardIndex,
+    status,
+    reasonCode: status === 'succeeded' ? 'processed_all_planned' : 'processing_failed',
+    planned,
+    succeeded,
+    failed,
+    failureCategories: status === 'succeeded' ? [] : [...failureCategories].sort(),
+    attempts,
+  };
+  writeManifest(manifestPath, manifest);
+  return manifest;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const config = {
+    cli: option(args, '--cli'),
+    githubUrl: option(args, '--github-url'),
+    slugs: option(args, '--slugs'),
+    resultDir: option(args, '--result-dir'),
+    marketplaceRepo: option(args, '--marketplace-repo'),
+    shardIndex: option(args, '--shard-index'),
+    model: option(args, '--model', { required: false, defaultValue: '' }),
+    retryDelayMs: Number(option(args, '--retry-delay-ms', { required: false, defaultValue: '10000' })),
+  };
+  if (!Number.isSafeInteger(config.retryDelayMs) || config.retryDelayMs < 0) fail('--retry-delay-ms must be a non-negative integer');
+
+  let manifest;
+  try {
+    manifest = await processShard(config);
+  } catch (error) {
+    const planned = parseSlugCsv(config.slugs, 'planned slugs');
+    const shardIndex = parseCanonicalShardIndex(config.shardIndex);
+    mkdirSync(join(config.resultDir, 'pending'), { recursive: true });
+    const manifestPath = join(config.resultDir, 'shard-manifest.json');
+    const logPath = join(config.resultDir, `process-output-${shardIndex}.log`);
+    const message = error instanceof Error ? error.message : String(error);
+    writeFileSync(logPath, `Process step failed before a terminal result: ${message}\n`, { flag: existsSync(logPath) ? 'a' : 'w', mode: 0o600 });
+    manifest = {
+      schemaVersion: 1,
+      shardIndex,
+      status: 'failed',
+      reasonCode: 'process_step_failed',
+      planned,
+      succeeded: [],
+      failed: planned,
+      failureCategories: ['process_step_failed'],
+      attempts: [{
+        number: 1,
+        phase: 'first',
+        status: 'skipped',
+        exitCode: null,
+        requested: planned,
+        succeeded: [],
+        failed: planned,
+      }],
+    };
+    writeManifest(manifestPath, manifest);
+  }
+
+  process.stdout.write(`Shard ${manifest.shardIndex}: ${manifest.status} (${manifest.reasonCode}); ${manifest.succeeded.length} succeeded, ${manifest.failed.length} failed\n`);
+  // Always return zero after writing the diagnostic manifest. The workflow uploads
+  // the archive first, then the explicit terminal-status step fails the job.
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((error) => {
+    console.error(`::error::Submission shard processing failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/submission-shard-contract.mjs
+++ b/scripts/submission-shard-contract.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CANONICAL_INDEX = /^(0|[1-9][0-9]*)$/;
+const SLUG = /^[a-z0-9][a-z0-9-]*$/;
+const OVERALL_STATUSES = new Set(['succeeded', 'failed', 'cancelled', 'skipped']);
+const ATTEMPT_STATUSES = new Set(['succeeded', 'failed', 'cancelled', 'skipped']);
+const FAILURE_CATEGORIES = new Set([
+  'cancelled',
+  'cli_nonzero',
+  'cli_spawn_failed',
+  'duplicate_result',
+  'invalid_result',
+  'missing_result',
+  'process_step_failed',
+  'skipped',
+  'unexpected_result',
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name, { required = true } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) fail(`missing required option ${name}`);
+    return null;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) {
+    fail(`missing value for ${name}`);
+  }
+  return args[index + 1];
+}
+
+export function parseCanonicalShardIndex(value, label = 'shard index') {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) fail(`${label} must be a non-negative safe integer`);
+    return value;
+  }
+  if (typeof value !== 'string' || !CANONICAL_INDEX.test(value)) {
+    fail(`${label} must be canonical decimal (0 or a non-zero digit followed by digits)`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) fail(`${label} exceeds the safe integer range`);
+  return parsed;
+}
+
+export function parseSlugCsv(value, label = 'slug list') {
+  if (typeof value !== 'string') fail(`${label} must be a CSV string`);
+  if (value === '') return [];
+  const slugs = value.split(',');
+  const seen = new Set();
+  for (const slug of slugs) {
+    if (!SLUG.test(slug)) fail(`${label} contains invalid slug ${JSON.stringify(slug)}`);
+    if (seen.has(slug)) fail(`${label} contains duplicate slug ${JSON.stringify(slug)}`);
+    seen.add(slug);
+  }
+  return slugs;
+}
+
+function validateSlugArray(value, label) {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  const seen = new Set();
+  for (const slug of value) {
+    if (typeof slug !== 'string' || !SLUG.test(slug)) fail(`${label} contains invalid slug ${JSON.stringify(slug)}`);
+    if (seen.has(slug)) fail(`${label} contains duplicate slug ${JSON.stringify(slug)}`);
+    seen.add(slug);
+  }
+  return [...value];
+}
+
+function sorted(values) {
+  return [...values].sort((left, right) => left.localeCompare(right, 'en'));
+}
+
+function assertSameSet(actual, expected, label) {
+  assert.deepEqual(sorted(actual), sorted(expected), label);
+}
+
+const assert = {
+  deepEqual(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      fail(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+  },
+};
+
+function assertPartition(planned, succeeded, failed, label) {
+  const succeededSet = new Set(succeeded);
+  const failedSet = new Set(failed);
+  const overlap = succeeded.filter((slug) => failedSet.has(slug));
+  if (overlap.length > 0) fail(`${label} succeeded and failed overlap: ${overlap.join(',')}`);
+  const combined = [...succeededSet, ...failedSet];
+  assertSameSet(combined, planned, `${label} succeeded union failed must equal planned`);
+}
+
+function collectReportSlugs(root) {
+  const slugs = [];
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) fail(`pending output contains symlink ${path}`);
+      if (entry.isDirectory()) {
+        walk(path);
+      } else if (entry.isFile() && entry.name === 'skill-report.json') {
+        slugs.push(basename(dirname(path)));
+      }
+    }
+  }
+  walk(root);
+  return slugs;
+}
+
+function validateAttempt(attempt, planned, expectedNumber) {
+  if (!attempt || typeof attempt !== 'object' || Array.isArray(attempt)) fail(`attempt ${expectedNumber} must be an object`);
+  if (attempt.number !== expectedNumber) fail(`attempt number must be contiguous; expected ${expectedNumber}`);
+  const expectedPhase = expectedNumber === 1 ? 'first' : 'retry';
+  if (attempt.phase !== expectedPhase) fail(`attempt ${expectedNumber} phase must be ${expectedPhase}`);
+  if (!ATTEMPT_STATUSES.has(attempt.status)) fail(`attempt ${expectedNumber} has invalid status ${JSON.stringify(attempt.status)}`);
+  const requested = validateSlugArray(attempt.requested, `attempt ${expectedNumber}.requested`);
+  const succeeded = validateSlugArray(attempt.succeeded, `attempt ${expectedNumber}.succeeded`);
+  const failed = validateSlugArray(attempt.failed, `attempt ${expectedNumber}.failed`);
+  for (const slug of requested) {
+    if (!planned.includes(slug)) fail(`attempt ${expectedNumber} requested unplanned slug ${slug}`);
+  }
+  assertPartition(requested, succeeded, failed, `attempt ${expectedNumber}`);
+  if (attempt.status === 'succeeded' && (attempt.exitCode !== 0 || failed.length !== 0)) {
+    fail(`attempt ${expectedNumber} succeeded must have exitCode 0 and no failed slugs`);
+  }
+  if (attempt.status === 'failed' && !Number.isInteger(attempt.exitCode)) {
+    fail(`attempt ${expectedNumber} failed must have an integer exitCode`);
+  }
+  if ((attempt.status === 'cancelled' || attempt.status === 'skipped') && attempt.exitCode !== null) {
+    fail(`attempt ${expectedNumber} ${attempt.status} must have a null exitCode`);
+  }
+}
+
+export function validateSubmissionShardManifest(manifest, {
+  expectedIndex = null,
+  expectedPlanned = null,
+  pendingRoot = null,
+  requireSuccess = false,
+} = {}) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) fail('manifest must be an object');
+  if (manifest.schemaVersion !== 1) fail('manifest schemaVersion must be 1');
+  const shardIndex = parseCanonicalShardIndex(manifest.shardIndex, 'manifest shardIndex');
+  if (expectedIndex !== null && shardIndex !== parseCanonicalShardIndex(expectedIndex, 'expected shard index')) {
+    fail(`manifest shardIndex ${shardIndex} does not match expected shard index ${expectedIndex}`);
+  }
+  if (!OVERALL_STATUSES.has(manifest.status)) fail(`manifest has invalid status ${JSON.stringify(manifest.status)}`);
+  if (typeof manifest.reasonCode !== 'string' || manifest.reasonCode.length === 0) fail('manifest reasonCode is required');
+
+  const planned = validateSlugArray(manifest.planned, 'manifest.planned');
+  const succeeded = validateSlugArray(manifest.succeeded, 'manifest.succeeded');
+  const failed = validateSlugArray(manifest.failed, 'manifest.failed');
+  assertPartition(planned, succeeded, failed, 'manifest');
+  if (expectedPlanned !== null) assertSameSet(planned, expectedPlanned, 'manifest planned slugs do not match matrix');
+
+  if (!Array.isArray(manifest.failureCategories)) fail('manifest.failureCategories must be an array');
+  for (const category of manifest.failureCategories) {
+    if (!FAILURE_CATEGORIES.has(category)) fail(`manifest has unknown failure category ${JSON.stringify(category)}`);
+  }
+  if (new Set(manifest.failureCategories).size !== manifest.failureCategories.length) {
+    fail('manifest.failureCategories contains duplicates');
+  }
+
+  if (!Array.isArray(manifest.attempts) || manifest.attempts.length === 0) fail('manifest.attempts must not be empty');
+  manifest.attempts.forEach((attempt, index) => validateAttempt(attempt, planned, index + 1));
+
+  if (manifest.status === 'succeeded') {
+    if (planned.length === 0) {
+      if (manifest.reasonCode !== 'no_skills_planned') fail('empty successful manifest must use no_skills_planned');
+      if (succeeded.length !== 0 || failed.length !== 0) fail('no_skills_planned must have empty outcome sets');
+      if (manifest.attempts.length !== 1 || manifest.attempts[0].status !== 'skipped') {
+        fail('no_skills_planned must contain one skipped first attempt');
+      }
+    } else {
+      if (manifest.reasonCode !== 'processed_all_planned') fail('successful manifest must use processed_all_planned');
+      if (failed.length !== 0) fail('successful manifest cannot contain failed slugs');
+      assertSameSet(succeeded, planned, 'successful manifest must succeed every planned slug');
+      if (manifest.attempts.at(-1)?.status !== 'succeeded') fail('successful manifest terminal attempt must be succeeded');
+    }
+    if (manifest.failureCategories.length !== 0) fail('successful manifest cannot contain failure categories');
+  }
+
+  if (pendingRoot !== null) {
+    const reports = collectReportSlugs(pendingRoot);
+    if (new Set(reports).size !== reports.length) fail('pending output contains duplicate canonical report slug');
+    assertSameSet(reports, succeeded, 'pending report slugs do not match manifest succeeded slugs');
+  }
+
+  if (requireSuccess && manifest.status !== 'succeeded') {
+    fail(`shard ${shardIndex} terminal status is ${manifest.status} (${manifest.reasonCode})`);
+  }
+
+  return { ...manifest, shardIndex, planned, succeeded, failed };
+}
+
+export function readAndValidateSubmissionShardManifest(path, options = {}) {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`cannot read shard manifest ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return validateSubmissionShardManifest(manifest, options);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const manifestPath = option(args, '--manifest');
+  const expectedIndex = option(args, '--expected-index');
+  const expectedSlugs = parseSlugCsv(option(args, '--expected-slugs'), 'expected slugs');
+  const pendingRoot = option(args, '--pending-root');
+  const manifest = readAndValidateSubmissionShardManifest(manifestPath, {
+    expectedIndex,
+    expectedPlanned: expectedSlugs,
+    pendingRoot,
+    requireSuccess: args.includes('--require-success'),
+  });
+  process.stdout.write(`Validated shard ${manifest.shardIndex}: ${manifest.status} (${manifest.reasonCode})\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Shard manifest validation failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -1,37 +1,413 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
 
 const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
 const approval = readFileSync('.github/workflows/on-pr-merge.yml', 'utf8');
+const processSubmission = readFileSync('.github/workflows/process-submission.yml', 'utf8');
+const approveSubmission = readFileSync('.github/workflows/approve-submission.yml', 'utf8');
+const processShardScript = 'scripts/process-submission-shard.mjs';
+const aggregateShardsScript = 'scripts/aggregate-submission-shards.mjs';
+const shardContractScript = 'scripts/submission-shard-contract.mjs';
+
+function withTempDirectory(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'submission-shards-'));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runNode(script, args, options = {}) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, ...(options.env ?? {}) },
+  });
+}
+
+function writePendingSkill(root, slug) {
+  const pendingDir = `pending/${slug}`;
+  const absoluteDir = join(root, pendingDir);
+  mkdirSync(absoluteDir, { recursive: true });
+  const skillBytes = `---\nname: ${slug}\ndescription: fixture\n---\n`;
+  writeFileSync(join(absoluteDir, 'SKILL.md'), skillBytes);
+  const contentHash = createHash('sha256').update(skillBytes).digest('hex');
+  const treeHash = calculateCanonicalTreeHash(root, pendingDir);
+  writeFileSync(join(absoluteDir, 'skill-report.json'), `${JSON.stringify({
+    meta: {
+      source_type: 'official',
+      slug,
+      content_hash: contentHash,
+      tree_hash: treeHash,
+    },
+    security_audit: { is_blocked: false, safe_to_publish: true, risk_level: 'safe' },
+  })}\n`);
+}
+
+function successfulManifest(index, planned, { reasonCode = 'processed_all_planned' } = {}) {
+  const noOp = planned.length === 0;
+  return {
+    schemaVersion: 1,
+    shardIndex: index,
+    status: 'succeeded',
+    reasonCode: noOp ? 'no_skills_planned' : reasonCode,
+    planned,
+    succeeded: planned,
+    failed: [],
+    failureCategories: [],
+    attempts: [{
+      number: 1,
+      phase: 'first',
+      status: noOp ? 'skipped' : 'succeeded',
+      exitCode: noOp ? null : 0,
+      requested: planned,
+      succeeded: planned,
+      failed: [],
+    }],
+  };
+}
+
+function failedManifest(index, planned, status = 'failed') {
+  return {
+    schemaVersion: 1,
+    shardIndex: index,
+    status,
+    reasonCode: status === 'failed' ? 'processing_failed' : `processing_${status}`,
+    planned,
+    succeeded: [],
+    failed: planned,
+    failureCategories: [status === 'failed' ? 'cli_nonzero' : status],
+    attempts: [{
+      number: 1,
+      phase: 'first',
+      status,
+      exitCode: status === 'failed' ? 23 : null,
+      requested: planned,
+      succeeded: [],
+      failed: planned,
+    }],
+  };
+}
+
+function createShardArchive(artifactsDir, {
+  rawIndex,
+  manifest,
+  slugs = manifest?.succeeded ?? [],
+  nested = '',
+  omitManifest = false,
+}) {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'submission-archive-root-'));
+  try {
+    mkdirSync(join(fixtureRoot, 'pending'), { recursive: true });
+    for (const slug of slugs) writePendingSkill(fixtureRoot, slug);
+    if (!omitManifest) {
+      writeFileSync(join(fixtureRoot, 'shard-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+    }
+    const archiveDir = join(artifactsDir, nested);
+    mkdirSync(archiveDir, { recursive: true });
+    const archive = join(archiveDir, `process-shard-1-${rawIndex}.tar.gz`);
+    const entries = ['pending'];
+    if (!omitManifest) entries.push('shard-manifest.json');
+    const tar = spawnSync('tar', ['-C', fixtureRoot, '-czf', archive, ...entries], { encoding: 'utf8' });
+    assert.equal(tar.status, 0, tar.stderr);
+    return archive;
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+function runAggregate(root, matrix, expectedCount = matrix.include.length) {
+  const approvalPlan = join(root, 'approval-plan.json');
+  const mergedResults = join(root, 'merged');
+  const summary = join(root, 'summary.json');
+  const result = runNode(aggregateShardsScript, [
+    '--artifacts-dir', join(root, 'artifacts'),
+    '--run-attempt', '1',
+    '--matrix-json', JSON.stringify(matrix),
+    '--expected-count', String(expectedCount),
+    '--approval-plan', approvalPlan,
+    '--merged-results', mergedResults,
+    '--summary', summary,
+  ]);
+  return { result, approvalPlan, mergedResults, summary };
+}
 
 test('submission processing isolates every shard and stages only its frozen plan', () => {
   assert.match(reusable, /RESULT_DIR="\/tmp\/submission-shard-/);
   assert.match(reusable, /process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}/);
-  assert.match(reusable, /--output "\$RESULT_DIR"/);
-  assert.match(reusable, /tar -C "\$RESULT_DIR" -czf "\$RESULT_DIR\/\$SHARD_ARCHIVE_NAME"/);
-  assert.match(reusable, /planned-slugs\.csv/);
-  assert.match(reusable, /tar -xzf "\$SHARD_ARCHIVE" -C "\$SHARD_ROOT" --no-same-owner/);
-  assert.match(reusable, /node scripts\/resolve-approved-submission\.mjs/);
+  assert.match(reusable, /node scripts\/process-submission-shard\.mjs/);
+  assert.match(reusable, /node scripts\/aggregate-submission-shards\.mjs/);
   assert.match(reusable, /git add -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
-  assert.doesNotMatch(reusable, /--output \./);
-  assert.doesNotMatch(reusable, /find pending/);
-  assert.doesNotMatch(reusable, /git add pending\//);
-  assert.match(reusable, /Downloaded \$\{#SHARD_ARCHIVES\[@\]\}\/\$\{\{ needs\.discover-and-plan\.outputs\.shard_count \}\} shard archive/);
+  assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
+  assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);
+  assert.match(reusable, /Enforce shard terminal status/);
   assert.match(reusable, /Published target already exists; use the explicit update workflow/);
-  assert.match(reusable, /produced a skill outside its planned slug set/);
-  assert.match(reusable, /produced no successful skills/);
 });
 
-test('submission aggregation uses shard-addressed archives and keeps failure closed', () => {
-  assert.match(reusable, /SHARD_ARCHIVE_NAME="process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\.tar\.gz"/);
-  assert.match(reusable, /path: \/tmp\/submission-shard-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\/process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\.tar\.gz/);
-  assert.match(reusable, /find "\$ARTIFACTS_DIR" -type f/);
-  assert.match(reusable, /-name 'process-shard-\$\{\{ github\.run_attempt \}\}-\*\.tar\.gz'/);
-  assert.match(reusable, /Downloaded \$\{#SHARD_ARCHIVES\[@\]\}\/\$\{\{ needs\.discover-and-plan\.outputs\.shard_count \}\} shard archive\(s\)/);
-  assert.match(reusable, /Missing or duplicate shard artifact index/);
-  assert.match(reusable, /Shard processing did not complete successfully; refusing to aggregate/);
-  assert.match(reusable, /No skills were successfully processed/);
+test('real CLI two-round failure produces a failed manifest and cannot aggregate as no-op', () => withTempDirectory((root) => {
+  const fakeCli = join(root, 'fake-cli.sh');
+  const state = join(root, 'calls.txt');
+  const resultDir = join(root, 'result');
+  writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\necho "fixture CLI failure $count" >&2\nexit 23\n`);
+  chmodSync(fakeCli, 0o755);
+
+  const processing = runNode(processShardScript, [
+    '--cli', fakeCli,
+    '--github-url', 'https://github.com/example/source',
+    '--slugs', 'broken-skill',
+    '--result-dir', resultDir,
+    '--marketplace-repo', 'aiskillstore/marketplace',
+    '--shard-index', '0',
+    '--retry-delay-ms', '0',
+  ], { env: { FAKE_STATE: state } });
+  assert.equal(processing.status, 0, processing.stderr);
+  assert.equal(readFileSync(state, 'utf8').trim(), '2');
+  const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.equal(manifest.status, 'failed');
+  assert.deepEqual(manifest.planned, ['broken-skill']);
+  assert.deepEqual(manifest.succeeded, []);
+  assert.deepEqual(manifest.failed, ['broken-skill']);
+  assert.deepEqual(manifest.attempts.map(({ status }) => status), ['failed', 'failed']);
+
+  const terminal = runNode(shardContractScript, [
+    '--manifest', join(resultDir, 'shard-manifest.json'),
+    '--expected-index', '0',
+    '--expected-slugs', 'broken-skill',
+    '--pending-root', join(resultDir, 'pending'),
+    '--require-success',
+  ]);
+  assert.notEqual(terminal.status, 0, 'failed manifest must fail the post-upload terminal gate');
+
+  const artifacts = join(root, 'artifacts');
+  mkdirSync(artifacts);
+  const archive = join(artifacts, 'process-shard-1-0.tar.gz');
+  const tar = spawnSync('tar', [
+    '-C', resultDir,
+    '-czf', archive,
+    'pending',
+    'shard-manifest.json',
+  ], { encoding: 'utf8' });
+  assert.equal(tar.status, 0, tar.stderr);
+  const aggregate = runAggregate(root, { include: [{ shard: 0, slugs: 'broken-skill' }] });
+  assert.notEqual(aggregate.result.status, 0, 'failed shard archive must not become a successful no-op');
+}));
+
+test('a successful retry closes the manifest only after every planned result exists', () => withTempDirectory((root) => {
+  const fakeCli = join(root, 'fake-cli.sh');
+  const state = join(root, 'calls.txt');
+  const sourceFixture = join(root, 'source-fixture');
+  const resultDir = join(root, 'result');
+  mkdirSync(join(sourceFixture, 'pending'), { recursive: true });
+  writePendingSkill(sourceFixture, 'recoverable');
+  writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\nif [ "$count" -eq 1 ]; then\n  echo 'first attempt fails' >&2\n  exit 23\nfi\noutput=''\nwhile [ "$#" -gt 0 ]; do\n  if [ "$1" = '--output' ]; then output="$2"; break; fi\n  shift\ndone\ntest -n "$output"\nmkdir -p "$output/pending"\ncp -R "$FIXTURE_PENDING/recoverable" "$output/pending/recoverable"\n`);
+  chmodSync(fakeCli, 0o755);
+
+  const processing = runNode(processShardScript, [
+    '--cli', fakeCli,
+    '--github-url', 'https://github.com/example/source',
+    '--slugs', 'recoverable',
+    '--result-dir', resultDir,
+    '--marketplace-repo', 'aiskillstore/marketplace',
+    '--shard-index', '0',
+    '--retry-delay-ms', '0',
+  ], { env: { FAKE_STATE: state, FIXTURE_PENDING: join(sourceFixture, 'pending') } });
+  assert.equal(processing.status, 0, processing.stderr);
+  const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.equal(manifest.status, 'succeeded');
+  assert.equal(manifest.reasonCode, 'processed_all_planned');
+  assert.deepEqual(manifest.succeeded, ['recoverable']);
+  assert.deepEqual(manifest.failed, []);
+  assert.deepEqual(manifest.attempts.map(({ status }) => status), ['failed', 'succeeded']);
+
+  const terminal = runNode(shardContractScript, [
+    '--manifest', join(resultDir, 'shard-manifest.json'),
+    '--expected-index', '0',
+    '--expected-slugs', 'recoverable',
+    '--pending-root', join(resultDir, 'pending'),
+    '--require-success',
+  ]);
+  assert.equal(terminal.status, 0, terminal.stderr);
+}));
+
+test('aggregation accepts root and nested archives only when manifests and pending results agree', () => withTempDirectory((root) => {
+  const artifacts = join(root, 'artifacts');
+  mkdirSync(artifacts);
+  createShardArchive(artifacts, {
+    rawIndex: '0',
+    manifest: successfulManifest(0, ['alpha']),
+    slugs: ['alpha'],
+  });
+  createShardArchive(artifacts, {
+    rawIndex: '1',
+    manifest: successfulManifest(1, ['beta']),
+    slugs: ['beta'],
+    nested: 'process-shard-1-1',
+  });
+
+  const aggregate = runAggregate(root, {
+    include: [
+      { shard: 0, slugs: 'alpha' },
+      { shard: 1, slugs: 'beta' },
+    ],
+  });
+  assert.equal(aggregate.result.status, 0, aggregate.result.stderr);
+  const plan = JSON.parse(readFileSync(aggregate.approvalPlan, 'utf8'));
+  assert.deepEqual(plan.skills.map(({ pendingDir }) => pendingDir), ['pending/alpha', 'pending/beta']);
+  assert.equal(JSON.parse(readFileSync(aggregate.summary, 'utf8')).status, 'has_results');
+}));
+
+test('legal no-op requires an explicit successful no_skills_planned manifest', () => withTempDirectory((root) => {
+  const artifacts = join(root, 'artifacts');
+  mkdirSync(artifacts);
+  createShardArchive(artifacts, {
+    rawIndex: '0',
+    manifest: successfulManifest(0, []),
+    slugs: [],
+  });
+  const aggregate = runAggregate(root, { include: [{ shard: 0, slugs: '' }] });
+  assert.equal(aggregate.result.status, 0, aggregate.result.stderr);
+  assert.deepEqual(JSON.parse(readFileSync(aggregate.approvalPlan, 'utf8')), { schemaVersion: 1, skills: [] });
+  assert.deepEqual(JSON.parse(readFileSync(aggregate.summary, 'utf8')), {
+    schemaVersion: 1,
+    status: 'no_op',
+    reasonCode: 'no_skills_planned',
+    shardIndices: [0],
+  });
+}));
+
+const rejectedFixtures = [
+  {
+    name: 'failed manifest',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: failedManifest(0, ['alpha']) }],
+  },
+  {
+    name: 'cancelled manifest',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: failedManifest(0, ['alpha'], 'cancelled') }],
+  },
+  {
+    name: 'skipped manifest',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: failedManifest(0, ['alpha'], 'skipped') }],
+  },
+  {
+    name: 'missing manifest',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'], omitManifest: true }],
+  },
+  {
+    name: '0 and 00 leading-zero alias',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }, { shard: 1, slugs: 'beta' }] },
+    archives: [
+      { rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] },
+      { rawIndex: '00', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'], nested: 'alias' },
+    ],
+  },
+  {
+    name: '01 leading-zero index',
+    matrix: { include: [{ shard: 1, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '01', manifest: successfulManifest(1, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: '+0 signed index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '+0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'negative index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '-1', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'non-decimal index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0x0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'unknown shard index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '2', manifest: successfulManifest(2, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'duplicate canonical index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [
+      { rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] },
+      { rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'], nested: 'duplicate' },
+    ],
+  },
+  {
+    name: 'missing expected shard',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }, { shard: 1, slugs: 'beta' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'matrix slug mismatch',
+    matrix: { include: [{ shard: 0, slugs: 'beta' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'manifest outcome partition mismatch',
+    matrix: { include: [{ shard: 0, slugs: 'alpha,beta' }] },
+    archives: [{
+      rawIndex: '0',
+      manifest: {
+        ...successfulManifest(0, ['alpha', 'beta']),
+        succeeded: ['alpha'],
+        failed: [],
+      },
+      slugs: ['alpha'],
+    }],
+  },
+  {
+    name: 'successful manifest with empty pending output',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: [] }],
+  },
+  {
+    name: 'noncanonical matrix index',
+    matrix: { include: [{ shard: '0', slugs: 'alpha' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+  {
+    name: 'duplicate matrix index',
+    matrix: { include: [{ shard: 0, slugs: 'alpha' }, { shard: 0, slugs: 'beta' }] },
+    archives: [{ rawIndex: '0', manifest: successfulManifest(0, ['alpha']), slugs: ['alpha'] }],
+  },
+];
+
+for (const fixture of rejectedFixtures) {
+  test(`aggregation rejects ${fixture.name}`, () => withTempDirectory((root) => {
+    const artifacts = join(root, 'artifacts');
+    mkdirSync(artifacts);
+    for (const archive of fixture.archives) createShardArchive(artifacts, archive);
+    const aggregate = runAggregate(root, fixture.matrix);
+    assert.notEqual(aggregate.result.status, 0, `${fixture.name} unexpectedly passed\n${aggregate.result.stdout}`);
+  }));
+}
+
+test('submission callers emit a terminal callback for explicit legal no-op and failure', () => {
+  for (const workflow of [processSubmission, approveSubmission]) {
+    assert.match(workflow, /needs\.process-skills\.result == 'failure'/);
+    assert.match(workflow, /needs\.process-skills\.outputs\.outcome == 'no_op'/);
+    assert.match(workflow, /"event": "completed"/);
+    assert.match(workflow, /"reason_code":/);
+  }
 });
 
 test('merged approval scope comes only from immutable PR changed files', () => {

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -9,7 +9,7 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.match(reusable, /RESULT_DIR="\/tmp\/submission-shard-/);
   assert.match(reusable, /process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}/);
   assert.match(reusable, /--output "\$RESULT_DIR"/);
-  assert.match(reusable, /tar -C "\$RESULT_DIR" -czf "\$RESULT_DIR\/shard-results\.tar\.gz"/);
+  assert.match(reusable, /tar -C "\$RESULT_DIR" -czf "\$RESULT_DIR\/\$SHARD_ARCHIVE_NAME"/);
   assert.match(reusable, /planned-slugs\.csv/);
   assert.match(reusable, /tar -xzf "\$SHARD_ARCHIVE" -C "\$SHARD_ROOT" --no-same-owner/);
   assert.match(reusable, /node scripts\/resolve-approved-submission\.mjs/);
@@ -17,10 +17,21 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.doesNotMatch(reusable, /--output \./);
   assert.doesNotMatch(reusable, /find pending/);
   assert.doesNotMatch(reusable, /git add pending\//);
-  assert.match(reusable, /Downloaded \$\{#SHARD_DIRS\[@\]\}\/\$\{\{ needs\.discover-and-plan\.outputs\.shard_count \}\} shard artifact/);
+  assert.match(reusable, /Downloaded \$\{#SHARD_ARCHIVES\[@\]\}\/\$\{\{ needs\.discover-and-plan\.outputs\.shard_count \}\} shard archive/);
   assert.match(reusable, /Published target already exists; use the explicit update workflow/);
   assert.match(reusable, /produced a skill outside its planned slug set/);
   assert.match(reusable, /produced no successful skills/);
+});
+
+test('submission aggregation uses shard-addressed archives and keeps failure closed', () => {
+  assert.match(reusable, /SHARD_ARCHIVE_NAME="process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\.tar\.gz"/);
+  assert.match(reusable, /path: \/tmp\/submission-shard-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\/process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}\.tar\.gz/);
+  assert.match(reusable, /find "\$ARTIFACTS_DIR" -type f/);
+  assert.match(reusable, /-name 'process-shard-\$\{\{ github\.run_attempt \}\}-\*\.tar\.gz'/);
+  assert.match(reusable, /Downloaded \$\{#SHARD_ARCHIVES\[@\]\}\/\$\{\{ needs\.discover-and-plan\.outputs\.shard_count \}\} shard archive\(s\)/);
+  assert.match(reusable, /Missing or duplicate shard artifact index/);
+  assert.match(reusable, /Shard processing did not complete successfully; refusing to aggregate/);
+  assert.match(reusable, /No skills were successfully processed/);
 });
 
 test('merged approval scope comes only from immutable PR changed files', () => {


### PR DESCRIPTION
## 背景 / 问题描述

`Process Skill Submission` 的分片链路存在两个独立的 fail-open：

1. 原失败 [Run 29538285551](https://github.com/aiskillstore/marketplace/actions/runs/29538285551) 中，job `process-skills / process (0, animate-roblox-characters)` 的真实 CLI 首轮和重试均因 schema/凭据错误失败，日志最终为 `0 processed, 1 errors`，但 shard job 仍显示 success；空 `pending/` 随 archive 上传后会被聚合器解释为合法 no-op。
2. 原失败 [Run 29535894148](https://github.com/aiskillstore/marketplace/actions/runs/29535894148) 中，CLI 两轮均返回 `No skills matched slugs`，同样产生空结果；旧聚合阶段另因 `download-artifact@v7` 根目录布局报 `Downloaded 0/1 shard artifact(s)`。
3. PR 初版只用 YAML 正则检查 archive 逻辑；shard index `0` / `00` 可作为两个字符串 key 通过去重，随后又都按 JSON 数字 `0` 查询 matrix。

Trent Retry source：[review 4718621553](https://github.com/aiskillstore/marketplace/pull/2578#pullrequestreview-4718621553)。本次只关闭该 review 的两个 BLOCKER，不包含 issue #2572 的 self-hosted schema checkout 或 terminal resubmit。

## 上次 FAIL 原因

- shard 首轮 exit 只记录不判、retry 用 `|| true` 吞错、`ERRORS` 只打印；job 级 `continue-on-error` 又把真实处理失败变成 success。
- 失败后 `if: always()` 上传完整但空的 archive；聚合器只看 `pending/` 为空便 `exit 0`，caller 无失败 callback。
- archive index 未 canonical 化，只比较数量和原始字符串 key；`0` / `00` 可重复映射 shard 0 并掩盖缺失 shard 1。
- 测试仅匹配 YAML 文本，没有执行生产聚合逻辑或真实 archive fixture。

## 本次修复

- 新增 `scripts/process-submission-shard.mjs`：真实执行首轮和一次 retry，记录每轮 `status / exitCode / requested / succeeded / failed`，并产出机器可校验 `shard-manifest.json`。
- 新增 `scripts/submission-shard-contract.mjs`：强制 `succeeded ∪ failed == planned`、集合互斥、成功 manifest 无 failed slug；固定失败类别，校验 manifest 与实际 `pending/*/skill-report.json` 全等。
- 新增 `scripts/aggregate-submission-shards.mjs`：递归发现根目录/嵌套 archive，在解析入口拒绝 `00`、`01`、`+0`、负数、非十进制和超范围 index；matrix 自身与 found canonical integer set 必须完全相等。
- 移除 process job 的 `continue-on-error` 与 retry 吞错。处理步骤先落诊断 manifest，`if: always()` 创建并上传 artifact，随后 `Enforce shard terminal status` 显式失败，确保 reusable workflow 与 failed callback 得到真实 failure。
- 合法 no-op 仅限 discovery 明确得到零 planned skill：生成单个 `no_skills_planned` 成功 manifest，聚合后 caller 发送 `completed + reason_code` 终态 callback；不再从空 `pending/` 猜测成功。
- 保留初版修复：archive 名绑定 `github.run_attempt + matrix.shard`，兼容 `download-artifact@v7` 根目录和多 artifact 嵌套布局。

## Acceptance Criteria

- [x] 真实 CLI 首轮 + retry 均非零且空 pending 时，manifest 为 failed、诊断 archive 可生成、post-upload gate 与聚合器均非零退出。验收：`scripts/tests/submission-scope-workflows.test.mjs::real CLI two-round failure produces a failed manifest and cannot aggregate as no-op` + CI [test 29547333042](https://github.com/aiskillstore/marketplace/actions/runs/29547333042)。
- [x] retry 只有在终轮 exit 0 且所有 planned output 存在时才能关闭为 success。验收：`scripts/tests/submission-scope-workflows.test.mjs::a successful retry closes the manifest only after every planned result exists` + 同一 CI。
- [x] failed / cancelled / skipped / missing manifest 或 archive、partial partition、空 pending 假成功全部 fail-closed。验收：`scripts/tests/submission-scope-workflows.test.mjs::aggregation rejects *` runtime fixtures + 同一 CI。
- [x] `0/00`、`01`、`+0`、负数、非十进制、unknown、duplicate canonical、missing shard、matrix duplicate/type/slug mismatch 均被拒绝，expected/found set 全等。验收：`scripts/tests/submission-scope-workflows.test.mjs::aggregation rejects * index|shard|matrix *` runtime fixtures + 同一 CI。
- [x] 根目录与嵌套 archive 在 manifest、matrix、pending output 一致时正常聚合。验收：`scripts/tests/submission-scope-workflows.test.mjs::aggregation accepts root and nested archives only when manifests and pending results agree` + 同一 CI。
- [x] 合法 no-op 必须是空 planned + `status=succeeded` + `reasonCode=no_skills_planned`，并发送终态 callback。验收：`scripts/tests/submission-scope-workflows.test.mjs::legal no-op requires an explicit successful no_skills_planned manifest`、`submission callers emit a terminal callback for explicit legal no-op and failure` + 同一 CI。
- [x] 既有冻结 plan、publication target collision 与 immutable approval scope guardrail 保持通过。验收：`scripts/tests/submission-scope-workflows.test.mjs::submission processing isolates every shard and stages only its frozen plan`、`merged approval scope comes only from immutable PR changed files` + 同一 CI。

## TDD / 验证证据

### RED（旧 head `97bacc30051b3f9a20bb9d25e66a751c4ece907f`）

先把 runtime fixture 与新 wiring contract 写入测试，再在旧实现上执行：

```bash
node --test scripts/tests/submission-scope-workflows.test.mjs
```

结果非零：旧 workflow 缺 manifest processor/validator/aggregator，仍保留 `continue-on-error` 与吞错链路；真实两轮失败 fixture 不能产生可拒绝的 manifest。

### GREEN（新 head）

```bash
node --test scripts/tests/submission-scope-workflows.test.mjs
node --test scripts/tests/*.test.mjs
node --check scripts/submission-shard-contract.mjs
node --check scripts/process-submission-shard.mjs
node --check scripts/aggregate-submission-shards.mjs
# Python PyYAML 解析 3 个 workflow，并对全部 run block 做 GitHub expression 替换后 bash -n
git diff --check
```

结果：focused 29/29、全量 354/354 通过；3 个 workflow YAML parse + 26 个 Bash run block 通过；Node syntax、diff check、二进制 evidence scan均通过。

### 新 CI

- [Test run 29547333042](https://github.com/aiskillstore/marketplace/actions/runs/29547333042)：SUCCESS。
- [Validate run 29547333052](https://github.com/aiskillstore/marketplace/actions/runs/29547333052)：SUCCESS。

未触发 `workflow_dispatch` / `repository_dispatch`，未创建 submission 内容 PR，未写生产数据。

## 风险点

- 数据写入：本 PR 只改 workflow、运行时校验脚本和测试；验证期间无生产写。
- 权限 / 安全：不扩大 token/secrets 权限；失败 shard 只能上传诊断 artifact，随后必须失败。
- 并发 / 一致性：manifest 同时绑定 canonical shard index、planned/outcome sets 和 attempt status；matrix/found set 全等，拒绝 alias、缺失与重复。
- 用户体验：真实失败会触发 failed callback；明确零 planned 才发送 completed no-op callback。
- 未覆盖项：未执行真实生产 submission；按 Human Gate 禁止用 dispatch 绕过 review。

## 回滚方式

若合并后发现 runner/CLI 兼容性问题，revert Retry commit `792d29337735266b1cb7a6ee0cc409c24e7fb897`（或整体 revert PR #2578）即可恢复旧 workflow。回滚不删除已存在 artifact、submission branch/PR、skill 内容或生产数据。

## 人类 review 关注点

请 Trent 重点复核：

1. process script 是否只在终轮成功且 `planned = succeeded` 时写 success manifest；失败 artifact 上传后 job 是否必然显式失败。
2. aggregate script 对 manifest/pending/matrix 三方全等和 canonical integer set 全等是否存在旁路。
3. `no_skills_planned` 是否是唯一合法 no-op，caller 是否有明确 completed callback。
4. diff 未倒灌 issue #2572 独立范围。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：改动已上线 submission workflow；即使 CI 与 Trent Retry PASS，仍不得自动合并、dispatch 或生产验证，等待 Human Gate。

Wiki delta: none
