### PR TITLE
fix: recover non-ASCII submission identities

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -131,6 +131,7 @@ jobs:
           set -euo pipefail
           REQUIRED_RUNTIME_FILES=(
             "schemas/skill-report.schema.json"
+            "governance/submission-slug-aliases.json"
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/reusable-process-skills.yml"
             "scripts/resolve-submission-source.mjs"
@@ -232,7 +233,9 @@ jobs:
           DISCOVERY=$(node "$GITHUB_WORKSPACE/scripts/discover-submission-skills.mjs" \
             --source-dir "$SOURCE_DIR" \
             --skill-path "$SKILL_PATH" \
-            --explicit-path "${{ steps.clone.outputs.explicit_path }}")
+            --explicit-path "${{ steps.clone.outputs.explicit_path }}" \
+            --repository "${{ steps.clone.outputs.owner }}/${{ steps.clone.outputs.repo }}" \
+            --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json")
           SKILLS_JSON=$(jq -cer '[.skills[].slug]' <<< "$DISCOVERY")
           SKILL_COUNT=$(jq -er '.skills | length' <<< "$DISCOVERY")
           echo "github_url=${{ steps.clone.outputs.normalized_url }}" >> "$GITHUB_OUTPUT"
@@ -386,6 +389,7 @@ jobs:
 
           REQUIRED_RUNTIME_FILES=(
             "schemas/skill-report.schema.json"
+            "governance/submission-slug-aliases.json"
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/reusable-process-skills.yml"
             "scripts/resolve-submission-source.mjs"
@@ -419,6 +423,7 @@ jobs:
           version: ${{ inputs.cli_version }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+          minimum-version: 2.14.3
           require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}
@@ -440,6 +445,7 @@ jobs:
             --result-dir "$RESULT_DIR" \
             --marketplace-repo "${{ github.repository }}" \
             --shard-index "${{ matrix.shard }}" \
+            --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json" \
             --model "$MODEL"
 
       - name: Create mode-preserving shard archive

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -121,6 +121,8 @@ jobs:
         run: |
           node --test \
             scripts/tests/resolve-approved-submission.test.mjs \
+            scripts/tests/submission-source-resolution.test.mjs \
+            scripts/tests/submission-runtime-workflow.test.mjs \
             scripts/tests/submission-scope-workflows.test.mjs \
             scripts/tests/detect-changed-skills.test.mjs \
             scripts/tests/resolve-manual-skills.test.mjs \

--- a/governance/submission-slug-aliases.json
+++ b/governance/submission-slug-aliases.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "aliases": [
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "老房改造不踩雷",
+      "expectedName": "老房改造不踩雷",
+      "baseSlug": "laofang-gaizao-bucailei"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "全屋定制不踩雷",
+      "expectedName": "全屋定制不踩雷",
+      "baseSlug": "quanwu-dingzhi-bucailei"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修报价审核",
+      "expectedName": "装修报价审核",
+      "baseSlug": "zhuangxiu-baojia-shenhe"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修方案诊断",
+      "expectedName": "装修方案诊断",
+      "baseSlug": "zhuangxiu-fangan-zhenduan"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修翻车急救",
+      "expectedName": "装修翻车急救",
+      "baseSlug": "zhuangxiu-fanche-jijiu"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修公司避雷指南",
+      "expectedName": "装修公司避雷指南",
+      "baseSlug": "zhuangxiu-gongsi-bilei-zhinan"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修合同审核",
+      "expectedName": "装修合同审核",
+      "baseSlug": "zhuangxiu-hetong-shenhe"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修环保避坑",
+      "expectedName": "装修环保避坑",
+      "baseSlug": "zhuangxiu-huanbao-bikeng"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修流程不踩坑",
+      "expectedName": "装修流程不踩坑",
+      "baseSlug": "zhuangxiu-liucheng-bucai"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修避坑问答",
+      "expectedName": "装修避坑问答",
+      "baseSlug": "zhuangxiu-bikeng-wenda"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修预算计算器",
+      "expectedName": "装修预算计算器",
+      "baseSlug": "zhuangxiu-yusuan-jisuanqi"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修增项避雷",
+      "expectedName": "装修增项避雷",
+      "baseSlug": "zhuangxiu-zengxiang-bilei"
+    }
+  ]
+}

