### PR TITLE
fix: keep validation auto-fixes on original PR

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/rebind-skill-report-hashes.mjs"
       - "scripts/verify-recovered-skill-reports.mjs"
       - "scripts/recovered-skill-reports.test.mjs"
       - "scripts/tests/**"
@@ -33,6 +34,7 @@ on:
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
+      - "scripts/rebind-skill-report-hashes.mjs"
       - "scripts/verify-recovered-skill-reports.mjs"
       - "scripts/recovered-skill-reports.test.mjs"
       - "scripts/tests/**"
@@ -99,6 +101,9 @@ jobs:
 
           cd "$WORK_DIR"
 
+          AUTO_FIX_BASE_SHA=$(git rev-parse HEAD)
+          echo "AUTO_FIX_BASE_SHA=$AUTO_FIX_BASE_SHA" >> "$GITHUB_ENV"
+
           # Configure git for potential commits
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -127,6 +132,8 @@ jobs:
             scripts/tests/detect-changed-skills.test.mjs \
             scripts/tests/resolve-manual-skills.test.mjs \
             scripts/tests/materialize-changed-skills.test.mjs \
+            scripts/tests/rebind-skill-report-hashes.test.mjs \
+            scripts/tests/validate-marketplace-autofix.test.mjs \
             scripts/recovered-skill-reports.test.mjs
 
       # Download CLI once at start - used by both SKILL.md and skill-report.json auto-fix steps
@@ -310,6 +317,26 @@ jobs:
 
           echo "::notice::SKILL.md auto-fix completed. Re-validating..."
 
+      - name: Rebind reports to auto-fixed SKILL.md artifacts
+        if: steps.validate-skill-md.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true'
+        working-directory: ${{ env.WORK_DIR }}
+        run: |
+          set -euo pipefail
+          CHANGED_SKILLS="$RUNNER_TEMP/auto-fixed-skill-paths-${{ github.run_id }}.bin"
+          git diff --name-only -z --diff-filter=ACMRT HEAD -- \
+            'skills/**/SKILL.md' 'pending/**/SKILL.md' > "$CHANGED_SKILLS"
+          if [ ! -s "$CHANGED_SKILLS" ]; then
+            if ! git diff --quiet --diff-filter=D HEAD -- 'skills/**/SKILL.md' 'pending/**/SKILL.md'; then
+              echo "::notice::Auto-fix only deleted invalid SKILL.md artifacts; no surviving report hashes to rebind"
+              exit 0
+            fi
+            echo "::error::SKILL.md auto-fix reported success without a changed SKILL.md artifact"
+            exit 1
+          fi
+          node scripts/rebind-skill-report-hashes.mjs \
+            --repo-root "$PWD" \
+            --skill-paths-file "$CHANGED_SKILLS"
+
       - name: Re-validate SKILL.md after auto-fix
         if: steps.validate-skill-md.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true'
         id: revalidate-skill-md
@@ -386,13 +413,9 @@ jobs:
             console.log('All SKILL.md files are now valid after auto-fix');
           "
 
-      - name: Create PR for SKILL.md fixes
+      - name: Commit auto-fixed SKILL.md artifacts locally
         if: steps.validate-skill-md.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true' && steps.revalidate-skill-md.outcome == 'success'
         working-directory: ${{ env.WORK_DIR }}
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -403,14 +426,6 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-
-          # Configure git remote URL with authentication token
-          echo "🔑 Configuring git authentication..."
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
-
-          # Create a new branch for the fixes
-          BRANCH_NAME="fix/skill-md-validation-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b "$BRANCH_NAME"
 
           # Stage all changes (modifications and deletions)
           git add -A
@@ -438,47 +453,7 @@ jobs:
           Co-Authored-By: Claude <noreply@anthropic.com>"
 
           git commit -m "$COMMIT_MSG"
