### PR TITLE
fix(workflow): isolate source monitor checkout

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -89,6 +89,19 @@ jobs:
     timeout-minutes: 1440
 
     steps:
+      - name: Initialize source monitor diagnostics
+        env:
+          DIAGNOSTIC_DIR: ${{ runner.temp }}/source-monitor-diagnostics-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIAGNOSTIC_DIR"
+          {
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "repository=$GITHUB_REPOSITORY"
+            echo "workflow_sha=${{ github.workflow_sha }}"
+            echo "runner_name=$RUNNER_NAME"
+          } > "$DIAGNOSTIC_DIR/run.txt"
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -97,11 +110,79 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Checkout marketplace
+      - name: Clear inherited source monitor checkout
+        env:
+          DIAGNOSTIC_DIR: ${{ runner.temp }}/source-monitor-diagnostics-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIAGNOSTIC_DIR"
+          {
+            echo "workspace=$GITHUB_WORKSPACE"
+            echo "expected_workspace=$RUNNER_WORKSPACE/${GITHUB_REPOSITORY#*/}"
+            git -C "$GITHUB_WORKSPACE" rev-parse HEAD 2>/dev/null || true
+            git -C "$GITHUB_WORKSPACE" config --show-origin --get-regexp '^(core\.sparseCheckout|extensions\.worktreeConfig)$' 2>/dev/null || true
+            git -C "$GITHUB_WORKSPACE" ls-files -v 2>/dev/null | awk '$1 ~ /^S/ { count += 1 } END { print "skip_worktree_count=" (count + 0) }'
+          } > "$DIAGNOSTIC_DIR/pre-checkout.txt"
+
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+          cd "${RUNNER_TEMP:?}"
+          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
+          fi
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
+      - name: Checkout immutable source monitor runtime
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.workflow_sha }}
           token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
+          fetch-depth: 1
+          clean: true
+          persist-credentials: false
+
+      - name: Verify immutable source monitor runtime
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          DIAGNOSTIC_DIR: ${{ runner.temp }}/source-monitor-diagnostics-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIAGNOSTIC_DIR"
+          REQUIRED_RUNTIME_FILES=(
+            ".github/actions/download-skillstore-cli/action.yml"
+            ".github/workflows/monitor-skill-sources.yml"
+          )
+          {
+            echo "expected_workflow_sha=$EXPECTED_WORKFLOW_SHA"
+            echo "actual_head=$(git rev-parse HEAD)"
+            echo "sparse_checkout=$(git config --bool core.sparseCheckout 2>/dev/null || echo false)"
+            echo "sparse_file=$(git rev-parse --git-path info/sparse-checkout)"
+            git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}"
+          } > "$DIAGNOSTIC_DIR/post-checkout.txt"
+
+          test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
+          test "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true"
+          test ! -f "$(git rev-parse --git-path info/sparse-checkout)"
+          if git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
+            echo "::error::Immutable source monitor runtime contains skip-worktree files"
+            exit 1
+          fi
+          for file in "${REQUIRED_RUNTIME_FILES[@]}"; do
+            test -f "$GITHUB_WORKSPACE/$file" && test ! -L "$GITHUB_WORKSPACE/$file" || {
+              echo "::error::Required source monitor runtime file is missing or not a regular file: $file"
+              exit 1
+            }
+            test "$(git hash-object -- "$GITHUB_WORKSPACE/$file")" = "$(git rev-parse "$EXPECTED_WORKFLOW_SHA:$file")" || {
+              echo "::error::Source monitor runtime file does not match workflow head: $file"
+              exit 1
+            }
+          done
 
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
@@ -109,6 +190,8 @@ jobs:
           version: latest
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+          minimum-version: 2.14.5
+          require-checksum: true
 
       - name: Prepare git workspace
         run: |
