### PR TITLE
fix(data): recover ten missing skill reports

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/verify-recovered-skill-reports.mjs"
       - "scripts/tests/**"
   pull_request:
     branches: [main]
@@ -31,6 +32,7 @@ on:
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/verify-recovered-skill-reports.mjs"
       - "scripts/tests/**"
   workflow_dispatch:
 
@@ -120,7 +122,8 @@ jobs:
             scripts/tests/submission-scope-workflows.test.mjs \
             scripts/tests/detect-changed-skills.test.mjs \
             scripts/tests/resolve-manual-skills.test.mjs \
-            scripts/tests/materialize-changed-skills.test.mjs
+            scripts/tests/materialize-changed-skills.test.mjs \
+            scripts/tests/recovered-skill-reports.test.mjs
 
       # Download CLI once at start - used by both SKILL.md and skill-report.json auto-fix steps
       - name: Checkout for CLI download action

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
       - "scripts/verify-recovered-skill-reports.mjs"
+      - "scripts/recovered-skill-reports.test.mjs"
       - "scripts/tests/**"
   pull_request:
     branches: [main]
@@ -33,6 +34,7 @@ on:
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
       - "scripts/verify-recovered-skill-reports.mjs"
+      - "scripts/recovered-skill-reports.test.mjs"
       - "scripts/tests/**"
   workflow_dispatch:
 
@@ -123,7 +125,7 @@ jobs:
             scripts/tests/detect-changed-skills.test.mjs \
             scripts/tests/resolve-manual-skills.test.mjs \
             scripts/tests/materialize-changed-skills.test.mjs \
-            scripts/tests/recovered-skill-reports.test.mjs
+            scripts/recovered-skill-reports.test.mjs
 
       # Download CLI once at start - used by both SKILL.md and skill-report.json auto-fix steps
       - name: Checkout for CLI download action

--- a/scripts/recovered-skill-reports.test.mjs
+++ b/scripts/recovered-skill-reports.test.mjs
@@ -10,9 +10,9 @@ import {
   calculateCanonicalSkillHashes,
   verifyRecoveredSkillReport,
   verifyRecoveredSkillReports,
-} from '../verify-recovered-skill-reports.mjs';
+} from './verify-recovered-skill-reports.mjs';
 
