### PR TITLE
fix(pack): 固定 evaluator 模型与输入快照

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -23,9 +23,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Production v4 requires the immutable binding-aware release and verifies its
-  # checksums.txt asset before the binary crosses into the evaluator boundary.
+  # Production v4 requires immutable CLI and model bindings. The release
+  # checksums.txt asset is verified before the binary crosses the boundary.
   PACK_PRODUCTION_CLI_VERSION: '2.14.2'
+  PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5'
+  PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5.5'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
@@ -193,6 +195,9 @@ jobs:
             echo "No eligible scenario is due; recording an audited no-op." >> "$GITHUB_STEP_SUMMARY"
           else
             GENERATION_ID=$(node -e "process.stdout.write(require('node:crypto').randomUUID())")
+            PLAN_PATH="$GITHUB_WORKSPACE/pack-plan/plan.json"
+            PLAN_SNAPSHOT_SHA=$(node --input-type=module -e 'import { readFileSync } from "node:fs"; import { immutablePlanSnapshotSha256 } from "./marketplace-plan/scripts/pack-production.mjs"; const plan = JSON.parse(readFileSync(process.argv[1], "utf8")); plan.scenarios[0].generationId = process.argv[2]; delete plan.workflowBinding; process.stdout.write(immutablePlanSnapshotSha256(plan));' "$PLAN_PATH" "$GENERATION_ID")
+            test "$PLAN_SNAPSHOT_SHA" = "$(printf %s "$PLAN_SNAPSHOT_SHA" | grep -E '^[0-9a-f]{64}$')"
             BOUND_PLAN=$(mktemp "$GITHUB_WORKSPACE/pack-plan/.plan.XXXXXX")
             jq \
               --arg generationId "$GENERATION_ID" \
@@ -201,6 +206,7 @@ jobs:
               --arg runId "$GITHUB_RUN_ID" \
               --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
               --arg commitSha "$GITHUB_SHA" \
+              --arg planSnapshotSha256 "$PLAN_SNAPSHOT_SHA" \
               '.scenarios[0].generationId = $generationId |
                .workflowBinding = {
                  repository: $repository,
@@ -208,15 +214,17 @@ jobs:
                  runId: $runId,
                  runAttempt: $runAttempt,
                  commitSha: $commitSha,
-                 scenarioId: .scenarios[0].id
+                 scenarioId: .scenarios[0].id,
+                 planSnapshotSha256: $planSnapshotSha256
                }' \
-              "$GITHUB_WORKSPACE/pack-plan/plan.json" > "$BOUND_PLAN"
+              "$PLAN_PATH" > "$BOUND_PLAN"
             jq -e \
               --arg generationId "$GENERATION_ID" \
               --arg repository "$GITHUB_REPOSITORY" \
               --arg runId "$GITHUB_RUN_ID" \
               --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
               --arg commitSha "$GITHUB_SHA" \
+              --arg planSnapshotSha256 "$PLAN_SNAPSHOT_SHA" \
               '.source == "signals" and
                (.scenarios | length) == 1 and
                .scenarios[0].generationId == $generationId and
@@ -227,7 +235,8 @@ jobs:
                  runId: $runId,
                  runAttempt: $runAttempt,
                  commitSha: $commitSha,
-                 scenarioId: .scenarios[0].id
+                 scenarioId: .scenarios[0].id,
+                 planSnapshotSha256: $planSnapshotSha256
                }' "$BOUND_PLAN" >/dev/null
             chmod 0600 "$BOUND_PLAN"
             mv -f "$BOUND_PLAN" "$GITHUB_WORKSPACE/pack-plan/plan.json"
@@ -860,8 +869,8 @@ jobs:
             --run-id "${{ github.run_id }}" \
             --run-attempt "${{ github.run_attempt }}" \
             --commit-sha "${{ github.sha }}" \
-            --model sonnet \
-            --judge-model gpt-5.5 \
+            --model "$PACK_EVALUATOR_RUNNER_MODEL" \
+            --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
             --max-candidates 2 \
             --pick 4 \
             --runs 1 \
@@ -941,8 +950,8 @@ jobs:
               --run-id "${{ github.run_id }}" \
               --run-attempt "${{ github.run_attempt }}" \
               --commit-sha "${{ github.sha }}" \
-              --model sonnet \
-              --judge-model gpt-5.5 \
+              --model "$PACK_EVALUATOR_RUNNER_MODEL" \
+              --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
               > "$GITHUB_WORKSPACE/pack-diagnostics/verification-command.json"; then
               echo 'trusted evaluation closure verification failed' \
                 > "$GITHUB_WORKSPACE/pack-diagnostics/verification-failure.txt"

--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       smoke_only:
-        description: 'Run exactly the Messages and Responses contract probes; never plan, generate, or persist'
+        description: 'Build one canonical Plan, then run exactly the Messages and Responses probes; never evaluate, generate, or persist'
         type: boolean
         default: false
       auto_publish:
@@ -23,18 +23,15 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Production v4 requires immutable CLI and model bindings. The release
-  # checksums.txt asset is verified before the binary crosses the boundary.
+  # Bootstrap only: the canonical Plan builder independently enforces this
+  # exact release version, asset name, and release-asset SHA-256.
   PACK_PRODUCTION_CLI_VERSION: '2.14.2'
-  PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5'
-  PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5.5'
-  # One cap feeds the local proxy and every Claude CLI process.
-  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 jobs:
   contract_smoke_only:
     name: Smoke Helm Messages and Responses only
-    if: github.event_name == 'workflow_dispatch' && inputs.smoke_only == true
+    needs: plan
+    if: github.event_name == 'workflow_dispatch' && inputs.smoke_only == true && needs.plan.outputs.has_scenarios == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,8 +43,16 @@ jobs:
           filter: ''
           clean: true
           persist-credentials: false
-          sparse-checkout: scripts/pack-evaluator-contract-smoke.mjs
+          sparse-checkout: |
+            scripts/pack-evaluator-contract-smoke.mjs
+            scripts/pack-production-plan.mjs
           sparse-checkout-cone-mode: false
+
+      - name: Download canonical execution Plan
+        uses: actions/download-artifact@v6
+        with:
+          name: pack-production-plan
+          path: pack-production-input
 
       - name: Send exactly one Messages and one Responses request
         env:
@@ -58,7 +63,7 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/pack-contract-smoke"
           PACK_EVALUATOR_PROXY_TOKEN="$PACK_EVALUATOR_HELM_API_KEY" \
           PACK_EVALUATOR_PROXY_URL=https://helm.easymeta.au \
-          PACK_EVALUATOR_CONTRACT_TIMEOUT_MS=30000 \
+          PACK_EVALUATOR_PLAN_PATH="$GITHUB_WORKSPACE/pack-production-input/plan.json" \
           PACK_EVALUATOR_CONTRACT_DIAGNOSTICS_FILE="$GITHUB_WORKSPACE/pack-contract-smoke/contract-smoke.json" \
           node scripts/pack-evaluator-contract-smoke.mjs
 
@@ -73,7 +78,6 @@ jobs:
 
   plan:
     name: Plan bounded scenario queue
-    if: github.event_name == 'schedule' || inputs.smoke_only != true
     runs-on: self-hosted
     timeout-minutes: 20
     outputs:
@@ -116,16 +120,14 @@ jobs:
         env:
           CLI: ${{ steps.cli.outputs.cli-path }}
           CLI_SHA256: ${{ steps.cli.outputs.cli-sha256 }}
-          CLI_VERSION: ${{ env.PACK_PRODUCTION_CLI_VERSION }}
         run: |
+          set -euo pipefail
+          test "$CLI_SHA256" = '21b1967e134622a40ae4d312278fa10d136103f0148887252f61e4e3b4536674'
+          VERSION=$("$CLI" --version | grep -Eo '[0-9]+([.][0-9]+){2}' | head -n1)
+          test "$VERSION" = '2.14.2'
           mkdir -p "$GITHUB_WORKSPACE/pack-plan" "$GITHUB_WORKSPACE/pack-cli"
           install -m 0555 "$CLI" "$GITHUB_WORKSPACE/pack-cli/skillstore-cli-linux-x64"
           printf '%s  skillstore-cli-linux-x64\n' "$CLI_SHA256" > "$GITHUB_WORKSPACE/pack-cli/checksums.txt"
-          jq -n \
-            --arg version "$CLI_VERSION" \
-            --arg sha256 "$CLI_SHA256" \
-            '{version: $version, sha256: $sha256}' \
-            > "$GITHUB_WORKSPACE/pack-plan/cli-identity.json"
 
       - name: Select at most one admitted scenario through the read-only API
         id: queue
@@ -151,7 +153,7 @@ jobs:
               --data-urlencode 'lookbackDays=30' \
               --data-urlencode 'cooldownDays=7' \
               --output "$RESPONSE"
-          jq -e '.data' "$RESPONSE" > "$GITHUB_WORKSPACE/pack-plan/plan.json"
+          jq -e '.data' "$RESPONSE" > "$GITHUB_WORKSPACE/pack-plan/queue.json"
           jq -e '
             .schemaVersion == "pack-production-queue/v1" and
             (.scenarios | type == "array" and length <= 1) and
@@ -161,8 +163,8 @@ jobs:
               (.capabilitySlots | length >= 1 and length <= 4) and
               (.requiredArtifacts | length >= 1)
             ))
-          ' "$GITHUB_WORKSPACE/pack-plan/plan.json"
-          SCENARIO_COUNT=$(jq -r '.scenarios | length' "$GITHUB_WORKSPACE/pack-plan/plan.json")
+          ' "$GITHUB_WORKSPACE/pack-plan/queue.json"
+          SCENARIO_COUNT=$(jq -r '.scenarios | length' "$GITHUB_WORKSPACE/pack-plan/queue.json")
           echo "scenario_count=$SCENARIO_COUNT" >> "$GITHUB_OUTPUT"
           if [ "$SCENARIO_COUNT" -eq 0 ]; then
             jq -e '
@@ -170,7 +172,7 @@ jobs:
               (.scenarios | length) == 0 and
               (has("generationId") | not) and
               (has("workflowBinding") | not)
-            ' "$GITHUB_WORKSPACE/pack-plan/plan.json" >/dev/null
+            ' "$GITHUB_WORKSPACE/pack-plan/queue.json" >/dev/null
             echo "has_scenarios=false" >> "$GITHUB_OUTPUT"
             jq \
               --arg runId "${{ github.run_id }}" \
@@ -191,59 +193,31 @@ jobs:
               generatedAt,
               lookbackDays,
               scenarioCount: (.scenarios | length)
-            }' "$GITHUB_WORKSPACE/pack-plan/plan.json" > "$GITHUB_WORKSPACE/pack-plan/no-op.json"
+            }' "$GITHUB_WORKSPACE/pack-plan/queue.json" > "$GITHUB_WORKSPACE/pack-plan/no-op.json"
             echo "No eligible scenario is due; recording an audited no-op." >> "$GITHUB_STEP_SUMMARY"
           else
             GENERATION_ID=$(node -e "process.stdout.write(require('node:crypto').randomUUID())")
-            PLAN_PATH="$GITHUB_WORKSPACE/pack-plan/plan.json"
-            PLAN_SNAPSHOT_SHA=$(node --input-type=module -e 'import { readFileSync } from "node:fs"; import { immutablePlanSnapshotSha256 } from "./marketplace-plan/scripts/pack-production.mjs"; const plan = JSON.parse(readFileSync(process.argv[1], "utf8")); plan.scenarios[0].generationId = process.argv[2]; delete plan.workflowBinding; process.stdout.write(immutablePlanSnapshotSha256(plan));' "$PLAN_PATH" "$GENERATION_ID")
-            test "$PLAN_SNAPSHOT_SHA" = "$(printf %s "$PLAN_SNAPSHOT_SHA" | grep -E '^[0-9a-f]{64}$')"
-            BOUND_PLAN=$(mktemp "$GITHUB_WORKSPACE/pack-plan/.plan.XXXXXX")
-            jq \
-              --arg generationId "$GENERATION_ID" \
-              --arg repository "$GITHUB_REPOSITORY" \
-              --arg workflow "Generate Pack" \
-              --arg runId "$GITHUB_RUN_ID" \
-              --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-              --arg commitSha "$GITHUB_SHA" \
-              --arg planSnapshotSha256 "$PLAN_SNAPSHOT_SHA" \
-              '.scenarios[0].generationId = $generationId |
-               .workflowBinding = {
-                 repository: $repository,
-                 workflow: $workflow,
-                 runId: $runId,
-                 runAttempt: $runAttempt,
-                 commitSha: $commitSha,
-                 scenarioId: .scenarios[0].id,
-                 planSnapshotSha256: $planSnapshotSha256
-               }' \
-              "$PLAN_PATH" > "$BOUND_PLAN"
-            jq -e \
-              --arg generationId "$GENERATION_ID" \
-              --arg repository "$GITHUB_REPOSITORY" \
-              --arg runId "$GITHUB_RUN_ID" \
-              --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-              --arg commitSha "$GITHUB_SHA" \
-              --arg planSnapshotSha256 "$PLAN_SNAPSHOT_SHA" \
-              '.source == "signals" and
-               (.scenarios | length) == 1 and
-               .scenarios[0].generationId == $generationId and
-               ($generationId | test("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"; "i")) and
-               .workflowBinding == {
-                 repository: $repository,
-                 workflow: "Generate Pack",
-                 runId: $runId,
-                 runAttempt: $runAttempt,
-                 commitSha: $commitSha,
-                 scenarioId: .scenarios[0].id,
-                 planSnapshotSha256: $planSnapshotSha256
-               }' "$BOUND_PLAN" >/dev/null
-            chmod 0600 "$BOUND_PLAN"
-            mv -f "$BOUND_PLAN" "$GITHUB_WORKSPACE/pack-plan/plan.json"
+            node "$GITHUB_WORKSPACE/marketplace-plan/scripts/pack-production-plan.mjs" create \
+              --queue "$GITHUB_WORKSPACE/pack-plan/queue.json" \
+              --output "$GITHUB_WORKSPACE/pack-plan/plan.json" \
+              --generation-id "$GENERATION_ID" \
+              --repository "$GITHUB_REPOSITORY" \
+              --workflow "$GITHUB_WORKFLOW" \
+              --run-id "$GITHUB_RUN_ID" \
+              --run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --head-sha "$GITHUB_SHA" \
+              --repo-root "$GITHUB_WORKSPACE/marketplace-plan" \
+              --cli "$GITHUB_WORKSPACE/pack-cli/skillstore-cli-linux-x64"
             echo "has_scenarios=true" >> "$GITHUB_OUTPUT"
           fi
-          jq '{source, scenarios: [.scenarios[] | {id, version, queueScore, reasons, generationId}]}' \
-            "$GITHUB_WORKSPACE/pack-plan/plan.json" >> "$GITHUB_STEP_SUMMARY"
+          jq '{source, scenarios: [.scenarios[] | {id, version, queueScore, reasons}]}' \
+            "$GITHUB_WORKSPACE/pack-plan/queue.json" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$SCENARIO_COUNT" -eq 1 ]; then
+            node "$GITHUB_WORKSPACE/marketplace-plan/scripts/pack-production.mjs" plan-values \
+              --plan "$GITHUB_WORKSPACE/pack-plan/plan.json" \
+              | jq '{digest, workflowBinding, cli, models, parameters}' \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload immutable plan
         uses: actions/upload-artifact@v6
@@ -265,7 +239,7 @@ jobs:
   evaluate:
     name: Evaluate without production credentials
     needs: plan
-    if: needs.plan.outputs.has_scenarios == 'true'
+    if: inputs.smoke_only != true && needs.plan.outputs.has_scenarios == 'true'
     # GitHub-hosted runners are single-use VMs. The evaluator never reuses the
     # persistent OAuth HOME or sibling workspaces from our self-hosted pool.
     runs-on: ubuntu-24.04
@@ -293,82 +267,73 @@ jobs:
           name: pack-production-cli
           path: pack-production-cli
 
-      - name: Verify Plan CLI handoff before execution
+      - name: Verify canonical Plan, source trees, scripts, and CLI before execution
         run: |
+          set -euo pipefail
           (cd pack-production-cli && sha256sum -c checksums.txt)
           chmod +x pack-production-cli/skillstore-cli-linux-x64
-          VERSION=$(pack-production-cli/skillstore-cli-linux-x64 --version | grep -Eo '[0-9]+([.][0-9]+){2}' | head -n1)
-          test "$VERSION" = "$PACK_PRODUCTION_CLI_VERSION"
+          node marketplace-evaluate/scripts/pack-production-plan.mjs verify-inputs \
+            --plan pack-production-input/plan.json \
+            --repo-root marketplace-evaluate \
+            --cli pack-production-cli/skillstore-cli-linux-x64
+          PLAN_VALUES=$(node marketplace-evaluate/scripts/pack-production.mjs plan-values \
+            --plan pack-production-input/plan.json)
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg workflow "$GITHUB_WORKFLOW" \
+            --arg runId "$GITHUB_RUN_ID" \
+            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
+            --arg headSha "$GITHUB_SHA" \
+            '.workflowBinding.repository == $repository and
+             .workflowBinding.workflow == $workflow and
+             .workflowBinding.runId == $runId and
+             .workflowBinding.runAttempt == $runAttempt and
+             .workflowBinding.headSha == $headSha' \
+            <<< "$PLAN_VALUES" >/dev/null
+          node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            import { canonicalJson } from "./marketplace-evaluate/scripts/pack-production-plan.mjs";
+            const plan = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            writeFileSync(process.argv[2], canonicalJson({
+              artifact: {
+                name: "pack-production-plan",
+                planDigest: plan.digest,
+                status: "downloaded"
+              },
+              producer: { name: "plan", status: "success" },
+              schemaVersion: "marketplace.pack-production-artifact-state/v1",
+              workflowBinding: plan.workflowBinding
+            }));
+          ' pack-production-input/plan.json pack-production-input/plan-artifact-state.json
+          node marketplace-evaluate/scripts/pack-production.mjs artifact-gate \
+            --plan pack-production-input/plan.json \
+            --state pack-production-input/plan-artifact-state.json \
+            --output pack-production-input/plan-artifact-gate.json
 
-      - name: Reject plans outside the bounded evaluation budget
+      - name: Record the Plan-bound evaluation budget
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/pack-diagnostics"
-          SLOT_COUNT=$(jq '[.scenarios[].capabilitySlots | length] | add' pack-production-input/plan.json)
-          MAX_CANDIDATES=2
-          MAX_PACK_SKILLS=4
-          HIDDEN_VARIANTS=3
-          MAX_BEST_SINGLE_COMPETITORS=$((SLOT_COUNT * MAX_CANDIDATES))
-          CONTRACT_PROBES=2
-          MAX_CLI_PREFLIGHT_REQUESTS=4
-          # The deterministic treatment floor is not a safe operating ceiling:
-          # real file/browser work can require additional tool-result turns.
-          # Reserve a bounded 64-request envelope and let the proxy enforce the
-          # absolute 256-request stop.
-          TOOL_LOOP_HEADROOM=64
-          PROXY_REQUEST_BUDGET=256
-          # Upper-bound actual proxy wire requests for one scenario. Every
-          # executor/Judge request is counted, plus one Claude follow-up for
-          # each installed Skill that must emit runtime invocation evidence.
-          # Both CLI preflights may receive one bounded retry. Candidate dedupe
-          # and parallel Skill tool calls can only lower this bound.
-          ESTIMATED_REQUESTS=$((
-            CONTRACT_PROBES +
-            MAX_CLI_PREFLIGHT_REQUESTS +
-            3 * SLOT_COUNT * MAX_CANDIDATES +
-            3 +
-            HIDDEN_VARIANTS * (MAX_PACK_SKILLS + 2) +
-            2 * HIDDEN_VARIANTS +
-            3 * HIDDEN_VARIANTS * MAX_BEST_SINGLE_COMPETITORS +
-            HIDDEN_VARIANTS * MAX_PACK_SKILLS * (MAX_PACK_SKILLS + 1)
-          ))
-          jq -n \
-            --argjson slotCount "$SLOT_COUNT" \
-            --argjson maxCandidates "$MAX_CANDIDATES" \
-            --argjson maxPackSkills "$MAX_PACK_SKILLS" \
-            --argjson maxBestSingleCompetitors "$MAX_BEST_SINGLE_COMPETITORS" \
-            --argjson variants "$HIDDEN_VARIANTS" \
-            --argjson contractProbes "$CONTRACT_PROBES" \
-            --argjson maxCliPreflightRequests "$MAX_CLI_PREFLIGHT_REQUESTS" \
-            --argjson toolLoopHeadroom "$TOOL_LOOP_HEADROOM" \
-            --argjson estimatedRequests "$ESTIMATED_REQUESTS" \
-            --argjson reservedRequests "$((ESTIMATED_REQUESTS + TOOL_LOOP_HEADROOM))" \
-            --argjson requestBudget "$PROXY_REQUEST_BUDGET" \
-            '{
-              schemaVersion: "marketplace.pack-evaluation-budget/v1",
-              slotCount: $slotCount,
-              maxCandidates: $maxCandidates,
-              maxPackSkills: $maxPackSkills,
-              maxBestSingleCompetitors: $maxBestSingleCompetitors,
-              variants: $variants,
-              contractProbes: $contractProbes,
-              maxCliPreflightRequests: $maxCliPreflightRequests,
-              skillToolFollowupsIncluded: true,
-              toolLoopHeadroom: $toolLoopHeadroom,
-              estimatedRequests: $estimatedRequests,
-              reservedRequests: $reservedRequests,
-              requestBudget: $requestBudget,
-              admitted: ($slotCount >= 1 and $slotCount <= 4 and $reservedRequests <= $requestBudget)
-            }' > "$GITHUB_WORKSPACE/pack-diagnostics/evaluation-budget.json"
-          if [ "$SLOT_COUNT" -lt 1 ] || [ "$SLOT_COUNT" -gt 4 ] || \
-             [ "$((ESTIMATED_REQUESTS + TOOL_LOOP_HEADROOM))" -gt "$PROXY_REQUEST_BUDGET" ]; then
-            echo "::error::Evaluation plan exceeds bounded budget: slots=$SLOT_COUNT reserved=$((ESTIMATED_REQUESTS + TOOL_LOOP_HEADROOM))/$PROXY_REQUEST_BUDGET"
-            exit 1
-          fi
+          node marketplace-evaluate/scripts/pack-production.mjs plan-values \
+            --plan pack-production-input/plan.json \
+            | jq '{
+                schemaVersion: "marketplace.pack-evaluation-budget/v1",
+                planDigest: .digest,
+                generation: .parameters.generation,
+                proxy: .parameters.proxy,
+                resources: .parameters.resources,
+                timeoutsMs: .parameters.timeoutsMs,
+                tokens: .parameters.tokens
+              }' > "$GITHUB_WORKSPACE/pack-diagnostics/evaluation-budget.json"
           jq . "$GITHUB_WORKSPACE/pack-diagnostics/evaluation-budget.json" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install evaluator runtimes before secrets are available
         run: |
+          set -euo pipefail
+          PLAN_VALUES=$(node marketplace-evaluate/scripts/pack-production.mjs plan-values \
+            --plan pack-production-input/plan.json)
+          CLAUDE_CODE_VERSION=$(jq -r '.parameters.runtime.claudeCodeVersion' <<< "$PLAN_VALUES")
+          CODEX_VERSION=$(jq -r '.parameters.runtime.codexVersion' <<< "$PLAN_VALUES")
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
             apparmor bubblewrap ffmpeg iptables poppler-utils ripgrep util-linux
@@ -376,8 +341,8 @@ jobs:
             /opt/pack-evaluator \
             /opt/pack-evaluator/runtime
           sudo npm install --global --prefix /opt/pack-evaluator/runtime \
-            @anthropic-ai/claude-code@2.1.210 \
-            @openai/codex@0.139.0
+            "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" \
+            "@openai/codex@$CODEX_VERSION"
           sudo chown -R root:root /opt/pack-evaluator/runtime
           sudo chmod -R a=rX /opt/pack-evaluator/runtime
           command -v ffprobe
@@ -389,13 +354,17 @@ jobs:
           test "$(command -v google-chrome)" = /usr/bin/google-chrome
           test -x /usr/bin/google-chrome
           /usr/bin/google-chrome --version
-          test "$(/opt/pack-evaluator/runtime/bin/claude --version | awk '{print $1}')" = '2.1.210'
-          test "$(/opt/pack-evaluator/runtime/bin/codex --version | awk '{print $2}')" = '0.139.0'
+          test "$(/opt/pack-evaluator/runtime/bin/claude --version | awk '{print $1}')" = "$CLAUDE_CODE_VERSION"
+          test "$(/opt/pack-evaluator/runtime/bin/codex --version | awk '{print $2}')" = "$CODEX_VERSION"
 
       - name: Prepare disposable evaluator identities and filesystem
         env:
           CLI: ${{ github.workspace }}/pack-production-cli/skillstore-cli-linux-x64
         run: |
+          set -euo pipefail
+          PLAN_VALUES=$(node marketplace-evaluate/scripts/pack-production.mjs plan-values \
+            --plan pack-production-input/plan.json)
+          PROXY_PORT=$(jq -r '.parameters.proxy.port' <<< "$PLAN_VALUES")
           sudo useradd --system --create-home --home-dir /home/packproxy --shell /usr/sbin/nologin packproxy
           sudo useradd --create-home --home-dir /home/packeval --shell /bin/bash packeval
           NODE_SOURCE=$(command -v node)
@@ -417,9 +386,15 @@ jobs:
           sudo install -o root -g root -m 0555 \
             "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-production.mjs" \
             /opt/pack-evaluator/lib/pack-production.mjs
+          sudo install -o root -g root -m 0555 \
+            "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-production-plan.mjs" \
+            /opt/pack-evaluator/lib/pack-production-plan.mjs
           sudo install -o root -g root -m 0444 \
             "$GITHUB_WORKSPACE/pack-production-input/plan.json" \
             /opt/pack-evaluator/input/plan.json
+          sudo install -o root -g root -m 0444 \
+            "$GITHUB_WORKSPACE/pack-production-input/plan-artifact-gate.json" \
+            /opt/pack-evaluator/input/plan-artifact-gate.json
           if find "$GITHUB_WORKSPACE/marketplace-evaluate/skills" -type l -print -quit | grep -q .; then
             echo '::error::Evaluator skill input contains a symbolic link'
             exit 1
@@ -460,7 +435,7 @@ jobs:
             'model_provider = "pack_evaluator_proxy"' \
             '[model_providers.pack_evaluator_proxy]' \
             'name = "Job-local Pack evaluator proxy"' \
-            'base_url = "http://127.0.0.1:18765/v1"' \
+            "base_url = \"http://127.0.0.1:$PROXY_PORT/v1\"" \
             'env_key = "PACK_EVALUATOR_PROXY_TOKEN"' \
             'wire_api = "responses"' \
             'supports_websockets = false' \
@@ -515,6 +490,24 @@ jobs:
           LOCAL_TOKEN=$(openssl rand -hex 32)
           NODE_BIN=/opt/pack-evaluator/bin/node
           test -x "$NODE_BIN"
