### PR TITLE
fix: 固化提交处理完整检出与运行时预检

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -349,10 +349,33 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
+      - name: Clear inherited marketplace checkout
+        run: |
+          set -euo pipefail
+
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+
+          cd "${RUNNER_TEMP:?}"
+          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+          fi
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
       - name: Checkout marketplace
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          clean: true
+          persist-credentials: false
 
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
@@ -360,6 +383,50 @@ jobs:
           version: ${{ inputs.cli_version }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify immutable processing runtime
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+
+          ACTUAL_HEAD=$(git rev-parse HEAD)
+          if [ "$ACTUAL_HEAD" != "$EXPECTED_WORKFLOW_SHA" ]; then
+            echo "::error::Marketplace checkout mismatch: expected $EXPECTED_WORKFLOW_SHA, got $ACTUAL_HEAD"
+            exit 1
+          fi
+
+          if [ "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" = "true" ]; then
+            echo "::error::Marketplace checkout is still sparse"
+            exit 1
+          fi
+          test ! -f "$(git rev-parse --git-path info/sparse-checkout)" || {
+            echo "::error::Inherited sparse-checkout definition is still present"
+            exit 1
+          }
+
+          REQUIRED_RUNTIME_FILES=(
+            "schemas/skill-report.schema.json"
+            ".github/actions/download-skillstore-cli/action.yml"
+            ".github/workflows/reusable-process-skills.yml"
+          )
+          for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
+            test -f "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required processing runtime file is missing: $file"
+              exit 1
+            }
+            EXPECTED_BLOB=$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")
+            ACTUAL_BLOB=$(git hash-object -- "$GITHUB_WORKSPACE/$file")
+            if [ "$ACTUAL_BLOB" != "$EXPECTED_BLOB" ]; then
+              echo "::error::Processing runtime file does not match workflow head: $file"
+              exit 1
+            fi
+          done
+
+          test -x "$GITHUB_WORKSPACE/skillstore-cli" || {
+            echo "::error::Downloaded skillstore-cli is missing or not executable"
+            exit 1
+          }
 
       - name: Process shard ${{ matrix.shard }}
         id: process

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+
+const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
+const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    assert.fail(
+      `${command} ${args.join(' ')} failed (${result.status})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+  return result;
+}
+
+function extractRunBlock(workflow, stepName) {
+  const lines = workflow.split('\n');
+  const nameIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(nameIndex, -1, `missing workflow step: ${stepName}`);
+
+  const stepIndent = lines[nameIndex].search(/\S/);
+  let runIndex = -1;
+  for (let index = nameIndex + 1; index < lines.length; index += 1) {
+    const indent = lines[index].search(/\S/);
+    if (indent !== -1 && indent <= stepIndent) break;
+    if (lines[index].trim() === 'run: |') {
+      runIndex = index;
+      break;
+    }
+  }
+  assert.notEqual(runIndex, -1, `missing run block for: ${stepName}`);
+
+  const runIndent = lines[runIndex].search(/\S/);
+  const body = [];
+  for (let index = runIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const indent = line.search(/\S/);
+    if (indent !== -1 && indent <= runIndent) break;
+    body.push(line.length > runIndent + 2 ? line.slice(runIndent + 2) : '');
+  }
+  return body.join('\n');
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'submission-runtime-'));
+  const seed = join(root, 'seed');
+  const origin = join(root, 'origin.git');
+  const runnerWorkspace = join(root, 'runner-workspace');
+  const workspace = join(runnerWorkspace, 'marketplace');
+  const runnerTemp = join(root, 'runner-temp');
+
+  mkdirSync(seed, { recursive: true });
+  mkdirSync(runnerWorkspace, { recursive: true });
+  mkdirSync(runnerTemp, { recursive: true });
+  run('git', ['init', '-q', seed]);
+  run('git', ['-C', seed, 'config', 'user.name', 'Fixture']);
+  run('git', ['-C', seed, 'config', 'user.email', 'fixture@example.com']);
+
+  const files = {
+    'schemas/skill-report.schema.json': '{"type":"object"}\n',
+    '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
+    '.github/workflows/reusable-process-skills.yml': 'name: fixture workflow\n',
+    'skills/example/SKILL.md': '---\nname: example\n---\n',
+  };
+  for (const [path, content] of Object.entries(files)) {
+    const fullPath = join(seed, path);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  run('git', ['-C', seed, 'add', '.']);
+  run('git', ['-C', seed, 'commit', '-qm', 'fixture']);
+  const head = run('git', ['-C', seed, 'rev-parse', 'HEAD']).stdout.trim();
+  run('git', ['clone', '--bare', '-q', seed, origin]);
+  run('git', ['clone', '-q', origin, workspace]);
+
+  return { root, origin, runnerWorkspace, runnerTemp, workspace, head };
+}
+
+test('process checkout clears inherited sparse state before cloning the immutable workflow head', () => {
+  const fixture = createFixture();
+  try {
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'init', '--cone']);
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'set', '.github']);
+    assert.equal(existsSync(join(fixture.workspace, 'schemas/skill-report.schema.json')), false);
+    writeFileSync(join(fixture.workspace, 'stale-runner-file'), 'stale\n');
+
+    const reset = extractRunBlock(reusable, 'Clear inherited marketplace checkout');
+    run('bash', ['-c', reset], {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        RUNNER_WORKSPACE: fixture.runnerWorkspace,
+        RUNNER_TEMP: fixture.runnerTemp,
+        GITHUB_REPOSITORY: `aiskillstore/${basename(fixture.workspace)}`,
+      },
+    });
+
+    assert.deepEqual(readdirSync(fixture.workspace), []);
+    run('git', ['clone', '-q', '--no-local', fixture.origin, fixture.workspace]);
+    assert.equal(existsSync(join(fixture.workspace, 'schemas/skill-report.schema.json')), true);
+    assert.equal(run('git', ['-C', fixture.workspace, 'config', '--bool', 'core.sparseCheckout'], { allowFailure: true }).stdout.trim(), '');
+
+    assert.match(reusable, /ref: \$\{\{ github\.workflow_sha \}\}/);
+    assert.match(reusable, /fetch-depth: 1/);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('runtime preflight rejects missing or modified schema/runtime files and a mismatched head', () => {
+  const fixture = createFixture();
+  try {
+    const preflight = extractRunBlock(reusable, 'Verify immutable processing runtime');
+    const cliPath = join(fixture.workspace, 'skillstore-cli');
+    writeFileSync(cliPath, '#!/usr/bin/env bash\nexit 0\n');
+    chmodSync(cliPath, 0o755);
+    const baseOptions = {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        EXPECTED_WORKFLOW_SHA: fixture.head,
+      },
+    };
+
+    run('bash', ['-c', preflight], baseOptions);
+
+    rmSync(join(fixture.workspace, 'schemas/skill-report.schema.json'));
+    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+
+    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
+    writeFileSync(join(fixture.workspace, 'schemas/skill-report.schema.json'), '{"tampered":true}\n');
+    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+
+    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
+    const wrongHeadOptions = {
+      ...baseOptions,
+      env: { ...baseOptions.env, EXPECTED_WORKFLOW_SHA: '0000000000000000000000000000000000000000' },
+      allowFailure: true,
+    };
+    assert.notEqual(run('bash', ['-c', preflight], wrongHeadOptions).status, 0);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('repository dispatch caller preserves reusable failure and callback status contracts', () => {
+  assert.match(caller, /notify:\n\s+needs: process-skills\n\s+if: always\(\) && github\.event_name == 'repository_dispatch'/);
+  assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);
+  assert.match(caller, /name: Notify skillstore - Failed\n\s+if: needs\.process-skills\.result == 'failure'/);
+  assert.match(caller, /"event": "failed"/);
+  assert.doesNotMatch(caller, /continue-on-error:\s*true/);
+});


### PR DESCRIPTION
## 背景 / 问题描述

关联 [issue #2572](https://github.com/aiskillstore/marketplace/issues/2572)。原失败链路为 [run 29410402198](https://github.com/aiskillstore/marketplace/actions/runs/29410402198)：

- attempt 1/2/3 的 `process-skills / process (0, localize-saas-for-china)` → `Process shard 0` 均报 `schemas/skill-report.schema.json` ENOENT，最终 `0 processed / 1 errors`。
- 三次 run 的 immutable head 均为 `17978ebd71b2412970cd2c33ed497ce7d2e1aa0e`；该 commit 实际包含 schema，缺失来自 self-hosted runner 继承 checkout/sparse state，而不是 source repo。
- attempts 2/3 随后错误地成为 success，`notify` 的 `pr_created` / `failed` callback 均 skipped。all-failed 聚合传播由 [PR #2578](https://github.com/aiskillstore/marketplace/pull/2578) 的独立 retry 负责，本 PR 不实现、不复制其 shard manifest / aggregation / canonical index / expected-found 逻辑。

## 做了什么

- 在 process matrix checkout 前校验目标 workspace，并从 `RUNNER_TEMP` 显式清除 inherited sparse/worktree 内容。
- `actions/checkout@v5` 固定到 immutable `${{ github.workflow_sha }}`，禁止复用凭据。
- 调用 Skillstore CLI 前验证：HEAD 等于 workflow SHA、checkout 非 sparse、schema / local action / reusable workflow 文件存在且 blob hash 与 workflow head 完全一致、CLI 可执行。
- 新增真实临时 Git fixture：复现 inherited sparse checkout、missing schema、tampered runtime、wrong head；同时锁定 repository_dispatch 的 failed callback/status 条件。

## 为什么改

普通 checkout 在持久化 self-hosted workspace 上不足以证明工作树完整。原 run 已证明 action step 可以显示 success，但 schema 仍不在工作树。这里把“完整、immutable、runtime 与 workflow head 同源”变成 CLI 前硬门。

## Acceptance Criteria

- [x] inherited sparse checkout 与 stale 文件在 checkout 前被清空，随后完整 clone 可见 schema。验收：`scripts/tests/submission-runtime-workflow.test.mjs::process checkout clears inherited sparse state before cloning the immutable workflow head`；CI：[test job](https://github.com/aiskillstore/marketplace/actions/runs/29547229953/job/87782060952)。
- [x] missing/tampered schema/runtime、mismatched HEAD 任一情况均在 CLI 前失败。验收：`scripts/tests/submission-runtime-workflow.test.mjs::runtime preflight rejects missing or modified schema/runtime files and a mismatched head`；CI：[test job](https://github.com/aiskillstore/marketplace/actions/runs/29547229953/job/87782060952)。
- [x] reusable workflow failure 仍由 repository_dispatch caller 映射为 `failed` callback；PR callback 只在存在 `pr_url` 时发送。验收：`scripts/tests/submission-runtime-workflow.test.mjs::repository dispatch caller preserves reusable failure and callback status contracts`；CI：[test job](https://github.com/aiskillstore/marketplace/actions/runs/29547229953/job/87782060952)。
- [x] 本 PR 不修改 #2578 的 archive、manifest、聚合、all-failed、canonical index 或 expected-found 集合逻辑。验收：diff 仅修改 process checkout/preflight 段 + 新测试文件；CI：[test job](https://github.com/aiskillstore/marketplace/actions/runs/29547229953/job/87782060952)。

## 原失败、红测与修复后同链路证据

- 原失败：run 29410402198 attempts 1/2/3，job `process-skills / process (0, localize-saas-for-china)`，step `Process shard 0`；schema ENOENT，最终 `0 processed / 1 errors`。
- RED：新增测试在旧 `origin/main` 上 2/3 失败，分别缺少 `Clear inherited marketplace checkout` 与 `Verify immutable processing runtime`。
- GREEN：同一 fixture 先创建 cone sparse checkout（schema 不在 working tree）与 stale 文件，执行 workflow 原样 reset block 后 workspace 为空；重新 clone 后 schema 存在。preflight 对 missing schema、篡改 blob、错误 SHA 均返回非 0。
- 本地 focused：`node --test scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs`，5/5 通过。
- 本地全量：`node --test scripts/tests/*.test.mjs`，1000/1000 通过。
- 静态：两个 workflow YAML parse；共 14 个 shell `run` block `bash -n` 通过；`git diff --check` 通过。
- 未触发 `workflow_dispatch` / `repository_dispatch`，未创建 submission 内容 PR，未写生产 API/DB。

## 依赖与合并顺序

1. 先完成并合并 #2578 的独立 retry（shard manifest + all-failed 传播 + canonical index / expected-found 全等）。
2. 再将本 PR 更新到 #2578 合并后的 main（如有同文件冲突，只保留本 PR checkout/preflight 范围）并合并。
3. 最后合并 Skillstore terminal resubmit PR；否则用户可能在 Marketplace fail-closed 链路完整前重提。

## 风险点

- 数据写入：本 PR 不写 DB；workflow 合并后仍沿用现有 submission branch/PR 写入行为。
- 权限 / 安全：不扩大 token 权限；workspace 删除前校验 `GITHUB_WORKSPACE == RUNNER_WORKSPACE/repo`，不匹配即拒绝。
- 兼容性：依赖 `github.workflow_sha` 与标准 self-hosted runner 环境变量；preflight 会把任何不一致变成明确红灯。
- 用户体验：本 PR 单独不修复 all-failed 假绿，完整闭环必须与 #2578 按顺序合并。

## 回滚方式

若 self-hosted runner 环境不兼容，revert commit `89e4fa9efc4bf8aaf61a883eed77e17d9eb66cac` 即恢复旧 checkout；无 DB migration、无数据回滚。回滚后必须暂停重提入口，不能在 fail-open 状态继续处理 submission。

## 人类 review 关注点

1. workspace 路径校验是否足够严格且兼容现有 runner 目录。
2. `${{ github.workflow_sha }}` 是否是 reusable workflow 当前 immutable head，blob hash 门是否覆盖 schema/runtime。
3. 与 #2578 的 diff 是否完全解耦；合并 #2578 后 rebase 不得把其 retry 复制进本 PR。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [ ] 需要生产部署确认

原因：修改已上线 submission workflow；不得自动合并，也不得以 CI 绿替代真实 Human Gate。

Wiki delta: none
