### PR TITLE
fix(submissions): accept repository root sources

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -197,7 +197,13 @@ jobs:
           REF=$(jq -er '.ref' <<< "$RESOLVED")
           REF_SHA=$(jq -er '.refSha' <<< "$RESOLVED")
           SKILL_PATH=$(jq -er '.skillPath' <<< "$RESOLVED")
-          EXPLICIT_PATH=$(jq -er '.explicitPath' <<< "$RESOLVED")
+          EXPLICIT_PATH=$(jq -r '
+            if (.explicitPath | type) == "boolean" then
+              .explicitPath
+            else
+              error("explicitPath must be a boolean")
+            end
+          ' <<< "$RESOLVED")
           NORMALIZED_URL=$(jq -er '.normalizedUrl' <<< "$RESOLVED")
           SOURCE_DIR="${RUNNER_TEMP:?}/submission-source-${{ github.run_id }}-${{ github.run_attempt }}"
           rm -rf "$SOURCE_DIR"

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -201,6 +201,33 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   );
 });
 
+test('clone step accepts repository-root false and explicit-path true without weakening type validation', () => {
+  const clone = extractRunBlock(reusable, 'Clone source repository');
+  const explicitPathFilter = [
+    'if (.explicitPath | type) == "boolean" then',
+    '.explicitPath',
+    'else',
+    'error("explicitPath must be a boolean")',
+    'end',
+  ].join('\n');
+
+  assert.match(clone, /EXPLICIT_PATH=\$\(jq -r '/);
+  assert.doesNotMatch(clone, /EXPLICIT_PATH=\$\(jq -er '/);
+
+  for (const [explicitPath, expected] of [[false, 'false'], [true, 'true']]) {
+    const result = run('jq', ['-r', explicitPathFilter], {
+      input: JSON.stringify({ explicitPath }),
+    });
+    assert.equal(result.stdout.trim(), expected);
+  }
+
+  const invalid = run('jq', ['-r', explicitPathFilter], {
+    input: JSON.stringify({ explicitPath: 'false' }),
+    allowFailure: true,
+  });
+  assert.notEqual(invalid.status, 0);
+});
+
 test('repository dispatch caller preserves reusable failure and callback status contracts', () => {
   assert.match(caller, /notify:\n\s+needs: process-skills\n\s+if: always\(\) && github\.event_name == 'repository_dispatch'/);
   assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);


### PR DESCRIPTION
## Summary

- preserve `explicitPath=false` when a repository-root submission is resolved
- fail closed if the resolver ever emits a non-boolean `explicitPath`
- cover both repository-root (`false`) and explicit-path (`true`) extraction contracts

## Root cause

Run 29556986396 reached the repaired immutable runtime but stopped before cloning `stomeonst/localize-saas-for-china`. `jq -e` treats a valid JSON `false` result as failure, so command substitution aborted under `set -e` for repository-root URLs.

## Verification

- `CI=true node --test scripts/tests/submission-source-resolution.test.mjs scripts/tests/submission-runtime-workflow.test.mjs` (10/10 passed)

Follow-up for #2572. The issue will only be closed after a fresh submission is published and verified live.