--- a/scripts/discover-submission-skills.mjs
+++ b/scripts/discover-submission-skills.mjs
@@ -5,6 +5,8 @@ import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const SKIP_DIRECTORIES = new Set(['node_modules', '.git', '.venv', 'venv', 'dist', 'build', '__pycache__', '.cache']);
+const REPOSITORY = /^[a-z0-9_-]+\/[a-z0-9._-]+$/;
+const CANONICAL_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function fail(message) {
   throw new Error(message);
@@ -22,6 +24,74 @@ function option(args, name, { required = true, defaultValue = null } = {}) {
 
 function slugify(value) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function repositoryPath(value, label) {
+  if (typeof value !== 'string' || value === '' || value !== value.normalize('NFC') || value.includes('\\')) {
+    fail(`${label} must be a non-empty NFC POSIX repository-relative path`);
+  }
+  const segments = value.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    fail(`${label} contains an empty or unsafe path segment`);
+  }
+  return segments.join('/');
+}
+
+function canonicalRepository(value, label) {
+  if (typeof value !== 'string' || !REPOSITORY.test(value) || value !== value.toLowerCase()) {
+    fail(`${label} must be canonical lowercase owner/repo`);
+  }
+  return value;
+}
+
+export function validateSlugAliasRegistry(registry) {
+  if (!registry || typeof registry !== 'object' || Array.isArray(registry)) fail('slug alias registry must be an object');
+  if (JSON.stringify(Object.keys(registry).sort()) !== JSON.stringify(['aliases', 'schemaVersion'])) {
+    fail('slug alias registry has unknown or missing fields');
+  }
+  if (registry.schemaVersion !== 1) fail('slug alias registry schemaVersion must be 1');
+  if (!Array.isArray(registry.aliases)) fail('slug alias registry aliases must be an array');
+
+  const aliases = [];
+  const paths = new Set();
+  const repositorySlugs = new Set();
+  const finalSlugs = new Set();
+  for (const [index, raw] of registry.aliases.entries()) {
+    const label = `slug alias ${index}`;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) fail(`${label} must be an object`);
+    const expectedKeys = ['baseSlug', 'expectedName', 'path', 'repository'];
+    const actualKeys = Object.keys(raw).sort();
+    if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) fail(`${label} has unknown or missing fields`);
+    const repository = canonicalRepository(raw.repository, `${label}.repository`);
+    const path = repositoryPath(raw.path, `${label}.path`);
+    if (typeof raw.expectedName !== 'string' || raw.expectedName === '' || raw.expectedName !== raw.expectedName.normalize('NFC')) {
+      fail(`${label}.expectedName must be a non-empty NFC string`);
+    }
+    if (typeof raw.baseSlug !== 'string' || !CANONICAL_SLUG.test(raw.baseSlug)) {
+      fail(`${label}.baseSlug must be canonical lowercase ASCII kebab-case`);
+    }
+
+    const pathKey = `${repository}:${path}`;
+    const repositorySlugKey = `${repository}:${raw.baseSlug}`;
+    const owner = repository.split('/', 1)[0];
+    const finalSlug = `${owner}-${raw.baseSlug}`;
+    if (paths.has(pathKey)) fail(`duplicate slug alias path: ${pathKey}`);
+    if (repositorySlugs.has(repositorySlugKey)) fail(`duplicate slug alias baseSlug in repository: ${repositorySlugKey}`);
+    if (finalSlugs.has(finalSlug)) fail(`duplicate slug alias final community slug: ${finalSlug}`);
+    paths.add(pathKey);
+    repositorySlugs.add(repositorySlugKey);
+    finalSlugs.add(finalSlug);
+    aliases.push({ repository, path, expectedName: raw.expectedName, baseSlug: raw.baseSlug });
+  }
+  return aliases;
+}
+
+function posixRelative(root, path) {
+  return relative(root, path).split(sep).join('/');
+}
+
+function isWithinScope(path, scope) {
+  return scope === '' || path === scope || path.startsWith(`${scope}/`);
 }
 
 function topLevelName(skillMdPath, content) {
@@ -74,7 +144,13 @@ function collectSkillFiles(root) {
   return files.sort();
 }
 
-export function discoverSubmissionSkills({ sourceDir, skillPath = '', explicitPath = false }) {
+export function discoverSubmissionSkills({
+  sourceDir,
+  skillPath = '',
+  explicitPath = false,
+  repository = '',
+  slugAliasRegistry = { schemaVersion: 1, aliases: [] },
+}) {
   const sourceRoot = resolve(sourceDir);
   const searchRoot = resolve(sourceRoot, skillPath);
   const relativeSearch = relative(sourceRoot, searchRoot);
@@ -88,31 +164,63 @@ export function discoverSubmissionSkills({ sourceDir, skillPath = '', explicitPa
   }
   if (!searchStat.isDirectory() || searchStat.isSymbolicLink()) fail(`skill search root must be a real directory: ${skillPath || '.'}`);
 
+  const aliases = validateSlugAliasRegistry(slugAliasRegistry);
+  const canonicalRepo = aliases.length > 0 || repository !== ''
+    ? canonicalRepository(repository, 'submission repository')
+    : '';
+  const repositoryAliases = aliases.filter((alias) => alias.repository === canonicalRepo);
+  const aliasByPath = new Map(repositoryAliases.map((alias) => [alias.path, alias]));
+  const normalizedSkillPath = skillPath === '' ? '' : repositoryPath(skillPath, 'skillPath');
+  const scopedAliases = repositoryAliases.filter((alias) => isWithinScope(alias.path, normalizedSkillPath));
+  const consumedAliases = new Set();
+
   const skillFiles = collectSkillFiles(searchRoot);
   if (explicitPath && skillFiles.length === 0) fail(`explicit skill path contains no SKILL.md: ${skillPath}`);
   const skills = [];
   const seen = new Set();
   for (const file of skillFiles) {
     const directory = dirname(file);
-    const name = topLevelName(relative(sourceRoot, file), readFileSync(file, 'utf8'));
+    const relativeFile = posixRelative(sourceRoot, file);
+    const relativeDirectory = posixRelative(sourceRoot, directory) || '.';
+    const name = topLevelName(relativeFile, readFileSync(file, 'utf8'));
     if (directory === sourceRoot && name === null) {
       fail('root-level SKILL.md must define a valid name so Marketplace and CLI discovery use the same slug');
     }
-    const slug = slugify(name ?? basename(directory));
-    if (slug === '') fail(`${relative(sourceRoot, file)} resolves to an empty slug`);
+    let slug = slugify(name ?? basename(directory));
+    const alias = aliasByPath.get(relativeDirectory);
+    if (slug !== '' && alias) fail(`${relativeFile} has an alias that would override an existing ASCII identity`);
+    if (slug === '') {
+      if (!alias) fail(`${relativeFile} resolves to an empty slug and has no verified path alias`);
+      if (name !== alias.expectedName) fail(`${relativeFile} name does not match its verified path alias`);
+      slug = alias.baseSlug;
+      consumedAliases.add(alias.path);
+    }
     if (seen.has(slug)) fail(`duplicate discovered skill slug: ${slug}`);
     seen.add(slug);
-    skills.push({ slug, path: relative(sourceRoot, directory) || '.' });
+    skills.push({ slug, path: relativeDirectory });
   }
+  const unconsumed = scopedAliases.filter((alias) => !consumedAliases.has(alias.path));
+  if (unconsumed.length > 0) fail(`slug alias scope contains unconsumed paths: ${unconsumed.map((alias) => alias.path).join(', ')}`);
   return { schemaVersion: 1, explicitPath, skillPath, skills };
 }
 
 function main() {
   const args = process.argv.slice(2);
+  const aliasFile = option(args, '--slug-aliases-file', { required: false, defaultValue: '' });
+  let slugAliasRegistry = { schemaVersion: 1, aliases: [] };
+  if (aliasFile !== '') {
+    try {
+      slugAliasRegistry = JSON.parse(readFileSync(aliasFile, 'utf8'));
+    } catch (error) {
+      fail(`cannot read slug alias registry: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
   const result = discoverSubmissionSkills({
     sourceDir: option(args, '--source-dir'),
     skillPath: option(args, '--skill-path', { required: false, defaultValue: '' }),
     explicitPath: option(args, '--explicit-path', { required: false, defaultValue: 'false' }) === 'true',
+    repository: option(args, '--repository', { required: false, defaultValue: '' }),
+    slugAliasRegistry,
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/process-submission-shard.mjs
+++ b/scripts/process-submission-shard.mjs
@@ -168,6 +168,7 @@ async function processShard(config) {
     '--marketplace-repo', config.marketplaceRepo,
     '--skip-pr',
   ];
+  if (config.slugAliasesFile !== '') baseArgs.push('--slug-aliases-file', config.slugAliasesFile);
   if (config.model !== '') baseArgs.push('--model', config.model);
 
   const firstExecution = await runCli({ cli: config.cli, cliArgs: baseArgs, logPath, append: false });
@@ -233,6 +234,7 @@ async function main() {
     marketplaceRepo: option(args, '--marketplace-repo'),
     shardIndex: option(args, '--shard-index'),
     model: option(args, '--model', { required: false, defaultValue: '' }),
+    slugAliasesFile: option(args, '--slug-aliases-file', { required: false, defaultValue: '' }),
     retryDelayMs: Number(option(args, '--retry-delay-ms', { required: false, defaultValue: '10000' })),
   };
   if (!Number.isSafeInteger(config.retryDelayMs) || config.retryDelayMs < 0) fail('--retry-delay-ms must be a non-negative integer');

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -18,6 +18,7 @@ const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', '
 const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
 const runtimeFiles = [
   'schemas/skill-report.schema.json',
+  'governance/submission-slug-aliases.json',
   '.github/actions/download-skillstore-cli/action.yml',
   '.github/workflows/reusable-process-skills.yml',
   'scripts/resolve-submission-source.mjs',
@@ -86,6 +87,7 @@ function createFixture() {
 
   const files = {
     'schemas/skill-report.schema.json': '{"type":"object"}\n',
+    'governance/submission-slug-aliases.json': '{"schemaVersion":1,"aliases":[]}\n',
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/reusable-process-skills.yml': 'name: fixture workflow\n',
     'scripts/resolve-submission-source.mjs': 'export const source = true;\n',
@@ -195,6 +197,8 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/submission-shard-contract\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
+  assert.match(reusable, /minimum-version: 2\.14\.3/);
+  assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
   assert.match(
     readFileSync('scripts/aggregate-submission-shards.mjs', 'utf8'),
     /from '\.\/resolve-approved-submission\.mjs'/,

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -151,6 +151,7 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.match(reusable, /process-shard-\$\{\{ github\.run_attempt \}\}-\$\{\{ matrix\.shard \}\}/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/process-submission-shard\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
+  assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
   assert.match(reusable, /git add -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
   assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
   assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);
@@ -161,8 +162,11 @@ test('submission processing isolates every shard and stages only its frozen plan
 test('real CLI two-round failure produces a failed manifest and cannot aggregate as no-op', () => withTempDirectory((root) => {
   const fakeCli = join(root, 'fake-cli.sh');
   const state = join(root, 'calls.txt');
+  const argsLog = join(root, 'args.txt');
+  const aliases = join(root, 'aliases.json');
   const resultDir = join(root, 'result');
-  writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\necho "fixture CLI failure $count" >&2\nexit 23\n`);
+  writeFileSync(aliases, '{"schemaVersion":1,"aliases":[]}\n');
+  writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\nprintf '%s\\n' "$*" >> "$FAKE_ARGS"\necho "fixture CLI failure $count" >&2\nexit 23\n`);
   chmodSync(fakeCli, 0o755);
 
   const processing = runNode(processShardScript, [
@@ -172,10 +176,14 @@ test('real CLI two-round failure produces a failed manifest and cannot aggregate
     '--result-dir', resultDir,
     '--marketplace-repo', 'aiskillstore/marketplace',
     '--shard-index', '0',
+    '--slug-aliases-file', aliases,
     '--retry-delay-ms', '0',
-  ], { env: { FAKE_STATE: state } });
+  ], { env: { FAKE_STATE: state, FAKE_ARGS: argsLog } });
   assert.equal(processing.status, 0, processing.stderr);
   assert.equal(readFileSync(state, 'utf8').trim(), '2');
+  const attempts = readFileSync(argsLog, 'utf8').trim().split('\n');
+  assert.equal(attempts.length, 2);
+  for (const args of attempts) assert.match(args, new RegExp(`--slug-aliases-file ${aliases.replaceAll('/', '\\/')}`));
   const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
   assert.equal(manifest.status, 'failed');
   assert.deepEqual(manifest.planned, ['broken-skill']);

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -4,7 +4,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test } from 'node:test';
 import { resolveSubmissionSource } from '../resolve-submission-source.mjs';
-import { discoverSubmissionSkills } from '../discover-submission-skills.mjs';
+import {
+  discoverSubmissionSkills,
+  validateSlugAliasRegistry,
+} from '../discover-submission-skills.mjs';
 
 const MAIN_SHA = '1'.repeat(40);
 const READY_SHA = '2'.repeat(40);
@@ -107,4 +110,124 @@ test('valid root-level names produce the same planned slug while malformed root 
     () => discoverSubmissionSkills({ sourceDir: root }),
     /invalid YAML plain scalar/,
   );
+}));
+
+test('pure Chinese path and frontmatter use an exact repository-bound alias', () => withDirectory((root) => {
+  mkdirSync(join(root, '装修方案诊断'));
+  writeFileSync(join(root, '装修方案诊断', 'SKILL.md'), '---\nname: 装修方案诊断\ndescription: 安全诊断\n---\n');
+  const registry = {
+    schemaVersion: 1,
+    aliases: [{
+      repository: 'zx029w/zhuangxiu-skills',
+      path: '装修方案诊断',
+      expectedName: '装修方案诊断',
+      baseSlug: 'zhuangxiu-fangan-zhenduan',
+    }],
+  };
+
+  assert.deepEqual(discoverSubmissionSkills({
+    sourceDir: root,
+    skillPath: '装修方案诊断',
+    explicitPath: true,
+    repository: 'zx029w/zhuangxiu-skills',
+    slugAliasRegistry: registry,
+  }).skills, [{ slug: 'zhuangxiu-fangan-zhenduan', path: '装修方案诊断' }]);
+
+  assert.throws(() => discoverSubmissionSkills({
+    sourceDir: root,
+    skillPath: '装修方案诊断',
+    explicitPath: true,
+    repository: 'zx029w/zhuangxiu-skills',
+  }), /no verified path alias/);
+}));
+
+test('aliases cannot override ASCII identities and exact expected names fail closed', () => withDirectory((root) => {
+  mkdirSync(join(root, 'skill'));
+  writeFileSync(join(root, 'skill', 'SKILL.md'), '---\nname: ascii-skill\n---\n');
+  const registry = {
+    schemaVersion: 1,
+    aliases: [{
+      repository: 'example/skills',
+      path: 'skill',
+      expectedName: 'ascii-skill',
+      baseSlug: 'different-skill',
+    }],
+  };
+  assert.throws(() => discoverSubmissionSkills({
+    sourceDir: root,
+    repository: 'example/skills',
+    slugAliasRegistry: registry,
+  }), /override an existing ASCII identity/);
+
+  writeFileSync(join(root, 'skill', 'SKILL.md'), '---\nname: 中文名称\n---\n');
+  assert.throws(() => discoverSubmissionSkills({
+    sourceDir: root,
+    repository: 'example/skills',
+    slugAliasRegistry: registry,
+  }), /name does not match/);
+}));
+
+test('multi-skill alias and ASCII collisions fail instead of choosing an order-dependent identity', () => withDirectory((root) => {
+  mkdirSync(join(root, '中文技能'));
+  mkdirSync(join(root, 'ascii'));
+  writeFileSync(join(root, '中文技能', 'SKILL.md'), '---\nname: 中文技能\n---\n');
+  writeFileSync(join(root, 'ascii', 'SKILL.md'), '---\nname: shared-slug\n---\n');
+  const registry = {
+    schemaVersion: 1,
+    aliases: [{
+      repository: 'example/skills',
+      path: '中文技能',
+      expectedName: '中文技能',
+      baseSlug: 'shared-slug',
+    }],
+  };
+  assert.throws(() => discoverSubmissionSkills({
+    sourceDir: root,
+    repository: 'example/skills',
+    slugAliasRegistry: registry,
+  }), /duplicate discovered skill slug/);
+}));
+
+test('alias registry rejects duplicate paths, canonical slugs, and unsafe paths', () => {
+  const base = {
+    repository: 'example/skills',
+    path: '中文技能',
+    expectedName: '中文技能',
+    baseSlug: 'zhongwen-jineng',
+  };
+  assert.throws(() => validateSlugAliasRegistry({
+    schemaVersion: 1,
+    aliases: [base, { ...base }],
+  }), /duplicate slug alias path/);
+  assert.throws(() => validateSlugAliasRegistry({
+    schemaVersion: 1,
+    aliases: [base, { ...base, path: '另一个技能' }],
+  }), /duplicate slug alias baseSlug/);
+  assert.throws(() => validateSlugAliasRegistry({
+    schemaVersion: 1,
+    aliases: [{ ...base, path: '../escape' }],
+  }), /unsafe path segment/);
+  assert.throws(() => validateSlugAliasRegistry({
+    schemaVersion: 1,
+    aliases: [],
+    extra: true,
+  }), /unknown or missing fields/);
+});
+
+test('ASCII discovery remains unchanged when aliases belong to another repository and scope', () => withDirectory((root) => {
+  mkdirSync(join(root, 'demo'));
+  writeFileSync(join(root, 'demo', 'SKILL.md'), '---\nname: Demo Skill\n---\n');
+  assert.deepEqual(discoverSubmissionSkills({
+    sourceDir: root,
+    repository: 'example/skills',
+    slugAliasRegistry: {
+      schemaVersion: 1,
+      aliases: [{
+        repository: 'other/skills',
+        path: '中文技能',
+        expectedName: '中文技能',
+        baseSlug: 'zhongwen-jineng',
+      }],
+    },
+  }).skills, [{ slug: 'demo-skill', path: 'demo' }]);
 }));


### PR DESCRIPTION
## Summary
- bind pure non-ASCII Skill names to a versioned repository/path/name identity registry
- fail closed on missing aliases, path/name drift, ASCII overrides, and multi-Skill collisions
- pass the immutable alias registry through discovery and Skillstore CLI processing
- require Skillstore CLI >= 2.14.3 and make the new tests required Validate checks

## Validation
- `CI=true node --test` on all 8 required submission contract files: 62/62 passed
- all 12 zx029w aliases match immutable source frontmatter names; existing published canonical slugs match

## Merge gate
Do not merge until Skillstore CLI 2.14.3 is released with the matching `--slug-aliases-file` contract.