### PR TITLE
fix(submissions): bind source refs and immutable runtime

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -355,10 +355,33 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
+      - name: Clear inherited marketplace checkout
+        run: |
+          set -euo pipefail
+
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+
+          cd "${RUNNER_TEMP:?}"
+          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+          fi
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
       - name: Checkout marketplace
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          clean: true
+          persist-credentials: false
 
       - name: Download Skillstore CLI
         if: matrix.slugs != ''
@@ -367,6 +390,50 @@ jobs:
           version: ${{ inputs.cli_version }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify immutable processing runtime
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+
+          ACTUAL_HEAD=$(git rev-parse HEAD)
+          if [ "$ACTUAL_HEAD" != "$EXPECTED_WORKFLOW_SHA" ]; then
+            echo "::error::Marketplace checkout mismatch: expected $EXPECTED_WORKFLOW_SHA, got $ACTUAL_HEAD"
+            exit 1
+          fi
+
+          if [ "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" = "true" ]; then
+            echo "::error::Marketplace checkout is still sparse"
+            exit 1
+          fi
+          test ! -f "$(git rev-parse --git-path info/sparse-checkout)" || {
+            echo "::error::Inherited sparse-checkout definition is still present"
+            exit 1
+          }
+
+          REQUIRED_RUNTIME_FILES=(
+            "schemas/skill-report.schema.json"
+            ".github/actions/download-skillstore-cli/action.yml"
+            ".github/workflows/reusable-process-skills.yml"
+          )
+          for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
+            test -f "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required processing runtime file is missing: $file"
+              exit 1
+            }
+            EXPECTED_BLOB=$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")
+            ACTUAL_BLOB=$(git hash-object -- "$GITHUB_WORKSPACE/$file")
+            if [ "$ACTUAL_BLOB" != "$EXPECTED_BLOB" ]; then
+              echo "::error::Processing runtime file does not match workflow head: $file"
+              exit 1
+            fi
+          done
+
+          test -x "$GITHUB_WORKSPACE/skillstore-cli" || {
+            echo "::error::Downloaded skillstore-cli is missing or not executable"
+            exit 1
+          }
 
       - name: Process shard ${{ matrix.shard }}
         id: process

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -99,6 +99,65 @@ jobs:
       branch: ${{ steps.clone.outputs.branch }}
       github_url: ${{ steps.discover.outputs.github_url }}
     steps:
+      - name: Clear inherited discovery checkout
+        run: |
+          set -euo pipefail
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+          cd "${RUNNER_TEMP:?}"
+          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+          fi
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
+      - name: Checkout immutable discovery runtime
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          clean: true
+          persist-credentials: false
+
+      - name: Verify immutable discovery runtime
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          REQUIRED_RUNTIME_FILES=(
+            "schemas/skill-report.schema.json"
+            ".github/actions/download-skillstore-cli/action.yml"
+            ".github/workflows/reusable-process-skills.yml"
+            "scripts/resolve-submission-source.mjs"
+            "scripts/discover-submission-skills.mjs"
+            "scripts/process-submission-shard.mjs"
+            "scripts/submission-shard-contract.mjs"
+            "scripts/aggregate-submission-shards.mjs"
+            "scripts/resolve-approved-submission.mjs"
+          )
+          test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
+          test "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true"
+          test ! -f "$(git rev-parse --git-path info/sparse-checkout)"
+          if git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
+            echo "::error::Immutable discovery runtime contains skip-worktree files"
+            exit 1
+          fi
+          for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
+            test -f "$GITHUB_WORKSPACE/$file" && test ! -L "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required runtime file is missing or not a regular file: $file"
+              exit 1
+            }
+            test "$(git hash-object -- "$GITHUB_WORKSPACE/$file")" = "$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")" || {
+              echo "::error::Runtime file does not match workflow head: $file"
+              exit 1
+            }
+          done
+
       - name: Notify skillstore - Processing started
         if: inputs.is_manual_approval == false
         run: |
@@ -119,150 +178,60 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           URL="${{ inputs.github_url }}"
-          URL="${URL%.git}"
+          REPOSITORY_ID=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
+            --github-url "$URL" --repository-only)
+          OWNER_REPO=$(jq -er '"\(.owner)/\(.repo)"' <<< "$REPOSITORY_ID")
+          DEFAULT_REF=$(gh api "repos/$OWNER_REPO" --jq '.default_branch')
+          REFS_FILE="${RUNNER_TEMP:?}/submission-refs-${{ github.run_id }}-${{ github.run_attempt }}.txt"
+          git ls-remote --heads --tags "https://github.com/$OWNER_REPO.git" > "$REFS_FILE"
+          RESOLVED=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
+            --github-url "$URL" \
+            --default-ref "$DEFAULT_REF" \
+            --refs-file "$REFS_FILE")
+          rm -f "$REFS_FILE"
 