@@ -321,7 +404,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: skill-source-monitor-${{ github.run_id }}
-          path: source-monitor-results/
+          path: |
+            source-monitor-results/
+            ${{ runner.temp }}/source-monitor-diagnostics-${{ github.run_id }}/
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+
+const workflow = readFileSync('.github/workflows/monitor-skill-sources.yml', 'utf8');
+const runtimeFiles = [
+  '.github/actions/download-skillstore-cli/action.yml',
+  '.github/workflows/monitor-skill-sources.yml',
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.status !== 0 && !options.allowFailure) {
+    assert.fail(`${command} ${args.join(' ')} failed (${result.status})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  return result;
+}
+
+function extractRunBlock(stepName) {
+  const lines = workflow.split('\n');
+  const nameIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(nameIndex, -1, `missing workflow step: ${stepName}`);
+  const stepIndent = lines[nameIndex].search(/\S/);
+  let runIndex = -1;
+  for (let index = nameIndex + 1; index < lines.length; index += 1) {
+    const indent = lines[index].search(/\S/);
+    if (indent !== -1 && indent <= stepIndent) break;
+    if (lines[index].trim() === 'run: |') {
+      runIndex = index;
+      break;
+    }
+  }
+  assert.notEqual(runIndex, -1, `missing run block for: ${stepName}`);
+  const runIndent = lines[runIndex].search(/\S/);
+  const body = [];
+  for (let index = runIndex + 1; index < lines.length; index += 1) {
+    const indent = lines[index].search(/\S/);
+    if (indent !== -1 && indent <= runIndent) break;
+    body.push(lines[index].length > runIndent + 2 ? lines[index].slice(runIndent + 2) : '');
+  }
+  return body.join('\n');
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'source-monitor-runtime-'));
+  const seed = join(root, 'seed');
+  const origin = join(root, 'origin.git');
+  const runnerWorkspace = join(root, 'runner-workspace');
+  const workspace = join(runnerWorkspace, 'marketplace');
+  const runnerTemp = join(root, 'runner-temp');
+  const diagnosticDir = join(runnerTemp, 'source-monitor-diagnostics-test');
+  mkdirSync(seed, { recursive: true });
+  mkdirSync(runnerWorkspace, { recursive: true });
+  mkdirSync(runnerTemp, { recursive: true });
+  run('git', ['init', '-q', seed]);
+  run('git', ['-C', seed, 'config', 'user.name', 'Fixture']);
+  run('git', ['-C', seed, 'config', 'user.email', 'fixture@example.com']);
+  const files = {
+    '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
+    '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
+    'README.md': 'fixture\n',
+  };
+  for (const [path, content] of Object.entries(files)) {
+    const absolute = join(seed, path);
+    mkdirSync(join(absolute, '..'), { recursive: true });
+    writeFileSync(absolute, content);
+  }
+  run('git', ['-C', seed, 'add', '.']);
+  run('git', ['-C', seed, 'commit', '-qm', 'fixture']);
+  const head = run('git', ['-C', seed, 'rev-parse', 'HEAD']).stdout.trim();
+  run('git', ['clone', '--bare', '-q', seed, origin]);
+  run('git', ['clone', '-q', origin, workspace]);
+  return { root, origin, runnerWorkspace, runnerTemp, workspace, diagnosticDir, head };
+}
+
+test('source monitor clears inherited sparse state and verifies an immutable full checkout', () => {
+  const fixture = createFixture();
+  try {
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'init', '--cone']);
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'set', '.github/workflows']);
+    assert.equal(existsSync(join(fixture.workspace, runtimeFiles[0])), false);
+    writeFileSync(join(fixture.workspace, 'stale-runner-file'), 'stale\n');
+
+    run('bash', ['-c', extractRunBlock('Clear inherited source monitor checkout')], {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        RUNNER_WORKSPACE: fixture.runnerWorkspace,
+        RUNNER_TEMP: fixture.runnerTemp,
+        GITHUB_REPOSITORY: `aiskillstore/${basename(fixture.workspace)}`,
+        DIAGNOSTIC_DIR: fixture.diagnosticDir,
+      },
+    });
+
+    assert.deepEqual(readdirSync(fixture.workspace), []);
+    assert.match(readFileSync(join(fixture.diagnosticDir, 'pre-checkout.txt'), 'utf8'), /skip_worktree_count=/);
+    run('git', ['clone', '-q', '--no-local', fixture.origin, fixture.workspace]);
+    run('bash', ['-c', extractRunBlock('Verify immutable source monitor runtime')], {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        EXPECTED_WORKFLOW_SHA: fixture.head,
+        DIAGNOSTIC_DIR: fixture.diagnosticDir,
+      },
+    });
+    assert.match(readFileSync(join(fixture.diagnosticDir, 'post-checkout.txt'), 'utf8'), new RegExp(`actual_head=${fixture.head}`));
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('source monitor runtime preflight rejects missing, modified, symlinked, skip-worktree, and wrong-head files', () => {
+  const fixture = createFixture();
+  try {
+    const preflight = extractRunBlock('Verify immutable source monitor runtime');
+    const base = {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        EXPECTED_WORKFLOW_SHA: fixture.head,
+        DIAGNOSTIC_DIR: fixture.diagnosticDir,
+      },
+    };
+    for (const file of runtimeFiles) {
+      const absolute = join(fixture.workspace, file);
+      rmSync(absolute);
+      assert.notEqual(run('bash', ['-c', preflight], { ...base, allowFailure: true }).status, 0);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
+      writeFileSync(absolute, 'tampered\n');
+      assert.notEqual(run('bash', ['-c', preflight], { ...base, allowFailure: true }).status, 0);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
+      rmSync(absolute);
+      symlinkSync(join(fixture.workspace, 'README.md'), absolute);
+      assert.notEqual(run('bash', ['-c', preflight], { ...base, allowFailure: true }).status, 0);
+      rmSync(absolute);
+      run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
+    }
+    run('git', ['-C', fixture.workspace, 'update-index', '--skip-worktree', runtimeFiles[0]]);
+    assert.notEqual(run('bash', ['-c', preflight], { ...base, allowFailure: true }).status, 0);
+    run('git', ['-C', fixture.workspace, 'update-index', '--no-skip-worktree', runtimeFiles[0]]);
+    assert.notEqual(run('bash', ['-c', preflight], {
+      ...base,
+      env: { ...base.env, EXPECTED_WORKFLOW_SHA: '0000000000000000000000000000000000000000' },
+      allowFailure: true,
+    }).status, 0);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('source monitor binds checkout and artifacts to immutable runtime evidence', () => {
+  assert.ok(workflow.indexOf('name: Initialize source monitor diagnostics') < workflow.indexOf('name: Generate GitHub App Token'));
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /fetch-depth: 1/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /minimum-version: 2\.14\.5/);
+  assert.match(workflow, /require-checksum: true/);
+  assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);
+  assert.match(workflow, /name: Upload monitor evidence\n\s+if: always\(\)/);
+  for (const file of runtimeFiles) assert.match(workflow, new RegExp(file.replaceAll('.', '\\.')));
+});


### PR DESCRIPTION
## Incident\n\nBounded Source Monitor run 29564480716 checked out current main but the reused self-hosted workspace retained sparse-checkout and skip-worktree state. The local download-skillstore-cli action was absent, so the job failed before the CLI started. The always artifact step then failed again because no evidence directory existed.\n\n## Fix\n\n- Record non-sensitive pre-checkout sparse and skip-worktree diagnostics in RUNNER_TEMP.\n- Validate the expected self-hosted workspace, disable inherited sparse state, and empty the workspace before checkout.\n- Checkout the immutable github.workflow_sha with depth 1 and no persisted credentials.\n- Verify HEAD, sparse state, skip-worktree state, regular non-symlink runtime files, and exact git blob hashes before invoking the local action.\n- Require checksummed Skillstore CLI 2.14.5 or newer.\n- Always upload the RUNNER_TEMP diagnostics directory so pre-CLI failures retain evidence.\n\n## Verification\n\n- CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs (3/3)\n- CI=true node --test scripts/tests/recalculate-scores.test.mjs (23/23)\n- workflow YAML parse\n- git diff --check\n\nThe fixture reproduces an inherited sparse checkout where the local action is missing, runs the cleanup, and proves immutable preflight behavior for missing, modified, symlinked, skip-worktree, and wrong-head runtimes.\n\nDo not rerun 29564480716. After merge, dispatch the same bounded budget monitor from current main.