+          PLAN_PATH=/opt/pack-evaluator/input/plan.json
+          PLAN_GATE_PATH=/opt/pack-evaluator/input/plan-artifact-gate.json
+          PLAN_VALUES=$("$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs plan-values \
+            --plan "$PLAN_PATH")
+          ALLOWED_MODELS=$(jq -r '.parameters.proxy.allowedModels | join(",")' <<< "$PLAN_VALUES")
+          MAX_REQUESTS=$(jq -r '.parameters.proxy.maxRequests' <<< "$PLAN_VALUES")
+          MAX_CONCURRENT=$(jq -r '.parameters.proxy.maxConcurrent' <<< "$PLAN_VALUES")
+          MAX_OUTPUT_TOKENS=$(jq -r '.parameters.tokens.maxOutput' <<< "$PLAN_VALUES")
+          PROXY_TTL_MS=$(jq -r '.parameters.timeoutsMs.proxyTtl' <<< "$PLAN_VALUES")
+          PROXY_REQUEST_TIMEOUT_MS=$(jq -r '.parameters.timeoutsMs.proxyRequest' <<< "$PLAN_VALUES")
+          PROXY_PORT=$(jq -r '.parameters.proxy.port' <<< "$PLAN_VALUES")
+          UPSTREAM_URL=$(jq -r '.parameters.proxy.upstreamUrl' <<< "$PLAN_VALUES")
+          OUTER_EVALUATION_MS=$(jq -r '.parameters.timeoutsMs.outerEvaluation' <<< "$PLAN_VALUES")
+          OUTER_EVALUATION_KILL_GRACE_MS=$(jq -r '.parameters.timeoutsMs.outerEvaluationKillGrace' <<< "$PLAN_VALUES")
+          MAX_PROCESSES=$(jq -r '.parameters.resources.maxProcesses' <<< "$PLAN_VALUES")
+          ADDRESS_SPACE_BYTES=$(jq -r '.parameters.resources.addressSpaceBytes' <<< "$PLAN_VALUES")
+          RESULT_BYTES_LIMIT=$(jq -r '.parameters.resources.resultBytes' <<< "$PLAN_VALUES")
+          RESULT_FILES_LIMIT=$(jq -r '.parameters.resources.resultFiles' <<< "$PLAN_VALUES")
           PROXY_LOG=$(mktemp)
           PROXY_ACTIVITY=$(mktemp)
           chmod 0600 "$PROXY_ACTIVITY"
@@ -640,14 +633,14 @@ jobs:
             PATH=/opt/pack-evaluator/bin:/usr/bin:/bin \
             PACK_EVALUATOR_LOCAL_TOKEN="$LOCAL_TOKEN" \
             PACK_EVALUATOR_UPSTREAM_KEY="$PACK_EVALUATOR_HELM_API_KEY" \
-            PACK_EVALUATOR_UPSTREAM_URL=https://helm.easymeta.au \
-            PACK_EVALUATOR_PROXY_PORT=18765 \
-            PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5.5 \
-            PACK_EVALUATOR_MAX_REQUESTS=256 \
-            PACK_EVALUATOR_MAX_CONCURRENT=4 \
-            PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
-            PACK_EVALUATOR_TTL_MS=14400000 \
-            PACK_EVALUATOR_REQUEST_TIMEOUT_MS=600000 \
+            PACK_EVALUATOR_UPSTREAM_URL="$UPSTREAM_URL" \
+            PACK_EVALUATOR_PROXY_PORT="$PROXY_PORT" \
+            PACK_EVALUATOR_ALLOWED_MODELS="$ALLOWED_MODELS" \
+            PACK_EVALUATOR_MAX_REQUESTS="$MAX_REQUESTS" \
+            PACK_EVALUATOR_MAX_CONCURRENT="$MAX_CONCURRENT" \
+            PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$MAX_OUTPUT_TOKENS" \
+            PACK_EVALUATOR_TTL_MS="$PROXY_TTL_MS" \
+            PACK_EVALUATOR_REQUEST_TIMEOUT_MS="$PROXY_REQUEST_TIMEOUT_MS" \
             PACK_EVALUATOR_ACTIVITY_FILE="$PROXY_ACTIVITY" \
             "$NODE_BIN" /opt/pack-evaluator/lib/pack-evaluator-proxy.mjs \
             >"$PROXY_LOG" 2>&1 &
@@ -658,7 +651,7 @@ jobs:
           for _ in $(seq 1 30); do
             if curl --fail --silent \
               -H "Authorization: Bearer $LOCAL_TOKEN" \
-              http://127.0.0.1:18765/healthz >/dev/null; then
+              "http://127.0.0.1:$PROXY_PORT/healthz" >/dev/null; then
               PROXY_READY=true
               break
             fi
@@ -727,8 +720,8 @@ jobs:
           CONTRACT_DIAGNOSTICS="$GITHUB_WORKSPACE/pack-diagnostics/contract-smoke.json"
           set +e
           PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
-          PACK_EVALUATOR_PROXY_URL=http://127.0.0.1:18765 \
-          PACK_EVALUATOR_CONTRACT_TIMEOUT_MS=30000 \
+          PACK_EVALUATOR_PROXY_URL="http://127.0.0.1:$PROXY_PORT" \
+          PACK_EVALUATOR_PLAN_PATH="$PLAN_PATH" \
           PACK_EVALUATOR_CONTRACT_DIAGNOSTICS_FILE="$CONTRACT_DIAGNOSTICS" \
           "$NODE_BIN" /opt/pack-evaluator/lib/pack-evaluator-contract-smoke.mjs
           CONTRACT_RC=$?
@@ -767,8 +760,8 @@ jobs:
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
             PACK_DIAGNOSTICS_DIR="$GITHUB_WORKSPACE/pack-diagnostics" \
             PACK_EVALUATOR_ACTIVITY_FILE="$PROXY_ACTIVITY" \
-            PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="$GITHUB_SHA" \
-            PACK_EVALUATOR_CLI_SHA256="$(jq -r '.sha256' "$GITHUB_WORKSPACE/pack-production-input/cli-identity.json")" \
+            PACK_EVALUATOR_PLAN_PATH="$PLAN_PATH" \
+            PACK_EVALUATOR_ARTIFACT_GATE_PATH="$PLAN_GATE_PATH" \
             bash "$GITHUB_WORKSPACE/marketplace-evaluate/scripts/pack-evaluator-preflight.sh"
             PREFLIGHT_RC=$?
             set -e
@@ -850,40 +843,25 @@ jobs:
             SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=/opt/pack-evaluator/runtime \
             PACK_EVALUATOR_CHROMIUM_PATH=/usr/bin/google-chrome \
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
-            ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
+            ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT" \
             ANTHROPIC_AUTH_TOKEN="$LOCAL_TOKEN" \
-            CLAUDE_CODE_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS="$MAX_OUTPUT_TOKENS" \
             NO_PROXY=127.0.0.1,localhost \
-            timeout --signal=TERM --kill-after=30s 4h \
-            prlimit --nproc=256:256 --as=6442450944:6442450944 -- \
+            timeout --signal=TERM --kill-after="${OUTER_EVALUATION_KILL_GRACE_MS}ms" "${OUTER_EVALUATION_MS}ms" \
+            prlimit \
+              --nproc="$MAX_PROCESSES:$MAX_PROCESSES" \
+              --as="$ADDRESS_SPACE_BYTES:$ADDRESS_SPACE_BYTES" \
+              -- \
             "$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs evaluate \
-            --plan /opt/pack-evaluator/input/plan.json \
+            --plan "$PLAN_PATH" \
+            --artifact-gate "$PLAN_GATE_PATH" \
             --results-dir /opt/pack-evaluator/results \
             --cli /opt/pack-evaluator/bin/skillstore-cli \
-            --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
             --skills-dir /opt/pack-evaluator/input/skills \
             --evaluator-uid "$PACKEVAL_UID" \
             --evaluator-gid "$PACKEVAL_GID" \
             --evaluator-cwd /home/packeval \
             --evaluator-runtime-root /opt/pack-evaluator/generations \
-            --run-id "${{ github.run_id }}" \
-            --run-attempt "${{ github.run_attempt }}" \
-            --commit-sha "${{ github.sha }}" \
-            --model "$PACK_EVALUATOR_RUNNER_MODEL" \
-            --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
-            --max-candidates 2 \
-            --pick 4 \
-            --runs 1 \
-            --final-runs 3 \
-            --agent-timeout-ms 360000 \
-            --agent-max-retries 1 \
-            --threshold 7 \
-            --baseline-delta 1 \
-            --auto-publish-threshold 8 \
-            --evaluation-budget-ms 13800000 \
-            --scenario-timeout-ms 7200000 \
-            --minimum-fallback-ms 2700000 \
-            --scenario-idle-timeout-ms 1200000 \
             --proxy-activity-file "$PROXY_ACTIVITY" \
             "${INFRASTRUCTURE_ARGS[@]}" \
             > "$GITHUB_WORKSPACE/pack-diagnostics/evaluate-command.json" &
@@ -916,11 +894,11 @@ jobs:
           else
             RESULT_BYTES=$(sudo du -sb /opt/pack-evaluator/results | awk '{print $1}')
             RESULT_FILES=$(sudo find /opt/pack-evaluator/results -type f | wc -l)
-            if [ "$RESULT_BYTES" -gt 268435456 ]; then
-              echo "::error::Evaluator result directory exceeds 256 MiB: $RESULT_BYTES bytes"
+            if [ "$RESULT_BYTES" -gt "$RESULT_BYTES_LIMIT" ]; then
+              echo "::error::Evaluator result directory exceeds Plan bound: $RESULT_BYTES/$RESULT_BYTES_LIMIT bytes"
               EVALUATOR_RC=1
-            elif [ "$RESULT_FILES" -gt 1000 ]; then
-              echo "::error::Evaluator result directory exceeds 1000 files: $RESULT_FILES"
+            elif [ "$RESULT_FILES" -gt "$RESULT_FILES_LIMIT" ]; then
+              echo "::error::Evaluator result directory exceeds Plan file bound: $RESULT_FILES/$RESULT_FILES_LIMIT"
               EVALUATOR_RC=1
             elif sudo find /opt/pack-evaluator/results ! -type f ! -type d -print -quit | grep -q .; then
               echo '::error::Evaluator result directory contains a non-regular entry'
@@ -943,15 +921,10 @@ jobs:
           if [ "$EVALUATOR_RC" -eq 0 ]; then
             if ! env -i PATH=/opt/pack-evaluator/runtime/bin:/usr/bin:/bin \
               "$NODE_BIN" /opt/pack-evaluator/lib/pack-production.mjs verify \
-              --plan /opt/pack-evaluator/input/plan.json \
+              --plan "$PLAN_PATH" \
+              --artifact-gate "$PLAN_GATE_PATH" \
               --results-dir "$GITHUB_WORKSPACE/pack-harvest" \
               --cli /opt/pack-evaluator/bin/skillstore-cli \
-              --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
-              --run-id "${{ github.run_id }}" \
-              --run-attempt "${{ github.run_attempt }}" \
-              --commit-sha "${{ github.sha }}" \
-              --model "$PACK_EVALUATOR_RUNNER_MODEL" \
-              --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
               > "$GITHUB_WORKSPACE/pack-diagnostics/verification-command.json"; then
               echo 'trusted evaluation closure verification failed' \
                 > "$GITHUB_WORKSPACE/pack-diagnostics/verification-failure.txt"
@@ -961,7 +934,9 @@ jobs:
           rm -f "$GITHUB_WORKSPACE/pack-harvest/"*.stdout.partial
           if [ "$EVALUATOR_RC" -eq 0 ]; then
             mkdir -p "$GITHUB_WORKSPACE/pack-trusted"
-            cp "$GITHUB_WORKSPACE/pack-harvest/evaluate-summary.json" \
+            cp "$PLAN_PATH" \
+              "$PLAN_GATE_PATH" \
+              "$GITHUB_WORKSPACE/pack-harvest/evaluate-summary.json" \
               "$GITHUB_WORKSPACE/pack-harvest/evaluation-verification.json" \
               "$GITHUB_WORKSPACE/pack-harvest/"*.evaluation.json \
               "$GITHUB_WORKSPACE/pack-harvest/"*.stdout.json \
@@ -1043,7 +1018,9 @@ jobs:
         with:
           path: marketplace-persist
           ref: ${{ github.sha }}
-          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout: |
+            scripts/pack-production-plan.mjs
+            scripts/pack-production.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1053,12 +1030,39 @@ jobs:
           name: pack-production-evaluation
           path: pack-results
 
+      - name: Gate the exact successful evaluation artifact
+        env:
+          PRODUCER_STATUS: ${{ needs.evaluate.result }}
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            import { canonicalJson } from "./marketplace-persist/scripts/pack-production-plan.mjs";
+            const plan = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            writeFileSync(process.argv[2], canonicalJson({
+              artifact: {
+                name: "pack-production-evaluation",
+                planDigest: plan.digest,
+                status: "downloaded"
+              },
+              producer: { name: "evaluate", status: process.env.PRODUCER_STATUS },
+              schemaVersion: "marketplace.pack-production-artifact-state/v1",
+              workflowBinding: plan.workflowBinding
+            }));
+          ' pack-results/plan.json pack-results/evaluate-artifact-state.json
+          node marketplace-persist/scripts/pack-production.mjs artifact-gate \
+            --plan pack-results/plan.json \
+            --state pack-results/evaluate-artifact-state.json \
+            --output pack-results/evaluate-artifact-gate.json
+
       - name: Persist every attempt atomically
         env:
           SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
           PACK_PRODUCTION_AUTOMATION_KEY: ${{ secrets.PACK_PRODUCTION_AUTOMATION_KEY }}
         run: |
           node marketplace-persist/scripts/pack-production.mjs persist \
+            --plan "$GITHUB_WORKSPACE/pack-results/plan.json" \
+            --artifact-gate "$GITHUB_WORKSPACE/pack-results/evaluate-artifact-gate.json" \
             --results-dir "$GITHUB_WORKSPACE/pack-results" \
             --api-url "$SKILLSTORE_API_URL" \
             --token "$PACK_PRODUCTION_AUTOMATION_KEY" \
@@ -1085,7 +1089,9 @@ jobs:
         with:
           path: marketplace-finalize
           ref: ${{ github.sha }}
-          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout: |
+            scripts/pack-production-plan.mjs
+            scripts/pack-production.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1094,6 +1100,31 @@ jobs:
         with:
           name: pack-production-persisted
           path: pack-results
+
+      - name: Gate the exact successful persistence artifact
+        env:
+          PRODUCER_STATUS: ${{ needs.persist.result }}
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            import { canonicalJson } from "./marketplace-finalize/scripts/pack-production-plan.mjs";
+            const plan = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            writeFileSync(process.argv[2], canonicalJson({
+              artifact: {
+                name: "pack-production-persisted",
+                planDigest: plan.digest,
+                status: "downloaded"
+              },
+              producer: { name: "persist", status: process.env.PRODUCER_STATUS },
+              schemaVersion: "marketplace.pack-production-artifact-state/v1",
+              workflowBinding: plan.workflowBinding
+            }));
+          ' pack-results/plan.json pack-results/persist-artifact-state.json
+          node marketplace-finalize/scripts/pack-production.mjs artifact-gate \
+            --plan pack-results/plan.json \
+            --state pack-results/persist-artifact-state.json \
+            --output pack-results/persist-artifact-gate.json
 
       - name: Await enrichment and enforce publish gates
         env:
@@ -1105,6 +1136,8 @@ jobs:
           AUTO_PUBLISH: ${{ vars.PACK_PRODUCTION_AUTO_PUBLISH_ENABLED == 'true' && (github.event_name == 'schedule' || inputs.auto_publish) && 'true' || 'false' }}
         run: |
           node marketplace-finalize/scripts/pack-production.mjs finalize \
+            --plan "$GITHUB_WORKSPACE/pack-results/plan.json" \
+            --artifact-gate "$GITHUB_WORKSPACE/pack-results/persist-artifact-gate.json" \
             --results-dir "$GITHUB_WORKSPACE/pack-results" \
             --api-url "$SKILLSTORE_API_URL" \
             --token "$PACK_PRODUCTION_AUTOMATION_KEY" \

--- a/.github/workflows/pack-production-slo.yml
+++ b/.github/workflows/pack-production-slo.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           path: marketplace-slo
           ref: ${{ github.sha }}
-          sparse-checkout: scripts/pack-production.mjs
+          sparse-checkout: |
+            scripts/pack-production-plan.mjs
+            scripts/pack-production.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 

--- a/.github/workflows/recover-cancelled-pack-production.yml
+++ b/.github/workflows/recover-cancelled-pack-production.yml
@@ -29,6 +29,7 @@ jobs:
           ref: ${{ github.sha }}
           sparse-checkout: |
             scripts/pack-production-cancellation-recovery.mjs
+            scripts/pack-production-plan.mjs
             scripts/pack-production.mjs
           sparse-checkout-cone-mode: false
           fetch-depth: 1

--- a/.github/workflows/test-pack-evaluator-bwrap.yml
+++ b/.github/workflows/test-pack-evaluator-bwrap.yml
@@ -10,7 +10,9 @@ on:
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
       - 'scripts/pack-evaluator-preflight-mock.mjs'
+      - 'scripts/pack-production-plan.mjs'
       - 'scripts/pack-production.mjs'
+      - 'scripts/tests/pack-production-execution-plan.test.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
       - 'scripts/tests/pack-evaluator-egress.test.mjs'
@@ -27,7 +29,9 @@ on:
       - 'scripts/pack-evaluator-bwrap.apparmor'
       - 'scripts/pack-evaluator-preflight.sh'
       - 'scripts/pack-evaluator-preflight-mock.mjs'
+      - 'scripts/pack-production-plan.mjs'
       - 'scripts/pack-production.mjs'
+      - 'scripts/tests/pack-production-execution-plan.test.mjs'
       - 'scripts/tests/generate-packs-workflow.test.mjs'
       - 'scripts/tests/pack-evaluator-bwrap-userns.test.mjs'
       - 'scripts/tests/pack-evaluator-egress.test.mjs'
@@ -40,7 +44,6 @@ permissions:
 
 env:
   PACK_PRODUCTION_CLI_VERSION: '2.14.2'
-  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 
 concurrency:
   group: test-pack-evaluator-bwrap-${{ github.ref }}
@@ -107,6 +110,7 @@ jobs:
           sudo install -d -o root -g root -m 0755 \
             /opt/pack-evaluator \
             /opt/pack-evaluator/bin \
+            /opt/pack-evaluator/input \
             /opt/pack-evaluator/lib \
             /opt/pack-evaluator/runtime \
             /opt/pack-evaluator/runtime/bin \
@@ -120,6 +124,9 @@ jobs:
           sudo install -o root -g root -m 0555 \
             "$NODE_SOURCE" \
             /opt/pack-evaluator/runtime/bin/node
+          sudo install -o root -g root -m 0444 \
+            scripts/pack-production-plan.mjs \
+            /opt/pack-evaluator/lib/pack-production-plan.mjs
           sudo install -o root -g root -m 0444 \
             scripts/pack-production.mjs \
             /opt/pack-evaluator/lib/pack-production.mjs
@@ -148,13 +155,14 @@ jobs:
             scripts/pack-evaluator-bwrap.apparmor \
             scripts/pack-evaluator-preflight.sh \
             scripts/pack-evaluator-preflight-mock.mjs \
+            scripts/pack-production-plan.mjs \
             scripts/pack-production.mjs
           sudo chmod 0555 \
             scripts/configure-pack-evaluator-bwrap.sh \
             scripts/configure-pack-evaluator-egress.sh \
             scripts/pack-evaluator-preflight.sh \
             scripts/pack-evaluator-preflight-mock.mjs
-          sudo chmod 0444 scripts/pack-production.mjs
+          sudo chmod 0444 scripts/pack-production-plan.mjs scripts/pack-production.mjs
           sudo chmod 0444 scripts/pack-evaluator-bwrap.apparmor
           test "$(/opt/pack-evaluator/runtime/bin/claude --version | awk '{print $1}')" = '2.1.210'
           test "$(/opt/pack-evaluator/runtime/bin/codex --version | awk '{print $2}')" = '0.139.0'
@@ -178,6 +186,57 @@ jobs:
           sudo install -o root -g root -m 0555 "$CLI" /opt/pack-evaluator/bin/skillstore-cli
           test "$(/opt/pack-evaluator/bin/skillstore-cli --version | grep -Eo '[0-9]+([.][0-9]+){2}' | head -n1)" = \
             "$PACK_PRODUCTION_CLI_VERSION"
+          PLAN_ROOT="$RUNNER_TEMP/pack-evaluator-plan"
+          mkdir -p "$PLAN_ROOT"
+          jq -n '{
+            schemaVersion: "pack-production-queue/v1",
+            source: "signals",
+            scenarios: [{
+              id: "hosted-preflight-proof",
+              version: "1.0.0",
+              task: "Prove the canonical Pack executor preflight path.",
+              slug: "hosted-preflight-proof",
+              name: "Hosted Preflight Proof",
+              tags: ["preflight"],
+              capabilitySlots: [{id: "proof", required: true, keywords: ["proof"]}],
+              requiredArtifacts: [{id: "proof", kind: "text"}]
+            }]
+          }' > "$PLAN_ROOT/queue.json"
+          node scripts/pack-production-plan.mjs create \
+            --queue "$PLAN_ROOT/queue.json" \
+            --output "$PLAN_ROOT/plan.json" \
+            --generation-id 00000000-0000-4000-8000-000000000002 \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow "Generate Pack" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --head-sha "$GITHUB_SHA" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --cli /opt/pack-evaluator/bin/skillstore-cli
+          node --input-type=module -e '
+            import { readExecutionPlan, writeCanonicalJsonAtomic } from "./scripts/pack-production-plan.mjs";
+            const plan = await readExecutionPlan(process.argv[1]);
+            await writeCanonicalJsonAtomic(process.argv[2], {
+              artifact: {
+                name: "pack-production-plan",
+                planDigest: plan.digest,
+                status: "downloaded"
+              },
+              producer: { name: "plan", status: "success" },
+              schemaVersion: "marketplace.pack-production-artifact-state/v1",
+              workflowBinding: plan.workflowBinding
+            });
+          ' "$PLAN_ROOT/plan.json" "$PLAN_ROOT/plan-artifact-state.json"
+          node scripts/pack-production.mjs artifact-gate \
+            --plan "$PLAN_ROOT/plan.json" \
+            --state "$PLAN_ROOT/plan-artifact-state.json" \
+            --output "$PLAN_ROOT/plan-artifact-gate.json"
+          sudo install -o root -g root -m 0444 \
+            "$PLAN_ROOT/plan.json" \
+            /opt/pack-evaluator/input/plan.json
+          sudo install -o root -g root -m 0444 \
+            "$PLAN_ROOT/plan-artifact-gate.json" \
+            /opt/pack-evaluator/input/plan-artifact-gate.json
 
       - name: Configure scoped AppArmor policy and prove the real sandbox
         run: |
@@ -256,10 +315,8 @@ jobs:
             PACK_EVALUATOR_PROXY_TOKEN="$LOCAL_TOKEN" \
             PACK_DIAGNOSTICS_DIR="$DIAGNOSTICS_DIR" \
             PACK_EVALUATOR_ACTIVITY_FILE="$ACTIVITY_FILE" \
-            PACK_EVALUATOR_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
-            PACK_PRODUCTION_CLI_VERSION="$PACK_PRODUCTION_CLI_VERSION" \
-            PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="$GITHUB_SHA" \
-            PACK_EVALUATOR_CLI_SHA256="$CLI_SHA256" \
+            PACK_EVALUATOR_PLAN_PATH=/opt/pack-evaluator/input/plan.json \
+            PACK_EVALUATOR_ARTIFACT_GATE_PATH=/opt/pack-evaluator/input/plan-artifact-gate.json \
             bash "$GITHUB_WORKSPACE/scripts/pack-evaluator-preflight.sh"
           IPV4_ACCEPT_AFTER=$(sudo iptables -w 5 -L PACK_EVALUATOR_EGRESS -v -n -x \
             | awk '$3 == "ACCEPT" {print $1}')

--- a/scripts/pack-evaluator-contract-smoke.mjs
+++ b/scripts/pack-evaluator-contract-smoke.mjs
@@ -2,7 +2,12 @@
 
 import { createHash } from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  assertProductionExecutionPolicy,
+  readExecutionPlan,
+  verifyRuntimeSourceFiles,
+} from './pack-production-plan.mjs';
 
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const EXPECTED_RESPONSE_TEXT = 'PACK_EVALUATOR_READY';
@@ -170,14 +175,17 @@ function validateResponsesEvents(events) {
   };
 }
 