-          # Validate GitHub URL format
-          if [[ ! "$URL" =~ ^https://github\.com/[a-zA-Z0-9_-]+/[a-zA-Z0-9._-]+(/.*)?$ ]]; then
-            echo "::error::Invalid GitHub URL format: $URL"
+          OWNER=$(jq -er '.owner' <<< "$RESOLVED")
+          REPO=$(jq -er '.repo' <<< "$RESOLVED")
+          REF=$(jq -er '.ref' <<< "$RESOLVED")
+          REF_SHA=$(jq -er '.refSha' <<< "$RESOLVED")
+          SKILL_PATH=$(jq -er '.skillPath' <<< "$RESOLVED")
+          EXPLICIT_PATH=$(jq -er '.explicitPath' <<< "$RESOLVED")
+          NORMALIZED_URL=$(jq -er '.normalizedUrl' <<< "$RESOLVED")
+          SOURCE_DIR="${RUNNER_TEMP:?}/submission-source-${{ github.run_id }}-${{ github.run_attempt }}"
+          rm -rf "$SOURCE_DIR"
+          git clone --depth 1 --branch "$REF" "https://github.com/$OWNER/$REPO.git" "$SOURCE_DIR"
+          test "$(git -C "$SOURCE_DIR" rev-parse HEAD)" = "$REF_SHA" || {
+            echo "::error::Resolved source ref moved during clone: $REF"
             exit 1
-          fi
+          }
 
-          if [[ "$URL" =~ github\.com[:/]([^/]+)/([^/]+) ]]; then
-            OWNER="${BASH_REMATCH[1]}"
-            REPO="${BASH_REMATCH[2]}"
-          else
-            echo "::error::Invalid GitHub URL: $URL"
-            exit 1
-          fi
-
-          echo "owner=$OWNER" >> $GITHUB_OUTPUT
-          echo "repo=$REPO" >> $GITHUB_OUTPUT
-
-          # Extract skillPath from URL (e.g., /tree/master/.claude/skills/clojure-review)
-          SKILL_PATH=""
-          if [[ "$URL" =~ /tree/[^/]+/(.+)$ ]]; then
-            SKILL_PATH="${BASH_REMATCH[1]}"
-
-            # Validate skill path - prevent path traversal attacks
-            if [[ "$SKILL_PATH" =~ \.\. ]]; then
-              echo "::error::Invalid skill path (contains '..'): $SKILL_PATH"
-              exit 1
-            fi
-            if [[ "$SKILL_PATH" =~ ^/ ]]; then
-              echo "::error::Invalid skill path (absolute path not allowed): $SKILL_PATH"
-              exit 1
-            fi
-
-            echo "📍 Skill path specified: $SKILL_PATH"
-          fi
-          echo "skill_path=$SKILL_PATH" >> $GITHUB_OUTPUT
-
-          BRANCH=$(gh api "repos/$OWNER/$REPO" --jq '.default_branch')
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-
-          SOURCE_DIR="/tmp/source-repo-${{ github.run_id }}"
-          git clone --depth 1 --branch "$BRANCH" "https://github.com/$OWNER/$REPO.git" "$SOURCE_DIR"
-
-          echo "source_dir=$SOURCE_DIR" >> $GITHUB_OUTPUT
-          echo "📦 Cloned $OWNER/$REPO (branch: $BRANCH)"
+          echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "branch=$REF" >> "$GITHUB_OUTPUT"
+          echo "skill_path=$SKILL_PATH" >> "$GITHUB_OUTPUT"
+          echo "explicit_path=$EXPLICIT_PATH" >> "$GITHUB_OUTPUT"
+          echo "normalized_url=$NORMALIZED_URL" >> "$GITHUB_OUTPUT"
+          echo "source_dir=$SOURCE_DIR" >> "$GITHUB_OUTPUT"
+          echo "📦 Cloned $OWNER/$REPO at immutable $REF ($REF_SHA)"
 
       - name: Discover skills (fast - no AI)
         id: discover
         env:
           SKILL_PATH: ${{ steps.clone.outputs.skill_path }}
-          OWNER: ${{ steps.clone.outputs.owner }}
-          REPO: ${{ steps.clone.outputs.repo }}
-          BRANCH: ${{ steps.clone.outputs.branch }}
-          ORIGINAL_URL: ${{ inputs.github_url }}
         run: |
+          set -euo pipefail
           SOURCE_DIR="${{ steps.clone.outputs.source_dir }}"
-          CORRECTED_URL=""  # Only set when FALLBACK occurs
-
-          # If skill_path is specified, only search within that path
-          if [ -n "$SKILL_PATH" ]; then
-            SEARCH_DIR="$SOURCE_DIR/$SKILL_PATH"
-            echo "📍 Searching within: $SKILL_PATH"
-
-            # FALLBACK: If specified path doesn't exist OR has no SKILL.md,
-            # search entire repo for matching folder name
-            if [ ! -d "$SEARCH_DIR" ] || [ -z "$(find "$SEARCH_DIR" -name "SKILL.md" -type f 2>/dev/null | head -1)" ]; then
-              FOLDER_NAME=$(basename "$SKILL_PATH")
-              echo "⚠️ No SKILL.md found at $SKILL_PATH, searching for folder '$FOLDER_NAME' in repository..."
-
-              # Find all directories matching the folder name that contain SKILL.md
-              FOUND_PATH=""
-              while IFS= read -r skill_md; do
-                SKILL_DIR=$(dirname "$skill_md")
-                DIR_NAME=$(basename "$SKILL_DIR")
-                if [ "$DIR_NAME" = "$FOLDER_NAME" ]; then
-                  FOUND_PATH="$SKILL_DIR"
-                  break
-                fi
-              done < <(find "$SOURCE_DIR" -name "SKILL.md" -type f ! -path "*/node_modules/*" ! -path "*/.git/*" 2>/dev/null)
-
-              # FALLBACK 2: If folder name match failed, try matching SKILL.md name field
-              if [ -z "$FOUND_PATH" ]; then
-                echo "⚠️ Folder name match failed, searching by SKILL.md name field '$FOLDER_NAME'..."
-
-                while IFS= read -r skill_md; do
-                  SKILL_NAME=$(grep -E '^name:' "$skill_md" 2>/dev/null | head -1 | sed 's/name:[[:space:]]*//')
-                  if [ "$SKILL_NAME" = "$FOLDER_NAME" ]; then
-                    FOUND_PATH=$(dirname "$skill_md")
-                    echo "✅ Found skill by name field: $SKILL_NAME"
-                    break
-                  fi
-                done < <(find "$SOURCE_DIR" -name "SKILL.md" -type f ! -path "*/node_modules/*" ! -path "*/.git/*" 2>/dev/null)
-              fi
-
-              if [ -n "$FOUND_PATH" ]; then
-                RELATIVE_PATH="${FOUND_PATH#$SOURCE_DIR/}"
-                echo "✅ Found skill at: $RELATIVE_PATH"
-                SEARCH_DIR="$FOUND_PATH"
-                # FALLBACK: Correct the URL to point to the discovered path
-                CORRECTED_URL="https://github.com/$OWNER/$REPO/tree/$BRANCH/$RELATIVE_PATH"
-                echo "🔄 Corrected URL: $CORRECTED_URL"
-              else
-                echo "❌ Could not find folder '$FOLDER_NAME' with SKILL.md in repository"
-                SEARCH_DIR="$SOURCE_DIR/$SKILL_PATH"  # Keep original (will find 0)
-              fi
-            fi
-          else
-            SEARCH_DIR="$SOURCE_DIR"
-            echo "🔍 Searching entire repository"
-          fi
-
-          # Output github_url: use corrected if FALLBACK occurred, otherwise original
-          if [ -n "$CORRECTED_URL" ]; then
-            echo "github_url=$CORRECTED_URL" >> $GITHUB_OUTPUT
-          else
-            echo "github_url=$ORIGINAL_URL" >> $GITHUB_OUTPUT
-          fi
-
-          SKILLS_JSON="["
-          FIRST=true
-
-          while IFS= read -r skill_md; do
-            SKILL_DIR=$(dirname "$skill_md")
-
-            SLUG=$(grep -E '^name:' "$skill_md" 2>/dev/null | head -1 | sed 's/name:[[:space:]]*//' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^-*//;s/-*$//' | sed 's/--*/-/g')
-            [ -z "$SLUG" ] && SLUG=$(basename "$SKILL_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^-*//;s/-*$//')
-
-            if [ "$FIRST" = true ]; then
-              FIRST=false
-            else
-              SKILLS_JSON+=","
-            fi
-            SKILLS_JSON+="\"$SLUG\""
-          done < <(find "$SEARCH_DIR" -name "SKILL.md" -type f ! -path "*/node_modules/*" ! -path "*/.git/*" ! -path "*/.venv/*" ! -path "*/venv/*" 2>/dev/null | sort)
-
-          SKILLS_JSON+="]"
-
-          SKILL_COUNT=$(echo "$SKILLS_JSON" | jq 'length')
-
-          echo "skills_json=$SKILLS_JSON" >> $GITHUB_OUTPUT
-          echo "skill_count=$SKILL_COUNT" >> $GITHUB_OUTPUT
-
+          DISCOVERY=$(node "$GITHUB_WORKSPACE/scripts/discover-submission-skills.mjs" \
+            --source-dir "$SOURCE_DIR" \
+            --skill-path "$SKILL_PATH" \
+            --explicit-path "${{ steps.clone.outputs.explicit_path }}")
+          SKILLS_JSON=$(jq -cer '[.skills[].slug]' <<< "$DISCOVERY")
+          SKILL_COUNT=$(jq -er '.skills | length' <<< "$DISCOVERY")
+          echo "github_url=${{ steps.clone.outputs.normalized_url }}" >> "$GITHUB_OUTPUT"
+          echo "skills_json=$SKILLS_JSON" >> "$GITHUB_OUTPUT"
+          echo "skill_count=$SKILL_COUNT" >> "$GITHUB_OUTPUT"
           echo "📊 Discovered $SKILL_COUNT skill(s)"
 
       - name: Plan processing strategy
@@ -270,12 +239,17 @@ jobs:
         env:
           SKILL_COUNT: ${{ steps.discover.outputs.skill_count }}
           SKILLS_JSON: ${{ steps.discover.outputs.skills_json }}
+          EXPLICIT_PATH: ${{ steps.clone.outputs.explicit_path }}
         run: |
           COUNT=$SKILL_COUNT
           THRESHOLD=${{ env.SHARD_THRESHOLD }}
           MAX_SHARDS=${{ env.MAX_SHARDS }}
 
           if [ "$COUNT" -eq 0 ]; then
+            if [ "$EXPLICIT_PATH" = "true" ]; then
+              echo "::error::Explicit GitHub skill path resolved to zero skills"
+              exit 1
+            fi
             echo "No skills found; planning one explicit no-op shard"
             echo 'matrix={"include":[{"shard":0,"slugs":""}]}' >> $GITHUB_OUTPUT
             echo "is_sharded=false" >> $GITHUB_OUTPUT
@@ -330,7 +304,7 @@ jobs:
 
       - name: Cleanup source
         if: always()
-        run: rm -rf /tmp/source-repo-${{ github.run_id }}
+        run: rm -rf "${{ steps.clone.outputs.source_dir }}"
 
   # ============================================================
   # JOB 2: PROCESS (Parallel Matrix)
@@ -383,14 +357,6 @@ jobs:
           clean: true
           persist-credentials: false
 
-      - name: Download Skillstore CLI
-        if: matrix.slugs != ''
-        uses: ./.github/actions/download-skillstore-cli
-        with:
-          version: ${{ inputs.cli_version }}
-          token: ${{ steps.app-token.outputs.token }}
-          cache-dir: /home/runner/_work/_cache/skillstore-cli
-
       - name: Verify immutable processing runtime
         env:
           EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -416,10 +382,20 @@ jobs:
             "schemas/skill-report.schema.json"
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/reusable-process-skills.yml"
+            "scripts/resolve-submission-source.mjs"
+            "scripts/discover-submission-skills.mjs"
+            "scripts/process-submission-shard.mjs"
+            "scripts/submission-shard-contract.mjs"
+            "scripts/aggregate-submission-shards.mjs"
+            "scripts/resolve-approved-submission.mjs"
           )
+          if git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
+            echo "::error::Immutable processing runtime contains skip-worktree files"
+            exit 1
+          fi
           for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
-            test -f "$GITHUB_WORKSPACE/$file" || {
-              echo "::error::Required processing runtime file is missing: $file"
+            test -f "$GITHUB_WORKSPACE/$file" && test ! -L "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required processing runtime file is missing or not a regular file: $file"
               exit 1
             }
             EXPECTED_BLOB=$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")
@@ -430,10 +406,14 @@ jobs:
             fi
           done
 
-          test -x "$GITHUB_WORKSPACE/skillstore-cli" || {
-            echo "::error::Downloaded skillstore-cli is missing or not executable"
-            exit 1
-          }
+      - name: Download Skillstore CLI
+        if: matrix.slugs != ''
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          version: ${{ inputs.cli_version }}
+          token: ${{ steps.app-token.outputs.token }}
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+          require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}
         id: process
@@ -447,7 +427,7 @@ jobs:
         run: |
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
-          node scripts/process-submission-shard.mjs \
+          node "$GITHUB_WORKSPACE/scripts/process-submission-shard.mjs" \
             --cli "$GITHUB_WORKSPACE/skillstore-cli" \
             --github-url "${{ needs.discover-and-plan.outputs.github_url }}" \
             --slugs "$SLUGS" \
@@ -492,7 +472,7 @@ jobs:
         run: |
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
-          node scripts/submission-shard-contract.mjs \
+          node "$GITHUB_WORKSPACE/scripts/submission-shard-contract.mjs" \
             --manifest "$RESULT_DIR/shard-manifest.json" \
             --expected-index "${{ matrix.shard }}" \
             --expected-slugs "$PLANNED_SLUGS" \
@@ -523,6 +503,65 @@ jobs:
       outcome: ${{ steps.create_pr.outputs.outcome }}
       outcome_reason: ${{ steps.create_pr.outputs.outcome_reason }}
     steps:
+      - name: Clear inherited aggregation checkout
+        run: |
+          set -euo pipefail
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+          cd "${RUNNER_TEMP:?}"
+          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+          fi
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
+      - name: Checkout immutable aggregation runtime
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          clean: true
+          persist-credentials: false
+
+      - name: Verify immutable aggregation runtime
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          REQUIRED_RUNTIME_FILES=(
+            "schemas/skill-report.schema.json"
+            ".github/actions/download-skillstore-cli/action.yml"
+            ".github/workflows/reusable-process-skills.yml"
+            "scripts/resolve-submission-source.mjs"
+            "scripts/discover-submission-skills.mjs"
+            "scripts/process-submission-shard.mjs"
+            "scripts/submission-shard-contract.mjs"
+            "scripts/aggregate-submission-shards.mjs"
+            "scripts/resolve-approved-submission.mjs"
+          )
+          test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
+          test "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true"
+          test ! -f "$(git rev-parse --git-path info/sparse-checkout)"
+          if git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
+            echo "::error::Immutable aggregation runtime contains skip-worktree files"
+            exit 1
+          fi
+          for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
+            test -f "$GITHUB_WORKSPACE/$file" && test ! -L "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required runtime file is missing or not a regular file: $file"
+              exit 1
+            }
+            test "$(git hash-object -- "$GITHUB_WORKSPACE/$file")" = "$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")" || {
+              echo "::error::Runtime file does not match workflow head: $file"
+              exit 1
+            }
+          done
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -535,7 +574,7 @@ jobs:
         with:
           pattern: process-shard-${{ github.run_attempt }}-*
           merge-multiple: false