-
-          # Push the branch
-          git push origin "$BRANCH_NAME"
-
-          # Build PR title
-          PR_TITLE="fix: Auto-fix SKILL.md validation errors"
-          [ "$MODIFIED_COUNT" -gt 0 ] && PR_TITLE="$PR_TITLE ($MODIFIED_COUNT fixed"
-          [ "$DELETED_COUNT" -gt 0 ] && [ "$MODIFIED_COUNT" -gt 0 ] && PR_TITLE="$PR_TITLE, $DELETED_COUNT deleted)"
-          [ "$DELETED_COUNT" -gt 0 ] && [ "$MODIFIED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE ($DELETED_COUNT deleted)"
-          [ "$MODIFIED_COUNT" -gt 0 ] && [ "$DELETED_COUNT" -eq 0 ] && PR_TITLE="$PR_TITLE)"
-
-          # Create PR
-          PR_URL=$(gh pr create \
-            --title "$PR_TITLE" \
-            --body "## Summary
-
-          AI-powered auto-fix for SKILL.md validation errors.
-
-          | Metric | Value |
-          |--------|-------|
-          | Files Fixed | $MODIFIED_COUNT |
-          | Empty Skills Deleted | $DELETED_COUNT |
-          | Triggered By | ${{ github.event_name }} |
-
-          ### Fixes Applied
-          - Added missing YAML frontmatter
-          - Fixed \`name\` field format (lowercase alphanumeric with hyphens)
-          - Added missing \`description\` field
-          - Truncated overly long descriptions
-          - **Deleted empty skill directories** (unfixable)
-
-          ### After Merge
-          The \`sync-to-supabase.yml\` workflow will automatically update the database.
-
-          ---
-          *Automated fix by validate-marketplace.yml*" \
-            --base main \
-            --head "$BRANCH_NAME")
-
-          echo "::notice::Created PR for SKILL.md fixes: $PR_URL"
-          echo "🔗 PR Created: $PR_URL"
+          echo "::notice::Staged SKILL.md and bound report fixes in a local commit; publishing waits for all validation repairs"
 
       - name: Fail if SKILL.md errors remain
         if: steps.validate-skill-md.outcome == 'failure' && (env.AUTO_FIX_ENABLED != 'true' || steps.revalidate-skill-md.outcome == 'failure')
@@ -650,12 +625,9 @@ jobs:
             exit 1
           fi
 
-      - name: Commit auto-fixed skill-report.json files
+      - name: Commit auto-fixed skill-report.json files locally
         if: steps.validate-skill-reports.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true' && steps.revalidate.outcome == 'success'
         working-directory: ${{ env.WORK_DIR }}
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -667,10 +639,6 @@ jobs:
             exit 0
           fi
 
-          # Configure git remote URL with authentication token
-          echo "🔑 Configuring git authentication..."
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
-
           # Stage all changes
           git add -A
 
@@ -680,21 +648,7 @@ jobs:
           AI-powered fix applied by GitHub Actions workflow.
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
-
-          # Push with retry for race conditions
-          for i in 1 2 3; do
-            if git push origin "$BRANCH"; then
-              echo "::notice::Successfully committed and pushed auto-fixed skill-report.json files"
-              break
-            fi
-            echo "Push failed, pulling and retrying ($i/3)..."
-            git pull --rebase origin "$BRANCH" || {
-              git rebase --abort 2>/dev/null || true
-              git reset --hard "origin/$BRANCH"
-              git cherry-pick HEAD@{1} || true
-            }
-            sleep 2
-          done
+          echo "::notice::Committed report repairs locally; publishing waits for the final validation gate"
 
       - name: Add summary
         if: always()
@@ -709,7 +663,11 @@ jobs:
           elif [ "${{ steps.revalidate-skill-md.outcome }}" == "success" ]; then
             echo "🔧 SKILL.md validation errors were automatically fixed by AI" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "A PR has been created with the fixes. Please review and merge." >> $GITHUB_STEP_SUMMARY
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "Validated fixes were pushed back to the original same-repository PR head." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "A dedicated repair PR was created for the validated fixes." >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "❌ SKILL.md validation failed" >> $GITHUB_STEP_SUMMARY
             if [ "${{ env.AUTO_FIX_ENABLED }}" == "true" ]; then
@@ -744,6 +702,62 @@ jobs:
         run: |
           echo "::error::skill-report.json validation failed"
           exit 1
+
+      - name: Publish validated auto-fixes
+        if: success() && env.AUTO_FIX_ENABLED == 'true' && (steps.revalidate-skill-md.outcome == 'success' || steps.revalidate.outcome == 'success')
+        working-directory: ${{ env.WORK_DIR }}
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git diff --quiet
+          git diff --cached --quiet
+          git merge-base --is-ancestor "$AUTO_FIX_BASE_SHA" HEAD
+          test "$(git rev-parse HEAD)" != "$AUTO_FIX_BASE_SHA" || {
+            echo "::error::Auto-fix completed without a final repair commit"
+            exit 1
+          }
+
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            test "$HEAD_REPOSITORY" = "$REPOSITORY" || {
+              echo "::error::Refusing to write auto-fixes to fork pull request $HEAD_REPOSITORY"
+              exit 1
+            }
+            test "$HEAD_REF" = "$BRANCH" || {
+              echo "::error::Pull request head branch changed during validation"
+              exit 1
+            }
+            git check-ref-format --branch "$BRANCH" >/dev/null
+            [[ "$BRANCH" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] \
+              && [[ "$BRANCH" != *..* ]] \
+              && [[ "$BRANCH" != *//* ]] \
+              && [[ "$BRANCH" != */ ]] || {
+              echo "::error::Refusing unsafe pull request head branch $BRANCH"
+              exit 1
+            }
+            REMOTE_SHA=$(git ls-remote origin "refs/heads/$BRANCH" | awk 'NR == 1 {print $1}')
+            test "$REMOTE_SHA" = "$AUTO_FIX_BASE_SHA" || {
+              echo "::error::Pull request head advanced during auto-fix: expected $AUTO_FIX_BASE_SHA, found ${REMOTE_SHA:-missing}"
+              exit 1
+            }
+            git push origin "HEAD:refs/heads/$BRANCH"
+            echo "::notice::Published validated auto-fixes to original PR head $BRANCH"
+          else
+            FIX_BRANCH="fix/validated-marketplace-artifacts-${{ github.run_id }}"
+            git push origin "HEAD:refs/heads/$FIX_BRANCH"
+            gh pr create \
+              --base main \
+              --head "$FIX_BRANCH" \
+              --title "fix: validate Marketplace artifacts" \
+              --body "Automated SKILL.md and skill-report.json repairs from workflow run ${{ github.run_id }}."
+          fi
 
       - name: Cleanup temporary workspace
         if: always()

--- a/scripts/rebind-skill-report-hashes.mjs
+++ b/scripts/rebind-skill-report-hashes.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { calculateCanonicalTreeHash } from './resolve-approved-submission.mjs';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+    fail(`missing required option ${name}`);
+  }
+  return args[index + 1];
+}
+
+function normalizeSkillPath(value) {
+  if (
+    value === ''
+    || value !== value.normalize('NFC')
+    || value.includes('\\')
+    || /[\0-\x1f\x7f]/.test(value)
+  ) {
+    fail(`unsafe SKILL.md path ${JSON.stringify(value)}`);
+  }
+  const segments = value.split('/');
+  if (
+    !['pending', 'skills'].includes(segments[0])
+    || segments.at(-1) !== 'SKILL.md'
+    || ![3, 4].includes(segments.length)
+    || segments.some((segment) => segment === '' || segment === '.' || segment === '..')
+  ) {
+    fail(`noncanonical SKILL.md path ${JSON.stringify(value)}`);
+  }
+  return segments.join('/');
+}
+
+function ensureInside(root, path, label) {
+  const rel = relative(root, path);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel === '') fail(`${label} escapes repository root`);
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function sha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function rebindSkillReportHashes({ repositoryRoot, skillPaths }) {
+  const root = realpathSync(repositoryRoot);
+  const normalized = [...new Set(skillPaths.map(normalizeSkillPath))].sort();
+  if (normalized.length === 0) fail('no changed SKILL.md paths were provided');
+
+  const rebound = [];
+  for (const skillPath of normalized) {
+    const absoluteSkill = resolve(root, ...skillPath.split('/'));
+    ensureInside(root, absoluteSkill, skillPath);
+    if (!existsSync(absoluteSkill)) continue;
+    const skillStat = lstatSync(absoluteSkill);
+    if (!skillStat.isFile() || skillStat.isSymbolicLink()) fail(`${skillPath} is not a regular file`);
+
+    const skillDirectory = dirname(skillPath).split(sep).join('/');
+    const reportPath = `${skillDirectory}/skill-report.json`;
+    const absoluteReport = resolve(root, ...reportPath.split('/'));
+    ensureInside(root, absoluteReport, reportPath);
+    if (!existsSync(absoluteReport)) fail(`${reportPath} is missing`);
+    const reportStat = lstatSync(absoluteReport);
+    if (!reportStat.isFile() || reportStat.isSymbolicLink()) fail(`${reportPath} is not a regular file`);
+
+    const report = readJson(absoluteReport, reportPath);
+    const sourceUrl = report?.meta?.source_url;
+    const sourceRef = report?.meta?.source_ref;
+    if (typeof sourceUrl !== 'string' || !sourceUrl.startsWith('https://github.com/')) {
+      fail(`${reportPath} has invalid source_url lineage`);
+    }
+    if (typeof sourceRef !== 'string' || sourceRef.trim() === '') {
+      fail(`${reportPath} has invalid source_ref lineage`);
+    }
+
+    const contentHash = sha256(absoluteSkill);
+    const treeHash = calculateCanonicalTreeHash(root, skillDirectory);
+    report.meta.content_hash = contentHash;
+    report.meta.tree_hash = treeHash;
+    writeFileSync(absoluteReport, `${JSON.stringify(report, null, 2)}\n`, { mode: reportStat.mode & 0o777 });
+
+    const written = readJson(absoluteReport, reportPath);
+    if (written.meta.source_url !== sourceUrl || written.meta.source_ref !== sourceRef) {
+      fail(`${reportPath} source lineage changed during hash rebinding`);
+    }
+    if (written.meta.content_hash !== sha256(absoluteSkill)) fail(`${reportPath} content_hash rebinding failed`);
+    if (written.meta.tree_hash !== calculateCanonicalTreeHash(root, skillDirectory)) {
+      fail(`${reportPath} tree_hash rebinding failed`);
+    }
+    rebound.push({ skillPath, reportPath, contentHash, treeHash, sourceUrl, sourceRef });
+  }
+  if (rebound.length === 0) fail('no existing changed SKILL.md files were rebound');
+  return rebound;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const pathsFile = option(args, '--skill-paths-file');
+  const bytes = readFileSync(pathsFile);
+  const skillPaths = bytes.toString('utf8').split('\0').filter(Boolean);
+  const rebound = rebindSkillReportHashes({
+    repositoryRoot: option(args, '--repo-root'),
+    skillPaths,
+  });
+  process.stdout.write(`${JSON.stringify({ schemaVersion: 1, rebound }, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Skill report hash rebinding failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/rebind-skill-report-hashes.test.mjs
+++ b/scripts/tests/rebind-skill-report-hashes.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  calculateCanonicalTreeHash,
+  resolveApprovedSubmission,
+} from '../resolve-approved-submission.mjs';
+
+const SCRIPT = 'scripts/rebind-skill-report-hashes.mjs';
+
+function withFixture(fn, { sourceUrl = 'https://github.com/example/source/tree/main/skill' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'rebind-report-hashes-'));
+  const skillDir = 'pending/example/fixture';
+  const absoluteDir = join(root, skillDir);
+  mkdirSync(join(absoluteDir, 'references'), { recursive: true });
+  writeFileSync(join(absoluteDir, 'SKILL.md'), '---\nname: fixture\ndescription: final artifact\n---\n');
+  writeFileSync(join(absoluteDir, 'references', '中文.md'), 'reference\n');
+  writeFileSync(join(absoluteDir, 'skill-report.json'), `${JSON.stringify({
+    meta: {
+      slug: 'example-fixture',
+      source_type: 'community',
+      source_url: sourceUrl,
+      source_ref: 'main',
+      content_hash: '0'.repeat(64),
+      tree_hash: '1'.repeat(64),
+    },
+    security_audit: { is_blocked: false, safe_to_publish: true },
+  }, null, 2)}\n`);
+  try {
+    return fn({ root, skillDir, absoluteDir });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function run(root, paths) {
+  const pathsFile = join(root, 'changed-skills.bin');
+  writeFileSync(pathsFile, Buffer.from(`${paths.join('\0')}\0`));
+  return spawnSync(process.execPath, [
+    SCRIPT,
+    '--repo-root', root,
+    '--skill-paths-file', pathsFile,
+  ], { cwd: process.cwd(), encoding: 'utf8' });
+}
+
+test('rebinds hashes to the final artifact while preserving source lineage', () => withFixture(({ root, skillDir, absoluteDir }) => {
+  const result = run(root, [`${skillDir}/SKILL.md`]);
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(readFileSync(join(absoluteDir, 'skill-report.json'), 'utf8'));
+  const expectedContent = createHash('sha256').update(readFileSync(join(absoluteDir, 'SKILL.md'))).digest('hex');
+  const expectedTree = calculateCanonicalTreeHash(root, skillDir);
+  assert.equal(report.meta.content_hash, expectedContent);
+  assert.equal(report.meta.tree_hash, expectedTree);
+  assert.equal(report.meta.source_url, 'https://github.com/example/source/tree/main/skill');
+  assert.equal(report.meta.source_ref, 'main');
+
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: [
+      `${skillDir}/SKILL.md`,
+      `${skillDir}/skill-report.json`,
+      `${skillDir}/references/中文.md`,
+    ],
+  });
+  assert.equal(plan.skills[0].contentHash, expectedContent);
+  assert.equal(plan.skills[0].treeHash, expectedTree);
+}));
+
+test('rejects missing source lineage before changing hashes', () => withFixture(({ root, absoluteDir, skillDir }) => {
+  const reportPath = join(absoluteDir, 'skill-report.json');
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  report.meta.source_ref = '';
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  const result = run(root, [`${skillDir}/SKILL.md`]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /invalid source_ref lineage/);
+  assert.equal(JSON.parse(readFileSync(reportPath, 'utf8')).meta.content_hash, '0'.repeat(64));
+}));
+
+test('rejects traversal and control characters in changed path input', () => withFixture(({ root }) => {
+  for (const path of ['../SKILL.md', 'pending/example/bad\npath/SKILL.md']) {
+    const result = run(root, [path]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unsafe SKILL\.md path|noncanonical SKILL\.md path/);
+  }
+}));

--- a/scripts/tests/validate-marketplace-autofix.test.mjs
+++ b/scripts/tests/validate-marketplace-autofix.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+const workflow = readFileSync('.github/workflows/validate-marketplace.yml', 'utf8');
+
+function runBlock(stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const start = workflow.indexOf(marker);
+  assert.ok(start >= 0, `missing step ${stepName}`);
+  const run = workflow.indexOf('        run: |\n', start);
+  assert.ok(run >= 0, `missing run block for ${stepName}`);
+  const end = workflow.indexOf('\n      - name:', run + 1);
+  const lines = workflow.slice(run + '        run: |\n'.length, end < 0 ? undefined : end).split('\n');
+  return lines.map((line) => line.startsWith('          ') ? line.slice(10) : line).join('\n');
+}
+
+const rebind = runBlock('Rebind reports to auto-fixed SKILL.md artifacts');
+const commitSkill = runBlock('Commit auto-fixed SKILL.md artifacts locally');
+const commitReport = runBlock('Commit auto-fixed skill-report.json files locally');
+const publish = runBlock('Publish validated auto-fixes');
+
+test('auto-fix binds final artifact hashes before creating local commits', () => {
+  assert.match(rebind, /git diff --name-only -z --diff-filter=ACMRT HEAD/);
+  assert.match(rebind, /scripts\/rebind-skill-report-hashes\.mjs/);
+  assert.match(rebind, /--skill-paths-file/);
+  assert.doesNotMatch(commitSkill, /git push|gh pr create/);
+  assert.doesNotMatch(commitReport, /git push|git pull|git reset|git cherry-pick/);
+});
+
+test('publishing updates only the original trusted PR head and fails closed on races', () => {
+  assert.match(publish, /test "\$HEAD_REPOSITORY" = "\$REPOSITORY"/);
+  assert.match(publish, /test "\$HEAD_REF" = "\$BRANCH"/);
+  assert.match(publish, /git check-ref-format --branch "\$BRANCH"/);
+  assert.match(publish, /test "\$REMOTE_SHA" = "\$AUTO_FIX_BASE_SHA"/);
+  assert.match(publish, /git push origin "HEAD:refs\/heads\/\$BRANCH"/);
+  assert.doesNotMatch(publish, /git pull|git rebase|git reset|git cherry-pick|\|\| true/);
+  assert.match(publish, /if \[ "\$EVENT_NAME" = "pull_request" \]; then[\s\S]*else[\s\S]*gh pr create/);
+});
+
+function executePullRequestPublish({ headRepository = 'aiskillstore/marketplace', pushStatus = 0 } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'validate-autofix-publish-'));
+  const log = join(root, 'commands.log');
+  const script = `${publish.replace('FIX_BRANCH="fix/validated-marketplace-artifacts-${{ github.run_id }}"', 'FIX_BRANCH="fix/test"')}\n`;
+  const harness = `
+git() {
+  printf 'git %s\\n' "$*" >> "$FAKE_LOG"
+  if [ "$1" = rev-parse ] && [ "$2" = HEAD ]; then printf '%s\\n' final; return 0; fi
+  if [ "$1" = ls-remote ]; then printf '%s\\trefs/heads/%s\\n' "$AUTO_FIX_BASE_SHA" "$BRANCH"; return 0; fi
+  if [ "$1" = push ]; then return "$FAKE_PUSH_STATUS"; fi
+  return 0
+}
+gh() { printf 'gh %s\\n' "$*" >> "$FAKE_LOG"; return 0; }
+${script}`;
+  writeFileSync(join(root, 'run.sh'), harness);
+  const result = spawnSync('bash', [join(root, 'run.sh')], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      APP_TOKEN: 'fixture-token',
+      AUTO_FIX_BASE_SHA: 'base',
+      BRANCH: 'submission/fixture',
+      EVENT_NAME: 'pull_request',
+      FAKE_LOG: log,
+      FAKE_PUSH_STATUS: String(pushStatus),
+      GH_TOKEN: 'fixture-token',
+      HEAD_REF: 'submission/fixture',
+      HEAD_REPOSITORY: headRepository,
+      REPOSITORY: 'aiskillstore/marketplace',
+    },
+  });
+  const commands = readFileSync(log, 'utf8');
+  rmSync(root, { recursive: true, force: true });
+  return { result, commands };
+}
+
+test('same-repository PR publishes the final commit to its original head', () => {
+  const { result, commands } = executePullRequestPublish();
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(commands, /git push origin HEAD:refs\/heads\/submission\/fixture/);
+  assert.doesNotMatch(commands, /gh pr create/);
+});
+
+test('fork PR and write-permission failure are terminal and never create a superset PR', () => {
+  const fork = executePullRequestPublish({ headRepository: 'external/fork' });
+  assert.notEqual(fork.result.status, 0);
+  assert.doesNotMatch(fork.commands, /git push|gh pr create/);
+
+  const denied = executePullRequestPublish({ pushStatus: 1 });
+  assert.notEqual(denied.result.status, 0);
+  assert.match(denied.commands, /git push origin HEAD:refs\/heads\/submission\/fixture/);
+  assert.doesNotMatch(denied.commands, /gh pr create/);
+});


### PR DESCRIPTION
## Summary
- rebind report content/tree hashes after SKILL.md normalization, preserving exact source URL/ref lineage
- accumulate SKILL/report repairs locally and publish only after final validation
- write same-repository PR fixes back to the exact original head; reject forks, unsafe refs, concurrent head movement, and permission failures
- create a separate repair PR only for non-PR workflow events

## Production evidence
PR #2604 normalized a Chinese `name` in a superset auto-fix PR while leaving the original submission head unchanged. After manually converging those commits, approval run 29561695856 correctly failed because the report hashes still described the pre-fix SKILL.md bytes.

## Verification
- `CI=true node --test ...` (74/74 related tests)
- YAML parse and `git diff --check`
- executable coverage for same-repo head update, fork rejection, permission failure, hash rebinding, lineage preservation, and approval hash contract