-const CONTRACTS = [
-  {
+function contractsFromPlan(plan) {
+  if (!plan) fail('Canonical execution Plan is required');
+  const { models, parameters } = assertProductionExecutionPolicy(plan).executionBinding;
+  const outputTokens = parameters.tokens.contractProbeOutput;
+  return [{
     name: 'claude_messages',
     path: '/v1/messages',
-    model: 'claude-sonnet-5',
+    model: models.runner.identity,
     payload: {
-      model: 'claude-sonnet-5',
-      max_tokens: 16,
+      model: models.runner.identity,
+      max_tokens: outputTokens,
       stream: true,
       messages: [{
         role: 'user',
@@ -189,16 +197,16 @@ const CONTRACTS = [
   {
     name: 'codex_responses',
     path: '/v1/responses',
-    model: 'gpt-5.5',
+    model: models.judge.identity,
     payload: {
-      model: 'gpt-5.5',
-      max_output_tokens: 16,
+      model: models.judge.identity,
+      max_output_tokens: outputTokens,
       stream: true,
       input: 'Reply with exactly PACK_EVALUATOR_READY and nothing else.',
     },
     validateEvents: validateResponsesEvents,
-  },
-];
+  }];
+}
 
 async function runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs }) {
   const endpoint = new URL(contract.path, proxyUrl);
@@ -275,12 +283,14 @@ async function runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs 
 }
 
 export async function runContractSmoke({
+  plan,
   proxyUrl,
   token,
   diagnosticsFile,
   fetchImpl = fetch,
-  timeoutMs = 30_000,
 }) {
+  const contractsToRun = contractsFromPlan(plan);
+  const timeoutMs = plan.executionBinding.parameters.timeoutsMs.contract;
   if (!proxyUrl) fail('PACK_EVALUATOR_PROXY_URL is required');
   if (!token) fail('PACK_EVALUATOR_PROXY_TOKEN is required');
   if (!diagnosticsFile) fail('PACK_EVALUATOR_CONTRACT_DIAGNOSTICS_FILE is required');
@@ -288,14 +298,15 @@ export async function runContractSmoke({
     fail('PACK_EVALUATOR_CONTRACT_TIMEOUT_MS must be between 1 and 120000');
   }
   const contracts = [];
-  for (const contract of CONTRACTS) {
+  for (const contract of contractsToRun) {
     const result = await runOneContract({ contract, proxyUrl, token, fetchImpl, timeoutMs });
     contracts.push(result);
   }
   const failed = contracts.find((contract) => contract.outcome !== 'passed');
   const diagnostics = {
     schemaVersion: 'marketplace.pack-evaluator-contract-smoke/v1',
-    outcome: failed ? 'failed' : contracts.length === CONTRACTS.length ? 'passed' : 'incomplete',
+    executionPlanDigest: plan.digest,
+    outcome: failed ? 'failed' : contracts.length === contractsToRun.length ? 'passed' : 'incomplete',
     contracts,
   };
   await writeFile(diagnosticsFile, `${JSON.stringify(diagnostics, null, 2)}\n`, { mode: 0o600 });
@@ -309,11 +320,21 @@ export async function runContractSmoke({
 }
 
 async function main(environment = process.env) {
+  if (!environment.PACK_EVALUATOR_PLAN_PATH) {
+    fail('PACK_EVALUATOR_PLAN_PATH is required');
+  }
+  const plan = await readExecutionPlan(environment.PACK_EVALUATOR_PLAN_PATH);
+  await verifyRuntimeSourceFiles(plan, {
+    'scripts/pack-evaluator-contract-smoke.mjs': fileURLToPath(import.meta.url),
+    'scripts/pack-production-plan.mjs': fileURLToPath(
+      new URL('./pack-production-plan.mjs', import.meta.url),
+    ),
+  });
   const result = await runContractSmoke({
+    plan,
     proxyUrl: environment.PACK_EVALUATOR_PROXY_URL || 'http://127.0.0.1:18765',
     token: environment.PACK_EVALUATOR_PROXY_TOKEN,
     diagnosticsFile: environment.PACK_EVALUATOR_CONTRACT_DIAGNOSTICS_FILE,
-    timeoutMs: Number(environment.PACK_EVALUATOR_CONTRACT_TIMEOUT_MS || '30000'),
   });
   process.stdout.write(`${JSON.stringify({
     outcome: result.outcome,

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -3,37 +3,15 @@ set -euo pipefail
 
 : "${PACK_EVALUATOR_PROXY_TOKEN:?PACK_EVALUATOR_PROXY_TOKEN is required}"
 : "${PACK_DIAGNOSTICS_DIR:?PACK_DIAGNOSTICS_DIR is required}"
-: "${PACK_EVALUATOR_MAX_OUTPUT_TOKENS:?PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required}"
-: "${PACK_PRODUCTION_CLI_VERSION:?PACK_PRODUCTION_CLI_VERSION is required}"
-: "${PACK_EVALUATOR_RUNNER_MODEL:?PACK_EVALUATOR_RUNNER_MODEL is required}"
-: "${PACK_EVALUATOR_JUDGE_MODEL:?PACK_EVALUATOR_JUDGE_MODEL is required}"
-if ! [[ "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" =~ ^[1-9][0-9]*$ ]]; then
-  echo 'PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer' >&2
-  exit 1
-fi
-: "${PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA:?PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA is required}"
-: "${PACK_EVALUATOR_CLI_SHA256:?PACK_EVALUATOR_CLI_SHA256 is required}"
-if ! [[ "$PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-  echo 'PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA must be a lowercase Git commit SHA' >&2
-  exit 1
-fi
-if ! [[ "$PACK_EVALUATOR_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
-  echo 'PACK_EVALUATOR_CLI_SHA256 must be a lowercase SHA-256' >&2
-  exit 1
-fi
+: "${PACK_EVALUATOR_PLAN_PATH:?PACK_EVALUATOR_PLAN_PATH is required}"
+: "${PACK_EVALUATOR_ARTIFACT_GATE_PATH:?PACK_EVALUATOR_ARTIFACT_GATE_PATH is required}"
 
-readonly PREFLIGHT_TIMEOUT_SECONDS=420
-readonly AGENT_TIMEOUT_MS=180000
 readonly NODE=/opt/pack-evaluator/bin/node
 readonly CLI=/opt/pack-evaluator/bin/skillstore-cli
 readonly ORCHESTRATOR=/opt/pack-evaluator/lib/pack-production.mjs
 readonly RUNTIME_ROOT=/opt/pack-evaluator/generations
-readonly PREFLIGHT_GENERATION_ID=00000000-0000-4000-8000-000000000001
 readonly PREFLIGHT_ROOT=/home/packeval/tmp/skillstore-executor-preflight
-readonly PREFLIGHT_SKILL_A="$PREFLIGHT_ROOT/input/skill-a"
-readonly PREFLIGHT_SKILL_B="$PREFLIGHT_ROOT/input/skill-b"
 readonly PREFLIGHT_RAW="$PREFLIGHT_ROOT/raw"
-readonly PREFLIGHT_TASK='Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second. After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.'
 readonly CLI_STDOUT="$(mktemp)"
 readonly CLI_STDERR="$(mktemp)"
 readonly ACTIVITY_SLICE="$(mktemp)"
@@ -42,14 +20,58 @@ for executable in "$NODE" "$CLI" /usr/bin/bwrap /usr/bin/jq /usr/bin/prlimit /us
   [ -x "$executable" ] || { echo "Required evaluator executable is missing: $executable" >&2; exit 1; }
 done
 [ -r "$ORCHESTRATOR" ] || { echo 'Pack production orchestrator is missing' >&2; exit 1; }
+[ -r "$PACK_EVALUATOR_PLAN_PATH" ] || { echo 'Canonical execution Plan is missing' >&2; exit 1; }
+[ -r "$PACK_EVALUATOR_ARTIFACT_GATE_PATH" ] || { echo 'Plan artifact gate is missing' >&2; exit 1; }
+
+readonly PLAN_VALUES="$("$NODE" "$ORCHESTRATOR" plan-values --plan "$PACK_EVALUATOR_PLAN_PATH")"
+EXPECTED_PREFLIGHT_SHA256=$(jq -er '
+  .executionBinding.source.files[]
+  | select(.path == "scripts/pack-evaluator-preflight.sh")
+  | .sha256
+' "$PACK_EVALUATOR_PLAN_PATH")
+ACTUAL_PREFLIGHT_SHA256=$(sha256sum "$0" | awk '{print $1}')
+if [ "$ACTUAL_PREFLIGHT_SHA256" != "$EXPECTED_PREFLIGHT_SHA256" ]; then
+  echo 'Pack evaluator preflight source differs from the execution Plan' >&2
+  exit 1
+fi
+jq -e '
+  (.digest | test("^[0-9a-f]{64}$")) and
+  (.workflowBinding.headSha | test("^[0-9a-f]{40}$")) and
+  (.cli.version | type == "string" and length > 0) and
+  (.cli.releaseAssetSha256 | test("^[0-9a-f]{64}$")) and
+  (.models.runner.pinType == "workflow-pinned alias") and
+  (.models.judge.pinType == "workflow-pinned alias") and
+  (.parameters.tokens.maxOutput | type == "number" and . > 0) and
+  (.parameters.proxy.port | type == "number" and . > 0) and
+  (.parameters.resources.maxProcesses | type == "number" and . > 0) and
+  (.parameters.resources.addressSpaceBytes | type == "number" and . > 0) and
+  (.parameters.timeoutsMs.executorPreflightOuter | type == "number" and . > 0) and
+  (.parameters.timeoutsMs.executorPreflightOuterKillGrace | type == "number" and . > 0) and
+  (.parameters.timeoutsMs.executorPreflightRetryDelay | type == "number" and . > 0) and
+  (.parameters.retries.executorPreflightMaxAttempts | type == "number" and . > 0)
+' <<< "$PLAN_VALUES" >/dev/null
+readonly EXECUTION_PLAN_DIGEST="$(jq -r '.digest' <<< "$PLAN_VALUES")"
+readonly MARKETPLACE_COMMIT_SHA="$(jq -r '.workflowBinding.headSha' <<< "$PLAN_VALUES")"
+readonly CLI_VERSION="$(jq -r '.cli.version' <<< "$PLAN_VALUES")"
+readonly CLI_SHA256="$(jq -r '.cli.releaseAssetSha256' <<< "$PLAN_VALUES")"
+readonly PREFLIGHT_GENERATION_ID="$(jq -r '.executorPreflight.generationId' <<< "$PLAN_VALUES")"
+readonly MAX_OUTPUT_TOKENS="$(jq -r '.parameters.tokens.maxOutput' <<< "$PLAN_VALUES")"
+readonly PREFLIGHT_TIMEOUT_MS="$(jq -r '.parameters.timeoutsMs.executorPreflightOuter' <<< "$PLAN_VALUES")"
+readonly PREFLIGHT_TIMEOUT_SECONDS="$(( (PREFLIGHT_TIMEOUT_MS + 999) / 1000 ))"
+readonly PREFLIGHT_KILL_GRACE_MS="$(jq -r '.parameters.timeoutsMs.executorPreflightOuterKillGrace' <<< "$PLAN_VALUES")"
+readonly PREFLIGHT_KILL_GRACE_SECONDS="$(( (PREFLIGHT_KILL_GRACE_MS + 999) / 1000 ))"
+readonly PREFLIGHT_RETRY_DELAY_MS="$(jq -r '.parameters.timeoutsMs.executorPreflightRetryDelay' <<< "$PLAN_VALUES")"
+readonly PREFLIGHT_RETRY_DELAY_SECONDS="$(( (PREFLIGHT_RETRY_DELAY_MS + 999) / 1000 ))"
+readonly MAX_PREFLIGHT_ATTEMPTS="$(jq -r '.parameters.retries.executorPreflightMaxAttempts' <<< "$PLAN_VALUES")"
+readonly PROXY_PORT="$(jq -r '.parameters.proxy.port' <<< "$PLAN_VALUES")"
+readonly MAX_PROCESSES="$(jq -r '.parameters.resources.maxProcesses' <<< "$PLAN_VALUES")"
+readonly ADDRESS_SPACE_BYTES="$(jq -r '.parameters.resources.addressSpaceBytes' <<< "$PLAN_VALUES")"
 
 cleanup_files() {
   rm -f \
     "$CLI_STDOUT" \
     "$CLI_STDERR" \
-    "$ACTIVITY_SLICE" \
-    "${PREFLIGHT_SKILL_MD_A:-}" \
-    "${PREFLIGHT_SKILL_MD_B:-}"
+    "$ACTIVITY_SLICE"
   sudo rm -rf "$PREFLIGHT_ROOT"
   sudo rm -rf "$RUNTIME_ROOT/$PREFLIGHT_GENERATION_ID"
 }
@@ -129,9 +151,10 @@ should_retry_preflight() {
   local outcome="$1"
   local error_class="$2"
   local attempt="$3"
+  local maximum_attempts="$4"
   [ "$outcome" = 'command_failed' ] && \
     [ "$error_class" = 'retryable_http' ] && \
-    [ "$attempt" -lt 2 ]
+    [ "$attempt" -lt "$maximum_attempts" ]
 }
 
 safe_execution_evidence() {
@@ -286,34 +309,8 @@ mark_recovered_command_attempts() {
   ' <<< "$history"
 }
 
-# The two synthetic Skills are immutable inputs for the exact verifyPack trace
-# path. They have no network/write instructions and live only in disposable HOME.
 sudo rm -rf "$PREFLIGHT_ROOT"
-sudo install -d -o packeval -g packeval -m 0700 "$PREFLIGHT_SKILL_A" "$PREFLIGHT_SKILL_B"
 sudo install -d -o root -g root -m 0700 "$PREFLIGHT_RAW"
-PREFLIGHT_SKILL_MD_A=$(mktemp)
-printf '%s\n' \
-  '---' \
-  'name: pack-executor-preflight-a' \
-  'description: Load first, then follow the evaluator task exactly.' \
-  '---' \
-  '' \
-  'Follow the evaluator task exactly. Do not inspect the host or call external tools.' \
-  > "$PREFLIGHT_SKILL_MD_A"
-PREFLIGHT_SKILL_MD_B=$(mktemp)
-printf '%s\n' \
-  '---' \
-  'name: pack-executor-preflight-b' \
-  'description: Load second, then return the exact marker requested by the evaluator.' \
-  '---' \
-  '' \
-  'Follow the evaluator task exactly. Do not inspect the host or call external tools.' \
-  > "$PREFLIGHT_SKILL_MD_B"
-sudo install -o packeval -g packeval -m 0444 \
-  "$PREFLIGHT_SKILL_MD_A" "$PREFLIGHT_SKILL_A/SKILL.md"
-sudo install -o packeval -g packeval -m 0444 \
-  "$PREFLIGHT_SKILL_MD_B" "$PREFLIGHT_SKILL_B/SKILL.md"
-rm -f "$PREFLIGHT_SKILL_MD_A" "$PREFLIGHT_SKILL_MD_B"
 
 COMMAND_ATTEMPTS='[]'
 RETRY_CLEANUP_OUTCOME=not_needed
@@ -325,7 +322,7 @@ FINAL_EXECUTION_EVIDENCE='[]'
 FINAL_RUNNER_TRACE_EVIDENCE='null'
 FINAL_OUTER_EXECUTION='{}'
 
-for ATTEMPT in 1 2; do
+for ATTEMPT in $(seq 1 "$MAX_PREFLIGHT_ATTEMPTS"); do
   : > "$CLI_STDOUT"
   : > "$CLI_STDERR"
   STARTED_MS=$(date +%s%3N)
@@ -345,28 +342,24 @@ for ATTEMPT in 1 2; do
     SKILLSTORE_AGENT_SANDBOX_RUNTIME_ROOT=/opt/pack-evaluator/runtime \
     PACK_EVALUATOR_CHROMIUM_PATH=/usr/bin/google-chrome \
     PACK_EVALUATOR_PROXY_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
-    ANTHROPIC_BASE_URL=http://127.0.0.1:18765 \
+    ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT" \
     ANTHROPIC_AUTH_TOKEN="$PACK_EVALUATOR_PROXY_TOKEN" \
-    CLAUDE_CODE_MAX_OUTPUT_TOKENS="$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" \
+    CLAUDE_CODE_MAX_OUTPUT_TOKENS="$MAX_OUTPUT_TOKENS" \
     NO_PROXY=127.0.0.1,localhost \
-    timeout --signal=TERM --kill-after=5s "${PREFLIGHT_TIMEOUT_SECONDS}s" \
-    prlimit --nproc=256:256 --as=6442450944:6442450944 -- \
+    timeout --signal=TERM --kill-after="${PREFLIGHT_KILL_GRACE_SECONDS}s" "${PREFLIGHT_TIMEOUT_SECONDS}s" \
+    prlimit \
+      --nproc="$MAX_PROCESSES:$MAX_PROCESSES" \
+      --as="$ADDRESS_SPACE_BYTES:$ADDRESS_SPACE_BYTES" \
+      -- \
     "$NODE" "$ORCHESTRATOR" executor-preflight \
+    --plan "$PACK_EVALUATOR_PLAN_PATH" \
+    --artifact-gate "$PACK_EVALUATOR_ARTIFACT_GATE_PATH" \
     --cli "$CLI" \
-    --expected-cli-version "$PACK_PRODUCTION_CLI_VERSION" \
-    --skill-a "$PREFLIGHT_SKILL_A" \
-    --skill-b "$PREFLIGHT_SKILL_B" \
+    --preflight-root "$PREFLIGHT_ROOT/input" \
     --results-dir "$PREFLIGHT_RAW" \
     --evaluator-runtime-root "$RUNTIME_ROOT" \
-    --generation-id "$PREFLIGHT_GENERATION_ID" \
     --evaluator-uid "$(id -u packeval)" \
     --evaluator-gid "$(id -g packeval)" \
-    --task "$PREFLIGHT_TASK" \
-    --model "$PACK_EVALUATOR_RUNNER_MODEL" \
-    --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
-    --agent-timeout-ms "$AGENT_TIMEOUT_MS" \
-    --timeout-ms 360000 \
-    --idle-timeout-ms 240000 \
     --proxy-activity-file "$PACK_EVALUATOR_ACTIVITY_FILE" \
     > "$CLI_STDOUT" 2> "$CLI_STDERR" &
   COMMAND_PID=$!
@@ -461,7 +454,11 @@ for ATTEMPT in 1 2; do
     }')
   COMMAND_ATTEMPTS=$(append_command_attempt "$COMMAND_ATTEMPTS" "$ATTEMPT_RECORD")
 
-  if ! should_retry_preflight "$PREFLIGHT_OUTCOME" "$PREFLIGHT_ERROR_CLASS" "$ATTEMPT"; then
+  if ! should_retry_preflight \
+    "$PREFLIGHT_OUTCOME" \
+    "$PREFLIGHT_ERROR_CLASS" \
+    "$ATTEMPT" \
+    "$MAX_PREFLIGHT_ATTEMPTS"; then
     break
   fi
   if cleanup_processes; then
@@ -471,7 +468,7 @@ for ATTEMPT in 1 2; do
     RETRY_CLEANUP_OUTCOME=$([ "$CLEANUP_RC" -eq 1 ] && printf failed || printf probe_failed)
     break
   fi
-  sleep 5
+  sleep "$PREFLIGHT_RETRY_DELAY_SECONDS"
 done
 
 COMMAND_ATTEMPTS=$(mark_recovered_command_attempts "$COMMAND_ATTEMPTS" "$PREFLIGHT_OUTCOME")
@@ -505,9 +502,10 @@ jq -n \
   --argjson http "$HTTP_EVIDENCE" \
   --arg cleanupOutcome "$CLEANUP_OUTCOME" \
   --arg retryCleanupOutcome "$RETRY_CLEANUP_OUTCOME" \
-  --arg marketplaceCommitSha "$PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA" \
-  --arg cliVersion "$PACK_PRODUCTION_CLI_VERSION" \
-  --arg cliSha256 "$PACK_EVALUATOR_CLI_SHA256" \
+  --arg executionPlanDigest "$EXECUTION_PLAN_DIGEST" \
+  --arg marketplaceCommitSha "$MARKETPLACE_COMMIT_SHA" \
+  --arg cliVersion "$CLI_VERSION" \
+  --arg cliSha256 "$CLI_SHA256" \
   '{
     schemaVersion: "marketplace.pack-executor-preflight/v1",
     mode: "pack-production-node-uid-nested-bwrap",
@@ -520,6 +518,7 @@ jq -n \
     http: $http,
     cleanup: { outcome: $cleanupOutcome, retryOutcome: $retryCleanupOutcome },
     proofBinding: {
+      executionPlanDigest: $executionPlanDigest,
       marketplaceCommitSha: $marketplaceCommitSha,
       cliVersion: $cliVersion,
       cliSha256: $cliSha256

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 : "${PACK_DIAGNOSTICS_DIR:?PACK_DIAGNOSTICS_DIR is required}"
 : "${PACK_EVALUATOR_MAX_OUTPUT_TOKENS:?PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required}"
 : "${PACK_PRODUCTION_CLI_VERSION:?PACK_PRODUCTION_CLI_VERSION is required}"
+: "${PACK_EVALUATOR_RUNNER_MODEL:?PACK_EVALUATOR_RUNNER_MODEL is required}"
+: "${PACK_EVALUATOR_JUDGE_MODEL:?PACK_EVALUATOR_JUDGE_MODEL is required}"
 if ! [[ "$PACK_EVALUATOR_MAX_OUTPUT_TOKENS" =~ ^[1-9][0-9]*$ ]]; then
   echo 'PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer' >&2
   exit 1
@@ -360,8 +362,8 @@ for ATTEMPT in 1 2; do
     --evaluator-uid "$(id -u packeval)" \
     --evaluator-gid "$(id -g packeval)" \
     --task "$PREFLIGHT_TASK" \
-    --model sonnet \
-    --judge-model gpt-5.5 \
+    --model "$PACK_EVALUATOR_RUNNER_MODEL" \
+    --judge-model "$PACK_EVALUATOR_JUDGE_MODEL" \
     --agent-timeout-ms "$AGENT_TIMEOUT_MS" \
     --timeout-ms 360000 \
     --idle-timeout-ms 240000 \

--- a/scripts/pack-production-cancellation-recovery.mjs
+++ b/scripts/pack-production-cancellation-recovery.mjs
@@ -8,6 +8,11 @@ import {
   buildInfrastructureApiEvaluation,
   canonicalJson,
 } from './pack-production.mjs';
+import {
+  CLI_IDENTITY,
+  assertProductionExecutionPolicy,
+  readExecutionPlan,
+} from './pack-production-plan.mjs';
 
 const RECOVERY_SCHEMA = 'marketplace.pack-production-cancellation-recovery/v1';
 const SOURCE_SCHEMA = 'marketplace.pack-production-source-run/v1';
@@ -191,17 +196,18 @@ export function verifySourceMetadata({ source, attempt, workflow, comparison, wo
     fail('Source Generate Pack workflow is missing or too large');
   }
   if (!/^name:\s*Generate Pack\s*$/m.test(workflowSource)) fail('Source workflow name contract is missing');
-  const cliVersion = workflowSource.match(/^\s*PACK_PRODUCTION_CLI_VERSION:\s*'([0-9]+\.[0-9]+\.[0-9]+)'\s*$/m)?.[1];
-  if (!cliVersion) fail('Source workflow does not pin a stable Pack production CLI');
-  if (!/--model sonnet(?:\s|\\|$)/.test(workflowSource) || !/--judge-model gpt-5\.5(?:\s|\\|$)/.test(workflowSource)) {
-    fail('Source workflow evaluator model identities differ from the recovery contract');
-  }
   if (
     !/randomUUID\(\)/.test(workflowSource)
-    || !/\.scenarios\[0\]\.generationId = \$generationId/.test(workflowSource)
-    || !/\.workflowBinding = \{/.test(workflowSource)
-  ) fail('Source workflow lacks immutable generation and workflow binding');
-  return { cliVersion, workflowSourceSha256: sha256(workflowSource) };
+    || !/pack-production-plan\.mjs" create/.test(workflowSource)
+    || !/--run-id "\$GITHUB_RUN_ID"/.test(workflowSource)
+    || !/--run-attempt "\$GITHUB_RUN_ATTEMPT"/.test(workflowSource)
+    || !/--head-sha "\$GITHUB_SHA"/.test(workflowSource)
+    || !/--workflow "\$GITHUB_WORKFLOW"/.test(workflowSource)
+  ) fail('Source workflow lacks canonical execution Plan creation and workflow binding');
+  if (/--(?:model|judge-model|expected-cli-version|agent-timeout-ms|max-candidates)\b/.test(workflowSource)) {
+    fail('Source workflow retains a deprecated execution override');
+  }
+  return { workflowSourceSha256: sha256(workflowSource) };
 }
 
 function artifactRun(artifact, source) {
@@ -349,7 +355,7 @@ async function progressBindings(file, scenarioId) {
   return bindings;
 }
 
-async function diagnosticsBinding(diagnosticsDir, scenario, cliIdentity) {
+async function diagnosticsBinding(diagnosticsDir, scenario, plan, cliIdentity) {
   const directory = resolve(diagnosticsDir);
   let entries;
   try {
@@ -367,6 +373,9 @@ async function diagnosticsBinding(diagnosticsDir, scenario, cliIdentity) {
   const statuses = [];
   if (summary) {
     if (summary.schemaVersion !== 'marketplace.pack-production-evaluate/v1') fail('Evaluator summary schema is invalid');
+    if (summary.executionPlanDigest !== plan.digest) {
+      fail('Evaluator summary execution Plan differs from the immutable plan');
+    }
     if (summary.cliVersion !== cliIdentity.version || summary.cliSha256 !== cliIdentity.sha256) {
       fail('Evaluator summary CLI identity differs from the immutable plan');
     }
@@ -396,18 +405,33 @@ async function diagnosticsBinding(diagnosticsDir, scenario, cliIdentity) {
   return { generationId: unique[0] ?? null, statuses: [...new Set(statuses)] };
 }
 
-function validateCliIdentity(value, expectedVersion) {
+function validateCliIdentity(value) {
   const identity = record(value, 'CLI identity');
-  if (identity.version !== expectedVersion || !/^[0-9]+\.[0-9]+\.[0-9]+$/.test(identity.version || '')) {
-    fail('Plan CLI version differs from the source workflow pin');
+  if (identity.version !== CLI_IDENTITY.version) {
+    fail(`Plan CLI version must be ${CLI_IDENTITY.version}`);
   }
-  if (!SHA256_RE.test(identity.sha256 || '')) fail('Plan CLI checksum is invalid');
-  return { version: identity.version, sha256: identity.sha256 };
+  if (
+    identity.assetName !== CLI_IDENTITY.assetName
+    || identity.releaseAssetSha256 !== CLI_IDENTITY.releaseAssetSha256
+  ) fail('Plan CLI release asset identity is invalid');
+  return {
+    assetName: identity.assetName,
+    version: identity.version,
+    sha256: identity.releaseAssetSha256,
+  };
 }
 
 function planBinding(plan, source, scenario) {
   const binding = plan.workflowBinding;
-  const expectedKeys = ['repository', 'workflow', 'runId', 'runAttempt', 'commitSha', 'scenarioId'];
+  const expectedKeys = [
+    'repository',
+    'workflow',
+    'runId',
+    'runAttempt',
+    'headSha',
+    'scenarioId',
+    'generationId',
+  ];
   if (
     !binding
     || typeof binding !== 'object'
@@ -417,8 +441,9 @@ function planBinding(plan, source, scenario) {
     || binding.workflow !== source.workflowName
     || String(binding.runId) !== String(source.runId)
     || Number(binding.runAttempt) !== source.runAttempt
-    || binding.commitSha !== source.commitSha
+    || binding.headSha !== source.commitSha
     || binding.scenarioId !== scenario.id
+    || binding.generationId !== scenario.generationId
   ) fail('Immutable plan workflow binding differs from the cancelled source run');
 }
 
@@ -459,31 +484,14 @@ export async function prepareCancellationRecovery({
   let plan;
   let cliIdentity;
   try {
-    plan = await readJson(resolve(planDir, 'plan.json'), MAX_JSON_BYTES, 'immutable plan');
-    cliIdentity = validateCliIdentity(
-      await readJson(resolve(planDir, 'cli-identity.json'), MAX_JSON_BYTES, 'CLI identity'),
-      sourceVerification.cliVersion,
+    plan = assertProductionExecutionPolicy(
+      await readExecutionPlan(resolve(planDir, 'plan.json')),
     );
+    cliIdentity = validateCliIdentity(plan.executionBinding.cli);
   } catch (error) {
     const result = unrecoverable(source, error?.code === 'ENOENT'
       ? 'immutable_plan_download_missing'
-      : 'immutable_plan_or_cli_identity_invalid', {
-      artifactVerification,
-      sourceVerification,
-    });
-    await writeJson(resolve(output, 'recovery-result.json'), result);
-    return result;
-  }
-  if (plan.schemaVersion !== 'pack-production-queue/v1' || !Array.isArray(plan.scenarios)) {
-    const result = unrecoverable(source, 'immutable_plan_or_cli_identity_invalid', {
-      artifactVerification,
-      sourceVerification,
-    });
-    await writeJson(resolve(output, 'recovery-result.json'), result);
-    return result;
-  }
-  if (plan.scenarios.length !== 1 || plan.source !== 'signals') {
-    const result = unrecoverable(source, 'immutable_plan_has_no_single_admitted_scenario', {
+      : 'immutable_execution_plan_invalid', {
       artifactVerification,
       sourceVerification,
     });
@@ -492,7 +500,7 @@ export async function prepareCancellationRecovery({
   }
   let scenario;
   try {
-    scenario = validateScenario(plan.scenarios[0]);
+    scenario = validateScenario(plan.scenario);
     planBinding(plan, source, scenario);
   } catch {
     const result = unrecoverable(source, 'immutable_plan_scenario_or_binding_invalid', {
@@ -505,7 +513,7 @@ export async function prepareCancellationRecovery({
   let diagnostics;
   try {
     diagnostics = artifactVerification.diagnosticsArtifact
-      ? await diagnosticsBinding(diagnosticsDir, scenario, cliIdentity)
+      ? await diagnosticsBinding(diagnosticsDir, scenario, plan, cliIdentity)
       : { generationId: null, statuses: [] };
   } catch {
     const result = unrecoverable(source, 'diagnostics_binding_invalid', {
@@ -553,12 +561,16 @@ export async function prepareCancellationRecovery({
     planArtifactId: artifactVerification.planArtifact.id,
     diagnosticsArtifactId: artifactVerification.diagnosticsArtifact?.id ?? null,
     planSha256: sha256(canonicalJson(plan)),
+    executionPlanDigest: plan.digest,
     cliIdentitySha256: sha256(canonicalJson(cliIdentity)),
     diagnosticsBindingSha256: artifactVerification.diagnosticsArtifact
       ? sha256(canonicalJson(diagnostics))
       : null,
     cliVersion: cliIdentity.version,
+    cliAssetName: cliIdentity.assetName,
     cliSha256: cliIdentity.sha256,
+    runner: plan.executionBinding.models.runner,
+    judge: plan.executionBinding.models.judge,
     workflowSourceSha256: sourceVerification.workflowSourceSha256,
   };
   const diagnosticSha256 = sha256(canonicalJson(recoveryBinding));
@@ -570,8 +582,13 @@ export async function prepareCancellationRecovery({
     commitSha: source.commitSha,
     cliVersion: cliIdentity.version,
     cliSha256: cliIdentity.sha256,
-    model: 'sonnet',
-    judgeModel: 'gpt-5.5',
+    model: plan.executionBinding.models.runner.identity,
+    modelRevision: plan.executionBinding.models.runner.revision,
+    modelPinType: plan.executionBinding.models.runner.pinType,
+    judgeModel: plan.executionBinding.models.judge.identity,
+    judgeModelRevision: plan.executionBinding.models.judge.revision,
+    judgeModelPinType: plan.executionBinding.models.judge.pinType,
+    executionPlanDigest: plan.digest,
   };
   const evaluation = buildInfrastructureApiEvaluation({
     scenario,

--- a/scripts/pack-production-plan.mjs
+++ b/scripts/pack-production-plan.mjs
@@ -1,0 +1,860 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  writeFile,
+} from 'node:fs/promises';
+import { basename, dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const EXECUTION_PLAN_SCHEMA = 'marketplace.pack-production-execution-plan/v1';
+export const ARTIFACT_STATE_SCHEMA = 'marketplace.pack-production-artifact-state/v1';
+export const ARTIFACT_GATE_SCHEMA = 'marketplace.pack-production-artifact-gate/v1';
+export const EXPECTED_REPOSITORY = 'aiskillstore/marketplace';
+export const EXPECTED_WORKFLOW = 'Generate Pack';
+export const CLI_IDENTITY = Object.freeze({
+  version: '2.14.2',
+  assetName: 'skillstore-cli-linux-x64',
+  releaseAssetSha256: '21b1967e134622a40ae4d312278fa10d136103f0148887252f61e4e3b4536674',
+});
+export const MODEL_IDENTITIES = Object.freeze({
+  runner: Object.freeze({
+    identity: 'claude-sonnet-5',
+    revision: 'workflow-pinned alias',
+    pinType: 'workflow-pinned alias',
+  }),
+  judge: Object.freeze({
+    identity: 'gpt-5.5',
+    revision: 'workflow-pinned alias',
+    pinType: 'workflow-pinned alias',
+  }),
+});
+
+export const EXECUTOR_PREFLIGHT_TASK = [
+  'Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second.',
+  'After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.',
+].join(' ');
+export const EXECUTOR_PREFLIGHT_SKILLS = Object.freeze([
+  Object.freeze({
+    canonicalId: 'pack-executor-preflight-a',
+    version: '1.0.0',
+    contents: [
+      '---',
+      'name: pack-executor-preflight-a',
+      'description: Load first, then follow the evaluator task exactly.',
+      '---',
+      '',
+      'Follow the evaluator task exactly. Do not inspect the host or call external tools.',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    canonicalId: 'pack-executor-preflight-b',
+    version: '1.0.0',
+    contents: [
+      '---',
+      'name: pack-executor-preflight-b',
+      'description: Load second, then return the exact marker requested by the evaluator.',
+      '---',
+      '',
+      'Follow the evaluator task exactly. Do not inspect the host or call external tools.',
+      '',
+    ].join('\n'),
+  }),
+]);
+
+export const EXECUTION_SOURCE_FILES = Object.freeze([
+  '.github/workflows/generate-packs.yml',
+  'scripts/configure-pack-evaluator-bwrap.sh',
+  'scripts/configure-pack-evaluator-egress.sh',
+  'scripts/pack-evaluator-bwrap.apparmor',
+  'scripts/pack-evaluator-contract-smoke.mjs',
+  'scripts/pack-evaluator-preflight.sh',
+  'scripts/pack-evaluator-proxy.mjs',
+  'scripts/pack-production-plan.mjs',
+  'scripts/pack-production.mjs',
+]);
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_SCENARIO_RE = /^[a-z0-9][a-z0-9-]{0,79}$/;
+const MAX_PLAN_BYTES = 4 * 1024 * 1024;
+const ARTIFACT_TRANSITIONS = new Map([
+  ['plan', 'pack-production-plan'],
+  ['evaluate', 'pack-production-evaluation'],
+  ['persist', 'pack-production-persisted'],
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function object(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function exactKeys(value, expected, label) {
+  object(value, label);
+  const actual = Object.keys(value).sort();
+  if (canonicalJson(actual) !== canonicalJson([...expected].sort())) {
+    fail(`${label} has unexpected fields`);
+  }
+}
+
+function nonEmptyString(value, label) {
+  if (typeof value !== 'string' || !value) fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) fail(`${label} must be a positive integer`);
+  return value;
+}
+
+function normalizeJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeJson(entry)]),
+    );
+  }
+  fail('Value is not canonical JSON');
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(normalizeJson(value));
+}
+
+export function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function withoutDigest(value) {
+  const { digest: _digest, ...unsigned } = value;
+  return unsigned;
+}
+
+export function executionPlanDigest(plan) {
+  return sha256(canonicalJson(withoutDigest(plan)));
+}
+
+function expectedParameters(slotCount) {
+  positiveInteger(slotCount, 'Plan capability slot count');
+  const maxCandidates = 2;
+  const hiddenVariants = 3;
+  const maxPackSkills = 4;
+  const maxBestSingleCompetitors = slotCount * maxCandidates;
+  const estimatedRequests = 2
+    + 4
+    + (3 * slotCount * maxCandidates)
+    + 3
+    + (hiddenVariants * (maxPackSkills + 2))
+    + (2 * hiddenVariants)
+    + (3 * hiddenVariants * maxBestSingleCompetitors)
+    + (hiddenVariants * maxPackSkills * (maxPackSkills + 1));
+  return {
+    generation: {
+      autoPublishThreshold: 8,
+      baselineDelta: 1,
+      finalRuns: 3,
+      maxCandidates,
+      pick: 4,
+      runs: 1,
+      threshold: 7,
+    },
+    proxy: {
+      allowedModels: [
+        MODEL_IDENTITIES.runner.identity,
+        MODEL_IDENTITIES.judge.identity,
+      ],
+      contractProbes: 2,
+      estimatedRequests,
+      hiddenVariants,
+      maxBestSingleCompetitors,
+      maxCliPreflightRequests: 4,
+      maxConcurrent: 4,
+      maxPackSkills,
+      maxRequests: 256,
+      port: 18765,
+      reservedRequests: estimatedRequests + 64,
+      toolLoopHeadroom: 64,
+      upstreamUrl: 'https://helm.easymeta.au',
+    },
+    resources: {
+      addressSpaceBytes: 6_442_450_944,
+      evaluatorOutputBytes: 16_777_216,
+      maxProcesses: 256,
+      proxyActivityBytes: 1_048_576,
+      resultBytes: 268_435_456,
+      resultFiles: 1000,
+    },
+    retries: {
+      agentMaxRetries: 1,
+      contractMaxRetries: 0,
+      executorPreflightMaxAttempts: 2,
+    },
+    runtime: {
+      claudeCodeVersion: '2.1.210',
+      codexVersion: '0.139.0',
+    },
+    timeoutsMs: {
+      agent: 360_000,
+      contract: 30_000,
+      evaluationBudget: 13_800_000,
+      evaluatorHeartbeat: 60_000,
+      executorPreflight: 360_000,
+      executorPreflightAgent: 180_000,
+      executorPreflightHeartbeat: 30_000,
+      executorPreflightIdle: 240_000,
+      executorPreflightOuterKillGrace: 5_000,
+      executorPreflightOuter: 420_000,
+      executorPreflightRetryDelay: 5_000,
+      minimumFallback: 2_700_000,
+      outerEvaluation: 14_400_000,
+      outerEvaluationKillGrace: 30_000,
+      processKillGrace: 3_000,
+      proxyRequest: 600_000,
+      proxyTtl: 14_400_000,
+      scenario: 7_200_000,
+      scenarioIdle: 1_200_000,
+    },
+    tokens: {
+      contractProbeOutput: 16,
+      maxOutput: 16_384,
+    },
+  };
+}
+
+export function productionExecutionParameters(slotCount) {
+  return structuredClone(expectedParameters(slotCount));
+}
+
+function validateModel(value, label) {
+  exactKeys(value, ['identity', 'revision', 'pinType'], label);
+  nonEmptyString(value.identity, `${label} identity`);
+  if (
+    value.revision !== 'workflow-pinned alias'
+    || value.pinType !== 'workflow-pinned alias'
+  ) {
+    fail(`${label} must explicitly use workflow-pinned alias because no immutable provider revision is available`);
+  }
+}
+
+function validateParameters(value) {
+  exactKeys(
+    value,
+    ['generation', 'proxy', 'resources', 'retries', 'runtime', 'timeoutsMs', 'tokens'],
+    'Execution Plan parameters',
+  );
+  for (const [group, entries] of Object.entries(value)) {
+    object(entries, `Execution Plan parameters.${group}`);
+    for (const [name, entry] of Object.entries(entries)) {
+      if (group === 'proxy' && name === 'allowedModels') {
+        if (!Array.isArray(entry) || entry.length !== 2 || entry.some((item) => typeof item !== 'string')) {
+          fail('Execution Plan proxy allowedModels must contain two model identities');
+        }
+      } else if (group === 'proxy' && ['upstreamUrl'].includes(name)) {
+        nonEmptyString(entry, `Execution Plan parameters.${group}.${name}`);
+      } else if (group === 'runtime') {
+        nonEmptyString(entry, `Execution Plan parameters.${group}.${name}`);
+      } else if (group === 'retries' && name === 'contractMaxRetries' && entry === 0) {
+        // The contract probes are intentionally single-attempt.
+      } else {
+        positiveInteger(entry, `Execution Plan parameters.${group}.${name}`);
+      }
+    }
+  }
+  if (value.proxy.reservedRequests > value.proxy.maxRequests) {
+    fail('Execution Plan proxy request reservation exceeds its budget');
+  }
+}
+
+function validateScenario(value) {
+  object(value, 'Execution Plan scenario');
+  if (!SAFE_SCENARIO_RE.test(value.id || '')) fail('Execution Plan scenario id is invalid');
+  if (!UUID_RE.test(value.generationId || '')) fail('Execution Plan scenario generationId is invalid');
+  nonEmptyString(value.task, 'Execution Plan scenario task');
+  if (!Array.isArray(value.capabilitySlots) || value.capabilitySlots.length < 1 || value.capabilitySlots.length > 4) {
+    fail('Execution Plan scenario capability slots are outside the production bound');
+  }
+  if (!Array.isArray(value.requiredArtifacts) || value.requiredArtifacts.length < 1) {
+    fail('Execution Plan scenario requires at least one artifact');
+  }
+}
+
+function validateSource(value) {
+  exactKeys(
+    value,
+    ['repositoryTreeSha', 'skillsTreeSha', 'skillsManifest', 'files'],
+    'Execution Plan source',
+  );
+  if (!SHA_RE.test(value.repositoryTreeSha || '') || !SHA_RE.test(value.skillsTreeSha || '')) {
+    fail('Execution Plan git tree identity is invalid');
+  }
+  exactKeys(value.skillsManifest, ['sha256', 'fileCount', 'totalBytes'], 'Execution Plan Skills manifest');
+  if (
+    !SHA256_RE.test(value.skillsManifest.sha256 || '')
+    || !Number.isSafeInteger(value.skillsManifest.fileCount)
+    || value.skillsManifest.fileCount < 1
+    || !Number.isSafeInteger(value.skillsManifest.totalBytes)
+    || value.skillsManifest.totalBytes < 1
+  ) fail('Execution Plan Skills manifest identity is invalid');
+  if (!Array.isArray(value.files) || value.files.length < 1) {
+    fail('Execution Plan source file identities are missing');
+  }
+  const paths = new Set();
+  for (const [index, entry] of value.files.entries()) {
+    exactKeys(entry, ['path', 'gitBlobSha', 'sha256'], `Execution Plan source file ${index + 1}`);
+    if (
+      typeof entry.path !== 'string'
+      || entry.path.startsWith('/')
+      || entry.path.includes('..')
+      || paths.has(entry.path)
+      || !SHA_RE.test(entry.gitBlobSha || '')
+      || !SHA256_RE.test(entry.sha256 || '')
+    ) fail(`Execution Plan source file ${index + 1} identity is invalid`);
+    paths.add(entry.path);
+  }
+}
+
+function validateEvaluatorInputs(value, plan) {
+  exactKeys(
+    value,
+    ['configSha256', 'promptSha256', 'rulesSha256', 'scenarioSha256'],
+    'Execution Plan evaluator inputs',
+  );
+  if (Object.values(value).some((digest) => !SHA256_RE.test(digest || ''))) {
+    fail('Execution Plan evaluator input digest is invalid');
+  }
+  const expected = {
+    configSha256: sha256(canonicalJson({
+      cli: plan.executionBinding.cli,
+      models: plan.executionBinding.models,
+      parameters: plan.executionBinding.parameters,
+    })),
+    promptSha256: sha256(plan.scenario.task),
+    rulesSha256: sha256(canonicalJson({
+      capabilitySlots: plan.scenario.capabilitySlots,
+      requiredArtifacts: plan.scenario.requiredArtifacts,
+    })),
+    scenarioSha256: sha256(canonicalJson(plan.scenario)),
+  };
+  if (canonicalJson(value) !== canonicalJson(expected)) {
+    fail('Execution Plan evaluator input digest differs from its bound bytes');
+  }
+}
+
+function validateExecutorPreflight(value) {
+  exactKeys(value, ['generationId', 'skillA', 'skillB', 'task'], 'Execution Plan executor preflight');
+  if (!UUID_RE.test(value.generationId || '')) fail('Execution Plan executor preflight generationId is invalid');
+  nonEmptyString(value.task, 'Execution Plan executor preflight task');
+  for (const [name, skill] of [['skillA', value.skillA], ['skillB', value.skillB]]) {
+    exactKeys(skill, ['canonicalId', 'version', 'contentSha256'], `Execution Plan executor preflight ${name}`);
+    nonEmptyString(skill.canonicalId, `Execution Plan executor preflight ${name} canonicalId`);
+    nonEmptyString(skill.version, `Execution Plan executor preflight ${name} version`);
+    if (!SHA256_RE.test(skill.contentSha256 || '')) {
+      fail(`Execution Plan executor preflight ${name} digest is invalid`);
+    }
+  }
+  if (value.skillA.canonicalId === value.skillB.canonicalId) {
+    fail('Execution Plan executor preflight Skills must be distinct');
+  }
+}
+
+export function validateExecutionPlan(plan) {
+  exactKeys(
+    plan,
+    ['schemaVersion', 'digest', 'workflowBinding', 'executionBinding', 'scenario'],
+    'Execution Plan',
+  );
+  if (plan.schemaVersion !== EXECUTION_PLAN_SCHEMA) {
+    fail(`Unsupported execution Plan schema: ${plan.schemaVersion}`);
+  }
+  if (!SHA256_RE.test(plan.digest || '') || plan.digest !== executionPlanDigest(plan)) {
+    fail('execution Plan digest mismatch');
+  }
+  validateScenario(plan.scenario);
+  exactKeys(
+    plan.workflowBinding,
+    ['repository', 'workflow', 'runId', 'runAttempt', 'headSha', 'scenarioId', 'generationId'],
+    'Execution Plan workflow binding',
+  );
+  const workflow = plan.workflowBinding;
+  if (
+    workflow.repository !== EXPECTED_REPOSITORY
+    || workflow.workflow !== EXPECTED_WORKFLOW
+    || !/^[1-9][0-9]*$/.test(workflow.runId || '')
+    || !Number.isSafeInteger(workflow.runAttempt)
+    || workflow.runAttempt < 1
+    || !SHA_RE.test(workflow.headSha || '')
+    || workflow.scenarioId !== plan.scenario.id
+    || workflow.generationId !== plan.scenario.generationId
+  ) fail('Execution Plan workflow binding is invalid or internally inconsistent');
+  exactKeys(
+    plan.executionBinding,
+    ['cli', 'evaluatorInputs', 'executorPreflight', 'models', 'parameters', 'source'],
+    'Execution Plan execution binding',
+  );
+  exactKeys(plan.executionBinding.models, ['runner', 'judge'], 'Execution Plan models');
+  validateModel(plan.executionBinding.models.runner, 'Execution Plan runner');
+  validateModel(plan.executionBinding.models.judge, 'Execution Plan judge');
+  exactKeys(
+    plan.executionBinding.cli,
+    ['assetName', 'releaseAssetSha256', 'version'],
+    'Execution Plan CLI',
+  );
+  nonEmptyString(plan.executionBinding.cli.assetName, 'Execution Plan CLI asset name');
+  nonEmptyString(plan.executionBinding.cli.version, 'Execution Plan CLI version');
+  if (!SHA256_RE.test(plan.executionBinding.cli.releaseAssetSha256 || '')) {
+    fail('Execution Plan CLI release asset SHA-256 is invalid');
+  }
+  validateParameters(plan.executionBinding.parameters);
+  validateEvaluatorInputs(plan.executionBinding.evaluatorInputs, plan);
+  validateExecutorPreflight(plan.executionBinding.executorPreflight);
+  validateSource(plan.executionBinding.source);
+  return plan;
+}
+
+export function assertProductionExecutionPolicy(plan) {
+  validateExecutionPlan(plan);
+  const expected = {
+    models: MODEL_IDENTITIES,
+  };
+  for (const [name, actual] of Object.entries({
+    models: plan.executionBinding.models,
+  })) {
+    if (canonicalJson(actual) !== canonicalJson(expected[name])) {
+      fail(`Execution Plan ${name} differs from the production policy`);
+    }
+  }
+  const paths = plan.executionBinding.source.files.map((entry) => entry.path).sort();
+  if (canonicalJson(paths) !== canonicalJson([...EXECUTION_SOURCE_FILES].sort())) {
+    fail('Execution Plan source file set differs from the production policy');
+  }
+  return plan;
+}
+
+async function readBoundedRegularFile(file, maximumBytes, label) {
+  const path = resolve(file);
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) fail(`${label} must be a regular file`);
+  if (metadata.size < 1 || metadata.size > maximumBytes) {
+    fail(`${label} is outside its ${maximumBytes}-byte bound`);
+  }
+  return readFile(path);
+}
+
+async function readCanonicalJson(file, label) {
+  const bytes = await readBoundedRegularFile(file, MAX_PLAN_BYTES, label);
+  let value;
+  try {
+    value = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+  if (!bytes.equals(Buffer.from(canonicalJson(value)))) {
+    fail(`${label} must contain canonical JSON bytes`);
+  }
+  return value;
+}
+
+export async function readExecutionPlan(file) {
+  return validateExecutionPlan(await readCanonicalJson(file, 'Execution Plan'));
+}
+
+export async function verifyRuntimeSourceFiles(plan, runtimeFiles) {
+  assertProductionExecutionPolicy(plan);
+  if (!runtimeFiles || typeof runtimeFiles !== 'object' || Array.isArray(runtimeFiles)) {
+    fail('Runtime source file mapping is required');
+  }
+  const expectedByPath = new Map(
+    plan.executionBinding.source.files.map((entry) => [entry.path, entry]),
+  );
+  for (const [sourcePath, runtimePath] of Object.entries(runtimeFiles)) {
+    const expected = expectedByPath.get(sourcePath);
+    if (!expected) fail(`Runtime source is not bound by the execution Plan: ${sourcePath}`);
+    if (sha256(await readFile(runtimePath)) !== expected.sha256) {
+      fail(`Runtime source differs from the execution Plan: ${sourcePath}`);
+    }
+  }
+  return true;
+}
+
+export async function writeCanonicalJsonAtomic(file, value, mode = 0o600) {
+  const target = resolve(file);
+  await mkdir(dirname(target), { recursive: true });
+  const temporary = resolve(dirname(target), `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporary, canonicalJson(value), { mode, flag: 'wx' });
+    await chmod(temporary, mode);
+    await rename(temporary, target);
+  } catch (error) {
+    await import('node:fs/promises').then(({ rm }) => rm(temporary, { force: true })).catch(() => {});
+    throw error;
+  }
+}
+
+export async function writeExecutionPlanAtomic(file, plan) {
+  validateExecutionPlan(plan);
+  await writeCanonicalJsonAtomic(file, plan);
+}
+
+function git(repoRoot, args, label) {
+  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  if (result.status !== 0) fail(`Cannot read ${label}: ${result.stderr || result.stdout}`);
+  return result.stdout.trim();
+}
+
+async function directoryManifest(root) {
+  const base = resolve(root);
+  const files = [];
+  const visit = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const path = resolve(directory, entry.name);
+      if (entry.isSymbolicLink()) fail(`Skills input contains a symbolic link: ${path}`);
+      if (entry.isDirectory()) {
+        await visit(path);
+        continue;
+      }
+      if (!entry.isFile()) fail(`Skills input contains a non-regular entry: ${path}`);
+      const bytes = await readFile(path);
+      files.push({
+        path: relative(base, path).split(sep).join('/'),
+        sha256: sha256(bytes),
+        size: bytes.length,
+      });
+    }
+  };
+  await visit(base);
+  if (files.length < 1) fail('Skills input manifest is empty');
+  return {
+    sha256: sha256(canonicalJson(files)),
+    fileCount: files.length,
+    totalBytes: files.reduce((total, entry) => total + entry.size, 0),
+  };
+}
+
+function cliVersion(cli) {
+  const result = spawnSync(cli, ['--version'], { encoding: 'utf8' });
+  if (result.status !== 0) fail(`Cannot read CLI version: ${result.stderr || result.stdout}`);
+  const version = `${result.stdout}\n${result.stderr}`.match(
+    /[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z._-]+)?/,
+  )?.[0];
+  if (!version) fail('CLI version output is not parseable');
+  return version;
+}
+
+export async function verifyCliAgainstPlan(plan, cliPath) {
+  validateExecutionPlan(plan);
+  const cli = resolve(cliPath);
+  const bytes = await readBoundedRegularFile(cli, 512 * 1024 * 1024, 'Skillstore CLI');
+  const identity = plan.executionBinding.cli;
+  if (sha256(bytes) !== identity.releaseAssetSha256) {
+    fail('CLI bytes differ from the execution Plan release asset SHA-256');
+  }
+  if (cliVersion(cli) !== identity.version) {
+    fail('CLI version differs from the execution Plan');
+  }
+  return identity;
+}
+
+async function sourceIdentity(repoRoot, headSha) {
+  const root = resolve(repoRoot);
+  const actualHead = git(root, ['rev-parse', 'HEAD'], 'repository HEAD');
+  if (actualHead !== headSha) fail('Repository HEAD differs from the execution Plan workflow binding');
+  const files = [];
+  for (const path of EXECUTION_SOURCE_FILES) {
+    const bytes = await readBoundedRegularFile(resolve(root, path), MAX_PLAN_BYTES, `source file ${path}`);
+    files.push({
+      path,
+      gitBlobSha: git(root, ['rev-parse', `HEAD:${path}`], `git blob ${path}`),
+      sha256: sha256(bytes),
+    });
+  }
+  return {
+    repositoryTreeSha: git(root, ['rev-parse', 'HEAD^{tree}'], 'repository tree'),
+    skillsTreeSha: git(root, ['rev-parse', 'HEAD:skills'], 'Skills tree'),
+    skillsManifest: await directoryManifest(resolve(root, 'skills')),
+    files,
+  };
+}
+
+export async function verifySourceAgainstPlan(plan, repoRoot) {
+  assertProductionExecutionPolicy(plan);
+  const actual = await sourceIdentity(repoRoot, plan.workflowBinding.headSha);
+  if (canonicalJson(actual) !== canonicalJson(plan.executionBinding.source)) {
+    fail('Repository source identity differs from the execution Plan');
+  }
+  return actual;
+}
+
+export async function verifySkillsAgainstPlan(plan, skillsDir) {
+  validateExecutionPlan(plan);
+  const actual = await directoryManifest(skillsDir);
+  if (canonicalJson(actual) !== canonicalJson(plan.executionBinding.source.skillsManifest)) {
+    fail('Skills bytes differ from the execution Plan manifest');
+  }
+  return actual;
+}
+
+function parseQueuePlan(bytes) {
+  let queue;
+  try {
+    queue = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail('Queue response is not valid JSON');
+  }
+  if (
+    queue?.schemaVersion !== 'pack-production-queue/v1'
+    || queue.source !== 'signals'
+    || !Array.isArray(queue.scenarios)
+    || queue.scenarios.length !== 1
+  ) fail('Execution Plan requires exactly one signal-admitted queue scenario');
+  return queue;
+}
+
+export async function createExecutionPlan({
+  queueFile,
+  generationId,
+  repository,
+  workflow,
+  runId,
+  runAttempt,
+  headSha,
+  repoRoot,
+  cliPath,
+}) {
+  if (!UUID_RE.test(generationId || '')) fail('Execution Plan generationId must be a UUID');
+  if (
+    repository !== EXPECTED_REPOSITORY
+    || workflow !== EXPECTED_WORKFLOW
+    || !/^[1-9][0-9]*$/.test(runId || '')
+    || !Number.isSafeInteger(runAttempt)
+    || runAttempt < 1
+    || !SHA_RE.test(headSha || '')
+  ) fail('Execution Plan workflow invocation is invalid');
+  const queueBytes = await readBoundedRegularFile(queueFile, MAX_PLAN_BYTES, 'queue response');
+  const queue = parseQueuePlan(queueBytes);
+  const plannedScenario = { ...queue.scenarios[0], generationId };
+  validateScenario(plannedScenario);
+  const parameters = expectedParameters(plannedScenario.capabilitySlots.length);
+  const source = await sourceIdentity(repoRoot, headSha);
+  const preflight = {
+    generationId: '00000000-0000-4000-8000-000000000001',
+    skillA: {
+      canonicalId: EXECUTOR_PREFLIGHT_SKILLS[0].canonicalId,
+      contentSha256: sha256(EXECUTOR_PREFLIGHT_SKILLS[0].contents),
+      version: EXECUTOR_PREFLIGHT_SKILLS[0].version,
+    },
+    skillB: {
+      canonicalId: EXECUTOR_PREFLIGHT_SKILLS[1].canonicalId,
+      contentSha256: sha256(EXECUTOR_PREFLIGHT_SKILLS[1].contents),
+      version: EXECUTOR_PREFLIGHT_SKILLS[1].version,
+    },
+    task: EXECUTOR_PREFLIGHT_TASK,
+  };
+  const executionBinding = {
+    cli: { ...CLI_IDENTITY },
+    evaluatorInputs: null,
+    executorPreflight: preflight,
+    models: structuredClone(MODEL_IDENTITIES),
+    parameters,
+    source,
+  };
+  const unsigned = {
+    schemaVersion: EXECUTION_PLAN_SCHEMA,
+    workflowBinding: {
+      repository,
+      workflow,
+      runId,
+      runAttempt,
+      headSha,
+      scenarioId: plannedScenario.id,
+      generationId,
+    },
+    executionBinding,
+    scenario: plannedScenario,
+  };
+  executionBinding.evaluatorInputs = {
+    configSha256: sha256(canonicalJson({
+      cli: executionBinding.cli,
+      models: executionBinding.models,
+      parameters,
+    })),
+    promptSha256: sha256(plannedScenario.task),
+    rulesSha256: sha256(canonicalJson({
+      capabilitySlots: plannedScenario.capabilitySlots,
+      requiredArtifacts: plannedScenario.requiredArtifacts,
+    })),
+    scenarioSha256: sha256(canonicalJson(plannedScenario)),
+  };
+  const plan = { ...unsigned, digest: sha256(canonicalJson(unsigned)) };
+  assertProductionExecutionPolicy(plan);
+  await verifyCliAgainstPlan(plan, cliPath);
+  return plan;
+}
+
+function artifactGateDigest(gate) {
+  return sha256(canonicalJson(withoutDigest(gate)));
+}
+
+function validateArtifactState(state, plan) {
+  exactKeys(
+    state,
+    ['schemaVersion', 'workflowBinding', 'producer', 'artifact'],
+    'Artifact state',
+  );
+  if (state.schemaVersion !== ARTIFACT_STATE_SCHEMA) {
+    fail(`Unsupported artifact state schema: ${state.schemaVersion}`);
+  }
+  exactKeys(state.producer, ['name', 'status'], 'Artifact producer state');
+  exactKeys(state.artifact, ['name', 'status', 'planDigest'], 'Artifact download state');
+  if (state.producer.status !== 'success') fail('artifact producer status must be success');
+  if (state.artifact.status !== 'downloaded') fail('artifact status must be downloaded');
+  if (
+    ARTIFACT_TRANSITIONS.get(state.producer.name) !== state.artifact.name
+    || state.artifact.planDigest !== plan.digest
+    || canonicalJson(state.workflowBinding) !== canonicalJson(plan.workflowBinding)
+  ) fail('artifact state differs from the execution Plan');
+  return state;
+}
+
+export async function createArtifactGate(planFile, stateFile, outputFile) {
+  const plan = await readExecutionPlan(planFile);
+  const state = validateArtifactState(
+    await readCanonicalJson(stateFile, 'Artifact state'),
+    plan,
+  );
+  const unsigned = {
+    schemaVersion: ARTIFACT_GATE_SCHEMA,
+    planDigest: plan.digest,
+    workflowBinding: plan.workflowBinding,
+    producer: state.producer,
+    artifact: state.artifact,
+  };
+  const gate = { ...unsigned, digest: sha256(canonicalJson(unsigned)) };
+  await writeCanonicalJsonAtomic(outputFile, gate);
+  return gate;
+}
+
+function validateArtifactGateValue(gate, plan, expectedProducer, expectedArtifact) {
+  exactKeys(
+    gate,
+    ['schemaVersion', 'planDigest', 'workflowBinding', 'producer', 'artifact', 'digest'],
+    'Artifact gate',
+  );
+  if (
+    gate.schemaVersion !== ARTIFACT_GATE_SCHEMA
+    || !SHA256_RE.test(gate.digest || '')
+    || gate.digest !== artifactGateDigest(gate)
+  ) fail('Artifact gate digest is invalid');
+  validateArtifactState({
+    schemaVersion: ARTIFACT_STATE_SCHEMA,
+    workflowBinding: gate.workflowBinding,
+    producer: gate.producer,
+    artifact: gate.artifact,
+  }, plan);
+  if (
+    gate.planDigest !== plan.digest
+    || gate.producer.name !== expectedProducer
+    || gate.artifact.name !== expectedArtifact
+  ) fail('Artifact gate does not authorize this runtime transition');
+  return gate;
+}
+
+export async function readArtifactGate(file, plan, expectedProducer, expectedArtifact) {
+  return validateArtifactGateValue(
+    await readCanonicalJson(file, 'Artifact gate'),
+    plan,
+    expectedProducer,
+    expectedArtifact,
+  );
+}
+
+export function planRuntimeValues(plan) {
+  assertProductionExecutionPolicy(plan);
+  return {
+    digest: plan.digest,
+    workflowBinding: plan.workflowBinding,
+    cli: plan.executionBinding.cli,
+    models: plan.executionBinding.models,
+    parameters: plan.executionBinding.parameters,
+    executorPreflight: plan.executionBinding.executorPreflight,
+  };
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = { command };
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith('--')) fail(`Unexpected argument: ${token}`);
+    const name = token.slice(2);
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) fail(`Missing value for --${name}`);
+    args[name] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function required(args, name) {
+  if (!args[name]) fail(`--${name} is required`);
+  return args[name];
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === 'create') {
+    const plan = await createExecutionPlan({
+      queueFile: required(args, 'queue'),
+      generationId: required(args, 'generation-id'),
+      repository: required(args, 'repository'),
+      workflow: required(args, 'workflow'),
+      runId: required(args, 'run-id'),
+      runAttempt: Number(required(args, 'run-attempt')),
+      headSha: required(args, 'head-sha'),
+      repoRoot: required(args, 'repo-root'),
+      cliPath: required(args, 'cli'),
+    });
+    await writeExecutionPlanAtomic(required(args, 'output'), plan);
+    process.stdout.write(`${JSON.stringify({ digest: plan.digest })}\n`);
+    return;
+  }
+  if (args.command === 'verify-inputs') {
+    const plan = await readExecutionPlan(required(args, 'plan'));
+    await verifySourceAgainstPlan(plan, required(args, 'repo-root'));
+    await verifyCliAgainstPlan(plan, required(args, 'cli'));
+    process.stdout.write(`${JSON.stringify({ digest: plan.digest, outcome: 'passed' })}\n`);
+    return;
+  }
+  if (args.command === 'values') {
+    const plan = await readExecutionPlan(required(args, 'plan'));
+    process.stdout.write(`${JSON.stringify(planRuntimeValues(plan))}\n`);
+    return;
+  }
+  fail('Usage: pack-production-plan.mjs <create|verify-inputs|values> [options]');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack ?? error.message ?? String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -7,6 +7,33 @@ import { chmod, chown, copyFile, mkdir, readFile, readdir, rename, writeFile } f
 import { basename, resolve } from 'node:path';
 import { finished } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
+import {
+  EXECUTOR_PREFLIGHT_SKILLS,
+  assertProductionExecutionPolicy,
+  canonicalJson as canonicalPlanJson,
+  createArtifactGate,
+  planRuntimeValues,
+  readArtifactGate,
+  readExecutionPlan as readCanonicalExecutionPlan,
+  validateExecutionPlan,
+  verifyCliAgainstPlan,
+  verifyRuntimeSourceFiles,
+  verifySkillsAgainstPlan,
+} from './pack-production-plan.mjs';
+
+const RUNTIME_SOURCE_FILES = {
+  'scripts/pack-production.mjs': fileURLToPath(import.meta.url),
+  'scripts/pack-production-plan.mjs': fileURLToPath(
+    new URL('./pack-production-plan.mjs', import.meta.url),
+  ),
+};
+
+async function readExecutionPlan(file) {
+  const plan = await readCanonicalExecutionPlan(file);
+  planRuntimeValues(plan);
+  await verifyRuntimeSourceFiles(plan, RUNTIME_SOURCE_FILES);
+  return plan;
+}
 
 const CLI_SCHEMA = 'pack-generation-evaluation/v2';
 const API_SCHEMA = 'skillstore.pack-evaluation/v4';
@@ -70,23 +97,8 @@ function positiveInteger(value, name, fallback) {
   return parsed;
 }
 
-function normalizeJson(value) {
-  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (Array.isArray(value)) return value.map(normalizeJson);
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value)
-        .filter(([, entry]) => entry !== undefined)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [key, normalizeJson(entry)]),
-    );
-  }
-  fail('Value is not canonical JSON');
-}
-
 export function canonicalJson(value) {
-  return JSON.stringify(normalizeJson(value));
+  return canonicalPlanJson(value);
 }
 
 function sha256(value) {
@@ -1539,6 +1551,13 @@ export function buildInfrastructureApiEvaluation({
       cliSha256: context.cliSha256,
       model: context.model,
       judgeModel: context.judgeModel,
+      ...(context.executionPlanDigest ? {
+        executionPlanDigest: context.executionPlanDigest,
+        modelRevision: context.modelRevision,
+        modelPinType: context.modelPinType,
+        judgeModelRevision: context.judgeModelRevision,
+        judgeModelPinType: context.judgeModelPinType,
+      } : {}),
       startedAt: safeEvidence.startedAt,
       completedAt: safeEvidence.completedAt,
     },
@@ -1756,6 +1775,13 @@ export function buildApiEvaluation(raw, context) {
       cliSha256: context.cliSha256,
       model: context.model,
       judgeModel: context.judgeModel,
+      ...(context.executionPlanDigest ? {
+        executionPlanDigest: context.executionPlanDigest,
+        modelRevision: context.modelRevision,
+        modelPinType: context.modelPinType,
+        judgeModelRevision: context.judgeModelRevision,
+        judgeModelPinType: context.judgeModelPinType,
+      } : {}),
       startedAt: raw.evaluationStartedAt,
       completedAt: raw.evaluationCompletedAt,
     },
@@ -1766,69 +1792,59 @@ export function buildApiEvaluation(raw, context) {
   return { ...unsigned, evidenceDigest: sha256(canonicalJson(unsigned)) };
 }
 
-function workflowContext(args, generationId, scenarioId, cli, version, checksum) {
-  const runId = required(args, 'run-id');
-  if (!/^[1-9][0-9]*$/.test(runId)) fail('--run-id must be a GitHub Actions numeric run id');
-  const runAttempt = positiveInteger(args['run-attempt'], 'run-attempt', 1);
-  const commitSha = required(args, 'commit-sha');
-  if (!/^[0-9a-f]{40}$/.test(commitSha)) fail('--commit-sha must be a 40-character lowercase SHA');
+function workflowContext(plan, cli, version, checksum) {
+  const workflow = plan.workflowBinding;
+  const models = plan.executionBinding.models;
   return {
-    generationId,
-    scenarioId,
-    runId,
-    runAttempt,
-    commitSha,
+    generationId: workflow.generationId,
+    scenarioId: workflow.scenarioId,
+    runId: workflow.runId,
+    runAttempt: workflow.runAttempt,
+    commitSha: workflow.headSha,
     cli,
     cliVersion: version,
     cliSha256: checksum,
-    model: args.model ?? 'sonnet',
-    judgeModel: args['judge-model'] ?? 'gpt-5.5',
+    model: models.runner.identity,
+    modelRevision: models.runner.revision,
+    modelPinType: models.runner.pinType,
+    judgeModel: models.judge.identity,
+    judgeModelRevision: models.judge.revision,
+    judgeModelPinType: models.judge.pinType,
+    executionPlanDigest: plan.digest,
   };
 }
 
-function exactObjectKeys(value, expected) {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    && canonicalJson(Object.keys(value).sort()) === canonicalJson([...expected].sort());
+export function validateImmutableProductionPlan(plan) {
+  return validateExecutionPlan(plan).scenario;
 }
 
-export function immutablePlanSnapshotSha256(plan) {
-  const { workflowBinding: _workflowBinding, ...snapshot } = plan ?? {};
-  return sha256(canonicalJson(snapshot));
-}
+const DEPRECATED_EXECUTION_OVERRIDES = new Set([
+  'agent-max-retries',
+  'agent-timeout-ms',
+  'auto-publish-threshold',
+  'baseline-delta',
+  'commit-sha',
+  'evaluation-budget-ms',
+  'expected-cli-version',
+  'final-runs',
+  'judge-model',
+  'max-candidates',
+  'minimum-fallback-ms',
+  'model',
+  'pick',
+  'run-attempt',
+  'run-id',
+  'runs',
+  'scenario-idle-timeout-ms',
+  'scenario-timeout-ms',
+  'threshold',
+]);
 
-export function validateImmutableProductionPlan(plan, args) {
-  if (plan?.schemaVersion !== 'pack-production-queue/v1') {
-    fail(`Unsupported plan schema: ${plan?.schemaVersion}`);
+function rejectDeprecatedExecutionOverrides(args, command) {
+  const supplied = [...DEPRECATED_EXECUTION_OVERRIDES].filter((name) => Object.hasOwn(args, name));
+  if (supplied.length > 0) {
+    fail(`${command} rejects deprecated execution override flag(s): ${supplied.map((name) => `--${name}`).join(', ')}`);
   }
-  if (plan.source !== 'signals' || !Array.isArray(plan.scenarios) || plan.scenarios.length !== 1) {
-    fail('Production v4 plan must contain exactly one signal-admitted scenario');
-  }
-  const scenario = plan.scenarios[0];
-  if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(scenario?.id || '')) fail(`Unsafe scenario id: ${scenario?.id}`);
-  if (!UUID_RE.test(scenario.generationId || '')) {
-    fail(`Immutable plan generation id is invalid for ${scenario.id}`);
-  }
-  const binding = plan.workflowBinding;
-  const bindingKeys = ['repository', 'workflow', 'runId', 'runAttempt', 'commitSha', 'scenarioId', 'planSnapshotSha256'];
-  if (!exactObjectKeys(binding, bindingKeys)) fail('Immutable plan workflow binding has unexpected fields');
-  if (!/^[0-9a-f]{64}$/.test(binding.planSnapshotSha256 || '')) {
-    fail('Immutable plan snapshot SHA-256 is invalid');
-  }
-  if (binding.planSnapshotSha256 !== immutablePlanSnapshotSha256(plan)) {
-    fail('Immutable plan snapshot SHA-256 differs from its bound input snapshot');
-  }
-  const runId = required(args, 'run-id');
-  const runAttempt = positiveInteger(args['run-attempt'], 'run-attempt', 1);
-  const commitSha = required(args, 'commit-sha');
-  if (
-    binding.repository !== EXPECTED_REPOSITORY
-    || binding.workflow !== EXPECTED_WORKFLOW
-    || String(binding.runId) !== runId
-    || binding.runAttempt !== runAttempt
-    || binding.commitSha !== commitSha
-    || binding.scenarioId !== scenario.id
-  ) fail('Immutable plan workflow binding differs from this workflow invocation');
-  return scenario;
 }
 
 function safeSpawnErrorCode(value) {
@@ -1934,35 +1950,56 @@ export function exactExecutorPreflightClosure(raw, expectedBindings) {
 }
 
 export async function executorPreflight(args) {
+  rejectDeprecatedExecutionOverrides(args, 'executor-preflight');
+  for (const name of ['generation-id', 'idle-timeout-ms', 'task', 'timeout-ms']) {
+    if (Object.hasOwn(args, name)) fail(`executor-preflight rejects deprecated execution override flag --${name}`);
+  }
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  await readArtifactGate(
+    resolve(required(args, 'artifact-gate')),
+    plan,
+    'plan',
+    'pack-production-plan',
+  );
   const cli = resolve(required(args, 'cli'));
-  const expectedCliVersion = required(args, 'expected-cli-version');
-  if (cliVersion(cli) !== expectedCliVersion) fail('Executor preflight CLI version mismatch');
-  const skillDirectories = [
-    resolve(required(args, 'skill-a')),
-    resolve(required(args, 'skill-b')),
-  ];
-  if (skillDirectories[0] === skillDirectories[1]) fail('Executor preflight Skills must be distinct');
-  const expectedBindings = await Promise.all([
-    { canonicalId: 'pack-executor-preflight-a', directory: skillDirectories[0] },
-    { canonicalId: 'pack-executor-preflight-b', directory: skillDirectories[1] },
-  ].map(async ({ canonicalId, directory }) => ({
-    canonicalId,
-    contentHash: await sha256File(resolve(directory, 'SKILL.md')),
-    version: '1.0.0',
-  })));
+  await verifyCliAgainstPlan(plan, cli);
+  const execution = plan.executionBinding;
+  const parameters = execution.parameters;
   const resultsDir = resolve(required(args, 'results-dir'));
   const runtimeRoot = resolve(required(args, 'evaluator-runtime-root'));
-  const generationId = required(args, 'generation-id');
-  if (!UUID_RE.test(generationId)) fail('--generation-id must be a UUID');
+  const preflightRoot = resolve(required(args, 'preflight-root'));
+  const generationId = execution.executorPreflight.generationId;
   const uid = positiveInteger(required(args, 'evaluator-uid'), 'evaluator-uid');
   const gid = positiveInteger(required(args, 'evaluator-gid'), 'evaluator-gid');
-  const timeoutMs = positiveInteger(args['timeout-ms'], 'timeout-ms', 360_000);
-  const idleTimeoutMs = positiveInteger(args['idle-timeout-ms'], 'idle-timeout-ms', 240_000);
-  const agentTimeoutMs = positiveInteger(args['agent-timeout-ms'], 'agent-timeout-ms', 180_000);
+  const timeoutMs = parameters.timeoutsMs.executorPreflight;
+  const idleTimeoutMs = parameters.timeoutsMs.executorPreflightIdle;
+  const agentTimeoutMs = parameters.timeoutsMs.executorPreflightAgent;
   const proxyActivityFile = args['proxy-activity-file']
     ? resolve(args['proxy-activity-file'])
     : null;
   await mkdir(resultsDir, { recursive: true, mode: 0o700 });
+  const skillDirectories = await Promise.all(EXECUTOR_PREFLIGHT_SKILLS.map(async (skill, index) => {
+    const directory = resolve(preflightRoot, `skill-${index + 1}`);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chown(directory, uid, gid);
+    const skillFile = resolve(directory, 'SKILL.md');
+    await writeFile(skillFile, skill.contents, { mode: 0o444 });
+    await chown(skillFile, uid, gid);
+    await chmod(skillFile, 0o444);
+    return directory;
+  }));
+  const expectedBindings = await Promise.all([
+    execution.executorPreflight.skillA,
+    execution.executorPreflight.skillB,
+  ].map(async (skill, index) => {
+    const contentHash = await sha256File(resolve(skillDirectories[index], 'SKILL.md'));
+    if (contentHash !== skill.contentSha256) fail('Executor preflight Skill bytes differ from the execution Plan');
+    return {
+      canonicalId: skill.canonicalId,
+      contentHash,
+      version: skill.version,
+    };
+  }));
   const stdoutFile = resolve(resultsDir, 'executor-preflight.raw.json');
   const stderrFile = resolve(resultsDir, 'executor-preflight.run.log');
   const progressFile = resolve(resultsDir, 'executor-preflight.progress.ndjson');
@@ -1981,10 +2018,7 @@ export async function executorPreflight(args) {
     const manifestFile = resolve(runtime.cwd, 'pack-executor-preflight-manifest.json');
     await writeFile(manifestFile, `${JSON.stringify({
       schemaVersion: 'skillstore.pack-executor-preflight-manifest/v1',
-      task: args.task ?? [
-        'Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second.',
-        'After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.',
-      ].join(' '),
+      task: execution.executorPreflight.task,
       skills: expectedBindings.map((binding, index) => ({
         directory: skillDirectories[index],
         ...binding,
@@ -1994,10 +2028,10 @@ export async function executorPreflight(args) {
     processResult = await runEvaluatorProcess(cli, [
       'pack', 'executor-preflight',
       '--manifest', manifestFile,
-      '--model', args.model ?? 'sonnet',
-      '--judge-model', args['judge-model'] ?? 'gpt-5.5',
+      '--model', execution.models.runner.identity,
+      '--judge-model', execution.models.judge.identity,
       '--agent-timeout-ms', String(agentTimeoutMs),
-      '--agent-max-retries', '1',
+      '--agent-max-retries', String(parameters.retries.agentMaxRetries),
     ], {
       cwd: runtime.cwd,
       env: runtime.env,
@@ -2010,7 +2044,8 @@ export async function executorPreflight(args) {
       generationId,
       timeoutMs,
       idleTimeoutMs,
-      heartbeatMs: 30_000,
+      heartbeatMs: parameters.timeoutsMs.executorPreflightHeartbeat,
+      killGraceMs: parameters.timeoutsMs.processKillGrace,
       ...(proxyActivityFile ? { externalActivityFile: proxyActivityFile } : {}),
       onProgress: () => {},
     });
@@ -2057,6 +2092,7 @@ export async function executorPreflight(args) {
   const stderrEvidence = await readFile(stderrFile).catch(() => Buffer.alloc(0));
   const summary = {
     schemaVersion: 'marketplace.pack-executor-preflight/v1',
+    executionPlanDigest: plan.digest,
     mode: 'pack-production-node-uid-nested-bwrap',
     outcome,
     errorClass,
@@ -2089,41 +2125,33 @@ export async function executorPreflight(args) {
 }
 
 async function evaluate(args) {
+  rejectDeprecatedExecutionOverrides(args, 'evaluate');
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  await readArtifactGate(
+    resolve(required(args, 'artifact-gate')),
+    plan,
+    'plan',
+    'pack-production-plan',
+  );
   const cli = resolve(required(args, 'cli'));
-  const plan = await readJson(resolve(required(args, 'plan')));
   const resultsDir = resolve(required(args, 'results-dir'));
   const skillsDir = resolve(required(args, 'skills-dir'));
-  validateImmutableProductionPlan(plan, args);
+  await verifyCliAgainstPlan(plan, cli);
+  await verifySkillsAgainstPlan(plan, skillsDir);
   await mkdir(resultsDir, { recursive: true });
 
-  const version = cliVersion(cli);
-  const expectedVersion = required(args, 'expected-cli-version');
-  if (version !== expectedVersion) fail(`CLI version mismatch: expected ${expectedVersion}, got ${version}`);
+  const version = plan.executionBinding.cli.version;
   const checksum = await sha256File(cli);
-  const evaluationBudgetMs = positiveInteger(
-    args['evaluation-budget-ms'],
-    'evaluation-budget-ms',
-    230 * 60_000,
-  );
-  const maxScenarioMs = positiveInteger(
-    args['scenario-timeout-ms'],
-    'scenario-timeout-ms',
-    120 * 60_000,
-  );
-  const scenarioIdleTimeoutMs = positiveInteger(
-    args['scenario-idle-timeout-ms'],
-    'scenario-idle-timeout-ms',
-    20 * 60_000,
-  );
+  const parameters = plan.executionBinding.parameters;
+  const evaluationBudgetMs = parameters.timeoutsMs.evaluationBudget;
+  const maxScenarioMs = parameters.timeoutsMs.scenario;
+  const scenarioIdleTimeoutMs = parameters.timeoutsMs.scenarioIdle;
   const proxyActivityFile = args['proxy-activity-file'] ? resolve(args['proxy-activity-file']) : null;
   const externalInfrastructureFailure = args['infrastructure-failure-file']
     ? normalizeInfrastructureFailure(await readJson(resolve(args['infrastructure-failure-file'])))
     : null;
-  const minimumFallbackMs = positiveInteger(
-    args['minimum-fallback-ms'],
-    'minimum-fallback-ms',
-    45 * 60_000,
-  );
+  const minimumFallbackMs = parameters.timeoutsMs.minimumFallback;
+  const scenarios = [plan.scenario];
   const progressFile = resolve(resultsDir, 'evaluate-progress.ndjson');
   const checkpointFile = resolve(resultsDir, 'evaluate-checkpoint.json');
   await writeFile(progressFile, '', { mode: 0o600 });
@@ -2153,6 +2181,7 @@ async function evaluate(args) {
 
   const buildSummary = () => ({
     schemaVersion: 'marketplace.pack-production-evaluate/v1',
+    executionPlanDigest: plan.digest,
     cliVersion: version,
     cliSha256: checksum,
     evaluationBudgetMs,
@@ -2165,12 +2194,12 @@ async function evaluate(args) {
     await writeJson(resolve(resultsDir, 'evaluate-summary.json'), buildSummary());
   };
 
-  for (const [scenarioIndex, scenario] of plan.scenarios.entries()) {
+  for (const [scenarioIndex, scenario] of scenarios.entries()) {
     if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(scenario.id || '')) fail(`Unsafe scenario id: ${scenario.id}`);
     const remainingBudgetMs = evaluationDeadline - Date.now();
     const scenarioBudgetMs = allocateScenarioBudgetMs({
       remainingBudgetMs,
-      remainingScenarios: plan.scenarios.length - scenarioIndex,
+      remainingScenarios: scenarios.length - scenarioIndex,
       maxScenarioMs,
       minimumFallbackMs,
     });
@@ -2187,23 +2216,23 @@ async function evaluate(args) {
     }
     const ordinal = String(scenarioIndex + 1).padStart(2, '0');
     const generationId = scenario.generationId;
-    const context = workflowContext(args, generationId, scenario.id, cli, version, checksum);
+    const context = workflowContext(plan, cli, version, checksum);
     const commandArgs = [
       'pack', 'generate',
       '--scenario', scenario.id,
       '--generation-id', generationId,
       '--skills-dir', skillsDir,
-      '--max-candidates', args['max-candidates'] ?? '3',
-      '--pick', args.pick ?? '4',
+      '--max-candidates', String(parameters.generation.maxCandidates),
+      '--pick', String(parameters.generation.pick),
       '--model', context.model,
       '--judge-model', context.judgeModel,
-      '--runs', args.runs ?? '1',
-      '--final-runs', args['final-runs'] ?? '3',
-      '--agent-timeout-ms', args['agent-timeout-ms'] ?? '360000',
-      '--agent-max-retries', args['agent-max-retries'] ?? '1',
-      '--threshold', args.threshold ?? '7',
-      '--baseline-delta', args['baseline-delta'] ?? '1',
-      '--auto-publish-threshold', args['auto-publish-threshold'] ?? '8',
+      '--runs', String(parameters.generation.runs),
+      '--final-runs', String(parameters.generation.finalRuns),
+      '--agent-timeout-ms', String(parameters.timeoutsMs.agent),
+      '--agent-max-retries', String(parameters.retries.agentMaxRetries),
+      '--threshold', String(parameters.generation.threshold),
+      '--baseline-delta', String(parameters.generation.baselineDelta),
+      '--auto-publish-threshold', String(parameters.generation.autoPublishThreshold),
       '--json',
     ];
     const partialStdoutFile = resolve(resultsDir, `${ordinal}-${scenario.id}.stdout.partial`);
@@ -2274,10 +2303,12 @@ async function evaluate(args) {
         label: scenario.id,
         generationId,
         scenarioIndex: scenarioIndex + 1,
-        scenarioCount: plan.scenarios.length,
+        scenarioCount: scenarios.length,
         progressSequenceStart: progressSequence,
         timeoutMs: scenarioBudgetMs,
         idleTimeoutMs: scenarioIdleTimeoutMs,
+        heartbeatMs: parameters.timeoutsMs.evaluatorHeartbeat,
+        killGraceMs: parameters.timeoutsMs.processKillGrace,
         ...(proxyActivityFile ? { externalActivityFile: proxyActivityFile } : {}),
         ...(hasEvaluatorIdentity ? { uid: evaluatorUid, gid: evaluatorGid } : {}),
         env: runtime.env,
@@ -2391,18 +2422,28 @@ async function evaluate(args) {
 }
 
 async function verifyEvaluation(args) {
+  rejectDeprecatedExecutionOverrides(args, 'verify');
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  await readArtifactGate(
+    resolve(required(args, 'artifact-gate')),
+    plan,
+    'plan',
+    'pack-production-plan',
+  );
   const cli = resolve(required(args, 'cli'));
-  const plan = await readJson(resolve(required(args, 'plan')));
   const resultsDir = resolve(required(args, 'results-dir'));
   const summary = await readJson(resolve(resultsDir, 'evaluate-summary.json'));
-  validateImmutableProductionPlan(plan, args);
   if (summary.schemaVersion !== 'marketplace.pack-production-evaluate/v1') {
     fail(`Unsupported evaluate summary schema: ${summary.schemaVersion}`);
   }
-  if (!Array.isArray(summary.reports) || summary.reports.length < 1 || summary.reports.length > plan.scenarios.length) {
+  if (summary.executionPlanDigest !== plan.digest) {
+    fail('Evaluate summary differs from the execution Plan digest');
+  }
+  const scenarios = [plan.scenario];
+  if (!Array.isArray(summary.reports) || summary.reports.length < 1 || summary.reports.length > scenarios.length) {
     fail('Evaluate summary report count is outside the immutable plan');
   }
-  if (!Array.isArray(summary.attempts) || summary.attempts.length !== plan.scenarios.length) {
+  if (!Array.isArray(summary.attempts) || summary.attempts.length !== scenarios.length) {
     fail('Evaluate summary attempts do not exactly cover the immutable plan');
   }
   const incompleteAttempts = summary.attempts.filter((attempt) => attempt?.status !== 'completed');
@@ -2413,7 +2454,7 @@ async function verifyEvaluation(args) {
     );
   }
   for (const [planIndex, attempt] of summary.attempts.entries()) {
-    const scenario = plan.scenarios[planIndex];
+    const scenario = scenarios[planIndex];
     if (
       attempt?.planIndex !== planIndex
       || attempt.scenarioId !== scenario.id
@@ -2421,10 +2462,10 @@ async function verifyEvaluation(args) {
     ) fail('Evaluate summary attempt differs from the immutable plan generation binding');
   }
 
-  const version = cliVersion(cli);
-  const expectedVersion = required(args, 'expected-cli-version');
-  if (version !== expectedVersion || summary.cliVersion !== version) {
-    fail(`Evaluation CLI version mismatch: expected ${expectedVersion}, got ${version}/${summary.cliVersion}`);
+  await verifyCliAgainstPlan(plan, cli);
+  const version = plan.executionBinding.cli.version;
+  if (summary.cliVersion !== version) {
+    fail(`Evaluation CLI version mismatch: expected ${version}, got ${summary.cliVersion}`);
   }
   const checksum = await sha256File(cli);
   if (summary.cliSha256 !== checksum) fail('Evaluation CLI checksum differs from the trusted CLI');
@@ -2437,12 +2478,12 @@ async function verifyEvaluation(args) {
   let previousPlanIndex = -1;
   for (const [index, report] of summary.reports.entries()) {
     const planIndex = report.planIndex ?? index;
-    if (!Number.isSafeInteger(planIndex) || planIndex < 0 || planIndex >= plan.scenarios.length) {
+    if (!Number.isSafeInteger(planIndex) || planIndex < 0 || planIndex >= scenarios.length) {
       fail(`Invalid evaluate summary plan index: ${report.planIndex}`);
     }
     if (planIndex <= previousPlanIndex) fail('Evaluate summary plan indexes are not strictly increasing');
     previousPlanIndex = planIndex;
-    const scenario = plan.scenarios[planIndex];
+    const scenario = scenarios[planIndex];
     if (!scenario || report.scenarioId !== scenario.id) fail('Evaluate summary scenario differs from the immutable plan');
     if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(scenario.id)) fail(`Unsafe scenario id: ${scenario.id}`);
     if (report.generationId !== scenario.generationId) {
@@ -2465,7 +2506,7 @@ async function verifyEvaluation(args) {
     ) {
       fail(`Evaluate summary outcome differs from stdout for ${scenario.id}`);
     }
-    const context = workflowContext(args, report.generationId, scenario.id, cli, version, checksum);
+    const context = workflowContext(plan, cli, version, checksum);
     const rebuilt = buildApiEvaluation(raw, context);
     const recorded = await readJson(resolve(resultsDir, evaluationFile));
     if (canonicalJson(recorded) !== canonicalJson(rebuilt)) {
@@ -2494,6 +2535,7 @@ async function verifyEvaluation(args) {
   ));
   const verification = {
     schemaVersion: VERIFICATION_SCHEMA,
+    executionPlanDigest: plan.digest,
     cliVersion: version,
     cliSha256: checksum,
     selectedGenerationId,
@@ -2767,11 +2809,20 @@ export async function readExactPublicPack(base, expected, fetchImpl = fetch) {
 }
 
 async function persist(args) {
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  await readArtifactGate(
+    resolve(required(args, 'artifact-gate')),
+    plan,
+    'evaluate',
+    'pack-production-evaluation',
+  );
   const resultsDir = resolve(required(args, 'results-dir'));
-  const token = required(args, 'token');
-  const base = apiBase(args);
   const verification = await readJson(resolve(resultsDir, 'evaluation-verification.json'));
-  if (verification.schemaVersion !== VERIFICATION_SCHEMA || !Array.isArray(verification.files)) {
+  if (
+    verification.schemaVersion !== VERIFICATION_SCHEMA
+    || verification.executionPlanDigest !== plan.digest
+    || !Array.isArray(verification.files)
+  ) {
     fail('Trusted evaluation verification is missing or invalid');
   }
   const files = (await readdir(resultsDir))
@@ -2800,7 +2851,12 @@ async function persist(args) {
     file,
     evaluation: await readJson(resolve(resultsDir, file)),
   })));
+  if (evaluations.some(({ evaluation }) => evaluation.evaluator?.executionPlanDigest !== plan.digest)) {
+    fail('Persist evaluation artifact differs from the execution Plan');
+  }
   const persistencePlan = planTrustedPersistence(evaluations, verification.selectedGenerationId ?? null);
+  const token = required(args, 'token');
+  const base = apiBase(args);
   const persisted = persistencePlan.auditOnly.map(({ file, evaluation }) => ({
     file,
     request: evaluation,
@@ -2852,6 +2908,7 @@ async function persist(args) {
   }
   const summary = {
     schemaVersion: 'marketplace.pack-production-persist/v1',
+    executionPlanDigest: plan.digest,
     persisted,
     selected,
   };
@@ -2944,8 +3001,18 @@ export function buildHardDisabledReviewPendingResult(selected, autoPublishReques
 }
 
 async function finalize(args) {
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  await readArtifactGate(
+    resolve(required(args, 'artifact-gate')),
+    plan,
+    'persist',
+    'pack-production-persisted',
+  );
   const resultsDir = resolve(required(args, 'results-dir'));
   const persisted = await readJson(resolve(resultsDir, 'persist-summary.json'));
+  if (persisted.executionPlanDigest !== plan.digest) {
+    fail('Persist summary differs from the execution Plan');
+  }
   const selected = persisted.selected;
   const rawOutcomes = persisted.persisted.map((item) => item.request.outcome);
   if (!selected) {
@@ -3046,9 +3113,27 @@ async function reportSlo(args) {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
+async function artifactGate(args) {
+  const gate = await createArtifactGate(
+    resolve(required(args, 'plan')),
+    resolve(required(args, 'state')),
+    resolve(required(args, 'output')),
+  );
+  process.stdout.write(`${JSON.stringify(gate)}\n`);
+}
+
+async function printPlanValues(args) {
+  const plan = await readExecutionPlan(resolve(required(args, 'plan')));
+  process.stdout.write(`${JSON.stringify(planRuntimeValues(plan))}\n`);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   switch (args.command) {
+    case 'artifact-gate':
+      return artifactGate(args);
+    case 'plan-values':
+      return printPlanValues(args);
     case 'executor-preflight':
       return executorPreflight(args);
     case 'evaluate':
@@ -3062,7 +3147,7 @@ async function main() {
     case 'slo':
       return reportSlo(args);
     default:
-      fail('Usage: pack-production.mjs <executor-preflight|evaluate|verify|persist|finalize|slo> [options]');
+      fail('Usage: pack-production.mjs <artifact-gate|plan-values|executor-preflight|evaluate|verify|persist|finalize|slo> [options]');
   }
 }
 

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -1791,6 +1791,11 @@ function exactObjectKeys(value, expected) {
     && canonicalJson(Object.keys(value).sort()) === canonicalJson([...expected].sort());
 }
 
+export function immutablePlanSnapshotSha256(plan) {
+  const { workflowBinding: _workflowBinding, ...snapshot } = plan ?? {};
+  return sha256(canonicalJson(snapshot));
+}
+
 export function validateImmutableProductionPlan(plan, args) {
   if (plan?.schemaVersion !== 'pack-production-queue/v1') {
     fail(`Unsupported plan schema: ${plan?.schemaVersion}`);
@@ -1804,8 +1809,14 @@ export function validateImmutableProductionPlan(plan, args) {
     fail(`Immutable plan generation id is invalid for ${scenario.id}`);
   }
   const binding = plan.workflowBinding;
-  const bindingKeys = ['repository', 'workflow', 'runId', 'runAttempt', 'commitSha', 'scenarioId'];
+  const bindingKeys = ['repository', 'workflow', 'runId', 'runAttempt', 'commitSha', 'scenarioId', 'planSnapshotSha256'];
   if (!exactObjectKeys(binding, bindingKeys)) fail('Immutable plan workflow binding has unexpected fields');
+  if (!/^[0-9a-f]{64}$/.test(binding.planSnapshotSha256 || '')) {
+    fail('Immutable plan snapshot SHA-256 is invalid');
+  }
+  if (binding.planSnapshotSha256 !== immutablePlanSnapshotSha256(plan)) {
+    fail('Immutable plan snapshot SHA-256 differs from its bound input snapshot');
+  }
   const runId = required(args, 'run-id');
   const runAttempt = positiveInteger(args['run-attempt'], 'run-attempt', 1);
   const commitSha = required(args, 'commit-sha');

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -198,6 +198,8 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(CONTRACT_SMOKE, /path: '\/v1\/responses'/);
   assert.match(CONTRACT_SMOKE, /max_tokens: 16/);
   assert.match(CONTRACT_SMOKE, /max_output_tokens: 16/);
+  assert.match(WORKFLOW, /PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5'/);
+  assert.match(WORKFLOW, /PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5\.5'/);
   assert.match(CONTRACT_SMOKE, /model: 'claude-sonnet-5'/);
   assert.equal((CONTRACT_SMOKE.match(/stream: true/g) ?? []).length, 2);
   assert.match(CONTRACT_SMOKE, /content_block_delta/);
@@ -211,8 +213,9 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.match(evaluate, /--evaluator-runtime-root "\$RUNTIME_ROOT"/);
   assert.match(evaluate, /--evaluator-uid "\$\(id -u packeval\)"/);
   assert.match(evaluate, /--evaluator-gid "\$\(id -g packeval\)"/);
-  assert.match(evaluate, /--model sonnet/);
-  assert.match(evaluate, /--judge-model gpt-5\.5/);
+  assert.match(evaluate, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
+  assert.match(evaluate, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
+  assert.doesNotMatch(evaluate, /--model sonnet/);
   assert.match(evaluate, /--agent-timeout-ms "\$AGENT_TIMEOUT_MS"/);
   assert.match(evaluate, /--agent-max-retries 1/);
   assert.match(evaluate, /PREFLIGHT_OUTCOME=command_failed/);
@@ -330,6 +333,8 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /"\$NODE" "\$ORCHESTRATOR" executor-preflight/);
   assert.match(EVALUATOR_PREFLIGHT, /--skill-a "\$PREFLIGHT_SKILL_A"/);
   assert.match(EVALUATOR_PREFLIGHT, /--skill-b "\$PREFLIGHT_SKILL_B"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
   assert.match(EVALUATOR_PREFLIGHT, /safe_runner_trace_evidence\(\)/);
   assert.match(EVALUATOR_PREFLIGHT, /proofBinding:/);
   assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_ENV_MODE=strict/);
@@ -347,6 +352,8 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
     env: {
       PATH: process.env.PATH,
       PACK_PRODUCTION_CLI_VERSION: '2.14.2',
+      PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5',
+      PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5.5',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
       PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
@@ -618,8 +625,9 @@ test('evaluate emits bounded progress and checkpoints cancellation-safe evidence
   assert.match(evaluate, /sudo ps -o stat= -g "\$EVALUATOR_PID"/);
   assert.match(evaluate, /sudo kill -TERM -- "-\$EVALUATOR_PID"/);
   assert.doesNotMatch(evaluate, /pgrep -f '\/opt\/pack-evaluator\/lib\/pack-production\.mjs evaluate'/);
-  assert.match(evaluate, /--model sonnet/);
-  assert.match(evaluate, /--judge-model gpt-5\.5/);
+  assert.match(evaluate, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
+  assert.match(evaluate, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
+  assert.doesNotMatch(evaluate, /--model sonnet/);
   assert.match(evaluate, /--max-candidates 2/);
   assert.match(evaluate, /--agent-timeout-ms 360000/);
   assert.match(evaluate, /--agent-max-retries 1/);
@@ -677,6 +685,8 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(plan, /workflow: "Generate Pack"/);
   assert.match(plan, /runAttempt: \$runAttempt/);
   assert.match(plan, /scenarioId: \.scenarios\[0\]\.id/);
+  assert.match(plan, /immutablePlanSnapshotSha256/);
+  assert.match(plan, /planSnapshotSha256: \$planSnapshotSha256/);
   assert.match(plan, /\(has\("generationId"\) \| not\)/);
   assert.match(plan, /\(has\("workflowBinding"\) \| not\)/);
   const allocationIndex = plan.indexOf('.scenarios[0].generationId = $generationId');
@@ -692,6 +702,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.doesNotMatch(PACK_PRODUCTION, /randomUUID/);
   assert.match(PACK_PRODUCTION, /const generationId = scenario\.generationId/);
   assert.match(PACK_PRODUCTION, /Evaluate summary generation id differs from the immutable plan/);
+  assert.match(PACK_PRODUCTION, /Immutable plan snapshot SHA-256 differs from its bound input snapshot/);
   const evaluate = section('  evaluate:', '  persist:');
   const persist = section('  persist:', '  enrich_publish_readback:');
   const finalize = section('  enrich_publish_readback:');

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -14,6 +14,7 @@ const EVALUATOR_PREFLIGHT = readFileSync(EVALUATOR_PREFLIGHT_PATH, 'utf8');
 const DOWNLOAD_ACTION = readFileSync(join(REPO_ROOT, '.github/actions/download-skillstore-cli/action.yml'), 'utf8');
 const EVALUATOR_PROXY = readFileSync(join(REPO_ROOT, 'scripts/pack-evaluator-proxy.mjs'), 'utf8');
 const PACK_PRODUCTION = readFileSync(join(REPO_ROOT, 'scripts/pack-production.mjs'), 'utf8');
+const PACK_PRODUCTION_PLAN = readFileSync(join(REPO_ROOT, 'scripts/pack-production-plan.mjs'), 'utf8');
 const CONTRACT_SMOKE = readFileSync(join(REPO_ROOT, 'scripts/pack-evaluator-contract-smoke.mjs'), 'utf8');
 const ADMISSION_WORKFLOW = readFileSync(
   join(REPO_ROOT, '.github/workflows/pack-opportunity-admission.yml'),
@@ -41,22 +42,26 @@ test('production workflow has separate Plan, secret-free Evaluate, Persist, and 
   assert.match(WORKFLOW, /permissions:\n  contents: read/);
 });
 
-test('manual smoke-only dispatch cannot enter Queue, generation, or persistence', () => {
-  assert.match(WORKFLOW, /smoke_only:\n\s+description: 'Run exactly the Messages and Responses contract probes; never plan, generate, or persist'\n\s+type: boolean\n\s+default: false/);
+test('manual smoke-only dispatch builds one Plan but cannot evaluate, generate, or persist', () => {
+  assert.match(WORKFLOW, /smoke_only:\n\s+description: 'Build one canonical Plan, then run exactly the Messages and Responses probes; never evaluate, generate, or persist'\n\s+type: boolean\n\s+default: false/);
   const smoke = section('  contract_smoke_only:', '  plan:');
   const plan = section('  plan:', '  evaluate:');
-  assert.match(smoke, /if: github\.event_name == 'workflow_dispatch' && inputs\.smoke_only == true/);
+  assert.match(smoke, /needs: plan/);
+  assert.match(smoke, /if: github\.event_name == 'workflow_dispatch' && inputs\.smoke_only == true && needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(smoke, /runs-on: ubuntu-latest/);
   assert.match(smoke, /PACK_EVALUATOR_HELM_API_KEY: \$\{\{ secrets\.PACK_EVALUATOR_HELM_API_KEY \}\}/);
   assert.match(smoke, /PACK_EVALUATOR_PROXY_URL=https:\/\/helm\.easymeta\.au/);
+  assert.match(smoke, /PACK_EVALUATOR_PLAN_PATH=/);
+  assert.match(smoke, /name: pack-production-plan/);
   assert.match(smoke, /pack-evaluator-contract-smoke\.mjs/);
   assert.match(smoke, /Upload sanitized contract diagnostics/);
   assert.doesNotMatch(
     smoke,
     /SKILLSTORE_API_URL|PACK_PRODUCTION_(?:PLANNER|AUTOMATION)_KEY|SUPABASE|APP_PRIVATE_KEY|skillstore-cli|api\/automation\/packs\/production|pack-production\.mjs|generate-content/
   );
-  assert.match(plan, /if: github\.event_name == 'schedule' \|\| inputs\.smoke_only != true/);
+  assert.doesNotMatch(plan, /^    if:/m);
   assert.match(section('  evaluate:', '  persist:'), /needs: plan/);
+  assert.match(section('  evaluate:', '  persist:'), /if: inputs\.smoke_only != true/);
   assert.match(section('  persist:', '  enrich_publish_readback:'), /needs: \[plan, evaluate\]/);
   assert.match(section('  enrich_publish_readback:'), /needs: \[plan, persist\]/);
 });
@@ -85,8 +90,10 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(preflightCallLines.every((line) => line.endsWith(` ${continuation}`)));
   assert.ok(preflightCallLines.every((line) => !line.endsWith(` ${continuation}${continuation}`)));
   assert.match(evaluate, /runs-on: ubuntu-24\.04/);
-  assert.match(evaluate, /@anthropic-ai\/claude-code@2\.1\.210/);
-  assert.match(evaluate, /@openai\/codex@0\.139\.0/);
+  assert.match(evaluate, /CLAUDE_CODE_VERSION=\$\(jq -r '\.parameters\.runtime\.claudeCodeVersion'/);
+  assert.match(evaluate, /CODEX_VERSION=\$\(jq -r '\.parameters\.runtime\.codexVersion'/);
+  assert.match(evaluate, /"@anthropic-ai\/claude-code@\$CLAUDE_CODE_VERSION"/);
+  assert.match(evaluate, /"@openai\/codex@\$CODEX_VERSION"/);
   assert.match(
     evaluate,
     /apt-get install --yes --no-install-recommends[\s\\]+apparmor bubblewrap ffmpeg iptables poppler-utils ripgrep util-linux/,
@@ -146,87 +153,78 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.doesNotMatch(evaluate, /cp .*\.codex\/auth\.json|\/home\/runner\/_work\/_cache/);
   assert.match(evaluate, /name: pack-production-cli/);
   assert.match(evaluate, /sha256sum -c checksums\.txt/);
-  assert.match(evaluate, /Verify Plan CLI handoff before execution/);
+  assert.match(evaluate, /Verify canonical Plan, source trees, scripts, and CLI before execution/);
+  assert.match(evaluate, /pack-production-plan\.mjs verify-inputs/);
   assert.doesNotMatch(evaluate, /secrets\.APP_PRIVATE_KEY|steps\.cli-app-token/);
   assert.match(EVALUATOR_PROXY, /127\.0\.0\.1/);
   assert.match(EVALUATOR_PROXY, /ALLOWED_PATHS/);
   assert.match(EVALUATOR_PROXY, /authorization.*Bearer.*upstreamKey/s);
-  assert.match(evaluate, /PACK_EVALUATOR_ALLOWED_MODELS=claude-sonnet-4\.6,claude-sonnet-4-6,claude-sonnet-5,sonnet,gpt-5\.5/);
-  assert.match(evaluate, /PACK_EVALUATOR_MAX_REQUESTS=256/);
-  assert.match(evaluate, /PACK_EVALUATOR_MAX_CONCURRENT=4/);
-  assert.equal(
-    (WORKFLOW.match(/^  PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'$/gm) ?? []).length,
-    1,
-    'the production workflow must define one output-token cap',
-  );
+  assert.match(evaluate, /ALLOWED_MODELS=\$\(jq -r '\.parameters\.proxy\.allowedModels \| join\(","\)'/);
+  assert.match(evaluate, /MAX_REQUESTS=\$\(jq -r '\.parameters\.proxy\.maxRequests'/);
+  assert.match(evaluate, /MAX_CONCURRENT=\$\(jq -r '\.parameters\.proxy\.maxConcurrent'/);
+  assert.match(evaluate, /MAX_OUTPUT_TOKENS=\$\(jq -r '\.parameters\.tokens\.maxOutput'/);
+  assert.doesNotMatch(WORKFLOW, /^  PACK_EVALUATOR_MAX_OUTPUT_TOKENS:/m);
   assert.match(
     evaluateWorkflow,
-    /PACK_EVALUATOR_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
-  );
-  assert.match(
-    evaluateWorkflow,
-    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$MAX_OUTPUT_TOKENS"/,
   );
   assert.match(
     evaluateWorkflow,
     /SKILLSTORE_AGENT_ENV_ALLOWLIST=.*CLAUDE_CODE_MAX_OUTPUT_TOKENS/,
   );
-  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS is required/);
-  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA is required/);
-  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_CLI_SHA256 is required/);
-  assert.match(EVALUATOR_PREFLIGHT, /\^\[1-9\]\[0-9\]\*\$/);
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_PLAN_PATH is required/);
+  assert.match(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_ARTIFACT_GATE_PATH is required/);
+  assert.match(EVALUATOR_PREFLIGHT, /plan-values --plan "\$PACK_EVALUATOR_PLAN_PATH"/);
   assert.match(
     EVALUATOR_PREFLIGHT,
-    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
+    /CLAUDE_CODE_MAX_OUTPUT_TOKENS="\$MAX_OUTPUT_TOKENS"/,
   );
   assert.match(evaluate, /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"/);
   assert.match(
     evaluate,
-    /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\S]*PACK_EVALUATOR_MARKETPLACE_COMMIT_SHA="\$GITHUB_SHA"[\s\S]*bash .*pack-evaluator-preflight\.sh/,
+    /PACK_EVALUATOR_ACTIVITY_FILE="\$PROXY_ACTIVITY"[\s\S]*PACK_EVALUATOR_PLAN_PATH="\$PLAN_PATH"[\s\S]*PACK_EVALUATOR_ARTIFACT_GATE_PATH="\$PLAN_GATE_PATH"[\s\S]*bash .*pack-evaluator-preflight\.sh/,
   );
-  assert.match(evaluate, /PACK_EVALUATOR_CLI_SHA256="\$\(jq -r '\.sha256'/);
   assert.match(evaluate, /sudo rm -f "\$PROXY_ACTIVITY"/);
   assert.match(evaluate, /Pack evaluator proxy did not become healthy within 30 seconds/);
   assert.match(evaluate, /proxy-diagnostics\.json/);
-  assert.match(evaluate, /pack-executor-preflight-a first and Skill pack-executor-preflight-b second/);
-  assert.match(evaluate, /PACK_EVALUATOR_READY and nothing else/);
+  assert.match(PACK_PRODUCTION_PLAN, /pack-executor-preflight-a first and Skill pack-executor-preflight-b second/);
+  assert.match(PACK_PRODUCTION_PLAN, /PACK_EVALUATOR_READY and nothing else/);
   assert.match(evaluate, /pack-evaluator-contract-smoke\.mjs/);
-  assert.match(evaluate, /PACK_EVALUATOR_CONTRACT_TIMEOUT_MS=30000/);
+  assert.match(CONTRACT_SMOKE, /\.parameters\.timeoutsMs\.contract/);
   assert.match(evaluate, /contract-smoke\.json/);
   assert.ok(evaluate.indexOf('pack-evaluator-contract-smoke.mjs') < evaluate.indexOf('pack-evaluator-preflight.sh'));
   assert.match(CONTRACT_SMOKE, /path: '\/v1\/messages'/);
   assert.match(CONTRACT_SMOKE, /path: '\/v1\/responses'/);
-  assert.match(CONTRACT_SMOKE, /max_tokens: 16/);
-  assert.match(CONTRACT_SMOKE, /max_output_tokens: 16/);
-  assert.match(WORKFLOW, /PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5'/);
-  assert.match(WORKFLOW, /PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5\.5'/);
-  assert.match(CONTRACT_SMOKE, /model: 'claude-sonnet-5'/);
+  assert.match(CONTRACT_SMOKE, /max_tokens: outputTokens/);
+  assert.match(CONTRACT_SMOKE, /max_output_tokens: outputTokens/);
+  assert.doesNotMatch(WORKFLOW, /PACK_EVALUATOR_(?:RUNNER|JUDGE)_MODEL/);
+  assert.doesNotMatch(CONTRACT_SMOKE, /claude-sonnet-5|gpt-5\.5/);
+  assert.match(CONTRACT_SMOKE, /models\.runner\.identity/);
+  assert.match(CONTRACT_SMOKE, /models\.judge\.identity/);
   assert.equal((CONTRACT_SMOKE.match(/stream: true/g) ?? []).length, 2);
   assert.match(CONTRACT_SMOKE, /content_block_delta/);
   assert.match(CONTRACT_SMOKE, /response\.output_text\.delta/);
-  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_SECONDS=420/);
-  assert.match(evaluate, /timeout --signal=TERM --kill-after=5s "\$\{PREFLIGHT_TIMEOUT_SECONDS\}s"/);
+  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_MS=.*executorPreflightOuter/);
+  assert.match(evaluate, /readonly PREFLIGHT_TIMEOUT_SECONDS=/);
+  assert.match(evaluate, /timeout --signal=TERM --kill-after="\$\{PREFLIGHT_KILL_GRACE_SECONDS\}s" "\$\{PREFLIGHT_TIMEOUT_SECONDS\}s"/);
   assert.match(evaluate, /setsid sudo env -i/);
   assert.match(evaluate, /"\$NODE" "\$ORCHESTRATOR" executor-preflight/);
-  assert.match(evaluate, /--skill-a "\$PREFLIGHT_SKILL_A"/);
-  assert.match(evaluate, /--skill-b "\$PREFLIGHT_SKILL_B"/);
+  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--skill-a|--skill-b|--task|--generation-id/);
   assert.match(evaluate, /--evaluator-runtime-root "\$RUNTIME_ROOT"/);
   assert.match(evaluate, /--evaluator-uid "\$\(id -u packeval\)"/);
   assert.match(evaluate, /--evaluator-gid "\$\(id -g packeval\)"/);
-  assert.match(evaluate, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
-  assert.match(evaluate, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
-  assert.doesNotMatch(evaluate, /--model sonnet/);
-  assert.match(evaluate, /--agent-timeout-ms "\$AGENT_TIMEOUT_MS"/);
-  assert.match(evaluate, /--agent-max-retries 1/);
+  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /--model|--judge-model|--agent-timeout-ms|--agent-max-retries/);
+  assert.match(evaluate, /executor-preflight[\s\S]*--plan "\$PACK_EVALUATOR_PLAN_PATH"/);
+  assert.match(evaluate, /executor-preflight[\s\S]*--artifact-gate "\$PACK_EVALUATOR_ARTIFACT_GATE_PATH"/);
   assert.match(evaluate, /PREFLIGHT_OUTCOME=command_failed/);
   assert.match(evaluate, /PREFLIGHT_ERROR_CLASS=unknown/);
-  assert.match(evaluate, /for ATTEMPT in 1 2/);
-  assert.match(evaluate, /should_retry_preflight "\$PREFLIGHT_OUTCOME" "\$PREFLIGHT_ERROR_CLASS" "\$ATTEMPT"/);
+  assert.match(evaluate, /for ATTEMPT in \$\(seq 1 "\$MAX_PREFLIGHT_ATTEMPTS"\)/);
+  assert.match(evaluate, /should_retry_preflight[\s\\]*"\$PREFLIGHT_OUTCOME"[\s\\]*"\$PREFLIGHT_ERROR_CLASS"[\s\\]*"\$ATTEMPT"[\s\\]*"\$MAX_PREFLIGHT_ATTEMPTS"/);
   assert.match(EVALUATOR_PREFLIGHT, /\[ "\$error_class" = 'retryable_http' \]/);
-  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$attempt" -lt 2 \]/);
+  assert.match(EVALUATOR_PREFLIGHT, /\[ "\$attempt" -lt "\$maximum_attempts" \]/);
   assert.match(evaluate, /cleanup_processes\(\)/);
   assert.match(evaluate, /RETRY_CLEANUP_OUTCOME=passed/);
-  assert.match(evaluate, /sleep 5/);
+  assert.match(evaluate, /sleep "\$PREFLIGHT_RETRY_DELAY_SECONDS"/);
   assert.match(evaluate, /commandAttempts: \$commandAttempts/);
   assert.match(evaluate, /agentExecutionEvidence: \$executionEvidence/);
   assert.match(evaluate, /durationMs: \$durationMs/);
@@ -286,26 +284,27 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
   assert.ok(evaluatorIndex > relaxedErrorIndex);
   assert.match(evaluate, /pack-production\.mjs verify/);
   assert.match(evaluate, /trusted evaluation closure verification failed/);
-  assert.match(evaluate, /timeout --signal=TERM --kill-after=30s 4h/);
-  assert.match(evaluate, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
+  assert.match(evaluate, /OUTER_EVALUATION_MS=\$\(jq -r '\.parameters\.timeoutsMs\.outerEvaluation'/);
+  assert.match(evaluate, /OUTER_EVALUATION_KILL_GRACE_MS=\$\(jq -r '\.parameters\.timeoutsMs\.outerEvaluationKillGrace'/);
+  assert.match(evaluate, /--nproc="\$MAX_PROCESSES:\$MAX_PROCESSES"/);
+  assert.match(evaluate, /--as="\$ADDRESS_SPACE_BYTES:\$ADDRESS_SPACE_BYTES"/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy request budget exhausted/);
   assert.match(EVALUATOR_PROXY, /evaluator proxy token has expired/);
   assert.match(EVALUATOR_PROXY, /response\.once\('close', abortUpstream\)/);
   assert.match(EVALUATOR_PROXY, /isDeterministicClientFailure/);
   assert.match(EVALUATOR_PROXY, /phase: 'circuit_open'/);
-  assert.match(evaluate, /Reject plans outside the bounded evaluation budget/);
-  assert.match(evaluate, /MAX_CANDIDATES=2/);
-  assert.match(evaluate, /MAX_BEST_SINGLE_COMPETITORS=\$\(\(SLOT_COUNT \* MAX_CANDIDATES\)\)/);
-  assert.match(evaluate, /CONTRACT_PROBES=2/);
-  assert.match(evaluate, /MAX_CLI_PREFLIGHT_REQUESTS=4/);
-  assert.match(evaluate, /TOOL_LOOP_HEADROOM=64/);
-  assert.match(evaluate, /PROXY_REQUEST_BUDGET=256/);
-  assert.match(evaluate, /3 \* SLOT_COUNT \* MAX_CANDIDATES/);
-  assert.match(evaluate, /3 \* HIDDEN_VARIANTS \* MAX_BEST_SINGLE_COMPETITORS/);
-  assert.match(evaluate, /HIDDEN_VARIANTS \* MAX_PACK_SKILLS \* \(MAX_PACK_SKILLS \+ 1\)/);
-  assert.match(evaluate, /skillToolFollowupsIncluded: true/);
-  assert.match(evaluate, /maxBestSingleCompetitors: \$maxBestSingleCompetitors/);
-  assert.match(evaluate, /ESTIMATED_REQUESTS[\s\S]*PROXY_REQUEST_BUDGET/);
+  assert.match(evaluate, /Record the Plan-bound evaluation budget/);
+  assert.match(PACK_PRODUCTION_PLAN, /proxy request reservation exceeds its budget/);
+  assert.match(PACK_PRODUCTION_PLAN, /const maxCandidates = 2/);
+  assert.match(PACK_PRODUCTION_PLAN, /const maxBestSingleCompetitors = slotCount \* maxCandidates/);
+  assert.match(PACK_PRODUCTION_PLAN, /contractProbes: 2/);
+  assert.match(PACK_PRODUCTION_PLAN, /maxCliPreflightRequests: 4/);
+  assert.match(PACK_PRODUCTION_PLAN, /toolLoopHeadroom: 64/);
+  assert.match(PACK_PRODUCTION_PLAN, /maxRequests: 256/);
+  assert.match(PACK_PRODUCTION_PLAN, /3 \* slotCount \* maxCandidates/);
+  assert.match(PACK_PRODUCTION_PLAN, /3 \* hiddenVariants \* maxBestSingleCompetitors/);
+  assert.match(PACK_PRODUCTION_PLAN, /hiddenVariants \* maxPackSkills \* \(maxPackSkills \+ 1\)/);
+  assert.match(PACK_PRODUCTION_PLAN, /reservedRequests: estimatedRequests \+ 64/);
   const maximumWireRequests = 2 + 4 + (3 * 4 * 2) + 3 + (3 * (4 + 2))
     + (2 * 3) + (3 * 3 * 8) + (3 * 4 * (4 + 1));
   assert.equal(maximumWireRequests, 189);
@@ -321,7 +320,7 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
 test('extracted evaluator preflight is valid bounded bash', () => {
   const result = spawnSync('bash', ['-n', EVALUATOR_PREFLIGHT_PATH], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
-  assert.match(EVALUATOR_PREFLIGHT, /for ATTEMPT in 1 2/);
+  assert.match(EVALUATOR_PREFLIGHT, /for ATTEMPT in \$\(seq 1 "\$MAX_PREFLIGHT_ATTEMPTS"\)/);
   assert.match(EVALUATOR_PREFLIGHT, /COMMAND_EXIT_CODE=\$\?/);
   assert.match(EVALUATOR_PREFLIGHT, /COMMAND_ATTEMPTS=/);
   assert.match(EVALUATOR_PREFLIGHT, /--argjson commandAttempts/);
@@ -329,12 +328,14 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/agent-preflight-diagnostics\.json/);
   assert.match(EVALUATOR_PREFLIGHT, /PACK_DIAGNOSTICS_DIR\/proxy-activity\.ndjson/);
   assert.match(EVALUATOR_PREFLIGHT, /setsid sudo env -i/);
-  assert.match(EVALUATOR_PREFLIGHT, /prlimit --nproc=256:256 --as=6442450944:6442450944/);
+  assert.match(EVALUATOR_PREFLIGHT, /--nproc="\$MAX_PROCESSES:\$MAX_PROCESSES"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--as="\$ADDRESS_SPACE_BYTES:\$ADDRESS_SPACE_BYTES"/);
   assert.match(EVALUATOR_PREFLIGHT, /"\$NODE" "\$ORCHESTRATOR" executor-preflight/);
-  assert.match(EVALUATOR_PREFLIGHT, /--skill-a "\$PREFLIGHT_SKILL_A"/);
-  assert.match(EVALUATOR_PREFLIGHT, /--skill-b "\$PREFLIGHT_SKILL_B"/);
-  assert.match(EVALUATOR_PREFLIGHT, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
-  assert.match(EVALUATOR_PREFLIGHT, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--plan "\$PACK_EVALUATOR_PLAN_PATH"/);
+  assert.match(EVALUATOR_PREFLIGHT, /--artifact-gate "\$PACK_EVALUATOR_ARTIFACT_GATE_PATH"/);
+  assert.match(EVALUATOR_PREFLIGHT, /EXPECTED_PREFLIGHT_SHA256/);
+  assert.match(EVALUATOR_PREFLIGHT, /ACTUAL_PREFLIGHT_SHA256/);
+  assert.doesNotMatch(EVALUATOR_PREFLIGHT, /PACK_EVALUATOR_(?:RUNNER|JUDGE)_MODEL/);
   assert.match(EVALUATOR_PREFLIGHT, /safe_runner_trace_evidence\(\)/);
   assert.match(EVALUATOR_PREFLIGHT, /proofBinding:/);
   assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_ENV_MODE=strict/);
@@ -346,21 +347,17 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.doesNotMatch(EVALUATOR_PREFLIGHT, /GITHUB_WORKSPACE/);
 });
 
-test('evaluator preflight rejects a non-positive Claude output-token cap before execution', () => {
+test('evaluator preflight requires the canonical Plan before execution', () => {
   const result = spawnSync('bash', [EVALUATOR_PREFLIGHT_PATH], {
     encoding: 'utf8',
     env: {
       PATH: process.env.PATH,
-      PACK_PRODUCTION_CLI_VERSION: '2.14.2',
-      PACK_EVALUATOR_RUNNER_MODEL: 'claude-sonnet-5',
-      PACK_EVALUATOR_JUDGE_MODEL: 'gpt-5.5',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
-      PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
     },
   });
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer/);
+  assert.match(result.stderr, /PACK_EVALUATOR_PLAN_PATH is required/);
 });
 
 test('preflight infrastructure evidence selects the last fatal response before category allowlisting', () => {
@@ -550,7 +547,7 @@ test('evaluator preflight retries only an exact bounded HTTP failure once', () =
   for (const errorClass of ['retryable_http']) {
     const result = spawnSync(
       'bash',
-      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', errorClass, '1'],
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3" "$4"`, 'policy', 'command_failed', errorClass, '1', '2'],
       { encoding: 'utf8' }
     );
     assert.equal(result.status, 0, `${errorClass} should receive one retry`);
@@ -567,7 +564,7 @@ test('evaluator preflight retries only an exact bounded HTTP failure once', () =
   ]) {
     const result = spawnSync(
       'bash',
-      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', errorClass, '1'],
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3" "$4"`, 'policy', 'command_failed', errorClass, '1', '2'],
       { encoding: 'utf8' }
     );
     assert.equal(result.status, 1, `${errorClass} must fail closed without retry`);
@@ -575,7 +572,7 @@ test('evaluator preflight retries only an exact bounded HTTP failure once', () =
   assert.equal(
     spawnSync(
       'bash',
-      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'command_failed', 'retryable_http', '2'],
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3" "$4"`, 'policy', 'command_failed', 'retryable_http', '2', '2'],
       { encoding: 'utf8' }
     ).status,
     1,
@@ -584,7 +581,7 @@ test('evaluator preflight retries only an exact bounded HTTP failure once', () =
   assert.equal(
     spawnSync(
       'bash',
-      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3"`, 'policy', 'invalid_response', 'unknown', '1'],
+      ['-c', `${policy}\nshould_retry_preflight "$1" "$2" "$3" "$4"`, 'policy', 'invalid_response', 'unknown', '1', '2'],
       { encoding: 'utf8' }
     ).status,
     1,
@@ -625,16 +622,12 @@ test('evaluate emits bounded progress and checkpoints cancellation-safe evidence
   assert.match(evaluate, /sudo ps -o stat= -g "\$EVALUATOR_PID"/);
   assert.match(evaluate, /sudo kill -TERM -- "-\$EVALUATOR_PID"/);
   assert.doesNotMatch(evaluate, /pgrep -f '\/opt\/pack-evaluator\/lib\/pack-production\.mjs evaluate'/);
-  assert.match(evaluate, /--model "\$PACK_EVALUATOR_RUNNER_MODEL"/);
-  assert.match(evaluate, /--judge-model "\$PACK_EVALUATOR_JUDGE_MODEL"/);
-  assert.doesNotMatch(evaluate, /--model sonnet/);
-  assert.match(evaluate, /--max-candidates 2/);
-  assert.match(evaluate, /--agent-timeout-ms 360000/);
-  assert.match(evaluate, /--agent-max-retries 1/);
-  assert.match(evaluate, /--evaluation-budget-ms 13800000/);
-  assert.match(evaluate, /--scenario-timeout-ms 7200000/);
-  assert.match(evaluate, /--minimum-fallback-ms 2700000/);
-  assert.match(evaluate, /--scenario-idle-timeout-ms 1200000/);
+  assert.doesNotMatch(
+    evaluate,
+    /--(?:model|judge-model|max-candidates|agent-timeout-ms|agent-max-retries|evaluation-budget-ms|scenario-timeout-ms|minimum-fallback-ms|scenario-idle-timeout-ms)/,
+  );
+  assert.match(evaluate, /pack-production\.mjs evaluate[\s\S]*--plan "\$PLAN_PATH"/);
+  assert.match(evaluate, /pack-production\.mjs evaluate[\s\S]*--artifact-gate "\$PLAN_GATE_PATH"/);
   assert.match(evaluate, /--proxy-activity-file "\$PROXY_ACTIVITY"/);
   assert.match(evaluate, /name: Upload trusted evaluation evidence\n\s+if: success\(\)/);
   assert.match(evaluate, /name: Upload bounded evaluation diagnostics\n\s+if: always\(\)/);
@@ -681,15 +674,19 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(plan, /commitSha: \$commitSha/);
   assert.match(plan, /has_scenarios=false/);
   assert.match(plan, /require\('node:crypto'\)\.randomUUID\(\)/);
-  assert.match(plan, /\.scenarios\[0\]\.generationId = \$generationId/);
-  assert.match(plan, /workflow: "Generate Pack"/);
-  assert.match(plan, /runAttempt: \$runAttempt/);
-  assert.match(plan, /scenarioId: \.scenarios\[0\]\.id/);
-  assert.match(plan, /immutablePlanSnapshotSha256/);
-  assert.match(plan, /planSnapshotSha256: \$planSnapshotSha256/);
+  assert.match(plan, /pack-production-plan\.mjs" create/);
+  assert.match(plan, /--workflow "\$GITHUB_WORKFLOW"/);
+  assert.match(plan, /--run-attempt "\$GITHUB_RUN_ATTEMPT"/);
+  assert.match(plan, /--head-sha "\$GITHUB_SHA"/);
+  assert.match(plan, /--cli "\$GITHUB_WORKSPACE\/pack-cli\/skillstore-cli-linux-x64"/);
+  assert.match(plan, /21b1967e134622a40ae4d312278fa10d136103f0148887252f61e4e3b4536674/);
+  assert.match(PACK_PRODUCTION_PLAN, /writeExecutionPlanAtomic/);
+  assert.match(PACK_PRODUCTION_PLAN, /writeCanonicalJsonAtomic/);
+  assert.match(PACK_PRODUCTION_PLAN, /rename\(temporary, target\)/);
+  assert.doesNotMatch(plan, /immutablePlanSnapshotSha256|planSnapshotSha256/);
   assert.match(plan, /\(has\("generationId"\) \| not\)/);
   assert.match(plan, /\(has\("workflowBinding"\) \| not\)/);
-  const allocationIndex = plan.indexOf('.scenarios[0].generationId = $generationId');
+  const allocationIndex = plan.indexOf('pack-production-plan.mjs" create');
   const uploadIndex = plan.indexOf('name: Upload immutable plan');
   assert.ok(allocationIndex >= 0 && uploadIndex > allocationIndex);
   const noOpStart = plan.indexOf('if [ "$SCENARIO_COUNT" -eq 0 ]; then');
@@ -701,14 +698,14 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   );
   assert.doesNotMatch(PACK_PRODUCTION, /randomUUID/);
   assert.match(PACK_PRODUCTION, /const generationId = scenario\.generationId/);
-  assert.match(PACK_PRODUCTION, /Evaluate summary generation id differs from the immutable plan/);
-  assert.match(PACK_PRODUCTION, /Immutable plan snapshot SHA-256 differs from its bound input snapshot/);
+  assert.match(PACK_PRODUCTION, /Evaluate summary attempt differs from the immutable plan generation binding/);
+  assert.match(PACK_PRODUCTION, /Evaluate summary differs from the execution Plan digest/);
   const evaluate = section('  evaluate:', '  persist:');
   const persist = section('  persist:', '  enrich_publish_readback:');
   const finalize = section('  enrich_publish_readback:');
-  assert.match(evaluate, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
-  assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
-  assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(evaluate, /if: inputs\.smoke_only != true && needs\.plan\.outputs\.has_scenarios == 'true'/);
+  assert.match(persist, /if: needs\.plan\.outputs\.has_scenarios == 'true' && needs\.evaluate\.result == 'success'/);
+  assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true' && needs\.persist\.result == 'success'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
   assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.2'/);
@@ -773,9 +770,10 @@ test('checkouts use isolated directories and never persist tokens', () => {
   assert.ok((WORKFLOW.match(/persist-credentials: false/g) ?? []).length >= 4);
   const persist = section('  persist:', '  enrich_publish_readback:');
   const finalize = section('  enrich_publish_readback:');
-  assert.match(persist, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
-  assert.match(finalize, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
-  assert.match(SLO_WORKFLOW, /sparse-checkout: scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/);
+  const sparseRuntime = /sparse-checkout: \|\n\s+scripts\/pack-production-plan\.mjs\n\s+scripts\/pack-production\.mjs\n\s+sparse-checkout-cone-mode: false/;
+  assert.match(persist, sparseRuntime);
+  assert.match(finalize, sparseRuntime);
+  assert.match(SLO_WORKFLOW, sparseRuntime);
 });
 
 test('CLI downloader verifies checksum before execution and shared-cache writes', () => {

--- a/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
+++ b/scripts/tests/pack-evaluator-bwrap-userns.test.mjs
@@ -123,11 +123,11 @@ test('hosted proof is manually gated, read-only, pinned, and invokes the product
   assert.match(HOSTED_CI, /download-skillstore-cli/);
   assert.match(HOSTED_CI, /require-checksum: 'true'/);
   assert.match(HOSTED_CI, /\/opt\/pack-evaluator\/bin\/skillstore-cli/);
-  assert.match(HOSTED_CI, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'/);
-  assert.match(
-    HOSTED_CI,
-    /PACK_EVALUATOR_MAX_OUTPUT_TOKENS="\$PACK_EVALUATOR_MAX_OUTPUT_TOKENS"/,
-  );
+  assert.match(HOSTED_CI, /pack-production-plan\.mjs create/);
+  assert.match(HOSTED_CI, /pack-production\.mjs artifact-gate/);
+  assert.match(HOSTED_CI, /PACK_EVALUATOR_PLAN_PATH=\/opt\/pack-evaluator\/input\/plan\.json/);
+  assert.match(HOSTED_CI, /PACK_EVALUATOR_ARTIFACT_GATE_PATH=\/opt\/pack-evaluator\/input\/plan-artifact-gate\.json/);
+  assert.doesNotMatch(HOSTED_CI, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS:/);
   assert.match(HOSTED_CI, /\.maxTokens == 16384/);
   assert.match(HOSTED_CI, /\.schemaVersion == "marketplace\.pack-executor-preflight\/v1"/);
   assert.match(HOSTED_CI, /\.mode == "pack-production-node-uid-nested-bwrap"/);

--- a/scripts/tests/pack-evaluator-contract-smoke.test.mjs
+++ b/scripts/tests/pack-evaluator-contract-smoke.test.mjs
@@ -3,7 +3,93 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import { runContractSmoke } from '../pack-evaluator-contract-smoke.mjs';
+import {
+  CLI_IDENTITY,
+  EXECUTION_SOURCE_FILES,
+  EXECUTOR_PREFLIGHT_SKILLS,
+  EXECUTOR_PREFLIGHT_TASK,
+  MODEL_IDENTITIES,
+  canonicalJson,
+  executionPlanDigest,
+  productionExecutionParameters,
+} from '../pack-production-plan.mjs';
+
+const digest = (value) => createHash('sha256').update(canonicalJson(value)).digest('hex');
+
+function contractExecutionPlan() {
+  const scenario = {
+    generationId: '123e4567-e89b-42d3-a456-426614174000',
+    id: 'contract-smoke',
+    task: 'Return the exact contract token.',
+    capabilitySlots: [{
+      id: 'contract-smoke', name: 'Contract Smoke', task: 'Return the exact token.',
+      keywords: ['contract'], required: true, artifactIds: ['contract-output'],
+    }],
+    requiredArtifacts: [{
+      id: 'contract-output', description: 'Exact contract token.', extensions: ['.txt'], minimumCount: 1,
+    }],
+  };
+  const parameters = productionExecutionParameters(1);
+  const models = {
+    runner: { ...MODEL_IDENTITIES.runner },
+    judge: { ...MODEL_IDENTITIES.judge },
+  };
+  const sourceFiles = EXECUTION_SOURCE_FILES.map((path) => ({
+    gitBlobSha: '1'.repeat(40), path, sha256: '2'.repeat(64),
+  }));
+  const plan = {
+    schemaVersion: 'marketplace.pack-production-execution-plan/v1',
+    scenario,
+    workflowBinding: {
+      repository: 'aiskillstore/marketplace', workflow: 'Generate Pack', runId: '111',
+      runAttempt: 1, headSha: '3'.repeat(40), scenarioId: scenario.id,
+      generationId: scenario.generationId,
+    },
+    executionBinding: {
+      cli: { ...CLI_IDENTITY },
+      evaluatorInputs: {
+        promptSha256: createHash('sha256').update(scenario.task).digest('hex'),
+        rulesSha256: digest({
+          capabilitySlots: scenario.capabilitySlots,
+          requiredArtifacts: scenario.requiredArtifacts,
+        }),
+        configSha256: digest({ cli: CLI_IDENTITY, models, parameters }),
+        scenarioSha256: digest(scenario),
+      },
+      models,
+      parameters,
+      executorPreflight: {
+        generationId: '00000000-0000-4000-8000-000000000001',
+        skillA: {
+          canonicalId: EXECUTOR_PREFLIGHT_SKILLS[0].canonicalId,
+          contentSha256: createHash('sha256').update(EXECUTOR_PREFLIGHT_SKILLS[0].contents).digest('hex'),
+          version: EXECUTOR_PREFLIGHT_SKILLS[0].version,
+        },
+        skillB: {
+          canonicalId: EXECUTOR_PREFLIGHT_SKILLS[1].canonicalId,
+          contentSha256: createHash('sha256').update(EXECUTOR_PREFLIGHT_SKILLS[1].contents).digest('hex'),
+          version: EXECUTOR_PREFLIGHT_SKILLS[1].version,
+        },
+        task: EXECUTOR_PREFLIGHT_TASK,
+      },
+      source: {
+        repositoryTreeSha: '4'.repeat(40),
+        skillsTreeSha: '5'.repeat(40),
+        skillsManifest: {
+          fileCount: 1, totalBytes: 1, sha256: '6'.repeat(64),
+        },
+        files: sourceFiles,
+      },
+    },
+  };
+  return { ...plan, digest: executionPlanDigest(plan) };
+}
+
+function contractSmoke(options) {
+  return runContractSmoke({ ...options, plan: contractExecutionPlan() });
+}
 
 function sse(events) {
   return `${events.map(({ type, data }) => (
@@ -33,11 +119,24 @@ function contractSse(url, { messagesText, responsesText, responsesCompleted = tr
     : sse(responsesEvents(responsesText, { completed: responsesCompleted }));
 }
 
+test('contract smoke rejects calls without the canonical execution Plan', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-no-plan-'));
+  await assert.rejects(
+    () => runContractSmoke({
+      proxyUrl: 'http://127.0.0.1:1',
+      proxyToken: 'local-token',
+      diagnosticsFile: join(directory, 'diagnostics.json'),
+      fetchImpl: async () => { throw new Error('must not call network'); },
+    }),
+    /Canonical execution Plan is required/,
+  );
+});
+
 test('contract smoke makes one bounded request for Messages and Responses before evaluation', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   const calls = [];
-  const diagnostics = await runContractSmoke({
+  const diagnostics = await contractSmoke({
     proxyUrl: 'http://127.0.0.1:18765',
     token: 'job-local-secret',
     diagnosticsFile,
@@ -78,7 +177,7 @@ test('generated text mismatch is redacted diagnostics and not a protocol failure
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-content-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   let calls = 0;
-  const diagnostics = await runContractSmoke({
+  const diagnostics = await contractSmoke({
     proxyUrl: 'http://127.0.0.1:18765',
     token: 'job-local-secret',
     diagnosticsFile,
@@ -112,7 +211,7 @@ for (const emptyContract of ['messages', 'responses']) {
     const diagnosticsFile = join(directory, 'contract-smoke.json');
     let calls = 0;
     await assert.rejects(
-      runContractSmoke({
+      contractSmoke({
         proxyUrl: 'http://127.0.0.1:18765',
         token: 'job-local-secret',
         diagnosticsFile,
@@ -145,7 +244,7 @@ for (const errorContract of ['messages', 'responses']) {
     const diagnosticsFile = join(directory, 'contract-smoke.json');
     let calls = 0;
     await assert.rejects(
-      runContractSmoke({
+      contractSmoke({
         proxyUrl: 'http://127.0.0.1:18765',
         token: 'job-local-secret',
         diagnosticsFile,
@@ -185,7 +284,7 @@ test('HTTP 200 JSON is not accepted as an SSE protocol response', async () => {
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   let calls = 0;
   await assert.rejects(
-    runContractSmoke({
+    contractSmoke({
       proxyUrl: 'http://127.0.0.1:18765',
       token: 'job-local-secret',
       diagnosticsFile,
@@ -209,7 +308,7 @@ test('malformed SSE JSON remains a protocol failure', async () => {
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   let calls = 0;
   await assert.rejects(
-    runContractSmoke({
+    contractSmoke({
       proxyUrl: 'http://127.0.0.1:18765',
       token: 'job-local-secret',
       diagnosticsFile,
@@ -235,7 +334,7 @@ test('wrong first SSE event remains a protocol failure', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-first-event-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   await assert.rejects(
-    runContractSmoke({
+    contractSmoke({
       proxyUrl: 'http://127.0.0.1:18765',
       token: 'job-local-secret',
       diagnosticsFile,
@@ -263,7 +362,7 @@ test('missing completion SSE event remains a protocol failure', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-contract-smoke-completed-'));
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   await assert.rejects(
-    runContractSmoke({
+    contractSmoke({
       proxyUrl: 'http://127.0.0.1:18765',
       token: 'job-local-secret',
       diagnosticsFile,
@@ -285,7 +384,7 @@ test('contract smoke still sends exactly two probes after an HTTP error without 
   const diagnosticsFile = join(directory, 'contract-smoke.json');
   let calls = 0;
   await assert.rejects(
-    runContractSmoke({
+    contractSmoke({
       proxyUrl: 'http://127.0.0.1:18765',
       token: 'job-local-secret',
       diagnosticsFile,

--- a/scripts/tests/pack-production-cancellation-recovery.test.mjs
+++ b/scripts/tests/pack-production-cancellation-recovery.test.mjs
@@ -9,6 +9,17 @@ import {
   persistCancellationRecovery,
   prepareCancellationRecovery,
 } from '../pack-production-cancellation-recovery.mjs';
+import {
+  CLI_IDENTITY,
+  EXECUTION_SOURCE_FILES,
+  EXECUTOR_PREFLIGHT_SKILLS,
+  EXECUTOR_PREFLIGHT_TASK,
+  MODEL_IDENTITIES,
+  canonicalJson,
+  executionPlanDigest,
+  productionExecutionParameters,
+  sha256,
+} from '../pack-production-plan.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const WORKFLOW_FILE = join(REPO_ROOT, '.github/workflows/recover-cancelled-pack-production.yml');
@@ -17,7 +28,7 @@ const RECOVERY_HELPER = readFileSync(join(REPO_ROOT, 'scripts/pack-production-ca
 const GENERATION_ID = '11111111-1111-4111-8111-111111111111';
 const SOURCE_SHA = 'a'.repeat(40);
 const CURRENT_SHA = 'b'.repeat(40);
-const CLI_SHA = 'c'.repeat(64);
+const CLI_SHA = CLI_IDENTITY.releaseAssetSha256;
 
 function json(file, value) {
   writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
@@ -84,13 +95,15 @@ function metadata() {
 env:
   PACK_PRODUCTION_CLI_VERSION: '2.14.2'
 jobs:
-  evaluate:
+  plan:
     steps:
       - run: |
-          command --model sonnet \\
-            --judge-model gpt-5.5 \\
           GENERATION_ID=$(node -e "process.stdout.write(require('node:crypto').randomUUID())")
-          jq '.scenarios[0].generationId = $generationId | .workflowBinding = {' plan.json
+          node "$GITHUB_WORKSPACE/marketplace-plan/scripts/pack-production-plan.mjs" create \\
+            --workflow "$GITHUB_WORKFLOW" \\
+            --run-id "$GITHUB_RUN_ID" \\
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \\
+            --head-sha "$GITHUB_SHA"
 `,
   };
 }
@@ -130,6 +143,72 @@ function scenario(generationId = GENERATION_ID) {
   };
 }
 
+function executionPlan(generationId = GENERATION_ID) {
+  const plannedScenario = scenario(generationId);
+  const parameters = productionExecutionParameters(plannedScenario.capabilitySlots.length);
+  const cli = { ...CLI_IDENTITY };
+  const models = structuredClone(MODEL_IDENTITIES);
+  const executorPreflight = {
+    generationId: '00000000-0000-4000-8000-000000000001',
+    skillA: {
+      canonicalId: EXECUTOR_PREFLIGHT_SKILLS[0].canonicalId,
+      contentSha256: sha256(EXECUTOR_PREFLIGHT_SKILLS[0].contents),
+      version: EXECUTOR_PREFLIGHT_SKILLS[0].version,
+    },
+    skillB: {
+      canonicalId: EXECUTOR_PREFLIGHT_SKILLS[1].canonicalId,
+      contentSha256: sha256(EXECUTOR_PREFLIGHT_SKILLS[1].contents),
+      version: EXECUTOR_PREFLIGHT_SKILLS[1].version,
+    },
+    task: EXECUTOR_PREFLIGHT_TASK,
+  };
+  const executionBinding = {
+    cli,
+    evaluatorInputs: null,
+    executorPreflight,
+    models,
+    parameters,
+    source: {
+      repositoryTreeSha: 'c'.repeat(40),
+      skillsTreeSha: 'd'.repeat(40),
+      skillsManifest: {
+        sha256: 'e'.repeat(64),
+        fileCount: 1,
+        totalBytes: 1,
+      },
+      files: EXECUTION_SOURCE_FILES.map((path, index) => ({
+        path,
+        gitBlobSha: `${(index + 1).toString(16)}`.repeat(40),
+        sha256: `${(index + 1).toString(16)}`.repeat(64),
+      })),
+    },
+  };
+  executionBinding.evaluatorInputs = {
+    configSha256: sha256(canonicalJson({ cli, models, parameters })),
+    promptSha256: sha256(plannedScenario.task),
+    rulesSha256: sha256(canonicalJson({
+      capabilitySlots: plannedScenario.capabilitySlots,
+      requiredArtifacts: plannedScenario.requiredArtifacts,
+    })),
+    scenarioSha256: sha256(canonicalJson(plannedScenario)),
+  };
+  const plan = {
+    schemaVersion: 'marketplace.pack-production-execution-plan/v1',
+    workflowBinding: {
+      repository: 'aiskillstore/marketplace',
+      workflow: 'Generate Pack',
+      runId: '12345',
+      runAttempt: 2,
+      headSha: SOURCE_SHA,
+      scenarioId: plannedScenario.id,
+      generationId,
+    },
+    executionBinding,
+    scenario: plannedScenario,
+  };
+  return { ...plan, digest: executionPlanDigest(plan) };
+}
+
 function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = null } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'pack-cancellation-recovery-'));
   const planDir = join(root, 'plan');
@@ -138,21 +217,7 @@ function createInput({ generationId = GENERATION_ID, artifacts, diagnostics = nu
   mkdirSync(planDir, { recursive: true });
   mkdirSync(diagnosticsDir, { recursive: true });
   mkdirSync(outputDir, { recursive: true });
-  const frozen = source();
-  json(join(planDir, 'plan.json'), {
-    schemaVersion: 'pack-production-queue/v1',
-    source: 'signals',
-    scenarios: [scenario(generationId)],
-    workflowBinding: {
-      repository: frozen.repository,
-      workflow: frozen.workflowName,
-      runId: String(frozen.runId),
-      runAttempt: frozen.runAttempt,
-      commitSha: frozen.commitSha,
-      scenarioId: 'spreadsheet-audit',
-    },
-  });
-  json(join(planDir, 'cli-identity.json'), { version: '2.14.2', sha256: CLI_SHA });
+  writeFileSync(join(planDir, 'plan.json'), canonicalJson(executionPlan(generationId)));
   if (diagnostics) {
     for (const [name, value] of Object.entries(diagnostics)) {
       if (typeof value === 'string') writeFileSync(join(diagnosticsDir, name), value);
@@ -192,7 +257,10 @@ test('immutable plan generation id produces a sanitized v4 candidate-null recove
   assert.equal(result.generationId, GENERATION_ID);
   assert.equal(result.evidence.recoveryBinding.generationSource, 'immutable-plan');
   assert.match(result.evidence.recoveryBinding.planSha256, /^[0-9a-f]{64}$/);
+  assert.match(result.evidence.recoveryBinding.executionPlanDigest, /^[0-9a-f]{64}$/);
   assert.match(result.evidence.recoveryBinding.cliIdentitySha256, /^[0-9a-f]{64}$/);
+  assert.deepEqual(result.evidence.recoveryBinding.runner, MODEL_IDENTITIES.runner);
+  assert.deepEqual(result.evidence.recoveryBinding.judge, MODEL_IDENTITIES.judge);
   assert.equal(result.evidence.recoveryBinding.diagnosticsBindingSha256, null);
   const evaluation = JSON.parse(readFileSync(join(input.outputDir, 'candidate-null.evaluation.json')));
   assert.equal(evaluation.schemaVersion, 'skillstore.pack-evaluation/v4');
@@ -256,7 +324,7 @@ test('missing or conflicting immutable generation provenance never invents an id
   const missing = createInput({ generationId: null });
   const missingResult = await prepareCancellationRecovery(missing);
   assert.equal(missingResult.outcome, 'unrecoverable');
-  assert.equal(missingResult.reason, 'immutable_plan_generation_id_invalid');
+  assert.equal(missingResult.reason, 'immutable_execution_plan_invalid');
   assert.equal(missingResult.generationId, null);
 
   const progress = [GENERATION_ID, '22222222-2222-4222-8222-222222222222']
@@ -298,7 +366,7 @@ test('source attempt and artifact provenance are bound to the exact cancelled at
   legacySourceWorkflow.workflowSource = legacySourceWorkflow.workflowSource.replace('randomUUID()', 'legacyId()');
   await assert.rejects(
     prepareCancellationRecovery(legacySourceWorkflow),
-    /lacks immutable generation and workflow binding/,
+    /lacks canonical execution Plan creation and workflow binding/,
   );
 });
 
@@ -327,6 +395,7 @@ test('an evaluator summary with a recorded report is never overwritten by recove
     diagnostics: {
       'evaluate-summary.json': {
         schemaVersion: 'marketplace.pack-production-evaluate/v1',
+        executionPlanDigest: executionPlan().digest,
         cliVersion: '2.14.2',
         cliSha256: CLI_SHA,
         attempts: [{ scenarioId: 'spreadsheet-audit', generationId: GENERATION_ID, status: 'completed' }],

--- a/scripts/tests/pack-production-execution-plan.test.mjs
+++ b/scripts/tests/pack-production-execution-plan.test.mjs
@@ -1,0 +1,491 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PACK_PRODUCTION = fileURLToPath(new URL('../pack-production.mjs', import.meta.url));
+const PLAN_MODULE = new URL('../pack-production-plan.mjs', import.meta.url);
+const GENERATION_ID = 'a43f792e-92ac-4b9d-b0fe-eafe4855d3a0';
+const HEAD_SHA = 'a'.repeat(40);
+const CLI_ASSET = 'skillstore-cli-linux-x64';
+
+function normalizeJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeJson(entry)]),
+    );
+  }
+  throw new Error('fixture value is not JSON');
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(normalizeJson(value));
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function scenario() {
+  return {
+    capabilitySlots: [
+      { id: 'workbook', required: true },
+      { id: 'validation', required: true },
+    ],
+    generationId: GENERATION_ID,
+    id: 'excel-dashboard',
+    name: 'Monthly Sales Excel Dashboard',
+    requiredArtifacts: [
+      { extensions: ['.xlsx'], id: 'workbook', minimumCount: 1 },
+    ],
+    slug: 'monthly-sales-excel-workbook',
+    tags: ['excel', 'dashboard'],
+    task: 'Create a real workbook.',
+    version: '1.0.0',
+  };
+}
+
+function parameters(slotCount = 2) {
+  const maxCandidates = 2;
+  const hiddenVariants = 3;
+  const maxPackSkills = 4;
+  const maxBestSingleCompetitors = slotCount * maxCandidates;
+  const estimatedRequests = 2
+    + 4
+    + (3 * slotCount * maxCandidates)
+    + 3
+    + (hiddenVariants * (maxPackSkills + 2))
+    + (2 * hiddenVariants)
+    + (3 * hiddenVariants * maxBestSingleCompetitors)
+    + (hiddenVariants * maxPackSkills * (maxPackSkills + 1));
+  return {
+    generation: {
+      autoPublishThreshold: 8,
+      baselineDelta: 1,
+      finalRuns: 3,
+      maxCandidates,
+      pick: 4,
+      runs: 1,
+      threshold: 7,
+    },
+    proxy: {
+      allowedModels: ['claude-sonnet-5', 'gpt-5.5'],
+      contractProbes: 2,
+      estimatedRequests,
+      hiddenVariants,
+      maxBestSingleCompetitors,
+      maxCliPreflightRequests: 4,
+      maxConcurrent: 4,
+      maxPackSkills,
+      maxRequests: 256,
+      port: 18765,
+      reservedRequests: estimatedRequests + 64,
+      toolLoopHeadroom: 64,
+      upstreamUrl: 'https://helm.easymeta.au',
+    },
+    resources: {
+      addressSpaceBytes: 6_442_450_944,
+      evaluatorOutputBytes: 16_777_216,
+      maxProcesses: 256,
+      proxyActivityBytes: 1_048_576,
+      resultBytes: 268_435_456,
+      resultFiles: 1000,
+    },
+    retries: {
+      agentMaxRetries: 1,
+      contractMaxRetries: 0,
+      executorPreflightMaxAttempts: 2,
+    },
+    runtime: {
+      claudeCodeVersion: '2.1.210',
+      codexVersion: '0.139.0',
+    },
+    timeoutsMs: {
+      agent: 360_000,
+      contract: 30_000,
+      evaluationBudget: 13_800_000,
+      evaluatorHeartbeat: 60_000,
+      executorPreflight: 360_000,
+      executorPreflightAgent: 180_000,
+      executorPreflightHeartbeat: 30_000,
+      executorPreflightIdle: 240_000,
+      executorPreflightOuterKillGrace: 5_000,
+      executorPreflightOuter: 420_000,
+      executorPreflightRetryDelay: 5_000,
+      minimumFallback: 2_700_000,
+      outerEvaluation: 14_400_000,
+      outerEvaluationKillGrace: 30_000,
+      processKillGrace: 3_000,
+      proxyRequest: 600_000,
+      proxyTtl: 14_400_000,
+      scenario: 7_200_000,
+      scenarioIdle: 1_200_000,
+    },
+    tokens: {
+      contractProbeOutput: 16,
+      maxOutput: 16_384,
+    },
+  };
+}
+
+function executionPlan() {
+  const plannedScenario = scenario();
+  const models = {
+    judge: {
+      identity: 'gpt-5.5',
+      pinType: 'workflow-pinned alias',
+      revision: 'workflow-pinned alias',
+    },
+    runner: {
+      identity: 'claude-sonnet-5',
+      pinType: 'workflow-pinned alias',
+      revision: 'workflow-pinned alias',
+    },
+  };
+  const cli = {
+    assetName: CLI_ASSET,
+    releaseAssetSha256: '21b1967e134622a40ae4d312278fa10d136103f0148887252f61e4e3b4536674',
+    version: '2.14.2',
+  };
+  const boundParameters = parameters(plannedScenario.capabilitySlots.length);
+  const unsigned = {
+    executionBinding: {
+      cli,
+      evaluatorInputs: {
+        configSha256: sha256(canonicalJson({ cli, models, parameters: boundParameters })),
+        promptSha256: sha256(plannedScenario.task),
+        rulesSha256: sha256(canonicalJson({
+          capabilitySlots: plannedScenario.capabilitySlots,
+          requiredArtifacts: plannedScenario.requiredArtifacts,
+        })),
+        scenarioSha256: sha256(canonicalJson(plannedScenario)),
+      },
+      executorPreflight: {
+        generationId: '00000000-0000-4000-8000-000000000001',
+        skillA: {
+          canonicalId: 'pack-executor-preflight-a',
+          contentSha256: 'b'.repeat(64),
+          version: '1.0.0',
+        },
+        skillB: {
+          canonicalId: 'pack-executor-preflight-b',
+          contentSha256: 'c'.repeat(64),
+          version: '1.0.0',
+        },
+        task: 'Invoke Skill pack-executor-preflight-a first and Skill pack-executor-preflight-b second. After both Skills load successfully, reply with exactly PACK_EVALUATOR_READY and nothing else.',
+      },
+      models,
+      parameters: boundParameters,
+      source: {
+        files: [
+          {
+            gitBlobSha: '1'.repeat(40),
+            path: '.github/workflows/generate-packs.yml',
+            sha256: '1'.repeat(64),
+          },
+          {
+            gitBlobSha: '2'.repeat(40),
+            path: 'scripts/pack-evaluator-contract-smoke.mjs',
+            sha256: '2'.repeat(64),
+          },
+          {
+            gitBlobSha: '3'.repeat(40),
+            path: 'scripts/pack-evaluator-preflight.sh',
+            sha256: '3'.repeat(64),
+          },
+          {
+            gitBlobSha: '4'.repeat(40),
+            path: 'scripts/pack-evaluator-proxy.mjs',
+            sha256: '4'.repeat(64),
+          },
+          {
+            gitBlobSha: '5'.repeat(40),
+            path: 'scripts/pack-production-plan.mjs',
+            sha256: '5'.repeat(64),
+          },
+          {
+            gitBlobSha: '6'.repeat(40),
+            path: 'scripts/pack-production.mjs',
+            sha256: '6'.repeat(64),
+          },
+        ],
+        repositoryTreeSha: 'd'.repeat(40),
+        skillsManifest: {
+          fileCount: 1,
+          sha256: 'f'.repeat(64),
+          totalBytes: 1,
+        },
+        skillsTreeSha: 'e'.repeat(40),
+      },
+    },
+    scenario: plannedScenario,
+    schemaVersion: 'marketplace.pack-production-execution-plan/v1',
+    workflowBinding: {
+      generationId: GENERATION_ID,
+      headSha: HEAD_SHA,
+      repository: 'aiskillstore/marketplace',
+      runAttempt: 1,
+      runId: '123456789',
+      scenarioId: plannedScenario.id,
+      workflow: 'Generate Pack',
+    },
+  };
+  return { ...unsigned, digest: sha256(canonicalJson(unsigned)) };
+}
+
+function writeCanonical(file, value) {
+  writeFileSync(file, canonicalJson(value));
+}
+
+function mutatePlan(plan, mutate) {
+  const changed = structuredClone(plan);
+  mutate(changed);
+  return changed;
+}
+
+function evaluateResult(plan) {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-execution-plan-evaluate-'));
+  const cli = join(directory, CLI_ASSET);
+  writeFileSync(cli, '#!/bin/sh\necho "skillstore-cli 2.14.2"\n');
+  chmodSync(cli, 0o755);
+  const planFile = join(directory, 'plan.json');
+  writeCanonical(planFile, plan);
+  return spawnSync(process.execPath, [
+    PACK_PRODUCTION,
+    'evaluate',
+    '--plan', planFile,
+    '--results-dir', join(directory, 'results'),
+    '--cli', cli,
+    '--skills-dir', directory,
+  ], { encoding: 'utf8' });
+}
+
+function downstreamResult(command, plan) {
+  const directory = mkdtempSync(join(tmpdir(), `pack-${command}-execution-plan-`));
+  const planFile = join(directory, 'plan.json');
+  writeCanonical(planFile, plan);
+  return spawnSync(process.execPath, [
+    PACK_PRODUCTION,
+    command,
+    '--plan', planFile,
+    '--results-dir', directory,
+  ], { encoding: 'utf8' });
+}
+
+for (const command of ['evaluate', 'verify']) {
+  test(`${command} rejects deprecated model, CLI, and execution overrides before runtime`, () => {
+    const directory = mkdtempSync(join(tmpdir(), `pack-${command}-deprecated-overrides-`));
+    const planFile = join(directory, 'plan.json');
+    writeCanonical(planFile, executionPlan());
+    const result = spawnSync(process.execPath, [
+      PACK_PRODUCTION,
+      command,
+      '--plan', planFile,
+      '--model', 'changed-runner',
+      '--judge-model', 'changed-judge',
+      '--expected-cli-version', '0.0.0',
+      '--max-candidates', '99',
+    ], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, new RegExp(`${command} rejects deprecated execution override flag`));
+    assert.match(result.stderr, /--model/);
+    assert.match(result.stderr, /--judge-model/);
+    assert.match(result.stderr, /--expected-cli-version/);
+    assert.match(result.stderr, /--max-candidates/);
+    assert.doesNotMatch(result.stderr, /--artifact-gate is required|--cli is required/);
+  });
+}
+
+test('canonical execution Plan round-trips atomically and rejects non-canonical bytes', async () => {
+  const {
+    readExecutionPlan,
+    writeExecutionPlanAtomic,
+  } = await import(PLAN_MODULE);
+  const directory = mkdtempSync(join(tmpdir(), 'pack-execution-plan-canonical-'));
+  const planFile = join(directory, 'plan.json');
+  const plan = executionPlan();
+
+  await writeExecutionPlanAtomic(planFile, plan);
+  assert.equal(readFileSync(planFile, 'utf8'), canonicalJson(plan));
+  assert.deepEqual(await readExecutionPlan(planFile), plan);
+  assert.equal(existsSync(`${planFile}.tmp`), false);
+
+  writeFileSync(planFile, `${canonicalJson(plan)}\n`);
+  await assert.rejects(readExecutionPlan(planFile), /canonical JSON bytes/);
+
+  const duplicate = canonicalJson(plan).replace(
+    '"schemaVersion":"marketplace.pack-production-execution-plan/v1"',
+    '"schemaVersion":"marketplace.pack-production-execution-plan/v1","schemaVersion":"marketplace.pack-production-execution-plan/v1"',
+  );
+  writeFileSync(planFile, duplicate);
+  await assert.rejects(readExecutionPlan(planFile), /canonical JSON bytes/);
+});
+
+const planMutations = [
+  ['runId', (plan) => { plan.workflowBinding.runId = '987654321'; }],
+  ['runAttempt', (plan) => { plan.workflowBinding.runAttempt = 2; }],
+  ['headSha', (plan) => { plan.workflowBinding.headSha = 'f'.repeat(40); }],
+  ['scenarioId', (plan) => { plan.workflowBinding.scenarioId = 'changed-scenario'; }],
+  ['generationId', (plan) => {
+    plan.workflowBinding.generationId = '22222222-2222-4222-8222-222222222222';
+  }],
+  ['runner identity', (plan) => { plan.executionBinding.models.runner.identity = 'claude-other'; }],
+  ['runner revision', (plan) => { plan.executionBinding.models.runner.revision = 'claude-other'; }],
+  ['judge identity', (plan) => { plan.executionBinding.models.judge.identity = 'gpt-other'; }],
+  ['judge revision', (plan) => { plan.executionBinding.models.judge.revision = 'gpt-other'; }],
+  ['CLI version', (plan) => { plan.executionBinding.cli.version = '2.14.1'; }],
+  ['CLI asset name', (plan) => { plan.executionBinding.cli.assetName = 'other-cli'; }],
+  ['CLI asset SHA', (plan) => { plan.executionBinding.cli.releaseAssetSha256 = '0'.repeat(64); }],
+  ['evaluator prompt digest', (plan) => {
+    plan.executionBinding.evaluatorInputs.promptSha256 = '0'.repeat(64);
+  }],
+  ['evaluator rules digest', (plan) => {
+    plan.executionBinding.evaluatorInputs.rulesSha256 = '0'.repeat(64);
+  }],
+  ['evaluator config digest', (plan) => {
+    plan.executionBinding.evaluatorInputs.configSha256 = '0'.repeat(64);
+  }],
+  ['script digest', (plan) => { plan.executionBinding.source.files[0].sha256 = '0'.repeat(64); }],
+  ['Skills bytes manifest', (plan) => {
+    plan.executionBinding.source.skillsManifest.sha256 = '0'.repeat(64);
+  }],
+  ['skills tree', (plan) => { plan.executionBinding.source.skillsTreeSha = '0'.repeat(40); }],
+  ['repository tree', (plan) => {
+    plan.executionBinding.source.repositoryTreeSha = '0'.repeat(40);
+  }],
+  ['scenario digest', (plan) => {
+    plan.executionBinding.evaluatorInputs.scenarioSha256 = '0'.repeat(64);
+  }],
+  ['scenario bytes', (plan) => { plan.scenario.task = 'Changed task bytes.'; }],
+  ['threshold', (plan) => { plan.executionBinding.parameters.generation.threshold = 6; }],
+  ['timeout', (plan) => { plan.executionBinding.parameters.timeoutsMs.scenario = 1; }],
+  ['budget', (plan) => { plan.executionBinding.parameters.proxy.maxRequests = 255; }],
+  ['output cap', (plan) => { plan.executionBinding.parameters.tokens.maxOutput = 8192; }],
+  ['resource limit', (plan) => {
+    plan.executionBinding.parameters.resources.maxProcesses = 255;
+  }],
+];
+
+for (const [name, mutate] of planMutations) {
+  for (const command of ['evaluate', 'persist', 'finalize']) {
+    test(`${command} rejects a changed ${name} from an old Plan`, () => {
+      const changed = mutatePlan(executionPlan(), mutate);
+      const result = command === 'evaluate'
+        ? evaluateResult(changed)
+        : downstreamResult(command, changed);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /execution Plan digest mismatch/);
+      assert.doesNotMatch(result.stderr, /--token is required|--api-url is required/);
+    });
+  }
+}
+
+function artifactState(plan, producerStatus = 'success', artifactStatus = 'downloaded') {
+  return {
+    artifact: {
+      name: 'pack-production-evaluation',
+      planDigest: plan.digest,
+      status: artifactStatus,
+    },
+    producer: {
+      name: 'evaluate',
+      status: producerStatus,
+    },
+    schemaVersion: 'marketplace.pack-production-artifact-state/v1',
+    workflowBinding: plan.workflowBinding,
+  };
+}
+
+function artifactGateResult(state, plan = executionPlan()) {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-artifact-gate-'));
+  const planFile = join(directory, 'plan.json');
+  const stateFile = join(directory, 'state.json');
+  const outputFile = join(directory, 'gate.json');
+  writeCanonical(planFile, plan);
+  writeCanonical(stateFile, state);
+  const result = spawnSync(process.execPath, [
+    PACK_PRODUCTION,
+    'artifact-gate',
+    '--plan', planFile,
+    '--state', stateFile,
+    '--output', outputFile,
+  ], { encoding: 'utf8' });
+  return { directory, outputFile, result };
+}
+
+test('same-Plan producer and downloaded artifact pass the runtime artifact gate', () => {
+  const plan = executionPlan();
+  const { outputFile, result } = artifactGateResult(artifactState(plan), plan);
+  assert.equal(result.status, 0, result.stderr);
+  const gate = JSON.parse(readFileSync(outputFile, 'utf8'));
+  assert.equal(gate.planDigest, plan.digest);
+  assert.equal(gate.producer.status, 'success');
+  assert.equal(gate.artifact.status, 'downloaded');
+  assert.match(gate.digest, /^[0-9a-f]{64}$/);
+});
+
+for (const status of ['missing', 'failed', 'cancelled', 'skipped']) {
+  test(`artifact gate fails closed for ${status} producer state`, () => {
+    const plan = executionPlan();
+    const { result } = artifactGateResult(artifactState(plan, status), plan);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /producer status must be success/);
+  });
+
+  test(`artifact gate fails closed for ${status} artifact state`, () => {
+    const plan = executionPlan();
+    const { result } = artifactGateResult(artifactState(plan, 'success', status), plan);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /artifact status must be downloaded/);
+  });
+}
+
+test('artifact gate rejects an artifact made under a different complete Plan', () => {
+  const plan = executionPlan();
+  const changed = structuredClone(plan);
+  changed.workflowBinding.runAttempt = 2;
+  const { digest: _digest, ...unsigned } = changed;
+  changed.digest = sha256(canonicalJson(unsigned));
+  const { result } = artifactGateResult(artifactState(plan), changed);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /artifact state differs from the execution Plan/);
+});
+
+for (const command of ['persist', 'finalize']) {
+  test(`${command} rejects a changed Plan before any downstream write or publish action`, () => {
+    const original = executionPlan();
+    const { outputFile, result: gateResult } = artifactGateResult(artifactState(original), original);
+    assert.equal(gateResult.status, 0, gateResult.stderr);
+    const changed = mutatePlan(original, (plan) => {
+      plan.workflowBinding.headSha = 'f'.repeat(40);
+    });
+    const directory = mkdtempSync(join(tmpdir(), `pack-${command}-plan-gate-`));
+    const planFile = join(directory, 'plan.json');
+    writeCanonical(planFile, changed);
+    const result = spawnSync(process.execPath, [
+      PACK_PRODUCTION,
+      command,
+      '--plan', planFile,
+      '--artifact-gate', outputFile,
+      '--results-dir', directory,
+    ], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /execution Plan digest mismatch/);
+    assert.doesNotMatch(result.stderr, /--token is required|--api-url is required/);
+  });
+}

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -320,10 +320,13 @@ export const context = {
 };
 
 function immutableProductionPlan(scenario, generationId = context.generationId) {
-  return {
+  const plan = {
     schemaVersion: 'pack-production-queue/v1',
     source: 'signals',
     scenarios: [{ ...scenario, generationId }],
+  };
+  return {
+    ...plan,
     workflowBinding: {
       repository: 'aiskillstore/marketplace',
       workflow: 'Generate Pack',
@@ -331,6 +334,7 @@ function immutableProductionPlan(scenario, generationId = context.generationId) 
       runAttempt: context.runAttempt,
       commitSha: context.commitSha,
       scenarioId: scenario.id,
+      planSnapshotSha256: createHash('sha256').update(canonicalJson(plan)).digest('hex'),
     },
   };
 }
@@ -425,6 +429,20 @@ test('immutable production plan binds one generation id to the exact workflow in
       workflowBinding: { ...plan.workflowBinding, injected: true },
     }, workflowArgs),
     /unexpected fields/,
+  );
+  assert.throws(
+    () => validateImmutableProductionPlan({
+      ...plan,
+      workflowBinding: { ...plan.workflowBinding, planSnapshotSha256: undefined },
+    }, workflowArgs),
+    /snapshot SHA-256 is invalid/,
+  );
+  assert.throws(
+    () => validateImmutableProductionPlan({
+      ...plan,
+      scenarios: [{ ...plan.scenarios[0], task: 'live drift after snapshot' }],
+    }, workflowArgs),
+    /snapshot SHA-256 differs/,
   );
 });
 

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -12,6 +12,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
@@ -42,9 +43,20 @@ import {
   validateImmutableProductionPlan,
   validatePublicPackReadback,
 } from '../pack-production.mjs';
+import {
+  EXECUTION_SOURCE_FILES,
+  MODEL_IDENTITIES,
+  productionExecutionParameters,
+} from '../pack-production-plan.mjs';
 
 const PACK_PRODUCTION = fileURLToPath(new URL('../pack-production.mjs', import.meta.url));
+const PACK_PRODUCTION_PLAN = fileURLToPath(new URL('../pack-production-plan.mjs', import.meta.url));
 const PACK_PRODUCTION_URL = new URL('../pack-production.mjs', import.meta.url).href;
+const testSha256 = (value) => createHash('sha256').update(value).digest('hex');
+const RUNTIME_SOURCE_SHA256 = new Map([
+  ['scripts/pack-production.mjs', createHash('sha256').update(readFileSync(PACK_PRODUCTION)).digest('hex')],
+  ['scripts/pack-production-plan.mjs', createHash('sha256').update(readFileSync(PACK_PRODUCTION_PLAN)).digest('hex')],
+]);
 const V4_GOLDEN = fileURLToPath(new URL('./fixtures/pack-production-evaluation-v4.golden.json', import.meta.url));
 
 test('automatic publication is hard-disabled even when explicitly requested', () => {
@@ -319,31 +331,123 @@ export const context = {
   judgeModel: 'gpt-5.5',
 };
 
-function immutableProductionPlan(scenario, generationId = context.generationId) {
-  const plan = {
-    schemaVersion: 'pack-production-queue/v1',
-    source: 'signals',
-    scenarios: [{ ...scenario, generationId }],
+function fixtureSkillsManifest(root) {
+  const files = [];
+  const visit = (directory, prefix = '') => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name))) {
+      const path = join(directory, entry.name);
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) visit(path, relativePath);
+      else if (entry.isFile()) {
+        const bytes = readFileSync(path);
+        files.push({ path: relativePath, sha256: createHash('sha256').update(bytes).digest('hex'), size: bytes.length });
+      }
+    }
   };
+  visit(root);
+  if (files.length === 0) {
+    writeFileSync(join(root, 'fixture-skill.txt'), 'fixture\n');
+    return fixtureSkillsManifest(root);
+  }
   return {
-    ...plan,
+    sha256: createHash('sha256').update(canonicalJson(files)).digest('hex'),
+    fileCount: files.length,
+    totalBytes: files.reduce((total, file) => total + file.size, 0),
+  };
+}
+
+function immutableProductionPlan(scenarioValue, generationId = context.generationId, options = {}) {
+  const plannedScenario = { ...scenarioValue, generationId };
+  const parameters = productionExecutionParameters(plannedScenario.capabilitySlots.length);
+  for (const [group, values] of Object.entries(options.parameters ?? {})) {
+    Object.assign(parameters[group], values);
+  }
+  const cli = {
+    assetName: 'skillstore-cli-linux-x64',
+    releaseAssetSha256: options.cliSha256 ?? context.cliSha256,
+    version: options.cliVersion ?? context.cliVersion,
+  };
+  const models = structuredClone(MODEL_IDENTITIES);
+  const executionBinding = {
+    cli,
+    evaluatorInputs: null,
+    executorPreflight: {
+      generationId: '00000000-0000-4000-8000-000000000001',
+      skillA: {
+        canonicalId: 'pack-executor-preflight-a',
+        contentSha256: '1'.repeat(64),
+        version: '1.0.0',
+      },
+      skillB: {
+        canonicalId: 'pack-executor-preflight-b',
+        contentSha256: '2'.repeat(64),
+        version: '1.0.0',
+      },
+      task: 'Fixture executor preflight task.',
+    },
+    models,
+    parameters,
+    source: {
+      repositoryTreeSha: '1'.repeat(40),
+      skillsTreeSha: '2'.repeat(40),
+      skillsManifest: options.skillsDir
+        ? fixtureSkillsManifest(options.skillsDir)
+        : { sha256: '3'.repeat(64), fileCount: 1, totalBytes: 1 },
+      files: EXECUTION_SOURCE_FILES.map((path) => ({
+        path,
+        gitBlobSha: testSha256(path).slice(0, 40),
+        sha256: RUNTIME_SOURCE_SHA256.get(path) ?? testSha256(path),
+      })),
+    },
+  };
+  executionBinding.evaluatorInputs = {
+    configSha256: createHash('sha256').update(canonicalJson({ cli, models, parameters })).digest('hex'),
+    promptSha256: createHash('sha256').update(plannedScenario.task).digest('hex'),
+    rulesSha256: createHash('sha256').update(canonicalJson({
+      capabilitySlots: plannedScenario.capabilitySlots,
+      requiredArtifacts: plannedScenario.requiredArtifacts,
+    })).digest('hex'),
+    scenarioSha256: createHash('sha256').update(canonicalJson(plannedScenario)).digest('hex'),
+  };
+  const unsigned = {
+    schemaVersion: 'marketplace.pack-production-execution-plan/v1',
     workflowBinding: {
       repository: 'aiskillstore/marketplace',
       workflow: 'Generate Pack',
       runId: context.runId,
       runAttempt: context.runAttempt,
-      commitSha: context.commitSha,
-      scenarioId: scenario.id,
-      planSnapshotSha256: createHash('sha256').update(canonicalJson(plan)).digest('hex'),
+      headSha: context.commitSha,
+      scenarioId: plannedScenario.id,
+      generationId,
     },
+    executionBinding,
+    scenario: plannedScenario,
+  };
+  return {
+    ...unsigned,
+    digest: createHash('sha256').update(canonicalJson(unsigned)).digest('hex'),
   };
 }
 
-const workflowArgs = {
-  'run-id': context.runId,
-  'run-attempt': String(context.runAttempt),
-  'commit-sha': context.commitSha,
-};
+function writePlanGate(directory, plan, producer = 'plan', artifact = 'pack-production-plan') {
+  const planFile = join(directory, 'plan.json');
+  writeFileSync(planFile, canonicalJson(plan));
+  const unsigned = {
+    schemaVersion: 'marketplace.pack-production-artifact-gate/v1',
+    planDigest: plan.digest,
+    workflowBinding: plan.workflowBinding,
+    producer: { name: producer, status: 'success' },
+    artifact: { name: artifact, status: 'downloaded', planDigest: plan.digest },
+  };
+  const gate = {
+    ...unsigned,
+    digest: createHash('sha256').update(canonicalJson(unsigned)).digest('hex'),
+  };
+  const gateFile = join(directory, `${producer}-artifact-gate.json`);
+  writeFileSync(gateFile, canonicalJson(gate));
+  return { planFile, gateFile };
+}
 
 function verificationFixture(report = cliReport()) {
   const directory = mkdtempSync(join(tmpdir(), 'pack-production-verify-'));
@@ -351,16 +455,26 @@ function verificationFixture(report = cliReport()) {
   writeFileSync(cli, '#!/bin/sh\necho "skillstore-cli 2.10.0"\n');
   chmodSync(cli, 0o755);
   const cliSha256 = createHash('sha256').update(readFileSync(cli)).digest('hex');
-  const fixtureContext = { ...context, cliSha256 };
+  const plan = immutableProductionPlan(report.scenario, report.generationId, { cliSha256 });
+  const fixtureContext = {
+    ...context,
+    cliSha256,
+    model: plan.executionBinding.models.runner.identity,
+    modelRevision: plan.executionBinding.models.runner.revision,
+    modelPinType: plan.executionBinding.models.runner.pinType,
+    judgeModel: plan.executionBinding.models.judge.identity,
+    judgeModelRevision: plan.executionBinding.models.judge.revision,
+    judgeModelPinType: plan.executionBinding.models.judge.pinType,
+    executionPlanDigest: plan.digest,
+  };
   const evaluation = buildApiEvaluation(report, fixtureContext);
   const prefix = '01-excel-dashboard';
-  writeFileSync(join(directory, 'plan.json'), `${JSON.stringify(
-    immutableProductionPlan(report.scenario, report.generationId),
-  )}\n`);
+  const { gateFile } = writePlanGate(directory, plan);
   writeFileSync(join(directory, `${prefix}.stdout.json`), `${JSON.stringify(report)}\n`);
   writeFileSync(join(directory, `${prefix}.evaluation.json`), `${JSON.stringify(evaluation)}\n`);
   writeFileSync(join(directory, 'evaluate-summary.json'), `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-evaluate/v1',
+    executionPlanDigest: plan.digest,
     cliVersion: '2.10.0',
     cliSha256,
     attempts: [{
@@ -382,7 +496,12 @@ function verificationFixture(report = cliReport()) {
     }],
     selectedGenerationId: report.generationId,
   })}\n`);
-  return { directory, cli, evaluationFile: join(directory, `${prefix}.evaluation.json`) };
+  return {
+    directory,
+    cli,
+    gateFile,
+    evaluationFile: join(directory, `${prefix}.evaluation.json`),
+  };
 }
 
 function runVerification(fixture) {
@@ -390,14 +509,9 @@ function runVerification(fixture) {
     PACK_PRODUCTION,
     'verify',
     '--plan', join(fixture.directory, 'plan.json'),
+    '--artifact-gate', fixture.gateFile,
     '--results-dir', fixture.directory,
     '--cli', fixture.cli,
-    '--expected-cli-version', '2.10.0',
-    '--run-id', context.runId,
-    '--run-attempt', String(context.runAttempt),
-    '--commit-sha', context.commitSha,
-    '--model', context.model,
-    '--judge-model', context.judgeModel,
   ], { encoding: 'utf8' });
 }
 
@@ -408,41 +522,34 @@ test('canonical JSON is stable across object key order', () => {
 test('immutable production plan binds one generation id to the exact workflow invocation', () => {
   const report = cliReport();
   const plan = immutableProductionPlan(report.scenario, report.generationId);
-  assert.equal(validateImmutableProductionPlan(plan, workflowArgs).generationId, report.generationId);
+  assert.equal(validateImmutableProductionPlan(plan).generationId, report.generationId);
   assert.throws(
     () => validateImmutableProductionPlan({
       ...plan,
-      scenarios: [{ ...plan.scenarios[0], generationId: undefined }],
-    }, workflowArgs),
-    /generation id is invalid/,
+      scenario: { ...plan.scenario, generationId: undefined },
+    }),
+    /execution Plan digest mismatch/,
   );
   assert.throws(
     () => validateImmutableProductionPlan({
       ...plan,
       workflowBinding: { ...plan.workflowBinding, runAttempt: 2 },
-    }, workflowArgs),
-    /differs from this workflow invocation/,
+    }),
+    /execution Plan digest mismatch/,
   );
   assert.throws(
     () => validateImmutableProductionPlan({
       ...plan,
       workflowBinding: { ...plan.workflowBinding, injected: true },
-    }, workflowArgs),
-    /unexpected fields/,
+    }),
+    /execution Plan digest mismatch/,
   );
   assert.throws(
     () => validateImmutableProductionPlan({
       ...plan,
-      workflowBinding: { ...plan.workflowBinding, planSnapshotSha256: undefined },
-    }, workflowArgs),
-    /snapshot SHA-256 is invalid/,
-  );
-  assert.throws(
-    () => validateImmutableProductionPlan({
-      ...plan,
-      scenarios: [{ ...plan.scenarios[0], task: 'live drift after snapshot' }],
-    }, workflowArgs),
-    /snapshot SHA-256 differs/,
+      scenario: { ...plan.scenario, task: 'live drift after snapshot' },
+    }),
+    /execution Plan digest mismatch/,
   );
 });
 
@@ -1178,30 +1285,38 @@ if (scenarioId === 'slow') {
 `;
   writeFileSync(cli, script);
   chmodSync(cli, 0o755);
-  const planFile = join(directory, 'plan.json');
+  const skillsDir = join(directory, 'skills');
+  mkdirSync(skillsDir);
+  writeFileSync(join(skillsDir, 'fixture.txt'), 'fixture\n');
+  const cliSha256 = createHash('sha256').update(readFileSync(cli)).digest('hex');
+  const plan = immutableProductionPlan(scenarios.slow, context.generationId, {
+    cliSha256,
+    skillsDir,
+    parameters: {
+      retries: { agentMaxRetries: 2 },
+      timeoutsMs: {
+        agent: 1234,
+        evaluationBudget: 2000,
+        minimumFallback: 500,
+        scenario: 500,
+      },
+    },
+  });
+  const { planFile, gateFile } = writePlanGate(directory, plan);
   const resultsDir = join(directory, 'results');
-  writeFileSync(planFile, `${JSON.stringify(immutableProductionPlan(scenarios.slow))}\n`);
 
   const common = [
     '--plan', planFile,
+    '--artifact-gate', gateFile,
     '--results-dir', resultsDir,
     '--cli', cli,
-    '--expected-cli-version', '2.10.0',
-    '--skills-dir', directory,
-    '--run-id', context.runId,
-    '--run-attempt', String(context.runAttempt),
-    '--commit-sha', context.commitSha,
-    '--model', context.model,
-    '--judge-model', context.judgeModel,
+    '--skills-dir', skillsDir,
   ];
-  const evaluation = spawnSync(process.execPath, [
-    PACK_PRODUCTION, 'evaluate', ...common,
-    '--evaluation-budget-ms', '2000',
-    '--scenario-timeout-ms', '500',
-    '--minimum-fallback-ms', '500',
-    '--agent-timeout-ms', '1234',
-    '--agent-max-retries', '2',
-  ], { encoding: 'utf8', timeout: 5_000 });
+  const evaluation = spawnSync(
+    process.execPath,
+    [PACK_PRODUCTION, 'evaluate', ...common],
+    { encoding: 'utf8', timeout: 5_000 },
+  );
   assert.equal(evaluation.status, 0, evaluation.stderr);
 
   const summary = JSON.parse(readFileSync(join(resultsDir, 'evaluate-summary.json'), 'utf8'));
@@ -1232,7 +1347,7 @@ if (scenarioId === 'slow') {
   );
 });
 
-test('preflight failure evidence skips Pack generation and closes as an infrastructure audit', () => {
+test('agent preflight HTTP 401 skips every Pack generation and closes candidate-null', () => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-production-preflight-audit-'));
   const cli = join(directory, 'fake-skillstore-cli');
   const invoked = join(directory, 'pack-generate-invoked');
@@ -1243,31 +1358,32 @@ exit 99
 `);
   chmodSync(cli, 0o755);
   const report = cliReport();
-  const planFile = join(directory, 'plan.json');
+  const skillsDir = join(directory, 'skills');
+  mkdirSync(skillsDir);
+  writeFileSync(join(skillsDir, 'fixture.txt'), 'fixture\n');
+  const plan = immutableProductionPlan(report.scenario, context.generationId, {
+    cliSha256: createHash('sha256').update(readFileSync(cli)).digest('hex'),
+    skillsDir,
+  });
+  const { planFile, gateFile } = writePlanGate(directory, plan);
   const resultsDir = join(directory, 'results');
   const failureFile = join(directory, 'infrastructure-failure.json');
-  writeFileSync(planFile, `${JSON.stringify(immutableProductionPlan(report.scenario))}\n`);
   writeFileSync(failureFile, `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
     stage: 'agent_preflight',
     reason: 'deterministic_http',
-    status: 400,
-    errorCategory: 'invalid_output_token_limit',
+    status: 401,
+    errorCategory: 'authentication_failed',
     diagnosticSha256: 'a'.repeat(64),
   })}\n`);
   const result = spawnSync(process.execPath, [
     PACK_PRODUCTION,
     'evaluate',
     '--plan', planFile,
+    '--artifact-gate', gateFile,
     '--results-dir', resultsDir,
     '--cli', cli,
-    '--expected-cli-version', '2.10.0',
-    '--skills-dir', directory,
-    '--run-id', context.runId,
-    '--run-attempt', String(context.runAttempt),
-    '--commit-sha', context.commitSha,
-    '--model', context.model,
-    '--judge-model', context.judgeModel,
+    '--skills-dir', skillsDir,
     '--infrastructure-failure-file', failureFile,
   ], { encoding: 'utf8' });
 
@@ -1281,8 +1397,8 @@ exit 99
     schemaVersion: 'marketplace.pack-production-infrastructure-failure/v1',
     stage: 'agent_preflight',
     reason: 'deterministic_http',
-    status: 400,
-    errorCategory: 'invalid_output_token_limit',
+    status: 401,
+    errorCategory: 'authentication_failed',
     diagnosticSha256: 'a'.repeat(64),
     pathSha256: null,
     modelSha256: null,
@@ -1293,15 +1409,10 @@ exit 99
     PACK_PRODUCTION,
     'evaluate',
     '--plan', planFile,
+    '--artifact-gate', gateFile,
     '--results-dir', replayResultsDir,
     '--cli', cli,
-    '--expected-cli-version', '2.10.0',
-    '--skills-dir', directory,
-    '--run-id', context.runId,
-    '--run-attempt', String(context.runAttempt),
-    '--commit-sha', context.commitSha,
-    '--model', context.model,
-    '--judge-model', context.judgeModel,
+    '--skills-dir', skillsDir,
     '--infrastructure-failure-file', failureFile,
   ], { encoding: 'utf8' });
   assert.equal(replay.status, 0, replay.stderr);
@@ -1532,33 +1643,46 @@ test('finalize fails closed when a newer content dispatch supersedes its nonce',
   }, expected, 'generation-1'), /was superseded/);
 });
 