-          path: /tmp/submission-artifacts-${{ github.run_id }}
+          path: ${{ runner.temp }}/submission-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Merge results and create PR
         id: create_pr
@@ -547,8 +586,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          WORK_DIR="/tmp/marketplace-${{ github.run_id }}"
-          ARTIFACTS_DIR="/tmp/submission-artifacts-${{ github.run_id }}"
+          WORK_DIR="${RUNNER_TEMP:?}/marketplace-${{ github.run_id }}-${{ github.run_attempt }}"
+          ARTIFACTS_DIR="${RUNNER_TEMP:?}/submission-artifacts-${{ github.run_id }}-${{ github.run_attempt }}"
 
           cleanup() {
             echo "🧹 Cleaning up temp directories..."
@@ -573,7 +612,7 @@ jobs:
           APPROVAL_PLAN="${ARTIFACTS_DIR}.approval-plan.json"
           AGGREGATION_SUMMARY="${ARTIFACTS_DIR}.summary.json"
           MERGED_RESULTS="${ARTIFACTS_DIR}.merged"
-          node scripts/aggregate-submission-shards.mjs \
+          node "$GITHUB_WORKSPACE/scripts/aggregate-submission-shards.mjs" \
             --artifacts-dir "$ARTIFACTS_DIR" \
             --run-attempt "${{ github.run_attempt }}" \
             --matrix-json "$SHARD_MATRIX" \

--- a/scripts/discover-submission-skills.mjs
+++ b/scripts/discover-submission-skills.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SKIP_DIRECTORIES = new Set(['node_modules', '.git', '.venv', 'venv', 'dist', 'build', '__pycache__', '.cache']);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name, { required = true, defaultValue = null } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) fail(`missing required option ${name}`);
+    return defaultValue;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function slugify(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function topLevelName(skillMdPath, content) {
+  const lines = content.replace(/^\uFEFF/, '').split(/\r?\n/);
+  if (lines[0]?.trim() !== '---') return null;
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (end === -1) fail(`${skillMdPath}: frontmatter is not terminated`);
+  let name = null;
+  for (let index = 1; index < end; index += 1) {
+    const line = lines[index];
+    if (line.trim() === '' || /^\s*#/.test(line) || /^\s/.test(line)) continue;
+    const match = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+    if (!match) fail(`${skillMdPath}:${index + 1}: invalid top-level YAML`);
+    const [, key, rawValue = ''] = match;
+    const value = rawValue.trim();
+    if (value !== '' && !/^[>|][+-]?$/.test(value) && !value.startsWith('"') && !value.startsWith("'") && /:\s/.test(value)) {
+      fail(`${skillMdPath}:${index + 1}: invalid YAML plain scalar; quote values containing ': '`);
+    }
+    if (key !== 'name') continue;
+    if (name !== null) fail(`${skillMdPath}: duplicate top-level name field`);
+    if (value.startsWith('"')) {
+      try {
+        name = JSON.parse(value);
+      } catch {
+        fail(`${skillMdPath}:${index + 1}: invalid quoted name`);
+      }
+    } else if (value.startsWith("'")) {
+      if (!value.endsWith("'") || value.length < 2) fail(`${skillMdPath}:${index + 1}: invalid quoted name`);
+      name = value.slice(1, -1).replace(/''/g, "'");
+    } else {
+      name = value.replace(/\s+#.*$/, '').trim();
+    }
+    if (typeof name !== 'string' || name === '') fail(`${skillMdPath}:${index + 1}: name must be a non-empty scalar`);
+  }
+  return name;
+}
+
+function collectSkillFiles(root) {
+  const files = [];
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory() && !SKIP_DIRECTORIES.has(entry.name)) {
+        walk(join(directory, entry.name));
+      } else if (entry.isFile() && entry.name === 'SKILL.md') {
+        files.push(join(directory, entry.name));
+      }
+    }
+  }
+  walk(root);
+  return files.sort();
+}
+
+export function discoverSubmissionSkills({ sourceDir, skillPath = '', explicitPath = false }) {
+  const sourceRoot = resolve(sourceDir);
+  const searchRoot = resolve(sourceRoot, skillPath);
+  const relativeSearch = relative(sourceRoot, searchRoot);
+  if (relativeSearch === '..' || relativeSearch.startsWith(`..${sep}`)) fail(`skill path escapes source repository: ${skillPath}`);
+  let searchStat;
+  try {
+    searchStat = lstatSync(searchRoot);
+  } catch {
+    if (explicitPath) fail(`explicit skill path does not exist: ${skillPath}`);
+    return { schemaVersion: 1, explicitPath, skillPath, skills: [] };
+  }
+  if (!searchStat.isDirectory() || searchStat.isSymbolicLink()) fail(`skill search root must be a real directory: ${skillPath || '.'}`);
+
+  const skillFiles = collectSkillFiles(searchRoot);
+  if (explicitPath && skillFiles.length === 0) fail(`explicit skill path contains no SKILL.md: ${skillPath}`);
+  const skills = [];
+  const seen = new Set();
+  for (const file of skillFiles) {
+    const directory = dirname(file);
+    const name = topLevelName(relative(sourceRoot, file), readFileSync(file, 'utf8'));
+    if (directory === sourceRoot && name === null) {
+      fail('root-level SKILL.md must define a valid name so Marketplace and CLI discovery use the same slug');
+    }
+    const slug = slugify(name ?? basename(directory));
+    if (slug === '') fail(`${relative(sourceRoot, file)} resolves to an empty slug`);
+    if (seen.has(slug)) fail(`duplicate discovered skill slug: ${slug}`);
+    seen.add(slug);
+    skills.push({ slug, path: relative(sourceRoot, directory) || '.' });
+  }
+  return { schemaVersion: 1, explicitPath, skillPath, skills };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const result = discoverSubmissionSkills({
+    sourceDir: option(args, '--source-dir'),
+    skillPath: option(args, '--skill-path', { required: false, defaultValue: '' }),
+    explicitPath: option(args, '--explicit-path', { required: false, defaultValue: 'false' }) === 'true',
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Submission skill discovery failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/resolve-submission-source.mjs
+++ b/scripts/resolve-submission-source.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name, { required = true, defaultValue = null } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) fail(`missing required option ${name}`);
+    return defaultValue;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function decodePathSegment(raw) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    fail(`GitHub URL contains invalid percent encoding: ${raw}`);
+  }
+  if (decoded === '' || decoded === '.' || decoded === '..' || decoded.includes('\\') || decoded.includes('\0')) {
+    fail(`GitHub URL contains an unsafe path segment: ${raw}`);
+  }
+  return decoded;
+}
+
+function parseRemoteRefs(text) {
+  const refs = new Map();
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    const match = line.match(/^([0-9a-f]{40,64})\s+refs\/(heads|tags)\/(.+)$/);
+    if (!match) fail(`invalid git ls-remote line: ${line}`);
+    const [, sha, type, rawName] = match;
+    const peeled = type === 'tags' && rawName.endsWith('^{}');
+    const name = peeled ? rawName.slice(0, -3) : rawName;
+    const key = `${type}:${name}`;
+    if (refs.has(key) && refs.get(key).sha !== sha && !peeled) {
+      fail(`remote ref is not unique: refs/${type}/${name}`);
+    }
+    if (!refs.has(key) || peeled) refs.set(key, { sha, peeled });
+  }
+  return refs;
+}
+
+function matchesForCandidate(refs, candidate) {
+  const matches = [];
+  for (const type of ['heads', 'tags']) {
+    const key = `${type}:${candidate}`;
+    if (refs.has(key)) matches.push({ type, name: candidate, sha: refs.get(key).sha });
+  }
+  return matches;
+}
+
+function normalizedTreeUrl(owner, repo, ref, skillPath) {
+  const encodedRef = encodeURIComponent(ref);
+  const encodedPath = skillPath.map((segment) => encodeURIComponent(segment)).join('/');
+  return `https://github.com/${owner}/${repo}/tree/${encodedRef}${encodedPath === '' ? '' : `/${encodedPath}`}`;
+}
+
+export function parseGitHubRepository(githubUrl) {
+  const authorityStart = githubUrl.indexOf('//');
+  const rawPathStart = githubUrl.indexOf('/', authorityStart === -1 ? 0 : authorityStart + 2);
+  const rawPath = rawPathStart === -1 ? '' : githubUrl.slice(rawPathStart).split(/[?#]/, 1)[0];
+  for (const rawSegment of rawPath.split('/').filter(Boolean)) decodePathSegment(rawSegment);
+
+  let parsed;
+  try {
+    parsed = new URL(githubUrl);
+  } catch {
+    fail(`invalid GitHub URL: ${githubUrl}`);
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== 'github.com'
+      || parsed.username !== '' || parsed.password !== '' || parsed.port !== ''
+      || parsed.search !== '' || parsed.hash !== '') {
+    fail(`GitHub URL must be a plain https://github.com URL: ${githubUrl}`);
+  }
+
+  const rawSegments = parsed.pathname.split('/').filter(Boolean);
+  if (rawSegments.length < 2) fail(`GitHub URL must include owner and repository: ${githubUrl}`);
+  const segments = rawSegments.map(decodePathSegment);
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/i, '');
+  if (!/^[A-Za-z0-9_-]+$/.test(owner) || !/^[A-Za-z0-9._-]+$/.test(repo) || repo === '') {
+    fail(`invalid GitHub owner or repository: ${owner}/${repo}`);
+  }
+  return { owner, repo, segments };
+}
+
+export function resolveSubmissionSource({ githubUrl, defaultRef, refsText }) {
+  const { owner, repo, segments } = parseGitHubRepository(githubUrl);
+
+  const refs = parseRemoteRefs(refsText);
+  const mode = segments[2] ?? null;
+  if (mode !== null && mode !== 'tree' && mode !== 'blob') {
+    fail(`unsupported GitHub URL path; expected repository, tree, or blob URL: ${githubUrl}`);
+  }
+
+  if (mode === null) {
+    if (segments.length !== 2) fail(`unsupported GitHub repository URL: ${githubUrl}`);
+    const matches = matchesForCandidate(refs, defaultRef).filter(({ type }) => type === 'heads');
+    if (matches.length !== 1) fail(`default branch is not an exact remote head: ${defaultRef}`);
+    return {
+      schemaVersion: 1,
+      owner,
+      repo,
+      ref: defaultRef,
+      refType: 'heads',
+      refSha: matches[0].sha,
+      skillPath: '',
+      explicitPath: false,
+      normalizedUrl: normalizedTreeUrl(owner, repo, defaultRef, []),
+    };
+  }
+
+  const tail = segments.slice(3);
+  if (tail.length === 0) fail(`GitHub ${mode} URL is missing a ref: ${githubUrl}`);
+  const candidates = [];
+  for (let split = 1; split <= tail.length; split += 1) {
+    const candidate = tail.slice(0, split).join('/');
+    for (const match of matchesForCandidate(refs, candidate)) {
+      candidates.push({ ...match, split });
+    }
+  }
+  if (candidates.length === 0) fail(`GitHub URL ref does not exist: ${tail.join('/')}`);
+  if (candidates.length !== 1) {
+    fail(`GitHub tree URL is ambiguous across refs: ${candidates.map(({ type, name }) => `${type}/${name}`).join(', ')}`);
+  }
+
+  const selected = candidates[0];
+  let skillPath = tail.slice(selected.split);
+  if (mode === 'blob') {
+    if (skillPath.length === 0) fail('GitHub blob URL is missing a file path');
+    const file = skillPath.at(-1);
+    if (file.toLowerCase() !== 'skill.md') fail(`submission blob URL must point to SKILL.md, got ${file}`);
+    skillPath = skillPath.slice(0, -1);
+  }
+  return {
+    schemaVersion: 1,
+    owner,
+    repo,
+    ref: selected.name,
+    refType: selected.type,
+    refSha: selected.sha,
+    skillPath: skillPath.join('/'),
+    explicitPath: skillPath.length > 0,
+    normalizedUrl: normalizedTreeUrl(owner, repo, selected.name, skillPath),
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const githubUrl = option(args, '--github-url');
+  if (args.includes('--repository-only')) {
+    const { owner, repo } = parseGitHubRepository(githubUrl);
+    process.stdout.write(`${JSON.stringify({ owner, repo })}\n`);
+    return;
+  }
+  const result = resolveSubmissionSource({
+    githubUrl,
+    defaultRef: option(args, '--default-ref'),
+    refsText: readFileSync(option(args, '--refs-file'), 'utf8'),
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Submission source resolution failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { basename, join } from 'node:path';
@@ -16,6 +16,17 @@ import { test } from 'node:test';
 
 const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
 const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
+const runtimeFiles = [
+  'schemas/skill-report.schema.json',
+  '.github/actions/download-skillstore-cli/action.yml',
+  '.github/workflows/reusable-process-skills.yml',
+  'scripts/resolve-submission-source.mjs',
+  'scripts/discover-submission-skills.mjs',
+  'scripts/process-submission-shard.mjs',
+  'scripts/submission-shard-contract.mjs',
+  'scripts/aggregate-submission-shards.mjs',
+  'scripts/resolve-approved-submission.mjs',
+];
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -77,6 +88,12 @@ function createFixture() {
     'schemas/skill-report.schema.json': '{"type":"object"}\n',
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/reusable-process-skills.yml': 'name: fixture workflow\n',
+    'scripts/resolve-submission-source.mjs': 'export const source = true;\n',
+    'scripts/discover-submission-skills.mjs': 'export const discover = true;\n',
+    'scripts/process-submission-shard.mjs': 'export const process = true;\n',
+    'scripts/submission-shard-contract.mjs': 'export const contract = true;\n',
+    'scripts/aggregate-submission-shards.mjs': "import './resolve-approved-submission.mjs';\n",
+    'scripts/resolve-approved-submission.mjs': 'export const resolve = true;\n',
     'skills/example/SKILL.md': '---\nname: example\n---\n',
   };
   for (const [path, content] of Object.entries(files)) {
@@ -125,13 +142,10 @@ test('process checkout clears inherited sparse state before cloning the immutabl
   }
 });
 
-test('runtime preflight rejects missing or modified schema/runtime files and a mismatched head', () => {
+test('runtime preflight rejects every missing, modified, symlinked, or skip-worktree runtime and a mismatched head', () => {
   const fixture = createFixture();
   try {
     const preflight = extractRunBlock(reusable, 'Verify immutable processing runtime');
-    const cliPath = join(fixture.workspace, 'skillstore-cli');
-    writeFileSync(cliPath, '#!/usr/bin/env bash\nexit 0\n');
-    chmodSync(cliPath, 0o755);
     const baseOptions = {
       cwd: fixture.workspace,
       env: {
@@ -143,14 +157,27 @@ test('runtime preflight rejects missing or modified schema/runtime files and a m
 
     run('bash', ['-c', preflight], baseOptions);
 
-    rmSync(join(fixture.workspace, 'schemas/skill-report.schema.json'));
-    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+    for (const file of runtimeFiles) {
+      const absolute = join(fixture.workspace, file);
+      rmSync(absolute);
+      assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0, `${file} missing passed`);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
 
-    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
-    writeFileSync(join(fixture.workspace, 'schemas/skill-report.schema.json'), '{"tampered":true}\n');
-    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+      writeFileSync(absolute, 'tampered\n');
+      assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0, `${file} tamper passed`);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
 
-    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
+      rmSync(absolute);
+      symlinkSync(join(fixture.workspace, 'skills/example/SKILL.md'), absolute);
+      assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0, `${file} symlink passed`);
+      rmSync(absolute);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
+    }
+
+    run('git', ['-C', fixture.workspace, 'update-index', '--skip-worktree', runtimeFiles[0]]);
+    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+    run('git', ['-C', fixture.workspace, 'update-index', '--no-skip-worktree', runtimeFiles[0]]);
+
     const wrongHeadOptions = {
       ...baseOptions,
       env: { ...baseOptions.env, EXPECTED_WORKFLOW_SHA: '0000000000000000000000000000000000000000' },
@@ -160,6 +187,18 @@ test('runtime preflight rejects missing or modified schema/runtime files and a m
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
+});
+
+test('all submission entrypoints and the aggregation import closure are immutable and execute from GITHUB_WORKSPACE', () => {
+  for (const file of runtimeFiles) assert.match(reusable, new RegExp(file.replaceAll('.', '\\.')));
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/process-submission-shard\.mjs"/);
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/submission-shard-contract\.mjs"/);
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
+  assert.match(reusable, /require-checksum: true/);
+  assert.match(
+    readFileSync('scripts/aggregate-submission-shards.mjs', 'utf8'),
+    /from '\.\/resolve-approved-submission\.mjs'/,
+  );
 });
 
 test('repository dispatch caller preserves reusable failure and callback status contracts', () => {

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+
+const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
+const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    assert.fail(
+      `${command} ${args.join(' ')} failed (${result.status})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+  return result;
+}
+
+function extractRunBlock(workflow, stepName) {
+  const lines = workflow.split('\n');
+  const nameIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(nameIndex, -1, `missing workflow step: ${stepName}`);
+
+  const stepIndent = lines[nameIndex].search(/\S/);
+  let runIndex = -1;
+  for (let index = nameIndex + 1; index < lines.length; index += 1) {
+    const indent = lines[index].search(/\S/);
+    if (indent !== -1 && indent <= stepIndent) break;
+    if (lines[index].trim() === 'run: |') {
+      runIndex = index;
+      break;
+    }
+  }
+  assert.notEqual(runIndex, -1, `missing run block for: ${stepName}`);
+
+  const runIndent = lines[runIndex].search(/\S/);
+  const body = [];
+  for (let index = runIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const indent = line.search(/\S/);
+    if (indent !== -1 && indent <= runIndent) break;
+    body.push(line.length > runIndent + 2 ? line.slice(runIndent + 2) : '');
+  }
+  return body.join('\n');
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'submission-runtime-'));
+  const seed = join(root, 'seed');
+  const origin = join(root, 'origin.git');
+  const runnerWorkspace = join(root, 'runner-workspace');
+  const workspace = join(runnerWorkspace, 'marketplace');
+  const runnerTemp = join(root, 'runner-temp');
+
+  mkdirSync(seed, { recursive: true });
+  mkdirSync(runnerWorkspace, { recursive: true });
+  mkdirSync(runnerTemp, { recursive: true });
+  run('git', ['init', '-q', seed]);
+  run('git', ['-C', seed, 'config', 'user.name', 'Fixture']);
+  run('git', ['-C', seed, 'config', 'user.email', 'fixture@example.com']);
+
+  const files = {
+    'schemas/skill-report.schema.json': '{"type":"object"}\n',
+    '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
+    '.github/workflows/reusable-process-skills.yml': 'name: fixture workflow\n',
+    'skills/example/SKILL.md': '---\nname: example\n---\n',
+  };
+  for (const [path, content] of Object.entries(files)) {
+    const fullPath = join(seed, path);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  run('git', ['-C', seed, 'add', '.']);
+  run('git', ['-C', seed, 'commit', '-qm', 'fixture']);
+  const head = run('git', ['-C', seed, 'rev-parse', 'HEAD']).stdout.trim();
+  run('git', ['clone', '--bare', '-q', seed, origin]);
+  run('git', ['clone', '-q', origin, workspace]);
+
+  return { root, origin, runnerWorkspace, runnerTemp, workspace, head };
+}
+
+test('process checkout clears inherited sparse state before cloning the immutable workflow head', () => {
+  const fixture = createFixture();
+  try {
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'init', '--cone']);
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'set', '.github']);
+    assert.equal(existsSync(join(fixture.workspace, 'schemas/skill-report.schema.json')), false);
+    writeFileSync(join(fixture.workspace, 'stale-runner-file'), 'stale\n');
+
+    const reset = extractRunBlock(reusable, 'Clear inherited marketplace checkout');
+    run('bash', ['-c', reset], {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        RUNNER_WORKSPACE: fixture.runnerWorkspace,
+        RUNNER_TEMP: fixture.runnerTemp,
+        GITHUB_REPOSITORY: `aiskillstore/${basename(fixture.workspace)}`,
+      },
+    });
+
+    assert.deepEqual(readdirSync(fixture.workspace), []);
+    run('git', ['clone', '-q', '--no-local', fixture.origin, fixture.workspace]);
+    assert.equal(existsSync(join(fixture.workspace, 'schemas/skill-report.schema.json')), true);
+    assert.equal(run('git', ['-C', fixture.workspace, 'config', '--bool', 'core.sparseCheckout'], { allowFailure: true }).stdout.trim(), '');
+
+    assert.match(reusable, /ref: \$\{\{ github\.workflow_sha \}\}/);
+    assert.match(reusable, /fetch-depth: 1/);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('runtime preflight rejects missing or modified schema/runtime files and a mismatched head', () => {
+  const fixture = createFixture();
+  try {
+    const preflight = extractRunBlock(reusable, 'Verify immutable processing runtime');
+    const cliPath = join(fixture.workspace, 'skillstore-cli');
+    writeFileSync(cliPath, '#!/usr/bin/env bash\nexit 0\n');
+    chmodSync(cliPath, 0o755);
+    const baseOptions = {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        EXPECTED_WORKFLOW_SHA: fixture.head,
+      },
+    };
+
+    run('bash', ['-c', preflight], baseOptions);
+
+    rmSync(join(fixture.workspace, 'schemas/skill-report.schema.json'));
+    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+
+    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
+    writeFileSync(join(fixture.workspace, 'schemas/skill-report.schema.json'), '{"tampered":true}\n');
+    assert.notEqual(run('bash', ['-c', preflight], { ...baseOptions, allowFailure: true }).status, 0);
+
+    run('git', ['-C', fixture.workspace, 'checkout', '--', 'schemas/skill-report.schema.json']);
+    const wrongHeadOptions = {
+      ...baseOptions,
+      env: { ...baseOptions.env, EXPECTED_WORKFLOW_SHA: '0000000000000000000000000000000000000000' },
+      allowFailure: true,
+    };
+    assert.notEqual(run('bash', ['-c', preflight], wrongHeadOptions).status, 0);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('repository dispatch caller preserves reusable failure and callback status contracts', () => {
+  assert.match(caller, /notify:\n\s+needs: process-skills\n\s+if: always\(\) && github\.event_name == 'repository_dispatch'/);
+  assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);
+  assert.match(caller, /name: Notify skillstore - Failed\n\s+if: needs\.process-skills\.result == 'failure'/);
+  assert.match(caller, /"event": "failed"/);
+  assert.doesNotMatch(caller, /continue-on-error:\s*true/);
+});

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -149,8 +149,8 @@ function runAggregate(root, matrix, expectedCount = matrix.include.length) {
 test('submission processing isolates every shard and stages only its frozen plan', () => {
   assert.match(reusable, /RESULT_DIR="\/tmp\/submission-shard-/);
   assert.match(reusable, /process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}/);
-  assert.match(reusable, /node scripts\/process-submission-shard\.mjs/);
-  assert.match(reusable, /node scripts\/aggregate-submission-shards\.mjs/);
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/process-submission-shard\.mjs"/);
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /git add -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
   assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
   assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+import { resolveSubmissionSource } from '../resolve-submission-source.mjs';
+import { discoverSubmissionSkills } from '../discover-submission-skills.mjs';
+
+const MAIN_SHA = '1'.repeat(40);
+const READY_SHA = '2'.repeat(40);
+
+function refs(...entries) {
+  return `${entries.map(([sha, ref]) => `${sha}\t${ref}`).join('\n')}\n`;
+}
+
+function withDirectory(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'submission-source-'));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('tree URLs resolve the exact non-default ref before percent-decoding the skill path', () => {
+  const result = resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo/tree/skillstore-ready/skills/localize%20china',
+    defaultRef: 'main',
+    refsText: refs(
+      [MAIN_SHA, 'refs/heads/main'],
+      [READY_SHA, 'refs/heads/skillstore-ready'],
+    ),
+  });
+  assert.deepEqual(result, {
+    schemaVersion: 1,
+    owner: 'example',
+    repo: 'repo',
+    ref: 'skillstore-ready',
+    refType: 'heads',
+    refSha: READY_SHA,
+    skillPath: 'skills/localize china',
+    explicitPath: true,
+    normalizedUrl: 'https://github.com/example/repo/tree/skillstore-ready/skills/localize%20china',
+  });
+});
+
+test('slash refs are encoded for the CLI and ambiguous ref/path splits fail closed', () => {
+  const slash = resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo/tree/feature/ready/skills/demo',
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main'], [READY_SHA, 'refs/heads/feature/ready']),
+  });
+  assert.equal(slash.ref, 'feature/ready');
+  assert.equal(slash.skillPath, 'skills/demo');
+  assert.equal(slash.normalizedUrl, 'https://github.com/example/repo/tree/feature%2Fready/skills/demo');
+
+  assert.throws(() => resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo/tree/feature/ready/skills/demo',
+    defaultRef: 'main',
+    refsText: refs(
+      [MAIN_SHA, 'refs/heads/main'],
+      [MAIN_SHA, 'refs/heads/feature'],
+      [READY_SHA, 'refs/heads/feature/ready'],
+    ),
+  }), /ambiguous across refs/);
+});
+
+test('repository URLs use the exact default head and unsafe encoded paths are rejected', () => {
+  const result = resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo.git',
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main']),
+  });
+  assert.equal(result.explicitPath, false);
+  assert.equal(result.normalizedUrl, 'https://github.com/example/repo/tree/main');
+
+  assert.throws(() => resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo/tree/main/skills/%2e%2e/secret',
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main']),
+  }), /unsafe path segment/);
+});
+
+test('explicit paths with no SKILL.md fail while a repository-level empty scan remains an explicit no-op candidate', () => withDirectory((root) => {
+  mkdirSync(join(root, 'empty'));
+  assert.throws(() => discoverSubmissionSkills({
+    sourceDir: root,
+    skillPath: 'empty',
+    explicitPath: true,
+  }), /contains no SKILL\.md/);
+  assert.deepEqual(discoverSubmissionSkills({ sourceDir: root }), {
+    schemaVersion: 1,
+    explicitPath: false,
+    skillPath: '',
+    skills: [],
+  });
+}));
+
+test('valid root-level names produce the same planned slug while malformed root frontmatter fails before CLI execution', () => withDirectory((root) => {
+  writeFileSync(join(root, 'SKILL.md'), '---\nname: flops-compute-prices\ndescription: "GPU prices: verified"\n---\n');
+  assert.deepEqual(discoverSubmissionSkills({ sourceDir: root }).skills, [
+    { slug: 'flops-compute-prices', path: '.' },
+  ]);
+
+  writeFileSync(join(root, 'SKILL.md'), '---\nname: flops-compute-prices\ndescription: GPU prices Keywords: verified\n---\n');
+  assert.throws(
+    () => discoverSubmissionSkills({ sourceDir: root }),
+    /invalid YAML plain scalar/,
+  );
+}));


### PR DESCRIPTION
## Summary

- rebuild the closed #2582 deterministic self-hosted checkout on top of #2578
- verify the full submission runtime closure before any local action or script executes
- resolve GitHub tree/blob URLs against exact remote refs, percent-decode paths, and fail closed on ambiguous ref/path splits
- make explicit path submissions fail when they resolve to zero Skills instead of becoming legal repository-level no-ops
- align root-level discovery with CLI-compatible slugs and reject malformed root frontmatter before shard execution

## Incidents closed

- #2572 / run 29410402198: inherited sparse checkout omitted `schemas/skill-report.schema.json`, then surfaced `0 processed / 1 error` as success
- runs 29538285551, 29535894148, 29489365921 and related: #2578 fixed shard aggregation, but its newly executed scripts were not covered by #2582's immutable gate
- GitHub URLs such as `/tree/skillstore-ready/...` could be interpreted as default `main` plus the wrong path
- explicit bad paths could fall back to a different same-named directory or become a no-op

## Security and runtime contract

All three jobs clear inherited self-hosted workspace state and checkout `${{ github.workflow_sha }}` before executing repository-local code. The immutable gate verifies regular non-symlink files, no sparse/skip-worktree state, exact HEAD, and exact Git blob identity for:

- `schemas/skill-report.schema.json`
- `.github/actions/download-skillstore-cli/action.yml`
- `.github/workflows/reusable-process-skills.yml`
- `scripts/resolve-submission-source.mjs`
- `scripts/discover-submission-skills.mjs`
- `scripts/process-submission-shard.mjs`
- `scripts/submission-shard-contract.mjs`
- `scripts/aggregate-submission-shards.mjs`
- `scripts/resolve-approved-submission.mjs`

The merge job may still clone current `main` as the publication worktree, but aggregation executes from the pinned `$GITHUB_WORKSPACE` runtime. Submission CLI downloads now require the release checksum before execution.

## Source URL semantics

- exact branch/tag candidates are derived from `git ls-remote`
- slash refs are normalized as an encoded single ref segment for the CLI
- multiple valid ref/path splits fail as ambiguous
- invalid percent encoding, traversal, credentials, query, fragment, non-GitHub host, and unsupported URL modes fail closed
- the cloned source HEAD must still equal the resolved remote SHA
- explicit tree/blob paths never fall back to another directory

The reported FLOPS root Skill currently contains malformed YAML (`description` has an unquoted `: `). The old grep planner accepted it while the CLI parser fell back to a different slug. This PR rejects that mismatch before CLI execution; the source must quote/fix the YAML before recovery.

## Verification

- `CI=true node --test scripts/tests/submission-source-resolution.test.mjs scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs` — 33/33
- workflow YAML parses successfully
- all 16 Bash `run` blocks pass `bash -n` after expression substitution
- `git diff --check`

No workflow dispatch, submission retry, production API call, or database write was performed.

## Merge and recovery boundary

This PR requires human review. Do not recover historical submissions until this lands and the Skillstore terminal-state recovery uses an atomic lease with duplicate checks. Historical attempts must not be rerun because they retain their old workflow SHA; recovery must use a new dispatch from fixed `main`.
