### PR TITLE
fix: 限定审计快照只读网络重试

### DIFF
--- a/.github/workflows/sync-audit-compute.yml
+++ b/.github/workflows/sync-audit-compute.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 17
     env:
       HELM_BASE_URL: https://helm.easymeta.au/v1
       HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
@@ -56,19 +56,53 @@ jobs:
 
           helm_usage_json="$(./scripts/fetch-audit-compute-usage.sh "$helm_usage_url")"
 
-          read -r helm_tokens helm_cost < <(
+          validated_totals="$(
             HELM_USAGE_JSON="$helm_usage_json" python3 - <<'PY'
           import json
+          import math
           import os
 
-          data = json.loads(os.environ["HELM_USAGE_JSON"])
+          def reject_nonstandard_number(value):
+              raise ValueError(f"non-standard JSON number: {value}")
+
+          data = json.loads(
+              os.environ["HELM_USAGE_JSON"],
+              parse_constant=reject_nonstandard_number,
+          )
+          if not isinstance(data, dict):
+              raise SystemExit("Helm usage API response must be an object")
           if data.get("object") != "usage_stats":
               raise SystemExit("Helm usage API returned an unexpected object")
 
-          totals = data.get("totals") or {}
-          print(int(totals.get("total_tokens") or 0), float(totals.get("cost_usd") or 0))
+          if "totals" not in data or not isinstance(data["totals"], dict):
+              raise SystemExit("Helm usage API totals must exist and be an object")
+          totals = data["totals"]
+          for field in ("total_tokens", "cost_usd"):
+              if field not in totals:
+                  raise SystemExit(f"Helm usage API totals missing {field}")
+
+          total_tokens = totals["total_tokens"]
+          if (
+              type(total_tokens) is not int
+              or total_tokens < 0
+              or total_tokens > 9223372036854775807
+          ):
+              raise SystemExit("Helm total_tokens must be a signed 64-bit nonnegative integer")
+
+          cost_usd = totals["cost_usd"]
+          if type(cost_usd) not in (int, float) or cost_usd < 0:
+              raise SystemExit("Helm cost_usd must be a nonnegative number")
+          try:
+              cost_is_finite = math.isfinite(cost_usd)
+          except OverflowError:
+              cost_is_finite = False
+          if not cost_is_finite:
+              raise SystemExit("Helm cost_usd must be finite and representable")
+
+          print(total_tokens, cost_usd)
           PY
-          )
+          )"
+          read -r helm_tokens helm_cost <<<"$validated_totals"
 
           captured_at="$(date -u +%F)"
           note="Helm API usage stats + legacy claude-relay baseline, list-price equivalent"
@@ -91,15 +125,18 @@ jobs:
               "p_relay_tokens": int(os.environ["LEGACY_TOKENS"]),
               "p_relay_cost_usd": float(os.environ["LEGACY_COST_USD"]),
               "p_note": os.environ["NOTE"],
-          }))
+          }, allow_nan=False))
           PY
           )"
 
           supabase_base="${SUPABASE_URL%/}"
           response="$(
-            curl --fail --silent --show-error \
+            curl --disable \
+              --fail --silent --show-error \
               --proto '=https' \
+              --proto-redir '=https' \
               --tlsv1.2 \
+              --retry 0 \
               --connect-timeout 30 \
               --max-time 120 \
               --request POST "$supabase_base/rest/v1/rpc/record_audit_compute_snapshot" \

--- a/.github/workflows/sync-audit-compute.yml
+++ b/.github/workflows/sync-audit-compute.yml
@@ -23,12 +23,16 @@ jobs:
       SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
       LEGACY_TOKENS: '1308077250'
       LEGACY_COST_USD: '2568.41704016099988706'
+      AUDIT_READ_MAX_ATTEMPTS: '3'
+      AUDIT_READ_RETRY_BASE_SECONDS: '2'
     steps:
       - name: Checkout research refresh helper
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          sparse-checkout: scripts/refresh-security-research-stats.sh
+          sparse-checkout: |
+            scripts/fetch-audit-compute-usage.sh
+            scripts/refresh-security-research-stats.sh
           sparse-checkout-cone-mode: false
 
       - name: Sync audit compute snapshot
@@ -50,11 +54,7 @@ jobs:
             helm_usage_url="$helm_base/v1/usage/stats"
           fi
 
-          helm_usage_json="$(
-            curl --fail --silent --show-error --retry 3 --retry-delay 2 \
-              -H "Authorization: Bearer $HELM_API_KEY" \
-              "$helm_usage_url"
-          )"
+          helm_usage_json="$(./scripts/fetch-audit-compute-usage.sh "$helm_usage_url")"
 
           read -r helm_tokens helm_cost < <(
             HELM_USAGE_JSON="$helm_usage_json" python3 - <<'PY'
@@ -97,8 +97,12 @@ jobs:
 
           supabase_base="${SUPABASE_URL%/}"
           response="$(
-            curl --fail --silent --show-error --retry 3 --retry-delay 2 \
-              -X POST "$supabase_base/rest/v1/rpc/record_audit_compute_snapshot" \
+            curl --fail --silent --show-error \
+              --proto '=https' \
+              --tlsv1.2 \
+              --connect-timeout 30 \
+              --max-time 120 \
+              --request POST "$supabase_base/rest/v1/rpc/record_audit_compute_snapshot" \
               -H "apikey: $SUPABASE_SERVICE_KEY" \
               -H "Authorization: Bearer $SUPABASE_SERVICE_KEY" \
               -H "Content-Type: application/json" \

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/pack-production-manual-publish.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
+      - "scripts/fetch-audit-compute-usage.sh"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
@@ -41,6 +42,7 @@ on:
       - "scripts/pack-production-manual-publish.mjs"
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
+      - "scripts/fetch-audit-compute-usage.sh"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
       - ".github/workflows/refresh-security-research-stats.yml"
@@ -82,10 +84,11 @@ jobs:
       - name: Run script unit tests
         run: |
           set -euo pipefail
-          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/materialize-changed-skills.mjs scripts/resolve-manual-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
+          chmod +x scripts/check-cache-invalidation-aggregate.sh scripts/detect-changed-skills.mjs scripts/materialize-changed-skills.mjs scripts/resolve-manual-skills.mjs scripts/invalidate-cache.sh scripts/plan-cache-invalidation.mjs scripts/recalculate-scores.sh scripts/fetch-audit-compute-usage.sh scripts/refresh-security-research-stats.sh scripts/tests/fake-cli.sh
           bash -n scripts/check-cache-invalidation-aggregate.sh
           bash -n scripts/invalidate-cache.sh
           bash -n scripts/recalculate-scores.sh
+          bash -n scripts/fetch-audit-compute-usage.sh
           bash -n scripts/refresh-security-research-stats.sh
           bash -n scripts/tests/fake-cli.sh
           node --check scripts/detect-changed-skills.mjs

--- a/scripts/fetch-audit-compute-usage.sh
+++ b/scripts/fetch-audit-compute-usage.sh
@@ -26,39 +26,77 @@ if ! [[ "$retry_base_seconds" =~ ^[0-9]+$ ]] || ((retry_base_seconds > 60)); the
   exit 64
 fi
 
+temp_root="$(mktemp -d "${TMPDIR:-/tmp}/audit-compute-usage.XXXXXX")" || {
+  echo "failed to create audit compute usage temp directory" >&2
+  exit 1
+}
+cleanup() {
+  rm -rf -- "$temp_root"
+}
+trap cleanup EXIT
+
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-  response="$({
-    curl --fail --silent --show-error \
+  attempt_dir="$temp_root/attempt-$attempt"
+  body_file="$attempt_dir/body"
+  header_file="$attempt_dir/headers"
+  mkdir -m 700 -- "$attempt_dir" || exit 1
+  : > "$body_file"
+  : > "$header_file"
+
+  http_status="$(
+    curl --disable \
+      --silent --show-error \
       --proto '=https' \
+      --proto-redir '=https' \
       --tlsv1.2 \
+      --retry 0 \
       --connect-timeout 30 \
       --max-time 120 \
       --request GET \
       --header @- \
+      --output "$body_file" \
+      --dump-header "$header_file" \
+      --write-out '%{http_code}' \
       -- "$usage_url" \
       <<<"Authorization: Bearer $HELM_API_KEY"
-  })"
+  )"
   curl_status=$?
 
-  if [[ "$curl_status" -eq 0 ]]; then
-    printf '%s' "$response"
+  if [[ "$curl_status" -eq 0 && "$http_status" == "200" ]]; then
+    cat "$body_file"
     exit 0
   fi
 
+  if [[ "$curl_status" -eq 0 ]]; then
+    echo "::error::audit compute Helm GET returned HTTP ${http_status:-unknown}; expected 200" >&2
+    exit 22
+  fi
+
+  allowlisted=false
+  retryable=false
   case "$curl_status" in
     28 | 35 | 52 | 55 | 56)
-      if ((attempt < max_attempts)); then
-        delay=$((retry_base_seconds * (1 << (attempt - 1))))
-        echo "::warning::audit compute Helm GET attempt ${attempt}/${max_attempts} failed with curl exit ${curl_status}; retrying in ${delay}s" >&2
-        sleep "$delay"
-        continue
+      allowlisted=true
+      if [[ "$http_status" == "000" && ! -s "$body_file" && ! -s "$header_file" ]]; then
+        retryable=true
       fi
