### PR TITLE
fix(workflow): preserve source monitor failure evidence

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -223,7 +223,7 @@ jobs:
           echo "Archive missing: $ARCHIVE_MISSING"
           echo "Delete archived: $DELETE_ARCHIVED"
           echo "Command: ${CMD[*]}"
-          "${CMD[@]}" | tee "source-monitor-results/stdout-${GITHUB_RUN_ID}.jsonl"
+          "${CMD[@]}" 2>&1 | tee "source-monitor-results/stdout-${GITHUB_RUN_ID}.jsonl"
 
           echo "jsonl_file=$JSONL_FILE" >> "$GITHUB_OUTPUT"
           echo "summary_file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -506,4 +506,5 @@ test('source monitor warns and falls back when checkout-cache support is unavail
 	assert.match(workflow, /Downloaded Skillstore CLI does not support --checkoutCacheDir; continuing without checkout cache/, 'missing checkout cache support must be visible in workflow logs');
 	assert.match(workflow, /This only affects runtime and network usage/, 'fallback warning must explain the tradeoff');
 	assert.doesNotMatch(workflow, /Latest Skillstore CLI does not support --checkoutCacheDir/, 'workflow must not hard-fail when the latest release lags checkout-cache support');
+	assert.match(workflow, /"\$\{CMD\[@\]\}" 2>&1 \| tee/, 'monitor evidence must capture stderr progress and failures, not upload an empty stdout-only artifact');
 });


### PR DESCRIPTION
## Problem\n\nThe evidence artifacts from source-monitor runs 29318707778, 29402608201, and 29484402820 each contained a zero-byte stdout transcript. The CLI emits progress and fatal diagnostics on stderr, while the workflow only piped stdout to tee.\n\n## Fix\n\nCapture stderr in the uploaded monitor transcript while preserving pipefail, so a failing CLI still fails the workflow and the artifact contains exact progress and error evidence.\n\n## Verification\n\n- CI=true node --test scripts/tests/recalculate-scores.test.mjs (23/23)\n- workflow YAML parse\n- git diff --check\n\nThis does not change scan or write scope and does not interfere with slug recovery workflows.