### PR TITLE
fix: recover huanbao pending publication

### DIFF
--- a/pending/zx029w/zhuangxiu-huanbao-bikeng/SKILL.md
+++ b/pending/zx029w/zhuangxiu-huanbao-bikeng/SKILL.md
@@ -1,6 +1,6 @@
 ---
-skill_id: 2073
 name: zhuangxiu-huanbao-bikeng
+skill_id: 2073
 identifier: zhuangxiu-huanbao-bikeng
 slug: zhuangxiu-huanbao-bikeng
 description: 【装修环保必看】你担心装修污染吗？怕甲醛超标、不知道环保材料怎么选、被甲醛治理公司忽悠、搞不懂E0/ENF级？这个Skill内置装修课堂知识库，直接教你环保真相——问甲醛、问板材环保、问乳胶漆、问壁纸壁布、问甲醛治理、问通风方法，全部覆盖。适合担心装修污染、有孩子/老人要入住、想装出健康家的业主。

--- a/pending/zx029w/zhuangxiu-huanbao-bikeng/skill-report.json
+++ b/pending/zx029w/zhuangxiu-huanbao-bikeng/skill-report.json
@@ -8,8 +8,8 @@
     "model": "claude",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "0ccac36965538d3359891cc5692125187145a8d5b852fad14a9f30d1ec49a443",
-    "tree_hash": "660239300884db3b351e42f55e1291e5a0ccdd6206690708069818bb5337f92e",
+    "content_hash": "7e50fd2c6702d415a030f33e93a40a2bee64e9d0c9957293d9b70b21910a1303",
+    "tree_hash": "6fe7f8e9e329ed7b51d9ca7b5a16dde357c80a0bb2a0dc0b98097b1077543ff1",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [


### PR DESCRIPTION
## Skill Submission Recovery: zhuangxiu-huanbao-bikeng

**Submission ID**: `d554bd1a-5123-40cc-8210-a927572712f8`
**Source**: https://github.com/zx029w/zhuangxiu-skills/tree/main/装修环保避坑

The original reviewed PR #2604 normalized the SKILL.md `name`, but its approval failed closed because the report hashes still described the pre-normalization bytes. This recovery keeps the exact source URL/ref and reviewed safe audit, canonicalizes frontmatter order, and binds:

- `content_hash`: `7e50fd2c6702d415a030f33e93a40a2bee64e9d0c9957293d9b70b21910a1303`
- `tree_hash`: `6fe7f8e9e329ed7b51d9ca7b5a16dde357c80a0bb2a0dc0b98097b1077543ff1`

`resolve-approved-submission.mjs` now accepts the complete frozen pending tree and resolves the target only to `skills/zx029w/zhuangxiu-huanbao-bikeng`.