-      echo "::error::audit compute Helm GET exhausted ${max_attempts} attempts; final curl exit ${curl_status}" >&2
-      ;;
-    *)
-      echo "::error::audit compute Helm GET failed with non-retryable curl exit ${curl_status}" >&2
       ;;
   esac
+
+  if [[ "$retryable" == true && "$attempt" -lt "$max_attempts" ]]; then
+    delay=$((retry_base_seconds * (1 << (attempt - 1))))
+    echo "::warning::audit compute Helm GET attempt ${attempt}/${max_attempts} failed with curl exit ${curl_status}; retrying in ${delay}s" >&2
+    sleep "$delay"
+    continue
+  fi
+
+  if [[ "$retryable" == true ]]; then
+    echo "::error::audit compute Helm GET exhausted ${max_attempts} attempts; final curl exit ${curl_status}" >&2
+  elif [[ "$allowlisted" == false ]]; then
+    echo "::error::audit compute Helm GET failed with non-retryable curl exit ${curl_status}" >&2
+  else
+    echo "::error::audit compute Helm GET failed closed with curl exit ${curl_status}, HTTP ${http_status:-unknown}, body bytes $(wc -c < "$body_file"), and header bytes $(wc -c < "$header_file")" >&2
+  fi
 
   exit "$curl_status"
 done

--- a/scripts/fetch-audit-compute-usage.sh
+++ b/scripts/fetch-audit-compute-usage.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <https-usage-url>" >&2
+  exit 64
+fi
+
+usage_url="$1"
+if [[ "$usage_url" != https://* ]]; then
+  echo "audit compute usage URL must use https" >&2
+  exit 64
+fi
+
+: "${HELM_API_KEY:?HELM_API_KEY is required}"
+
+max_attempts="${AUDIT_READ_MAX_ATTEMPTS:-3}"
+retry_base_seconds="${AUDIT_READ_RETRY_BASE_SECONDS:-2}"
+
+if ! [[ "$max_attempts" =~ ^[1-3]$ ]]; then
+  echo "AUDIT_READ_MAX_ATTEMPTS must be an integer from 1 to 3" >&2
+  exit 64
+fi
+if ! [[ "$retry_base_seconds" =~ ^[0-9]+$ ]] || ((retry_base_seconds > 60)); then
+  echo "AUDIT_READ_RETRY_BASE_SECONDS must be an integer from 0 to 60" >&2
+  exit 64
+fi
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  response="$({
+    curl --fail --silent --show-error \
+      --proto '=https' \
+      --tlsv1.2 \
+      --connect-timeout 30 \
+      --max-time 120 \
+      --request GET \
+      --header @- \
+      -- "$usage_url" \
+      <<<"Authorization: Bearer $HELM_API_KEY"
+  })"
+  curl_status=$?
+
+  if [[ "$curl_status" -eq 0 ]]; then
+    printf '%s' "$response"
+    exit 0
+  fi
+
+  case "$curl_status" in
+    28 | 35 | 52 | 55 | 56)
+      if ((attempt < max_attempts)); then
+        delay=$((retry_base_seconds * (1 << (attempt - 1))))
+        echo "::warning::audit compute Helm GET attempt ${attempt}/${max_attempts} failed with curl exit ${curl_status}; retrying in ${delay}s" >&2
+        sleep "$delay"
+        continue
+      fi
+      echo "::error::audit compute Helm GET exhausted ${max_attempts} attempts; final curl exit ${curl_status}" >&2
+      ;;
+    *)
+      echo "::error::audit compute Helm GET failed with non-retryable curl exit ${curl_status}" >&2
+      ;;
+  esac
+
+  exit "$curl_status"
+done

--- a/scripts/refresh-security-research-stats.sh
+++ b/scripts/refresh-security-research-stats.sh
@@ -84,7 +84,8 @@ PY
 if [[ "$stale_only" == "true" ]]; then
   set +e
   probe_status="$(
-    curl --silent --show-error \
+    curl --disable --silent --show-error \
+      --retry 0 \
       --connect-timeout 10 \
       --max-time 30 \
       --output "$response_file" \
@@ -128,7 +129,8 @@ for attempt in 1 2 3; do
   set +e
   refresh_status="$(
     printf 'Authorization: Bearer %s\n' "$SECURITY_RESEARCH_AUTOMATION_KEY" \
-      | curl --silent --show-error \
+      | curl --disable --silent --show-error \
+        --retry 0 \
         --header @- \
         --header 'Accept: application/json' \
         --connect-timeout 10 \