-test('persist POSTs every verified v4 candidate-null outcome and creates no Pack', async () => {
+test('persist POSTs every verified v4 candidate-null outcome and creates no Pack', async (t) => {
   const directory = mkdtempSync(join(tmpdir(), 'pack-production-persist-audits-'));
-  const makeRejected = (generationId, outcome) => {
-    const report = cliReport();
-    report.generationId = generationId;
-    report.outcome = outcome;
-    report.outcomeReason = `${outcome} fixture`;
-    report.manifest = null;
-    report.packVerification = null;
-    report.baselineVerification = null;
-    return buildApiEvaluation(report, { ...context, generationId });
+  const report = cliReport();
+  report.outcome = 'infrastructure_failed';
+  report.outcomeReason = 'infrastructure_failed fixture';
+  report.manifest = null;
+  report.packVerification = null;
+  report.baselineVerification = null;
+  const plan = immutableProductionPlan(report.scenario, report.generationId);
+  const evaluationContext = {
+    ...context,
+    model: plan.executionBinding.models.runner.identity,
+    modelRevision: plan.executionBinding.models.runner.revision,
+    modelPinType: plan.executionBinding.models.runner.pinType,
+    judgeModel: plan.executionBinding.models.judge.identity,
+    judgeModelRevision: plan.executionBinding.models.judge.revision,
+    judgeModelPinType: plan.executionBinding.models.judge.pinType,
+    executionPlanDigest: plan.digest,
   };
   const evaluations = [
-    ['01-quality.evaluation.json', makeRejected('11111111-1111-4111-8111-111111111111', 'quality_rejected')],
-    ['02-infrastructure.evaluation.json', makeRejected('22222222-2222-4222-8222-222222222222', 'infrastructure_failed')],
+    ['01-infrastructure.evaluation.json', buildApiEvaluation(report, evaluationContext)],
   ];
   for (const [file, evaluation] of evaluations) {
     writeFileSync(join(directory, file), `${JSON.stringify(evaluation, null, 2)}\n`);
   }
   writeFileSync(join(directory, 'evaluation-verification.json'), `${JSON.stringify({
     schemaVersion: 'marketplace.pack-production-evaluation-verification/v1',
+    executionPlanDigest: plan.digest,
     selectedGenerationId: null,
     files: evaluations.map(([file]) => ({
       file,
       sha256: createHash('sha256').update(readFileSync(join(directory, file))).digest('hex'),
     })),
   })}\n`);
+  const { planFile, gateFile } = writePlanGate(
+    directory,
+    plan,
+    'evaluate',
+    'pack-production-evaluation',
+  );
 
   const observed = [];
   const server = createServer((request, response) => {
@@ -1588,11 +1712,24 @@ test('persist POSTs every verified v4 candidate-null outcome and creates no Pack
     });
   });
   server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
+  try {
+    await Promise.race([
+      once(server, 'listening'),
+      once(server, 'error').then(([error]) => Promise.reject(error)),
+    ]);
+  } catch (error) {
+    if (error?.code === 'EPERM') {
+      t.skip('local listening sockets are disabled by the test sandbox');
+      return;
+    }
+    throw error;
+  }
   const address = server.address();
   const child = spawn(process.execPath, [
     PACK_PRODUCTION,
     'persist',
+    '--plan', planFile,
+    '--artifact-gate', gateFile,
     '--results-dir', directory,
     '--api-url', `http://127.0.0.1:${address.port}`,
     '--token', 'test-token',
@@ -1606,11 +1743,8 @@ test('persist POSTs every verified v4 candidate-null outcome and creates no Pack
   await once(server, 'close');
 
   assert.equal(status, 0, stderr);
-  assert.equal(observed.length, 2);
-  assert.deepEqual(observed.map((item) => item.evaluation.outcome), [
-    'quality_rejected',
-    'infrastructure_failed',
-  ]);
+  assert.equal(observed.length, 1);
+  assert.deepEqual(observed.map((item) => item.evaluation.outcome), ['infrastructure_failed']);
   assert.ok(observed.every((item) => (
     item.method === 'POST'
     && item.url === '/api/automation/packs/production'
@@ -1619,7 +1753,7 @@ test('persist POSTs every verified v4 candidate-null outcome and creates no Pack
   )));
   const summary = JSON.parse(stdout);
   assert.equal(summary.selected, null);
-  assert.equal(summary.persisted.length, 2);
+  assert.equal(summary.persisted.length, 1);
   assert.ok(summary.persisted.every((item) => (
     item.auditOnly === true
     && item.persistedRemotely === true
@@ -1784,30 +1918,36 @@ test('internal SIGTERM becomes a verified candidate-null infrastructure closure'
   writeFileSync(cli, `#!/bin/sh
 if [ "$1" = "--version" ]; then echo "skillstore-cli 2.10.0"; exit 0; fi
 touch ${JSON.stringify(marker)}
-while :; do sleep 1; done
+  while :; do sleep 1; done
 `);
   chmodSync(cli, 0o755);
-  writeFileSync(planFile, `${JSON.stringify(immutableProductionPlan(cliReport().scenario))}\n`);
+  const skillsDir = join(directory, 'skills');
+  mkdirSync(skillsDir);
+  writeFileSync(join(skillsDir, 'fixture.txt'), 'fixture\n');
+  const plan = immutableProductionPlan(cliReport().scenario, context.generationId, {
+    cliSha256: createHash('sha256').update(readFileSync(cli)).digest('hex'),
+    skillsDir,
+    parameters: {
+      timeoutsMs: {
+        evaluationBudget: 10_000,
+        minimumFallback: 1,
+        scenario: 10_000,
+        scenarioIdle: 10_000,
+      },
+    },
+  });
+  const gateFile = writePlanGate(directory, plan).gateFile;
   const common = [
     '--plan', planFile,
+    '--artifact-gate', gateFile,
     '--results-dir', resultsDir,
     '--cli', cli,
-    '--expected-cli-version', '2.10.0',
-    '--run-id', context.runId,
-    '--run-attempt', String(context.runAttempt),
-    '--commit-sha', context.commitSha,
-    '--model', context.model,
-    '--judge-model', context.judgeModel,
   ];
   const child = spawn(process.execPath, [
     PACK_PRODUCTION,
     'evaluate',
     ...common,
-    '--skills-dir', directory,
-    '--evaluation-budget-ms', '10000',
-    '--scenario-timeout-ms', '10000',
-    '--scenario-idle-timeout-ms', '10000',
-    '--minimum-fallback-ms', '1',
+    '--skills-dir', skillsDir,
   ], { stdio: ['ignore', 'pipe', 'pipe'] });
   let stdout = '';
   let stderr = '';


### PR DESCRIPTION
## 背景 / 问题描述

[Generate Pack run 29530758895](https://github.com/aiskillstore/marketplace/actions/runs/29530758895) 在 runner same-path preflight 收到 HTTP 401，agent invocation 为 0；最终保持 `infrastructure_failed`、`candidate=null`，finalize 明确失败，没有被降格为 quality rejection 或 no-op 成功。

已核对 [skillstore CLI v2.14.2 release](https://github.com/aiskillstore/skillstore/releases/tag/cli-v2.14.2) 与 [skillstore PR #273](https://github.com/aiskillstore/skillstore/pull/273)：Linux asset `skillstore-cli-linux-x64` 的 exact SHA-256 为 `21b1967e134622a40ae4d312278fa10d136103f0148887252f61e4e3b4536674`。#273 的 Judge sandbox cwd 修复已包含在 2.14.2，本 PR 不把本次 401 误判为旧 sandbox 问题。

## Retry #1：上次 FAIL

Trent 在 [review 4718751146](https://github.com/aiskillstore/marketplace/pull/2580#pullrequestreview-4718751146) 指出 2 个 BLOCKER：

1. generation Plan 没绑定 runner/Judge model identity、CLI exact release asset SHA 和实际执行参数；evaluate/verify 接受命令行覆盖，smoke/generic helper 仍可漂移。
2. `planSnapshotSha256` 删除整个 `workflowBinding` 后计算，run/head/attempt/scenario 可换绑；digest 也未覆盖 skills/source、prompt/rules/config 和 threshold/timeout/budget 等执行输入。

## 本次修复

### 1. 单一 canonical execution Plan

新增 `scripts/pack-production-plan.mjs`，Plan 同时绑定：

- workflow：repository、workflow、runId、runAttempt、headSha、scenarioId、generationId；
- models：runner `claude-sonnet-5`、Judge `gpt-5.5` 的 identity；两者 `revision` / `pinType` 均明确为 **`workflow-pinned alias`**；
- CLI：version `2.14.2`、asset name、exact release asset SHA-256；
- source：repository tree、skills tree、全 skills bytes manifest、workflow/orchestrator/proxy/preflight/smoke/recovery/sandbox probe 的 blob + SHA-256；
- evaluator inputs：scenario、prompt、rules、config digest；
- parameters：maxCandidates、pick、runs、finalRuns、threshold、baseline delta、auto-publish threshold、agent retries、全部 timeout/budget、output token cap、proxy request/concurrency/TTL、resource limits。

Provider 当前没有提供 immutable model revision，因此本 PR只承诺“workflow 固定 alias + 同一 Plan 贯穿”，**不宣称模型本身 immutable，也不宣称一次 canary 能证明长期不漂移**。

### 2. 完整 execution digest + canonical bytes

- digest 覆盖除 `digest` 字段自身之外的完整 Plan，包含整个 `workflowBinding` 与 `executionBinding`；
- JSON key canonicalize 后用临时文件 + atomic rename 写入；读取时要求 raw bytes 与 canonical bytes exact 相等，duplicate key / 非 canonical bytes fail-closed；
- evaluate 从 artifact bytes 重算 digest，不再删除 workflow binding，也不再用调用参数同步改写旧 artifact。

### 3. 所有生产入口只消费 Plan

- contract smoke、executor preflight、evaluate、verify、persist、finalize、cancel recovery 全部读取并校验同一 Plan / artifact gate；
- evaluate/verify 删除 runner/Judge、CLI version、threshold/timeout/budget 等命令行覆盖；旧 override flag 明确拒绝；
- workflow 逐字节核验 source files、skills tree/manifest 和实际 CLI binary；preflight/smoke/evaluate 自身也复核 runtime source SHA；
- smoke-only 先生成 canonical Plan，再发且只发一条 Messages + 一条 Responses probe，不进入 evaluate/generate/persist。

### 4. 永久 runtime 负例矩阵

新增/扩充 runtime fixtures，阻断：

- old artifact 更换 runId / runAttempt / headSha / scenarioId / generationId；
- runner/Judge identity、revision 或 pin type 漂移；
- CLI version / asset name / SHA 漂移；
- prompt / rules / config / source script digest 漂移；
- skills tree / skills bytes manifest / scenario bytes漂移；
- max candidates、runs、threshold、timeout、budget、output cap 等执行参数漂移；
- artifact `missing` / producer `failed` / `cancelled` / `skipped`；
- evaluate/verify 传入任何已删除的执行覆盖参数。

正例证明 same-Plan producer + artifact 通过 gate；负例在 evaluate 与 finalize/publish 前 fail-closed。

## Acceptance Criteria

- [x] canonical Plan 的 digest 覆盖 workflow/generation、models、CLI asset、source、prompt/rules/config 和全部执行参数；非 canonical bytes、缺 digest、duplicate key、任一字段漂移均拒绝。验收：`scripts/tests/pack-production-execution-plan.test.mjs::canonical execution Plan round-trips atomically and rejects non-canonical bytes` + [CI #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)。
- [x] smoke/preflight/evaluate/verify 只从同一 Plan 读取 runner/Judge、CLI 与执行参数；生产入口无 `sonnet` default、无命令行 override。验收：`scripts/tests/generate-packs-workflow.test.mjs::production workflow consumes the canonical execution Plan without runtime overrides`、`scripts/tests/pack-evaluator-contract-smoke.test.mjs::contract smoke rejects calls without the canonical execution Plan` + [CI #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)。
- [x] old artifact 的 run/head/attempt/scenario/generation/model/CLI/source/config/threshold/timeout/budget 任一变化阻断 evaluate/finalize/publish。验收：`scripts/tests/pack-production-execution-plan.test.mjs::* rejects a changed * from an old Plan` + [CI #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)。
- [x] missing/failed/cancelled/skipped artifact fail-closed；same Plan 正例通过。验收：`scripts/tests/pack-production-execution-plan.test.mjs::same-Plan producer and downloaded artifact pass the runtime artifact gate`、`scripts/tests/pack-production-execution-plan.test.mjs::evaluate and finalize reject missing/failed/cancelled/skipped producer or artifact state` + [CI #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)。
- [x] `infrastructure_failed + candidate=null` 继续阻断 finalize，未触发真实模型生成、publish 或 DB 写。验收：`scripts/tests/pack-production.test.mjs::evaluate evidence skips Pack generation when infrastructure preflight failed`、`scripts/tests/pack-production.test.mjs::finalize refuses infrastructure_failed` + [CI #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)。

## TDD 证据

先只新增 runtime Plan 测试，在旧 head `634c3a5f157dce1fe4b6814374577bf16eec024d` 执行：

```bash
node --test scripts/tests/pack-production-execution-plan.test.mjs scripts/tests/pack-production.test.mjs
```

结果：**39 tests / 1 pass / 38 fail**。旧实现缺 canonical Plan module，且 model/CLI/run/head/parameters/artifact state 均未绑定，符合预期 RED。

实现后 GREEN：

- focused：177 tests / 176 pass / 1 skip / 0 fail；
- full：426 tests / 424 pass / 2 skip / 0 fail；
- `bash -n scripts/pack-evaluator-preflight.sh` ✅；
- changed `.mjs` 全部 `node --check` ✅；
- workflow Ruby YAML parse ✅；
- `git diff --check` ✅；
- binary evidence 扫描为空 ✅。

2 个 skip 是 macOS 上 Linux-only 的 process cleanup / userns signal 测试，不作为 AC 证据；本 PR没有把任何 bwrap `SKIPPED` 当成 hosted/production 证明。

## 新 CI

- Retry #1 head：`f5074883107d1b30fcb37851a451ddb07c095897`
- [Test and validate #29552443258](https://github.com/aiskillstore/marketplace/actions/runs/29552443258)
- [Validate Marketplace #29552443152](https://github.com/aiskillstore/marketplace/actions/runs/29552443152) ✅
- [Test Pack Evaluator Bubblewrap #29552443147](https://github.com/aiskillstore/marketplace/actions/runs/29552443147)：secret-free preflight contracts ✅；scoped bwrap user namespace **SKIPPED（不计 AC）**

本次新 head CI 已完成：test / validate / secret-free preflight contracts 通过；bwrap proof 仅 SKIPPED，不作为 hosted/production 证据。未触发 `workflow_dispatch`、真实 production canary、model generation、publish、merge 或 DB 写。

## 风险点

- models：当前只有 workflow-pinned alias，没有 provider immutable revision；alias 上游映射仍可能随 provider 漂移。
- source/Plan：任何 bytes、tree、config 或参数不一致会 fail-closed，代价是旧 artifact 不能 resume 到新 head。
- workflow：Plan/CLI artifact 增加校验与体积，但不扩大生产凭据暴露面。
- 回滚：revert commit `f50748831`；会恢复旧 snapshot digest 和命令行绑定路径，不涉及数据回滚。

## 人类 review 关注点

1. execution digest 是否已完整覆盖 `workflowBinding + executionBinding`（仅排除 digest 自身）。
2. source tree/skills bytes/prompt-rules-config/CLI asset/执行参数是否都由同一 Plan 约束，且没有 production override 后门。
3. `workflow-pinned alias` 口径是否准确：不把 alias 描述成 immutable model revision。
4. artifact status gate 是否在 evaluate/finalize/publish 前阻断 missing/failed/cancelled/skipped。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [x] 需要生产部署/受控 canary 另行确认

本 PR只修 workflow/runtime 绑定，不自行 merge 或运行真实 canary。