-const REPOSITORY_ROOT = resolve(import.meta.dirname, '../..');
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '..');
 
 test('ten recovered reports match canonical slugs, source URLs, paths, and exact bytes', () => {
   const results = verifyRecoveredSkillReports(REPOSITORY_ROOT);

--- a/scripts/tests/recovered-skill-reports.test.mjs
+++ b/scripts/tests/recovered-skill-reports.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import {
+  CANONICAL_CONTENT_HASH_SCHEME,
+  CANONICAL_TREE_HASH_SCHEME,
+  RECOVERED_SKILL_REPORTS,
+  calculateCanonicalSkillHashes,
+  verifyRecoveredSkillReport,
+  verifyRecoveredSkillReports,
+} from '../verify-recovered-skill-reports.mjs';
+
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '../..');
+
+test('ten recovered reports match canonical slugs, source URLs, paths, and exact bytes', () => {
+  const results = verifyRecoveredSkillReports(REPOSITORY_ROOT);
+  assert.equal(results.length, 10);
+  assert.equal(new Set(results.map((row) => row.slug)).size, 10);
+  assert.equal(new Set(results.map((row) => row.contentHash)).size, 10);
+  assert.equal(new Set(results.map((row) => row.treeHash)).size, 10);
+  assert.deepEqual(new Set(results.map((row) => row.contentHashScheme)), new Set([
+    CANONICAL_CONTENT_HASH_SCHEME,
+  ]));
+  assert.deepEqual(new Set(results.map((row) => row.treeHashScheme)), new Set([
+    CANONICAL_TREE_HASH_SCHEME,
+  ]));
+  assert.deepEqual(
+    results.map((row) => row.slug),
+    RECOVERED_SKILL_REPORTS.map((target) => target.slug),
+  );
+});
+
+test('verification fails closed when report identity drifts from canonical bytes', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'recovered-skill-report-'));
+  const target = {
+    path: 'skills/example/demo',
+    slug: 'example-demo',
+    sourceUrl: 'https://github.com/example/skills/tree/main/demo/',
+  };
+  const skillDirectory = join(repositoryRoot, target.path);
+  const skillPath = join(skillDirectory, 'SKILL.md');
+  const reportPath = join(skillDirectory, 'skill-report.json');
+  try {
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(skillPath, '---\nname: demo\ndescription: Demo\n---\n\n# Demo\n');
+    const canonical = calculateCanonicalSkillHashes(skillDirectory);
+    writeFileSync(reportPath, JSON.stringify({
+      schema_version: '2.0',
+      meta: {
+        slug: target.slug,
+        source_url: target.sourceUrl,
+        source_ref: 'main',
+        source_type: 'community',
+        content_hash: canonical.contentHash,
+        tree_hash: canonical.treeHash,
+      },
+      file_structure: [{ name: 'SKILL.md', type: 'file', path: 'SKILL.md', lines: 7 }],
+      security_audit: { analysis_status: 'ok' },
+    }, null, 2));
+    assert.equal(verifyRecoveredSkillReport(repositoryRoot, target).slug, target.slug);
+
+    const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+    report.meta.content_hash = '0'.repeat(64);
+    writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    assert.throws(
+      () => verifyRecoveredSkillReport(repositoryRoot, target),
+      /content_hash does not match exact SKILL\.md bytes/,
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-recovered-skill-reports.mjs
+++ b/scripts/verify-recovered-skill-reports.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+// Keep these contracts byte-for-byte compatible with Skillstore CLI v2.14.2
+// src/cli/lib/content-hash.ts. The recovery was also cross-checked by invoking
+// calculateCanonicalSkillHashes() from that release against all ten directories.
+export const CANONICAL_CONTENT_HASH_SCHEME = 'skill_md_raw_bytes_v1';
+export const CANONICAL_TREE_HASH_SCHEME = 'canonical_entries_v1';
+
+export const RECOVERED_SKILL_REPORTS = Object.freeze([
+  {
+    path: 'skills/atomic-mail/atomicmail',
+    slug: 'atomic-mail-atomicmail',
+    sourceUrl: 'https://github.com/atomic-mail/atomic-mail-agentic/tree/main/integrations/skill/atomicmail',
+  },
+  {
+    path: 'skills/skills-collective/ai-image-generation',
+    slug: 'skills-collective-ai-image-generation',
+    sourceUrl: 'https://github.com/skills-collective/skills/tree/main/ai-image-generation/',
+  },
+  {
+    path: 'skills/skills-collective/ai-music',
+    slug: 'skills-collective-ai-music',
+    sourceUrl: 'https://github.com/skills-collective/skills/tree/main/ai-music/',
+  },
+  {
+    path: 'skills/skills-collective/ai-video-generation',
+    slug: 'skills-collective-ai-video-generation',
+    sourceUrl: 'https://github.com/skills-collective/skills/tree/main/ai-video-generation/',
+  },
+  {
+    path: 'skills/zx029w/laofang-gaizao-bucailei',
+    slug: 'zx029w-laofang-gaizao-bucailei',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%80%81%E6%88%BF%E6%94%B9%E9%80%A0%E4%B8%8D%E8%B8%A9%E9%9B%B7/',
+  },
+  {
+    path: 'skills/zx029w/quanwu-dingzhi-bucailei',
+    slug: 'zx029w-quanwu-dingzhi-bucailei',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E5%85%A8%E5%B1%8B%E5%AE%9A%E5%88%B6%E4%B8%8D%E8%B8%A9%E9%9B%B7/',
+  },
+  {
+    path: 'skills/zx029w/zhuangxiu-baojia-shenhe',
+    slug: 'zx029w-zhuangxiu-baojia-shenhe',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E6%8A%A5%E4%BB%B7%E5%AE%A1%E6%A0%B8/',
+  },
+  {
+    path: 'skills/zx029w/zhuangxiu-hetong-shenhe',
+    slug: 'zx029w-zhuangxiu-hetong-shenhe',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E5%90%88%E5%90%8C%E5%AE%A1%E6%A0%B8/',
+  },
+  {
+    path: 'skills/zx029w/zhuangxiu-yusuan-jisuanqi',
+    slug: 'zx029w-zhuangxiu-yusuan-jisuanqi',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E9%A2%84%E7%AE%97%E8%AE%A1%E7%AE%97%E5%99%A8/',
+  },
+  {
+    path: 'skills/zx029w/zhuangxiu-zengxiang-bilei',
+    slug: 'zx029w-zhuangxiu-zengxiang-bilei',
+    sourceUrl: 'https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E5%A2%9E%E9%A1%B9%E9%81%BF%E9%9B%B7/',
+  },
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function toPosixPath(path) {
+  return path.split(/[\\/]+/).filter(Boolean).join('/');
+}
+
+function isSystemTempFile(name) {
+  return name === '.DS_Store' || name.endsWith('~') || name.endsWith('.tmp') || name.endsWith('.temp');
+}
+
+function gitMode(mode) {
+  return (mode & 0o111) ? '100755' : '100644';
+}
+
+function countLines(bytes) {
+  if (bytes.length === 0) return 0;
+  let lines = 1;
+  for (const byte of bytes) {
+    if (byte === 10) lines += 1;
+  }
+  return lines;
+}
+
+function collectCanonicalEntries(directory, baseDirectory = directory) {
+  const dirents = readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => !isSystemTempFile(entry.name) && entry.name !== '.git')
+    .sort((left, right) => left.name.localeCompare(right.name, 'en', { sensitivity: 'variant' }));
+  const entries = [];
+
+  for (const dirent of dirents) {
+    const fullPath = join(directory, dirent.name);
+    const relativePath = toPosixPath(relative(baseDirectory, fullPath));
+    const stat = lstatSync(fullPath);
+    if (dirent.isSymbolicLink() || (!dirent.isDirectory() && !dirent.isFile())) {
+      fail(`unsupported file type in canonical tree: ${relativePath}`);
+    }
+    if (dirent.isDirectory()) {
+      entries.push(...collectCanonicalEntries(fullPath, baseDirectory));
+      continue;
+    }
+    if (relativePath === 'skill-report.json') continue;
+    const bytes = readFileSync(fullPath);
+    entries.push({
+      path: relativePath,
+      mode: gitMode(stat.mode),
+      sha256: sha256(bytes),
+      size: bytes.byteLength,
+    });
+  }
+  return entries;
+}
+
+export function calculateCanonicalSkillHashes(skillDirectory) {
+  const skillBytes = readFileSync(join(skillDirectory, 'SKILL.md'));
+  const entries = collectCanonicalEntries(skillDirectory)
+    .sort((left, right) => left.path.localeCompare(right.path, 'en', { sensitivity: 'variant' }));
+  const serialized = entries.map((entry) => JSON.stringify(entry)).join('\n');
+  return {
+    contentHash: sha256(skillBytes),
+    treeHash: sha256(serialized),
+    entries,
+  };
+}
+
+function frontmatterName(skillBytes, label) {
+  const skill = skillBytes.toString('utf8');
+  const frontmatter = skill.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
+  const rawName = frontmatter?.match(/^name:\s*(.+?)\s*$/m)?.[1];
+  const name = rawName?.replace(/^(['"])(.*)\1$/, '$2');
+  if (!name || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    fail(`${label} has no canonical frontmatter name`);
+  }
+  return name;
+}
+
+function validateReportedFileStructure(skillDirectory, nodes, label, seen = new Set()) {
+  if (!Array.isArray(nodes)) fail(`${label} file_structure is not an array`);
+  for (const node of nodes) {
+    const path = toPosixPath(String(node?.path || ''));
+    if (!path || path.startsWith('../') || path === 'skill-report.json' || seen.has(path)) {
+      fail(`${label} has an invalid or duplicate file_structure path: ${path || '<missing>'}`);
+    }
+    seen.add(path);
+    if (node.name !== basename(path)) fail(`${label} file_structure name/path mismatch: ${path}`);
+    const fullPath = resolve(skillDirectory, path);
+    if (!fullPath.startsWith(`${resolve(skillDirectory)}/`)) fail(`${label} file_structure escapes its Skill: ${path}`);
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) fail(`${label} file_structure contains a symlink: ${path}`);
+    if (node.type === 'dir') {
+      if (!stat.isDirectory()) fail(`${label} expected directory: ${path}`);
+      if (node.children !== undefined) {
+        validateReportedFileStructure(skillDirectory, node.children, label, seen);
+      }
+    } else if (node.type === 'file') {
+      if (!stat.isFile()) fail(`${label} expected file: ${path}`);
+      if (node.lines !== countLines(readFileSync(fullPath))) {
+        fail(`${label} line count does not match bytes: ${path}`);
+      }
+    } else {
+      fail(`${label} has an invalid file_structure type: ${path}`);
+    }
+  }
+  return seen;
+}
+
+export function verifyRecoveredSkillReport(repositoryRoot, target) {
+  const skillDirectory = resolve(repositoryRoot, target.path);
+  const skillBytes = readFileSync(join(skillDirectory, 'SKILL.md'));
+  const report = JSON.parse(readFileSync(join(skillDirectory, 'skill-report.json'), 'utf8'));
+  const owner = target.path.split('/')[1];
+  const directoryName = basename(skillDirectory);
+  const name = frontmatterName(skillBytes, target.path);
+  const expectedSlug = `${owner}-${name}`;
+  const source = new URL(String(report.meta?.source_url || ''));
+  const canonical = calculateCanonicalSkillHashes(skillDirectory);
+
+  if (directoryName !== name) fail(`${target.path} directory does not match SKILL.md name`);
+  if (target.slug !== expectedSlug || report.meta?.slug !== expectedSlug) {
+    fail(`${target.path} does not use canonical community slug ${expectedSlug}`);
+  }
+  if (report.meta?.source_url !== target.sourceUrl) fail(`${target.path} source_url mismatch`);
+  if (source.hostname !== 'github.com' || decodeURIComponent(source.pathname).split('/')[1] !== owner) {
+    fail(`${target.path} source owner mismatch`);
+  }
+  if (report.meta?.source_ref !== 'main' || report.meta?.source_type !== 'community') {
+    fail(`${target.path} source metadata mismatch`);
+  }
+  if (!SHA256_RE.test(String(report.meta?.content_hash || ''))
+    || report.meta.content_hash !== canonical.contentHash) {
+    fail(`${target.path} content_hash does not match exact SKILL.md bytes`);
+  }
+  if (!SHA256_RE.test(String(report.meta?.tree_hash || ''))
+    || report.meta.tree_hash !== canonical.treeHash) {
+    fail(`${target.path} tree_hash does not match canonical source paths and bytes`);
+  }
+  if (report.security_audit?.analysis_status !== 'ok') {
+    fail(`${target.path} lacks a successful audit report`);
+  }
+  validateReportedFileStructure(skillDirectory, report.file_structure, target.path);
+
+  return {
+    path: target.path,
+    slug: expectedSlug,
+    sourceUrl: target.sourceUrl,
+    contentHash: canonical.contentHash,
+    contentHashScheme: CANONICAL_CONTENT_HASH_SCHEME,
+    treeHash: canonical.treeHash,
+    treeHashScheme: CANONICAL_TREE_HASH_SCHEME,
+    entryCount: canonical.entries.length,
+  };
+}
+
+function collectReportSlugPaths(directory, results = new Map()) {
+  for (const dirent of readdirSync(directory, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) continue;
+    const child = join(directory, dirent.name);
+    const reportPath = join(child, 'skill-report.json');
+    try {
+      const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+      const slug = report.meta?.slug;
+      if (typeof slug === 'string' && slug) {
+        const paths = results.get(slug) || [];
+        paths.push(reportPath);
+        results.set(slug, paths);
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      collectReportSlugPaths(child, results);
+    }
+  }
+  return results;
+}
+
+export function verifyRecoveredSkillReports(repositoryRoot) {
+  const results = RECOVERED_SKILL_REPORTS.map((target) =>
+    verifyRecoveredSkillReport(repositoryRoot, target));
+  const uniqueSlugs = new Set(results.map((row) => row.slug));
+  if (uniqueSlugs.size !== RECOVERED_SKILL_REPORTS.length) {
+    fail('recovered reports do not have ten unique canonical slugs');
+  }
+  const repositorySlugs = collectReportSlugPaths(resolve(repositoryRoot, 'skills'));
+  for (const row of results) {
+    const matches = repositorySlugs.get(row.slug) || [];
+    if (matches.length !== 1 || !matches[0].endsWith(`${row.path}/skill-report.json`)) {
+      fail(`${row.slug} is not unique at its canonical repository path`);
+    }
+  }
+  return results;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const repositoryRoot = resolve(process.argv[2] || '.');
+  console.log(JSON.stringify({
+    schemaVersion: 1,
+    verifiedCount: RECOVERED_SKILL_REPORTS.length,
+    results: verifyRecoveredSkillReports(repositoryRoot),
+  }, null, 2));
+}

--- a/skills/atomic-mail/atomicmail/skill-report.json
+++ b/skills/atomic-mail/atomicmail/skill-report.json
@@ -8,8 +8,8 @@
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "8aeeade504b5c2f69ebb96b60dd376ce044e2c65ceaec949bac9e97ad5358183",
-    "tree_hash": "08451d1c14341ba7d9832e3334af97520eeb066425bbf46feda41fceec2ebce3",
+    "content_hash": "62b39cc76041c42b784deaf7dadcdef852cda889d9d0c794e8db82fc4c69381e",
+    "tree_hash": "34bd98982f9a5b829b56e94da96380ba8433c7a3d43366ec57aaea0e36739232",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [
@@ -8068,7 +8068,7 @@
       "name": "SKILL.md",
       "type": "file",
       "path": "SKILL.md",
-      "lines": 263
+      "lines": 209
     }
   ]
 }

--- a/skills/skills-collective/ai-image-generation/skill-report.json
+++ b/skills/skills-collective/ai-image-generation/skill-report.json
@@ -8,8 +8,8 @@
     "model": "claude",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "d6db5a2052d5f3e7dfc687e72c14aa832a162a839cae755e360472d61d1ce3f6",
-    "tree_hash": "cbe1778bdb05043220dbbd2f2553654c64c0e741406797a3697b44f75572a74d",
+    "content_hash": "752a30e08a7c89fbca5a8bd2556654af9a7b6ce7fb6082098299fbdb49e6253b",
+    "tree_hash": "3362cd9914fa9950e2055fe6b8a955f019666b00c31dc93a51f19135920115a5",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/skills-collective/ai-music/skill-report.json
+++ b/skills/skills-collective/ai-music/skill-report.json
@@ -8,8 +8,8 @@
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "6636f4f02bcad9f19a17379a367eabc47b1459dfd1ae3f7c11b394f613d5bfdd",
-    "tree_hash": "2fb9d3baecc8f99d040afaaaaa80abc9561cfde1203bb0c6f4fab6ec35280564",
+    "content_hash": "f10c3e2809dd416aa22b8172297b942c18abbe4acb7753c547ec0834b8cdf080",
+    "tree_hash": "784c6b4f06efcc592b11098c58dc958db8884eb3300df59dc73f11d4e4251aa5",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [
@@ -1895,7 +1895,7 @@
       "name": "SKILL.md",
       "type": "file",
       "path": "SKILL.md",
-      "lines": 276
+      "lines": 260
     }
   ]
 }

--- a/skills/skills-collective/ai-video-generation/skill-report.json
+++ b/skills/skills-collective/ai-video-generation/skill-report.json
@@ -8,8 +8,8 @@
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "651098ea709ba81d5daa76ff57276ec0fcafd3c3cfddb11b171c374fc167cb48",
-    "tree_hash": "777e027aa49c9e5c9275895ccd0851e2a84c9b693fb08361e2d83e32ec599537",
+    "content_hash": "76511e833124b37cc19be3a341ef8dc6c62d283c93b89577ada1d16366210af6",
+    "tree_hash": "98fbb84b4eb09f5a24e429bfa7efb02d6d954259be9e45a4899423f83dc30453",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [

--- a/skills/zx029w/laofang-gaizao-bucailei/skill-report.json
+++ b/skills/zx029w/laofang-gaizao-bucailei/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T09:42:22.168Z",
-    "slug": "zx029w",
+    "slug": "zx029w-laofang-gaizao-bucailei",
     "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%80%81%E6%88%BF%E6%94%B9%E9%80%A0%E4%B8%8D%E8%B8%A9%E9%9B%B7/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "4bcc496b44679fdd898bf818a7f49e028848c6aa8fc1050f8ad7a4db854d6094",
-    "tree_hash": "960e6ef2deda2ec651ac99dfe6ee48ddde56bbb6079c10da44635b1ae05eb57e",
+    "content_hash": "70b5b1337c94f19ed10b27df02de6a93644b31bcfe7850e792c12e4a6c5536cf",
+    "tree_hash": "6a8fa28cfb6a157fa2926db74213df387608329c0009cc4012339af545dd5edd",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [

--- a/skills/zx029w/quanwu-dingzhi-bucailei/skill-report.json
+++ b/skills/zx029w/quanwu-dingzhi-bucailei/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T09:41:22.921Z",
-    "slug": "zx029w",
+    "slug": "zx029w-quanwu-dingzhi-bucailei",
     "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E5%85%A8%E5%B1%8B%E5%AE%9A%E5%88%B6%E4%B8%8D%E8%B8%A9%E9%9B%B7/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "07779cc1b8da6be751180f2480592b15317961be2bb24e15f37750367b8ceccc",
-    "tree_hash": "f85eef448465068f26e83503a2f4c308dbf12ec00ef9ae3a5c944c2793423932",
+    "content_hash": "4d1d35696c06eb93149d5be883eb236f85131d397c3262cde5d9ade406a296cc",
+    "tree_hash": "60b2597c913a44bb720ae72eab1dd6503b6f42dbdacdd7699c30fe2a2c05541f",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [

--- a/skills/zx029w/zhuangxiu-baojia-shenhe/skill-report.json
+++ b/skills/zx029w/zhuangxiu-baojia-shenhe/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T09:44:46.171Z",
-    "slug": "zx029w",
+    "slug": "zx029w-zhuangxiu-baojia-shenhe",
     "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E6%8A%A5%E4%BB%B7%E5%AE%A1%E6%A0%B8/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "e1d3a618531581a9f1695011ccde79fee2911ad72d2a9fbe1f5e7e71d1b59a82",
-    "tree_hash": "f74a57881461d99c3aed2b2085b053e7bdca1fb6f17451105d84accc3f6c943a",
+    "content_hash": "68c0bdb2bde11f06bdb24d041d88dc9f7d61824a8dd8482151b581bbc9615c56",
+    "tree_hash": "c5f48bc24c8e9eab4e13e557ab46af9b3e27aefbcfe57d2c7537dc6882db148e",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [

--- a/skills/zx029w/zhuangxiu-hetong-shenhe/skill-report.json
+++ b/skills/zx029w/zhuangxiu-hetong-shenhe/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T09:44:22.107Z",
-    "slug": "zx029w",
+    "slug": "zx029w-zhuangxiu-hetong-shenhe",
     "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E5%90%88%E5%90%8C%E5%AE%A1%E6%A0%B8/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "6749676ec38f93b9bf178403d1a2afc20f0c6218c224531ac7d1588f6c149e2e",
-    "tree_hash": "3070e2ea8e84ef906833278598dfd3d5c306587c2f1f0529f77e3835c9ad67c3",
+    "content_hash": "13977eb4402cf96957d3d7191409402430b61a40d52e9d4a8310995672217169",
+    "tree_hash": "97585495b5c06d38d58d03611cff9b69517ff15f630180ea89b8142b4f5f2e50",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [

--- a/skills/zx029w/zhuangxiu-yusuan-jisuanqi/skill-report.json
+++ b/skills/zx029w/zhuangxiu-yusuan-jisuanqi/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T10:46:18.167Z",
-    "slug": "zx029w",
-    "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E7%8E%AF%E4%BF%9D%E9%81%BF%E5%9D%91/",
+    "slug": "zx029w-zhuangxiu-yusuan-jisuanqi",
+    "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E9%A2%84%E7%AE%97%E8%AE%A1%E7%AE%97%E5%99%A8/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "0ccac36965538d3359891cc5692125187145a8d5b852fad14a9f30d1ec49a443",
-    "tree_hash": "660239300884db3b351e42f55e1291e5a0ccdd6206690708069818bb5337f92e",
+    "content_hash": "e1dc3c1cd4e9b4408b642916d26ceb2c9b58c0ef9080eb12b0a9e3738194b192",
+    "tree_hash": "fe4ba07f051e68ea3f42b7a88f33ff2aaaa33f3942c821d079798631c9d7534d",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [
@@ -564,7 +564,7 @@
       "name": "SKILL.md",
       "type": "file",
       "path": "SKILL.md",
-      "lines": 136
+      "lines": 128
     }
   ]
 }

--- a/skills/zx029w/zhuangxiu-zengxiang-bilei/skill-report.json
+++ b/skills/zx029w/zhuangxiu-zengxiang-bilei/skill-report.json
@@ -2,14 +2,14 @@
   "schema_version": "2.0",
   "meta": {
     "generated_at": "2026-07-14T09:44:35.185Z",
-    "slug": "zx029w",
+    "slug": "zx029w-zhuangxiu-zengxiang-bilei",
     "source_url": "https://github.com/zx029w/zhuangxiu-skills/tree/main/%E8%A3%85%E4%BF%AE%E5%A2%9E%E9%A1%B9%E9%81%BF%E9%9B%B7/",
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "e3b48cb213f0456db84f466d5ebd45dfa0a81b6b9e76525d5b093860ce326f63",
-    "tree_hash": "c7851c655692e46a0073560ed1525d909086f92fe14bb128c80b0a8072e84650",
+    "content_hash": "b0f7ad062bc0e9b826da4c7d768c797c71eb52d8aafde14817bbdb6e139f8d5f",
+    "tree_hash": "e5908dd81c16881582a33186728ea0540b4e88027a8a38412c454e927ae6ffac",
     "provenance": {
       "model_effective": "codex",
       "fallback_chain": [


### PR DESCRIPTION
## Summary

- recover the ten approved Skill reports that exist on Marketplace `main` but are absent from the production catalog
- replace stale report hashes with Skillstore CLI v2.14.2 canonical `skill_md_raw_bytes_v1` / `canonical_entries_v1` hashes
- give all six `zx029w` Skills unique owner-prefixed canonical slugs
- correct `zx029w-zhuangxiu-yusuan-jisuanqi` from the unrelated `装修环保避坑` source path to `装修预算计算器`
- add a fail-closed verifier for slug uniqueness, source identity, exact `SKILL.md` bytes, canonical tree entries, and reported file paths/line counts

## Recovered slugs

- `atomic-mail-atomicmail`
- `skills-collective-ai-image-generation`
- `skills-collective-ai-music`
- `skills-collective-ai-video-generation`
- `zx029w-laofang-gaizao-bucailei`
- `zx029w-quanwu-dingzhi-bucailei`
- `zx029w-zhuangxiu-baojia-shenhe`
- `zx029w-zhuangxiu-hetong-shenhe`
- `zx029w-zhuangxiu-yusuan-jisuanqi`
- `zx029w-zhuangxiu-zengxiang-bilei`

## Verification

- `CI=true node --test scripts/recovered-skill-reports.test.mjs` — 2/2 passed
- the full focused `Validate submission scope contracts` command — 47/47 passed
- all ten reports passed `schemas/skill-report.schema.json`
- all ten report hashes were independently cross-checked by invoking `calculateCanonicalSkillHashes()` from Skillstore CLI v2.14.2 source
- `git diff --check`

## Delivery boundary

This PR does not run production sync, mutate Supabase, warm caches, or merge itself. Production recovery should run only after review, green CI, and an explicit merge/sync decision.