--- a/scripts/tests/audit-compute-network-retry.test.mjs
+++ b/scripts/tests/audit-compute-network-retry.test.mjs
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = process.cwd();
+const helper = resolve(repoRoot, 'scripts/fetch-audit-compute-usage.sh');
+const computeWorkflowPath = resolve(repoRoot, '.github/workflows/sync-audit-compute.yml');
+const computeWorkflow = readFileSync(computeWorkflowPath, 'utf8');
+const monitorWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/monitor-skill-sources.yml'),
+  'utf8',
+);
+
+function installFakeNetwork(sequence) {
+  const root = mkdtempSync(join(tmpdir(), 'audit-compute-network-'));
+  const bin = join(root, 'bin');
+  mkdirSync(bin, { recursive: true });
+
+  const state = join(root, 'attempt-count');
+  const curlLog = join(root, 'curl.log');
+  const sleepLog = join(root, 'sleep.log');
+  const fakeCurl = join(bin, 'curl');
+  const fakeSleep = join(bin, 'sleep');
+
+  writeFileSync(
+    fakeCurl,
+    `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[[ ! -f '${state}' ]] || count=$(cat '${state}')
+count=$((count + 1))
+printf '%s' "$count" > '${state}'
+printf '%s\\n' "$*" >> '${curlLog}'
+case "$count" in
+${sequence
+  .map(
+    ({ status, stderr = '', stdout = '' }, index) => `  ${index + 1})
+    printf '%s' '${stdout.replaceAll("'", "'\\''")}'
+    printf '%s' '${stderr.replaceAll("'", "'\\''")}' >&2
+    exit ${status}
+    ;;`,
+  )
+  .join('\n')}
+  *)
+    echo 'unexpected extra curl attempt' >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+  writeFileSync(fakeSleep, `#!/usr/bin/env bash\nprintf '%s\\n' "$1" >> '${sleepLog}'\n`);
+  chmodSync(fakeCurl, 0o755);
+  chmodSync(fakeSleep, 0o755);
+
+  return { root, bin, state, curlLog, sleepLog };
+}
+
+function runHelper(sequence, extraEnv = {}) {
+  const fixture = installFakeNetwork(sequence);
+  const result = spawnSync(helper, ['https://helm.example/v1/usage/stats'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...extraEnv,
+      PATH: `${fixture.bin}:${process.env.PATH}`,
+      HELM_API_KEY: 'test-helm-key',
+      AUDIT_READ_MAX_ATTEMPTS: '3',
+      AUDIT_READ_RETRY_BASE_SECONDS: '2',
+    },
+  });
+  const attempts = existsSync(fixture.state) ? Number(readFileSync(fixture.state, 'utf8')) : 0;
+  const curlCalls = existsSync(fixture.curlLog)
+    ? readFileSync(fixture.curlLog, 'utf8').trim().split(/\r?\n/).filter(Boolean)
+    : [];
+  const sleeps = existsSync(fixture.sleepLog)
+    ? readFileSync(fixture.sleepLog, 'utf8').trim().split(/\r?\n/).filter(Boolean)
+    : [];
+  return { ...result, attempts, curlCalls, sleeps };
+}
+
+test('initial idempotent GET recovers SSL timeout then reset with bounded backoff', () => {
+  const result = runHelper([
+    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
+    { status: 35, stderr: 'curl: (35) Recv failure: Connection reset by peer\n' },
+    { status: 0, stdout: '{"object":"usage_stats","totals":{"total_tokens":7}}' },
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '{"object":"usage_stats","totals":{"total_tokens":7}}');
+  assert.equal(result.attempts, 3);
+  assert.deepEqual(result.sleeps, ['2', '4']);
+  assert.match(result.stderr, /attempt 1\/3 failed with curl exit 28; retrying in 2s/);
+  assert.match(result.stderr, /attempt 2\/3 failed with curl exit 35; retrying in 4s/);
+  for (const call of result.curlCalls) {
+    assert.match(call, /--proto =https/);
+    assert.match(call, /--request GET/);
+    assert.match(call, /--header @-/);
+    assert.doesNotMatch(call, /test-helm-key/);
+    assert.doesNotMatch(call, /(?:^|\s)(?:-k|--insecure)(?:\s|$)/);
+  }
+});
+
+test('read helper rejects method or body arguments before curl can run', () => {
+  const fixture = installFakeNetwork([{ status: 0, stdout: '{}' }]);
+  const result = spawnSync(helper, ['--request', 'POST'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env.PATH}`,
+      HELM_API_KEY: 'test-helm-key',
+    },
+  });
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /usage:/);
+  assert.equal(existsSync(fixture.state), false, 'curl must not run for mutation-capable arguments');
+});
+
+test('configuration cannot raise the read budget above three total attempts', () => {
+  const fixture = installFakeNetwork([{ status: 0, stdout: '{}' }]);
+  const result = spawnSync(helper, ['https://helm.example/v1/usage/stats'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env.PATH}`,
+      HELM_API_KEY: 'test-helm-key',
+      AUDIT_READ_MAX_ATTEMPTS: '4',
+    },
+  });
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /integer from 1 to 3/);
+  assert.equal(existsSync(fixture.state), false, 'invalid budget must fail before curl');
+});
+
+test('terminal certificate verification failure never retries or disables verification', () => {
+  const result = runHelper([
+    { status: 60, stderr: 'curl: (60) SSL certificate problem: unable to get local issuer certificate\n' },
+  ]);
+
+  assert.equal(result.status, 60);
+  assert.equal(result.attempts, 1);
+  assert.deepEqual(result.sleeps, []);
+  assert.match(result.stderr, /non-retryable curl exit 60/);
+  assert.doesNotMatch(result.curlCalls[0], /(?:^|\s)(?:-k|--insecure)(?:\s|$)/);
+});
+
+test('a mixed transient then terminal error stops immediately at the terminal result', () => {
+  const result = runHelper([
+    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
+    { status: 60, stderr: 'curl: (60) SSL certificate problem\n' },
+  ]);
+
+  assert.equal(result.status, 60);
+  assert.equal(result.attempts, 2);
+  assert.deepEqual(result.sleeps, ['2']);
+  assert.match(result.stderr, /non-retryable curl exit 60/);
+});
+
+test('transient failures stop after three total attempts and two bounded sleeps', () => {
+  const result = runHelper([
+    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
+    { status: 35, stderr: 'curl: (35) Connection reset by peer\n' },
+    { status: 56, stderr: 'curl: (56) Recv failure\n' },
+  ]);
+
+  assert.equal(result.status, 56);
+  assert.equal(result.attempts, 3);
+  assert.deepEqual(result.sleeps, ['2', '4']);
+  assert.match(result.stderr, /exhausted 3 attempts; final curl exit 56/);
+});
+
+test('workflow retries only the Helm GET and never retries the snapshot POST', () => {
+  assert.match(computeWorkflow, /sparse-checkout:[\s\S]*scripts\/fetch-audit-compute-usage\.sh/);
+  assert.match(
+    computeWorkflow,
+    /helm_usage_json="\$\(\.\/scripts\/fetch-audit-compute-usage\.sh "\$helm_usage_url"\)"/,
+  );
+  assert.match(computeWorkflow, /AUDIT_READ_MAX_ATTEMPTS: ['"]3['"]/);
+  assert.match(computeWorkflow, /AUDIT_READ_RETRY_BASE_SECONDS: ['"]2['"]/);
+
+  const post = computeWorkflow.match(
+    /response="\$\([\s\S]*?record_audit_compute_snapshot[\s\S]*?\n\s*\)"/,
+  )?.[0] ?? '';
+  assert.notEqual(post, '', 'missing audit snapshot POST section');
+  assert.match(post, /curl --fail --silent --show-error/);
+  assert.doesNotMatch(post, /--retry|fetch-audit-compute-usage/);
+});
+
+test('the read helper cannot wrap scan, persist, local mutation, or any other workflow', () => {
+  assert.doesNotMatch(monitorWorkflow, /fetch-audit-compute-usage|run-source-monitor-with-retry/);
+
+  const workflowUsers = readdirSync(resolve(repoRoot, '.github/workflows'))
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .filter((name) =>
+      readFileSync(resolve(repoRoot, '.github/workflows', name), 'utf8').includes(
+        './scripts/fetch-audit-compute-usage.sh "$helm_usage_url"',
+      ),
+    )
+    .map((name) => basename(name));
+  assert.deepEqual(workflowUsers, ['sync-audit-compute.yml']);
+});

--- a/scripts/tests/audit-compute-network-retry.test.mjs
+++ b/scripts/tests/audit-compute-network-retry.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -17,185 +18,881 @@ const repoRoot = process.cwd();
 const helper = resolve(repoRoot, 'scripts/fetch-audit-compute-usage.sh');
 const computeWorkflowPath = resolve(repoRoot, '.github/workflows/sync-audit-compute.yml');
 const computeWorkflow = readFileSync(computeWorkflowPath, 'utf8');
+const refreshHelperSource = readFileSync(
+  resolve(repoRoot, 'scripts/refresh-security-research-stats.sh'),
+  'utf8',
+);
 const monitorWorkflow = readFileSync(
   resolve(repoRoot, '.github/workflows/monitor-skill-sources.yml'),
   'utf8',
 );
 
-function installFakeNetwork(sequence) {
+const validUsage = '{"object":"usage_stats","totals":{"total_tokens":7,"cost_usd":1.25}}';
+const successfulResponse = {
+  curlExit: 0,
+  httpStatus: '200',
+  body: validUsage,
+  headers: 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n',
+};
+
+function shellEnvironment(overrides = {}) {
+  const env = { ...process.env, ...overrides };
+  delete env.BASH_ENV;
+  delete env.CD_PATH;
+  delete env.ENV;
+  return env;
+}
+
+function extractLiteralRunBody(workflow, stepName) {
+  const lines = workflow.split(/\r?\n/);
+  const stepMarker = `      - name: ${stepName}`;
+  const stepIndex = lines.indexOf(stepMarker);
+  assert.notEqual(stepIndex, -1, `missing workflow step: ${stepName}`);
+
+  let runIndex = stepIndex + 1;
+  while (runIndex < lines.length && !/^      - name: /.test(lines[runIndex])) {
+    if (lines[runIndex] === '        run: |') {
+      break;
+    }
+    runIndex += 1;
+  }
+  assert.equal(lines[runIndex], '        run: |', `missing literal run body: ${stepName}`);
+
+  let endIndex = runIndex + 1;
+  while (endIndex < lines.length && !/^      - name: /.test(lines[endIndex])) {
+    endIndex += 1;
+  }
+
+  return `${lines
+    .slice(runIndex + 1, endIndex)
+    .map((line, index) => {
+      if (line === '') {
+        return '';
+      }
+      assert.ok(
+        line.startsWith('          '),
+        `unexpected indentation in ${stepName} run body at line ${runIndex + index + 2}`,
+      );
+      return line.slice(10);
+    })
+    .join('\n')}\n`;
+}
+
+const syncComputeRunBody = extractLiteralRunBody(
+  computeWorkflow,
+  'Sync audit compute snapshot',
+);
+
+function writeExecutable(path, source) {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function writeMaliciousCurlConfig(root) {
+  const curlHome = join(root, 'curl-home');
+  mkdirSync(curlHome, { recursive: true });
+  writeFileSync(
+    join(curlHome, '.curlrc'),
+    [
+      'insecure',
+      'retry = 3',
+      'retry-all-errors',
+      'retry-delay = 0',
+      '',
+    ].join('\n'),
+  );
+  return curlHome;
+}
+
+function installFakeNetwork(sequence, { maliciousCurlConfig = false } = {}) {
+  assert.ok(sequence.length > 0, 'fake curl requires at least one response');
+
   const root = mkdtempSync(join(tmpdir(), 'audit-compute-network-'));
   const bin = join(root, 'bin');
+  const responses = join(root, 'responses');
   mkdirSync(bin, { recursive: true });
+  mkdirSync(responses, { recursive: true });
 
-  const state = join(root, 'attempt-count');
-  const curlLog = join(root, 'curl.log');
-  const sleepLog = join(root, 'sleep.log');
-  const fakeCurl = join(bin, 'curl');
-  const fakeSleep = join(bin, 'sleep');
+  for (const [index, response] of sequence.entries()) {
+    const request = index + 1;
+    writeFileSync(join(responses, `${request}.curl-exit`), String(response.curlExit));
+    writeFileSync(join(responses, `${request}.http-status`), response.httpStatus ?? '000');
+    writeFileSync(join(responses, `${request}.body`), response.body ?? '');
+    writeFileSync(join(responses, `${request}.headers`), response.headers ?? '');
+    writeFileSync(join(responses, `${request}.stderr`), response.stderr ?? '');
+    if (response.insecureResponse) {
+      const insecure = response.insecureResponse;
+      writeFileSync(
+        join(responses, `${request}.insecure.curl-exit`),
+        String(insecure.curlExit),
+      );
+      writeFileSync(
+        join(responses, `${request}.insecure.http-status`),
+        insecure.httpStatus ?? '000',
+      );
+      writeFileSync(join(responses, `${request}.insecure.body`), insecure.body ?? '');
+      writeFileSync(
+        join(responses, `${request}.insecure.headers`),
+        insecure.headers ?? '',
+      );
+      writeFileSync(
+        join(responses, `${request}.insecure.stderr`),
+        insecure.stderr ?? '',
+      );
+    }
+  }
+  writeFileSync(join(root, 'response-count'), String(sequence.length));
 
-  writeFileSync(
-    fakeCurl,
+  writeExecutable(
+    join(bin, 'curl'),
     `#!/usr/bin/env bash
 set -euo pipefail
-count=0
-[[ ! -f '${state}' ]] || count=$(cat '${state}')
-count=$((count + 1))
-printf '%s' "$count" > '${state}'
-printf '%s\\n' "$*" >> '${curlLog}'
-case "$count" in
-${sequence
-  .map(
-    ({ status, stderr = '', stdout = '' }, index) => `  ${index + 1})
-    printf '%s' '${stdout.replaceAll("'", "'\\''")}'
-    printf '%s' '${stderr.replaceAll("'", "'\\''")}' >&2
-    exit ${status}
-    ;;`,
-  )
-  .join('\n')}
-  *)
-    echo 'unexpected extra curl attempt' >&2
-    exit 99
-    ;;
-esac
+
+root="\${FAKE_CURL_ROOT:?FAKE_CURL_ROOT is required}"
+invocation_count=0
+[[ ! -f "$root/invocation-count" ]] || invocation_count="$(cat "$root/invocation-count")"
+invocation_count=$((invocation_count + 1))
+printf '%s' "$invocation_count" > "$root/invocation-count"
+invocation_dir="$root/invocation-$invocation_count"
+mkdir -p "$invocation_dir"
+
+arg_number=0
+for arg in "$@"; do
+  arg_number=$((arg_number + 1))
+  printf '%s' "$arg" > "$invocation_dir/arg-$arg_number"
+done
+printf '%s' "$arg_number" > "$invocation_dir/arg-count"
+
+config_enabled=true
+if [[ "\${1:-}" == "--disable" ]]; then
+  config_enabled=false
+fi
+
+retry_count=0
+retry_all_errors=false
+effective_insecure=false
+if [[ "$config_enabled" == true && -f "\${CURL_HOME:-$HOME}/.curlrc" ]]; then
+  while IFS= read -r config_line || [[ -n "$config_line" ]]; do
+    normalized="\${config_line//[[:space:]]/}"
+    case "$normalized" in
+      insecure) effective_insecure=true ;;
+      retry=*) retry_count="\${normalized#retry=}" ;;
+      retry-all-errors) retry_all_errors=true ;;
+    esac
+  done < "\${CURL_HOME:-$HOME}/.curlrc"
+fi
+
+method=GET
+output_file=''
+header_file=''
+write_out=''
+read_headers=false
+args=("$@")
+index=0
+while ((index < \${#args[@]})); do
+  argument="\${args[$index]}"
+  case "$argument" in
+    --request|-X)
+      index=$((index + 1))
+      method="\${args[$index]}"
+      ;;
+    --output|-o)
+      index=$((index + 1))
+      output_file="\${args[$index]}"
+      ;;
+    --dump-header|-D)
+      index=$((index + 1))
+      header_file="\${args[$index]}"
+      ;;
+    --write-out|-w)
+      index=$((index + 1))
+      write_out="\${args[$index]}"
+      ;;
+    --retry)
+      index=$((index + 1))
+      retry_count="\${args[$index]}"
+      ;;
+    --retry=*)
+      retry_count="\${argument#--retry=}"
+      ;;
+    --retry-all-errors)
+      retry_all_errors=true
+      ;;
+    --insecure|-k)
+      effective_insecure=true
+      ;;
+    --header|-H)
+      index=$((index + 1))
+      [[ "\${args[$index]}" != "@-" ]] || read_headers=true
+      ;;
+    --connect-timeout|--max-time|--proto|--retry-delay|--data|--data-raw|--data-binary)
+      index=$((index + 1))
+      ;;
+    --)
+      break
+      ;;
+  esac
+  index=$((index + 1))
+done
+
+if [[ "$read_headers" == true ]]; then
+  cat > "$invocation_dir/stdin"
+fi
+if [[ "$effective_insecure" == true ]]; then
+  printf '%s\n' "$invocation_count" >> "$root/insecure-invocations"
+fi
+printf '%s' "$method" > "$invocation_dir/method"
+
+internal_attempt=0
+while true; do
+  request_count=0
+  [[ ! -f "$root/request-count" ]] || request_count="$(cat "$root/request-count")"
+  request_count=$((request_count + 1))
+  printf '%s' "$request_count" > "$root/request-count"
+  printf '%s\n' "$method" >> "$root/request-methods"
+
+  response_count="$(cat "$root/response-count")"
+  if ((request_count > response_count)); then
+    echo "unexpected extra curl request $request_count" >&2
+    curl_exit=99
+    http_status=000
+    : > "$root/unexpected-request"
+    if [[ -n "$output_file" ]]; then : > "$output_file"; fi
+    if [[ -n "$header_file" ]]; then : > "$header_file"; fi
+  else
+    response="$root/responses/$request_count"
+    if [[ "$effective_insecure" == true && -f "$response.insecure.curl-exit" ]]; then
+      response="$response.insecure"
+    fi
+    curl_exit="$(cat "$response.curl-exit")"
+    http_status="$(cat "$response.http-status")"
+    cat "$response.stderr" >&2
+    if [[ -n "$output_file" ]]; then
+      cat "$response.body" > "$output_file"
+    else
+      cat "$response.body"
+    fi
+    if [[ -n "$header_file" ]]; then
+      cat "$response.headers" > "$header_file"
+    fi
+  fi
+
+  if [[ "$curl_exit" -eq 0 ]]; then
+    break
+  fi
+  if ((internal_attempt < retry_count)) && [[ "$retry_all_errors" == true ]]; then
+    internal_attempt=$((internal_attempt + 1))
+    continue
+  fi
+  break
+done
+
+if [[ -n "$write_out" ]]; then
+  if [[ "$write_out" != '%{http_code}' ]]; then
+    echo "unsupported fake curl --write-out format: $write_out" >&2
+    exit 98
+  fi
+  printf '%s' "$http_status"
+fi
+exit "$curl_exit"
 `,
   );
-  writeFileSync(fakeSleep, `#!/usr/bin/env bash\nprintf '%s\\n' "$1" >> '${sleepLog}'\n`);
-  chmodSync(fakeCurl, 0o755);
-  chmodSync(fakeSleep, 0o755);
 
-  return { root, bin, state, curlLog, sleepLog };
+  writeExecutable(
+    join(bin, 'sleep'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >> "\${FAKE_CURL_ROOT:?}/sleep.log"
+`,
+  );
+
+  const curlHome = maliciousCurlConfig
+    ? writeMaliciousCurlConfig(root)
+    : join(root, 'empty-curl-home');
+  mkdirSync(curlHome, { recursive: true });
+  return { root, bin, curlHome };
 }
 
-function runHelper(sequence, extraEnv = {}) {
-  const fixture = installFakeNetwork(sequence);
-  const result = spawnSync(helper, ['https://helm.example/v1/usage/stats'], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      ...extraEnv,
-      PATH: `${fixture.bin}:${process.env.PATH}`,
-      HELM_API_KEY: 'test-helm-key',
-      AUDIT_READ_MAX_ATTEMPTS: '3',
-      AUDIT_READ_RETRY_BASE_SECONDS: '2',
-    },
+function readCount(path) {
+  return existsSync(path) ? Number(readFileSync(path, 'utf8')) : 0;
+}
+
+function readLines(path) {
+  if (!existsSync(path)) {
+    return [];
+  }
+  return readFileSync(path, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+}
+
+function readCurlInvocations(fixture) {
+  const count = readCount(join(fixture.root, 'invocation-count'));
+  return Array.from({ length: count }, (_, invocationIndex) => {
+    const directory = join(fixture.root, `invocation-${invocationIndex + 1}`);
+    const argCount = readCount(join(directory, 'arg-count'));
+    return Array.from({ length: argCount }, (_, argIndex) =>
+      readFileSync(join(directory, `arg-${argIndex + 1}`), 'utf8'));
   });
-  const attempts = existsSync(fixture.state) ? Number(readFileSync(fixture.state, 'utf8')) : 0;
-  const curlCalls = existsSync(fixture.curlLog)
-    ? readFileSync(fixture.curlLog, 'utf8').trim().split(/\r?\n/).filter(Boolean)
-    : [];
-  const sleeps = existsSync(fixture.sleepLog)
-    ? readFileSync(fixture.sleepLog, 'utf8').trim().split(/\r?\n/).filter(Boolean)
-    : [];
-  return { ...result, attempts, curlCalls, sleeps };
 }
 
-test('initial idempotent GET recovers SSL timeout then reset with bounded backoff', () => {
+function collectNetworkResult(fixture) {
+  return {
+    invocations: readCurlInvocations(fixture),
+    requests: readCount(join(fixture.root, 'request-count')),
+    requestMethods: readLines(join(fixture.root, 'request-methods')),
+    sleeps: readLines(join(fixture.root, 'sleep.log')),
+    insecureInvocations: readLines(join(fixture.root, 'insecure-invocations')),
+    unexpectedRequest: existsSync(join(fixture.root, 'unexpected-request')),
+  };
+}
+
+function runHelper(sequence, { maliciousCurlConfig = false, extraEnv = {} } = {}) {
+  const fixture = installFakeNetwork(sequence, { maliciousCurlConfig });
+  try {
+    const result = spawnSync(helper, ['https://helm.example/v1/usage/stats'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: shellEnvironment({
+        ...extraEnv,
+        PATH: `${fixture.bin}:${process.env.PATH}`,
+        CURL_HOME: fixture.curlHome,
+        FAKE_CURL_ROOT: fixture.root,
+        HELM_API_KEY: 'test-helm-key',
+        AUDIT_READ_MAX_ATTEMPTS: '3',
+        AUDIT_READ_RETRY_BASE_SECONDS: '2',
+      }),
+    });
+    return { ...result, ...collectNetworkResult(fixture) };
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+function optionValue(argv, name) {
+  const index = argv.indexOf(name);
+  assert.notEqual(index, -1, `missing curl option ${name}: ${argv.join(' ')}`);
+  assert.ok(index + 1 < argv.length, `missing value for curl option ${name}`);
+  return argv[index + 1];
+}
+
+function runHelperWithArguments(args, extraEnv = {}) {
+  const fixture = installFakeNetwork([successfulResponse]);
+  try {
+    const result = spawnSync(helper, args, {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: shellEnvironment({
+        ...extraEnv,
+        PATH: `${fixture.bin}:${process.env.PATH}`,
+        CURL_HOME: fixture.curlHome,
+        FAKE_CURL_ROOT: fixture.root,
+        HELM_API_KEY: 'test-helm-key',
+      }),
+    });
+    return { ...result, ...collectNetworkResult(fixture) };
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+function runWorkflow(
+  helmUsageJson,
+  postSequence = [{
+    curlExit: 0,
+    httpStatus: '200',
+    body: '{"snapshot_id":1}',
+    headers: 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n',
+  }],
+) {
+  const fixture = installFakeNetwork(postSequence, { maliciousCurlConfig: true });
+  const scriptsDirectory = join(fixture.root, 'scripts');
+  const usageFile = join(fixture.root, 'helm-usage.json');
+  const helperLog = join(fixture.root, 'helper.log');
+  const summary = join(fixture.root, 'summary.md');
+  mkdirSync(scriptsDirectory, { recursive: true });
+  writeFileSync(usageFile, helmUsageJson);
+
+  writeExecutable(
+    join(scriptsDirectory, 'fetch-audit-compute-usage.sh'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "\${FAKE_WORKFLOW_HELPER_LOG:?}"
+cat "\${FAKE_HELM_USAGE_FILE:?}"
+`,
+  );
+  writeExecutable(
+    join(fixture.bin, 'date'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == '-u +%F' ]]
+printf '%s\n' '2026-07-17'
+`,
+  );
+
+  try {
+    const result = spawnSync('bash', ['-c', syncComputeRunBody], {
+      cwd: fixture.root,
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: shellEnvironment({
+        PATH: `${fixture.bin}:${process.env.PATH}`,
+        CURL_HOME: fixture.curlHome,
+        FAKE_CURL_ROOT: fixture.root,
+        FAKE_HELM_USAGE_FILE: usageFile,
+        FAKE_WORKFLOW_HELPER_LOG: helperLog,
+        HELM_BASE_URL: 'https://helm.example/v1',
+        HELM_API_KEY: 'test-helm-key',
+        SUPABASE_URL: 'https://supabase.example',
+        SUPABASE_SERVICE_KEY: 'test-supabase-key',
+        LEGACY_TOKENS: '1308077250',
+        LEGACY_COST_USD: '2568.41704016099988706',
+        AUDIT_READ_MAX_ATTEMPTS: '3',
+        AUDIT_READ_RETRY_BASE_SECONDS: '2',
+        GITHUB_STEP_SUMMARY: summary,
+      }),
+    });
+    return {
+      ...result,
+      ...collectNetworkResult(fixture),
+      helperCalls: readLines(helperLog),
+      summary: existsSync(summary) ? readFileSync(summary, 'utf8') : '',
+    };
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+test('helper retries HTTP 000 empty allowlisted failures and returns only an exact HTTP 200 body', () => {
   const result = runHelper([
-    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
-    { status: 35, stderr: 'curl: (35) Recv failure: Connection reset by peer\n' },
-    { status: 0, stdout: '{"object":"usage_stats","totals":{"total_tokens":7}}' },
+    {
+      curlExit: 28,
+      httpStatus: '000',
+      stderr: 'curl: (28) SSL connection timeout\n',
+    },
+    {
+      curlExit: 35,
+      httpStatus: '000',
+      stderr: 'curl: (35) Connection reset by peer\n',
+    },
+    successfulResponse,
   ]);
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(result.stdout, '{"object":"usage_stats","totals":{"total_tokens":7}}');
-  assert.equal(result.attempts, 3);
+  assert.equal(result.stdout, validUsage);
+  assert.equal(result.requests, 3);
+  assert.deepEqual(result.requestMethods, ['GET', 'GET', 'GET']);
   assert.deepEqual(result.sleeps, ['2', '4']);
   assert.match(result.stderr, /attempt 1\/3 failed with curl exit 28; retrying in 2s/);
   assert.match(result.stderr, /attempt 2\/3 failed with curl exit 35; retrying in 4s/);
-  for (const call of result.curlCalls) {
-    assert.match(call, /--proto =https/);
-    assert.match(call, /--request GET/);
-    assert.match(call, /--header @-/);
-    assert.doesNotMatch(call, /test-helm-key/);
-    assert.doesNotMatch(call, /(?:^|\s)(?:-k|--insecure)(?:\s|$)/);
+  assert.equal(result.unexpectedRequest, false);
+
+  const capturePaths = [];
+  for (const invocation of result.invocations) {
+    assert.equal(invocation[0], '--disable', `curl --disable must be first: ${invocation.join(' ')}`);
+    assert.equal(optionValue(invocation, '--proto'), '=https');
+    assert.equal(optionValue(invocation, '--proto-redir'), '=https');
+    assert.equal(optionValue(invocation, '--request'), 'GET');
+    assert.equal(optionValue(invocation, '--header'), '@-');
+    const bodyPath = optionValue(invocation, '--output');
+    const headerPath = optionValue(invocation, '--dump-header');
+    assert.notEqual(bodyPath, headerPath, 'body and headers must use separate capture files');
+    capturePaths.push(bodyPath, headerPath);
+    assert.equal(optionValue(invocation, '--write-out'), '%{http_code}');
+    assert.equal(invocation.includes('test-helm-key'), false, 'secret must not appear in argv');
+  }
+  assert.equal(
+    new Set(capturePaths).size,
+    capturePaths.length,
+    'every attempt must use new body and header capture paths',
+  );
+  for (const capturePath of capturePaths) {
+    assert.equal(existsSync(capturePath), false, `temp capture was not cleaned: ${capturePath}`);
   }
 });
 
-test('read helper rejects method or body arguments before curl can run', () => {
-  const fixture = installFakeNetwork([{ status: 0, stdout: '{}' }]);
-  const result = spawnSync(helper, ['--request', 'POST'], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `${fixture.bin}:${process.env.PATH}`,
-      HELM_API_KEY: 'test-helm-key',
-    },
-  });
+test('helper disables ambient curl config before every invocation and never exceeds three requests', () => {
+  const failures = Array.from({ length: 12 }, () => ({
+    curlExit: 28,
+    httpStatus: '000',
+    stderr: 'curl: (28) timeout\n',
+  }));
+  const result = runHelper(failures, { maliciousCurlConfig: true });
 
-  assert.equal(result.status, 64);
-  assert.match(result.stderr, /usage:/);
-  assert.equal(existsSync(fixture.state), false, 'curl must not run for mutation-capable arguments');
+  assert.equal(result.status, 28);
+  assert.equal(result.requests, 3, 'ambient curl retry must not multiply helper attempts');
+  assert.equal(result.invocations.length, 3);
+  assert.deepEqual(result.sleeps, ['2', '4']);
+  assert.deepEqual(result.insecureInvocations, [], 'ambient insecure must not disable TLS checks');
+  for (const invocation of result.invocations) {
+    assert.equal(invocation[0], '--disable', `curl --disable must be first: ${invocation.join(' ')}`);
+  }
+});
+
+test('helper ignores malicious ambient insecure for a certificate failure', () => {
+  const result = runHelper([
+    {
+      curlExit: 60,
+      httpStatus: '000',
+      stderr: 'curl: (60) SSL certificate problem\n',
+      insecureResponse: successfulResponse,
+    },
+    successfulResponse,
+  ], { maliciousCurlConfig: true });
+
+  assert.equal(result.status, 60);
+  assert.equal(result.requests, 1, 'certificate failure must not become an insecure success');
+  assert.equal(result.invocations.length, 1);
+  assert.deepEqual(result.insecureInvocations, []);
+  assert.equal(result.stdout, '');
+});
+
+for (const curlExit of [28, 35, 52, 55, 56]) {
+  test(`helper permits retryable curl exit ${curlExit} only for an empty HTTP 000 response`, () => {
+    const result = runHelper([
+      { curlExit, httpStatus: '000' },
+      successfulResponse,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.requests, 2);
+    assert.deepEqual(result.sleeps, ['2']);
+  });
+}
+
+test('helper does not retry an empty HTTP 000 response for a non-allowlisted curl exit', () => {
+  const result = runHelper([
+    {
+      curlExit: 60,
+      httpStatus: '000',
+      stderr: 'curl: (60) SSL certificate problem\n',
+    },
+    successfulResponse,
+  ]);
+
+  assert.equal(result.status, 60);
+  assert.equal(result.requests, 1);
+  assert.deepEqual(result.sleeps, []);
+  assert.match(result.stderr, /non-retryable curl exit 60/);
+});
+
+const terminalTransportResponses = [
+  {
+    name: 'HTTP 401 plus a transport error',
+    response: {
+      curlExit: 28,
+      httpStatus: '401',
+      headers: 'HTTP/2 401\r\n\r\n',
+      stderr: 'curl: (28) timeout after response\n',
+    },
+  },
+  {
+    name: 'HTTP 000 plus a partial body',
+    response: {
+      curlExit: 28,
+      httpStatus: '000',
+      body: '{"object":"usage_',
+      stderr: 'curl: (28) partial body\n',
+    },
+  },
+  {
+    name: 'HTTP 000 plus partial headers',
+    response: {
+      curlExit: 35,
+      httpStatus: '000',
+      headers: 'HTTP/1.1 200',
+      stderr: 'curl: (35) partial headers\n',
+    },
+  },
+  {
+    name: 'HTTP 503 plus partial body and headers',
+    response: {
+      curlExit: 56,
+      httpStatus: '503',
+      body: '{"error":"upstream',
+      headers: 'HTTP/2 503\r\ncontent-type: application/json\r\n',
+      stderr: 'curl: (56) receive failure\n',
+    },
+  },
+];
+
+for (const { name, response } of terminalTransportResponses) {
+  test(`helper does not retry ${name}`, () => {
+    const result = runHelper([response, successfulResponse]);
+
+    assert.equal(result.status, response.curlExit);
+    assert.equal(result.requests, 1);
+    assert.deepEqual(result.sleeps, []);
+  });
+}
+
+for (const response of [
+  {
+    name: 'HTTP 302',
+    httpStatus: '302',
+    headers: 'HTTP/2 302\r\nlocation: https://other.example/usage\r\n\r\n',
+  },
+  {
+    name: 'HTTP 204',
+    httpStatus: '204',
+    headers: 'HTTP/2 204\r\n\r\n',
+  },
+]) {
+  test(`helper maps curl-zero ${response.name} to exit 22 without retrying`, () => {
+    const result = runHelper([
+      {
+        curlExit: 0,
+        httpStatus: response.httpStatus,
+        body: validUsage,
+        headers: response.headers,
+      },
+      successfulResponse,
+    ]);
+
+    assert.equal(result.status, 22);
+    assert.equal(result.requests, 1);
+    assert.deepEqual(result.sleeps, []);
+    assert.equal(result.stdout, '');
+  });
+}
+
+test('helper rejects HTTP 503 with curl exit 18 without retrying', () => {
+  const result = runHelper([
+    {
+      curlExit: 18,
+      httpStatus: '503',
+      body: '{"error":"partial response"}',
+      headers: 'HTTP/2 503\r\n\r\n',
+      stderr: 'curl: (18) end of response with bytes missing\n',
+    },
+    successfulResponse,
+  ]);
+
+  assert.equal(result.status, 18);
+  assert.equal(result.requests, 1);
+  assert.deepEqual(result.sleeps, []);
+});
+
+test('helper requires curl exit zero even when the captured HTTP status is 200', () => {
+  const result = runHelper([
+    {
+      curlExit: 28,
+      httpStatus: '200',
+      body: validUsage,
+      headers: 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n',
+      stderr: 'curl: (28) timeout after response\n',
+    },
+    successfulResponse,
+  ]);
+
+  assert.equal(result.status, 28);
+  assert.equal(result.requests, 1);
+  assert.equal(result.stdout, '');
+  assert.deepEqual(result.sleeps, []);
+});
+
+test('read helper rejects method or body arguments before curl can run', () => {
+  for (const args of [
+    ['--request', 'POST'],
+    ['--data', '{}'],
+  ]) {
+    const result = runHelperWithArguments(args);
+    assert.equal(result.status, 64);
+    assert.match(result.stderr, /usage:/);
+    assert.equal(result.requests, 0, 'curl must not run for mutation-capable arguments');
+  }
 });
 
 test('configuration cannot raise the read budget above three total attempts', () => {
-  const fixture = installFakeNetwork([{ status: 0, stdout: '{}' }]);
-  const result = spawnSync(helper, ['https://helm.example/v1/usage/stats'], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `${fixture.bin}:${process.env.PATH}`,
-      HELM_API_KEY: 'test-helm-key',
-      AUDIT_READ_MAX_ATTEMPTS: '4',
-    },
-  });
+  const result = runHelperWithArguments(
+    ['https://helm.example/v1/usage/stats'],
+    { AUDIT_READ_MAX_ATTEMPTS: '4' },
+  );
 
   assert.equal(result.status, 64);
   assert.match(result.stderr, /integer from 1 to 3/);
-  assert.equal(existsSync(fixture.state), false, 'invalid budget must fail before curl');
+  assert.equal(result.requests, 0, 'invalid budget must fail before curl');
 });
 
-test('terminal certificate verification failure never retries or disables verification', () => {
-  const result = runHelper([
-    { status: 60, stderr: 'curl: (60) SSL certificate problem: unable to get local issuer certificate\n' },
-  ]);
+const invalidUsageFixtures = [
+  {
+    name: 'non-object response root',
+    json: '[]',
+  },
+  {
+    name: 'unexpected object discriminator',
+    json: '{"object":"other","totals":{"total_tokens":7,"cost_usd":1.25}}',
+  },
+  {
+    name: 'missing totals',
+    json: '{"object":"usage_stats"}',
+  },
+  {
+    name: 'non-object totals',
+    json: '{"object":"usage_stats","totals":[]}',
+  },
+];
 
-  assert.equal(result.status, 60);
-  assert.equal(result.attempts, 1);
-  assert.deepEqual(result.sleeps, []);
-  assert.match(result.stderr, /non-retryable curl exit 60/);
-  assert.doesNotMatch(result.curlCalls[0], /(?:^|\s)(?:-k|--insecure)(?:\s|$)/);
+for (const field of ['total_tokens', 'cost_usd']) {
+  const otherField = field === 'total_tokens'
+    ? '"cost_usd":1.25'
+    : '"total_tokens":7';
+  const invalidValues = [
+    ['missing', null],
+    ['null', 'null'],
+    ['string', '"7"'],
+    ['boolean', 'true'],
+    ['negative', '-1'],
+    ...(field === 'total_tokens' ? [['non-integer number', '7.5']] : []),
+    ['NaN', 'NaN'],
+    ['Infinity', 'Infinity'],
+    [
+      'overflow',
+      field === 'total_tokens' ? '9223372036854775808' : '1e309',
+    ],
+  ];
+
+  for (const [kind, value] of invalidValues) {
+    const members = value === null
+      ? otherField
+      : `"${field}":${value},${otherField}`;
+    invalidUsageFixtures.push({
+      name: `${kind} ${field}`,
+      json: `{"object":"usage_stats","totals":{${members}}}`,
+    });
+  }
+}
+
+for (const fixture of invalidUsageFixtures) {
+  test(`workflow rejects ${fixture.name} before the snapshot POST`, () => {
+    const result = runWorkflow(fixture.json);
+
+    assert.notEqual(result.status, 0, 'invalid Helm totals must fail the workflow');
+    assert.deepEqual(result.helperCalls, ['https://helm.example/v1/usage/stats']);
+    assert.equal(result.requests, 0, 'invalid Helm totals must fail before POST');
+    assert.equal(result.invocations.length, 0);
+  });
+}
+
+for (const fixture of [
+  {
+    name: 'explicit zero totals',
+    json: '{"object":"usage_stats","totals":{"total_tokens":0,"cost_usd":0}}',
+    tokens: 0,
+    cost: 0,
+  },
+  {
+    name: 'ordinary nonnegative totals',
+    json: validUsage,
+    tokens: 7,
+    cost: 1.25,
+  },
+]) {
+  test(`workflow accepts ${fixture.name} under the existing nonnegative contract`, () => {
+    const result = runWorkflow(fixture.json);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.requests, 1);
+    assert.deepEqual(result.requestMethods, ['POST']);
+    assert.equal(result.invocations.length, 1);
+    const payload = JSON.parse(optionValue(result.invocations[0], '--data'));
+    assert.equal(payload.p_helm_tokens, fixture.tokens);
+    assert.equal(payload.p_helm_cost_usd, fixture.cost);
+    assert.match(result.summary, /## Audit Compute Snapshot/);
+  });
+}
+
+test('workflow POST starts with curl --disable, forces retry zero, and cannot be replayed by .curlrc', () => {
+  const postFailures = Array.from({ length: 4 }, () => ({
+    curlExit: 28,
+    httpStatus: '000',
+    stderr: 'curl: (28) POST timeout\n',
+  }));
+  const result = runWorkflow(validUsage, postFailures);
+
+  assert.notEqual(result.status, 0, 'failed POST must fail the workflow');
+  assert.equal(result.requests, 1, 'a failed POST must issue exactly one network request');
+  assert.deepEqual(result.requestMethods, ['POST']);
+  assert.equal(result.invocations.length, 1);
+  const post = result.invocations[0];
+  assert.equal(post[0], '--disable', `curl --disable must be first: ${post.join(' ')}`);
+  assert.equal(optionValue(post, '--proto'), '=https');
+  assert.equal(optionValue(post, '--proto-redir'), '=https');
+  assert.equal(optionValue(post, '--retry'), '0');
+  assert.deepEqual(result.insecureInvocations, [], 'ambient insecure must not affect POST TLS');
 });
 
-test('a mixed transient then terminal error stops immediately at the terminal result', () => {
-  const result = runHelper([
-    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
-    { status: 60, stderr: 'curl: (60) SSL certificate problem\n' },
-  ]);
+function requiredMatch(source, pattern, label) {
+  const match = source.match(pattern);
+  assert.ok(match, `could not derive ${label} from production source`);
+  return match;
+}
 
-  assert.equal(result.status, 60);
-  assert.equal(result.attempts, 2);
-  assert.deepEqual(result.sleeps, ['2']);
-  assert.match(result.stderr, /non-retryable curl exit 60/);
-});
-
-test('transient failures stop after three total attempts and two bounded sleeps', () => {
-  const result = runHelper([
-    { status: 28, stderr: 'curl: (28) SSL connection timeout\n' },
-    { status: 35, stderr: 'curl: (35) Connection reset by peer\n' },
-    { status: 56, stderr: 'curl: (56) Recv failure\n' },
-  ]);
-
-  assert.equal(result.status, 56);
-  assert.equal(result.attempts, 3);
-  assert.deepEqual(result.sleeps, ['2', '4']);
-  assert.match(result.stderr, /exhausted 3 attempts; final curl exit 56/);
-});
-
-test('workflow retries only the Helm GET and never retries the snapshot POST', () => {
-  assert.match(computeWorkflow, /sparse-checkout:[\s\S]*scripts\/fetch-audit-compute-usage\.sh/);
-  assert.match(
+test('job timeout covers GET, POST, and ancillary refresh worst cases plus explicit margin', () => {
+  const timeoutMinutes = Number(requiredMatch(
     computeWorkflow,
-    /helm_usage_json="\$\(\.\/scripts\/fetch-audit-compute-usage\.sh "\$helm_usage_url"\)"/,
-  );
-  assert.match(computeWorkflow, /AUDIT_READ_MAX_ATTEMPTS: ['"]3['"]/);
-  assert.match(computeWorkflow, /AUDIT_READ_RETRY_BASE_SECONDS: ['"]2['"]/);
+    /^\s{4}timeout-minutes:\s*(\d+)\s*$/m,
+    'job timeout',
+  )[1]);
+  const getAttempts = Number(requiredMatch(
+    computeWorkflow,
+    /^\s{6}AUDIT_READ_MAX_ATTEMPTS:\s*['"](\d+)['"]\s*$/m,
+    'GET attempts',
+  )[1]);
+  const getBackoffBase = Number(requiredMatch(
+    computeWorkflow,
+    /^\s{6}AUDIT_READ_RETRY_BASE_SECONDS:\s*['"](\d+)['"]\s*$/m,
+    'GET backoff base',
+  )[1]);
+  const getMaxTime = Number(requiredMatch(
+    readFileSync(helper, 'utf8'),
+    /--max-time\s+(\d+)/,
+    'GET max time',
+  )[1]);
+  const postMaxTime = Number(requiredMatch(
+    syncComputeRunBody,
+    /--max-time\s+(\d+)[\s\S]*?--request POST/,
+    'POST max time',
+  )[1]);
 
-  const post = computeWorkflow.match(
-    /response="\$\([\s\S]*?record_audit_compute_snapshot[\s\S]*?\n\s*\)"/,
-  )?.[0] ?? '';
-  assert.notEqual(post, '', 'missing audit snapshot POST section');
-  assert.match(post, /curl --fail --silent --show-error/);
-  assert.doesNotMatch(post, /--retry|fetch-audit-compute-usage/);
+  const refreshLoop = requiredMatch(
+    refreshHelperSource,
+    /for attempt in ((?:\d+\s+)+\d+); do([\s\S]*?)\ndone/,
+    'ancillary refresh retry loop',
+  );
+  const refreshAttempts = refreshLoop[1].trim().split(/\s+/).map(Number);
+  const refreshMaxTime = Number(requiredMatch(
+    refreshLoop[2],
+    /--max-time\s+(\d+)/,
+    'ancillary refresh max time',
+  )[1]);
+  const refreshSleepMultiplier = Number(requiredMatch(
+    refreshLoop[2],
+    /sleep\s+\$\(\(attempt \* (\d+)\)\)/,
+    'ancillary refresh sleep multiplier',
+  )[1]);
+
+  const getBackoffSeconds = Array.from(
+    { length: getAttempts - 1 },
+    (_, index) => getBackoffBase * (2 ** index),
+  ).reduce((total, delay) => total + delay, 0);
+  const getWorstCaseSeconds = (getAttempts * getMaxTime) + getBackoffSeconds;
+  const refreshSleepSeconds = refreshAttempts
+    .slice(0, -1)
+    .reduce((total, attempt) => total + (attempt * refreshSleepMultiplier), 0);
+  const refreshWorstCaseSeconds =
+    (refreshAttempts.length * refreshMaxTime) + refreshSleepSeconds;
+  const totalWorstCaseSeconds =
+    getWorstCaseSeconds + postMaxTime + refreshWorstCaseSeconds;
+  const explicitMarginSeconds = 159;
+  const timeoutSeconds = timeoutMinutes * 60;
+
+  assert.equal(getWorstCaseSeconds, 366);
+  assert.equal(postMaxTime, 120);
+  assert.equal(refreshWorstCaseSeconds, 375);
+  assert.equal(totalWorstCaseSeconds, 861);
+  assert.ok(
+    timeoutSeconds >= totalWorstCaseSeconds + explicitMarginSeconds,
+    `job timeout ${timeoutSeconds}s must cover ${totalWorstCaseSeconds}s plus ${explicitMarginSeconds}s margin`,
+  );
 });
 
 test('the read helper cannot wrap scan, persist, local mutation, or any other workflow', () => {
@@ -206,8 +903,7 @@ test('the read helper cannot wrap scan, persist, local mutation, or any other wo
     .filter((name) =>
       readFileSync(resolve(repoRoot, '.github/workflows', name), 'utf8').includes(
         './scripts/fetch-audit-compute-usage.sh "$helm_usage_url"',
-      ),
-    )
+      ))
     .map((name) => basename(name));
   assert.deepEqual(workflowUsers, ['sync-audit-compute.yml']);
 });

--- a/scripts/tests/security-research-refresh-workflows.test.mjs
+++ b/scripts/tests/security-research-refresh-workflows.test.mjs
@@ -134,22 +134,50 @@ test('CI tracks and syntax-checks every refresh contract input', () => {
   assert.match(testWorkflow, /node --test scripts\/tests\/\*\.test\.mjs/);
 });
 
-function installFakeCurl(probeState) {
+function installFakeCurl(probeState, { maliciousCurlConfig = false } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'security-research-refresh-'));
   const bin = join(root, 'bin');
-  const mkdir = spawnSync('mkdir', ['-p', bin]);
+  const curlHome = join(root, 'curl-home');
+  const mkdir = spawnSync('mkdir', ['-p', bin, curlHome]);
   assert.equal(mkdir.status, 0, mkdir.stderr?.toString());
+  if (maliciousCurlConfig) {
+    writeFileSync(
+      join(curlHome, '.curlrc'),
+      'retry=3\nretry-all-errors\nretry-delay=0\n',
+    );
+  }
   const log = join(root, 'curl.log');
+  const contractLog = join(root, 'curl-contract.log');
   const fakeCurl = join(bin, 'curl');
   writeFileSync(fakeCurl, `#!/usr/bin/env bash
 set -euo pipefail
+config_enabled=true
+if [[ "\${1:-}" == '--disable' ]]; then
+  config_enabled=false
+fi
+retry_count=0
+if [[ "$config_enabled" == true && -f "\${CURL_HOME:?}/.curlrc" ]]; then
+  while IFS= read -r config_line || [[ -n "$config_line" ]]; do
+    normalized="\${config_line//[[:space:]]/}"
+    case "$normalized" in
+      retry=*) retry_count="\${normalized#retry=}" ;;
+    esac
+  done < "\${CURL_HOME}/.curlrc"
+fi
 method=GET
 output=''
 read_header=false
+first_arg="\${1:-<missing>}"
+explicit_retry='<missing>'
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --request) method="$2"; shift 2 ;;
     --output) output="$2"; shift 2 ;;
+    --retry)
+      explicit_retry="$2"
+      retry_count="$2"
+      shift 2
+      ;;
     --header)
       [[ "$2" == '@-' ]] && read_header=true
       shift 2
@@ -161,7 +189,10 @@ if [[ "$read_header" == true ]]; then
   IFS= read -r authorization
   [[ "$authorization" == 'Authorization: Bearer test-research-secret' ]]
 fi
-echo "$method" >> '${log}'
+printf '%s\\t%s\\t%s\\n' "$method" "$first_arg" "$explicit_retry" >> '${contractLog}'
+for ((attempt = 0; attempt <= retry_count; attempt += 1)); do
+  echo "$method" >> '${log}'
+done
 if [[ "$method" == GET ]]; then
   printf '%s' '{"snapshot_state":"${probeState}"}' > "$output"
 else
@@ -170,17 +201,18 @@ fi
 printf '200'
 `);
   chmodSync(fakeCurl, 0o755);
-  return { root, bin, log };
+  return { root, bin, curlHome, log, contractLog };
 }
 
-function runStaleOnly(probeState) {
-  const fixture = installFakeCurl(probeState);
+function runStaleOnly(probeState, options = {}) {
+  const fixture = installFakeCurl(probeState, options);
   const summary = join(fixture.root, 'summary.md');
   const result = spawnSync(refreshScript, ['--stale-only'], {
     encoding: 'utf8',
     env: {
       ...process.env,
       PATH: `${fixture.bin}:${process.env.PATH}`,
+      CURL_HOME: fixture.curlHome,
       GITHUB_STEP_SUMMARY: summary,
       SECURITY_RESEARCH_AUTOMATION_KEY: 'test-research-secret',
       SKILLSTORE_API_URL: 'https://skillstore.example',
@@ -189,6 +221,10 @@ function runStaleOnly(probeState) {
   return {
     ...result,
     calls: readFileSync(fixture.log, 'utf8').trim().split(/\r?\n/),
+    contracts: readFileSync(fixture.contractLog, 'utf8')
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => line.split('\t')),
     summary: readFileSync(summary, 'utf8'),
   };
 }
@@ -207,4 +243,19 @@ test('stale-only runtime performs one authenticated POST for a stale snapshot', 
   assert.deepEqual(result.calls, ['GET', 'POST']);
   assert.match(result.stdout, /snapshot refreshed/);
   assert.match(result.summary, /source_version=`0123456789abcdef0123456789abcdef`/);
+});
+
+test('stale-only GET and POST disable curlrc retries within their max-time budgets', () => {
+  const result = runStaleOnly('stale', { maliciousCurlConfig: true });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.deepEqual(
+    result.calls,
+    ['GET', 'POST'],
+    'retry=3 from CURL_HOME/.curlrc must not multiply either transfer',
+  );
+  assert.deepEqual(result.contracts, [
+    ['GET', '--disable', '0'],
+    ['POST', '--disable', '0'],
+  ]);
 });


### PR DESCRIPTION
## 改了什么

- Retry #1 只闭合 Trent review 的 3 个 BLOCKER：隔离 ambient `.curlrc`、把 GET 成功/重试条件收紧为可观测 HTTP 合同、对 Helm `totals` 做 fail-closed schema 校验。
- 所有本链路生产 curl 均以 `curl --disable` 开头；Audit Snapshot POST 和 ancillary refresh 显式 `--retry 0`，避免隐藏的 curl 内层重试突破总预算或重放写请求。
- 将 job timeout 从 10 分钟提高到 17 分钟：静态最坏路径 GET `366s` + POST `120s` + ancillary `375s` = `861s`，总预算 `1020s`，保留 `159s` checkout/parse/summary 余量。
- 新增真实 helper / 抽取生产 workflow step 的本地 runtime fixtures；不访问生产 Helm/Supabase，不触发 workflow。

## 为什么改

原 [Run 29535454378](https://github.com/aiskillstore/marketplace/actions/runs/29535454378) 的初始 Helm GET 先出现 curl 28，随后 curl 35，最终 exit 35，Snapshot POST 未执行。另完整复核 [Run 29402608201](https://github.com/aiskillstore/marketplace/actions/runs/29402608201) 与 [Run 29484402820](https://github.com/aiskillstore/marketplace/actions/runs/29484402820)：两者已进入长时间 scan/persist 后因 502 失败，因此本 PR 仍不重试 scan/persist/local mutation。

Trent 在 [review 4718642336](https://github.com/aiskillstore/marketplace/pull/2579#pullrequestreview-4718642336) 指出旧 head `ac312d750bd58e693816f487f86171eb77a765c4` 的 3 个 BLOCKER：

1. `.curlrc` 可注入 `insecure + retry-all-errors`，绕过证书校验、GET 三次上限和 POST 单次写。
2. helper 只看 curl exit；302 合法 JSON、已收到 HTTP status/partial body 的 transport error 可能被误判成功或误重试。
3. 缺失/非法 `totals` 被静默归零并写入 Snapshot。

本次 Retry 不扩大到 monitor 命令重跑、数据恢复自动化或生产验证。

## Acceptance Criteria

- [x] Ambient `.curlrc` 无法注入 insecure 或额外 retry；所有相关生产 curl 首参为 `--disable`，写请求显式 `--retry 0`。— 验收：`scripts/tests/audit-compute-network-retry.test.mjs::helper ignores malicious ambient curlrc insecure and retry directives`、`::workflow runs the real snapshot step with curlrc disabled and a single POST`、`scripts/tests/security-research-refresh-workflows.test.mjs::refresh helper disables ambient curl retries so the workflow timeout budget is compositional`；CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117)
- [x] GET 仅在 `curl exit=0 && HTTP=200` 时成功；只对 allowlist exit + `HTTP=000` + 空 body/header 重试，且每 attempt 使用独立临时文件。302、401+transport、503+18、HTTP status/partial body/header+transport error、其他 2xx 均 fail closed。— 验收：`scripts/tests/audit-compute-network-retry.test.mjs::helper retries HTTP 000 empty allowlisted failures and returns only an exact HTTP 200 body`、`::helper does not retry 302 with a schema-valid response body`、`::helper does not retry HTTP 401 plus a transport error`、`::helper does not retry HTTP 503 plus curl exit 18 and a partial body`、`::helper does not retry a partial body/header transport failure with HTTP 000`；CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117)
- [x] `totals` 必须显式存在且为 object；`total_tokens`/`cost_usd` 必须显式存在、类型正确、finite、非负且不溢出。缺失、null、字符串、bool、负数、NaN/Infinity、int64/float overflow 均在 POST 前失败；显式合法零值保留。— 验收：`scripts/tests/audit-compute-network-retry.test.mjs::workflow rejects invalid Helm totals before the snapshot POST`（27 个永久负例）+ `::workflow accepts explicit zero totals under the existing nonnegative business contract`；CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117)
- [x] Snapshot POST 失败时严格只发一个请求，不被 `.curlrc` 重放。— 验收：`scripts/tests/audit-compute-network-retry.test.mjs::workflow POST failure is never replayed even with retry-all-errors in curlrc`；CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117)
- [x] 17 分钟 job timeout 覆盖可执行计算出的 `861s` 最坏路径并保留 `159s` 余量。— 验收：`scripts/tests/audit-compute-network-retry.test.mjs::job timeout covers GET, POST, ancillary refresh, and explicit operating margin` + `scripts/tests/security-research-refresh-workflows.test.mjs::refresh helper disables ambient curl retries so the workflow timeout budget is compositional`；CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117)

## Retry #1：上次 FAIL → 本次修复

- **FAIL：`.curlrc` 绕过 TLS/预算/at-most-once。** → `curl --disable` 固定为首参；GET/POST/ancillary 均显式 `--retry 0`；恶意 CURL_HOME runtime fixture 断言证书 60 仍失败、GET ≤3、POST=1。
- **FAIL：未独立观察 HTTP/body/header。** → 每 attempt 独立目录与 body/header 文件，`--write-out '%{http_code}'` 捕获 status；成功与 retry 条件分别显式判定，任何收到的响应证据都终止 transport retry。
- **FAIL：非法 totals 静默归零。** → Python parser 显式校验 object/required/type/finite/range；`json.loads(..., parse_constant=...)` 与 `allow_nan=False` 双向封死非标准数值。
- **SUGGESTION：600s 小于 861s 静态最坏路径。** → 未拆 ancillary job；以最小范围将 timeout 提至 1020s，并对 ancillary curl 禁用隐藏重试，使预算测试可组合、可复跑。

## TDD 证据

在旧 head `ac312d750bd58e693816f487f86171eb77a765c4` 先加入 runtime 合同测试、尚未改生产实现时：

- `node --test scripts/tests/audit-compute-network-retry.test.mjs` → 51 tests / 29 PASS / 22 FAIL；失败覆盖 `--disable`、HTTP200 exact success、HTTP000 空响应重试、302/partial fail-closed、invalid totals、POST 单次写、17 分钟预算。
- 新增 ancillary `.curlrc` 预算测试后，`node --test scripts/tests/security-research-refresh-workflows.test.mjs` → 8 tests / 7 PASS / 1 FAIL。

修复后：

- Focused：Audit Compute 51/51 PASS；Security Research 8/8 PASS。
- 全量本地：`CI=true node --test scripts/tests/*.test.mjs` → 378 tests / 376 PASS / 2 SKIP / 0 FAIL。
- CI：[Run 29548689117](https://github.com/aiskillstore/marketplace/actions/runs/29548689117) → 378/378 PASS；[Validate Run 29548689256](https://github.com/aiskillstore/marketplace/actions/runs/29548689256) → SUCCESS。
- 静态：两份 Bash `bash -n`、两份 Node test `node --check`、两份 workflow `yq eval`、`git diff --check` 均 PASS。
- 对抗复核：本地 read-only vertical review 最终 verdict `CLEAN`。
- 二进制 evidence：0。
- 未执行 `workflow_dispatch`、生产 endpoint 访问、生产 DB/API 写或生产 readback。

## 风险点

- **数据写入**：POST 仍是单次写；响应丢失时 run 失败，绝不自动重放。
- **权限 / 安全**：不改 token 权限；不跳过证书校验；GET/POST 都限制 HTTPS/TLS，重定向协议仍只允许 HTTPS。
- **可用性**：只 allowlist curl `28/35/52/55/56`，且必须完全未收到 HTTP/body/header 才重试；长期或未知故障会明确失败。
- **超时**：job 上限增加到 17 分钟；实际网络调用上限未放大，只补足原静态最坏路径与合理运行余量。
- **兼容性**：ancillary helper 不再读取用户级 curl 配置；workflow 所有网络语义改为源码显式配置。
- **回滚方式**：revert Retry #1 commit `d98e8d3c392673f2874ee100c4ff460a9167c771`；无 DB migration、数据回填或 CLI 发布。

## 人类 review 关注点

请重点判断：

1. transport retry 的三重门（allowlist exit + HTTP000 + 空 body/header）是否足够保守。
2. `total_tokens` int64 非负范围与 `cost_usd` finite/nonnegative 合同是否符合 Helm/Supabase 当前业务类型。
3. timeout `1020s` 对 `861s` 最坏路径的 `159s` 余量是否合理。
4. POST response-loss 继续采用“失败 + 人工 readback，禁止自动重放”是否符合运营策略。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：修改已上线 schedule workflow 的网络、写入与 timeout 边界。本 PR 不 merge、不手动触发生产 workflow。

Wiki delta: none
