### PR TITLE
feat(cli): report durable Pack install outcomes

### DIFF
--- a/packages/skillstore/README.md
+++ b/packages/skillstore/README.md
@@ -174,9 +174,16 @@ import {
 |----------|-------------|
 | `SKILLSTORE_API_URL` | Custom API base URL (default: `https://skillstore.io/api`) |
 | `SKILLSTORE_VERIFY_KEY` | Override built-in manifest verification key (optional) |
+| `SKILLSTORE_TELEMETRY_DISABLED=1` | Disable installation telemetry and anonymous client ID storage |
+| `DO_NOT_TRACK=1` | Standard opt-out; also disables installation telemetry and ID storage |
 | `DEBUG` | Enable debug logging |
 
 > **Note**: Manifest signature verification is enabled by default using a built-in key. You don't need to configure anything for verification to work.
+
+Pack installation reports use a random UUID stored under the user's config
+directory. The identifier is not derived from the device, username, paths, or
+other personal data. Reporting is best-effort and never changes the install
+command's exit status.
 
 ## Directory Structure
 

--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/skillstore/src/cli/index.ts
+++ b/packages/skillstore/src/cli/index.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 import { defineCommand, runMain } from 'citty';
+import { CLI_VERSION } from '../lib/version.js';
 
 const main = defineCommand({
 	meta: {
 		name: 'skillstore',
-		version: '0.1.9',
+		version: CLI_VERSION,
 		description: 'Skillstore CLI - Manage AI skills for Claude, Codex, and Claude Code',
 	},
 	subCommands: {

--- a/packages/skillstore/src/commands/add.ts
+++ b/packages/skillstore/src/commands/add.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { getPluginConfig } from '../lib/plugin-config.js';
 import {
 	fetchManifest,
-	reportInstallation,
+	reportPackInstallation,
 	reportSkillInstall,
 	PluginApiError,
 } from '../lib/plugin-api.js';
@@ -28,6 +28,11 @@ import {
 } from '../lib/agents.js';
 import { addToLock, getLockEntry } from '../lib/skill-lock.js';
 import { lockVerifiedPackMembers } from '../lib/pack-lock.js';
+import {
+	createPackInstallReporter,
+	derivePackInstallOutcome,
+	readbackPackInstall,
+} from '../lib/pack-install-truth.js';
 import { extractSkillZip, installToAgents, getCanonicalSkillPath } from '../lib/installer.js';
 
 /**
@@ -101,6 +106,7 @@ export default defineCommand({
 
 		// Determine target agents
 		let targetAgents: AgentConfig[];
+		let reportTargetAgents: string[] | undefined;
 		if (agentArg) {
 			// Parse comma-separated agent IDs
 			const agentIds = agentArg.split(',').map((s) => s.trim());
@@ -112,9 +118,13 @@ export default defineCommand({
 				process.exit(1);
 			}
 			targetAgents = getAgentsByIds(agentIds);
+			reportTargetAgents = targetAgents.map((agent) => agent.id);
 		} else {
 			// Auto-detect the default Skillstore targets only.
 			targetAgents = detectDefaultInstallAgents();
+			if (targetAgents.length > 0) {
+				reportTargetAgents = targetAgents.map((agent) => agent.id);
+			}
 			if (targetAgents.length === 0) {
 				logger.warn('No Codex or Claude Code folders detected. Installing to Claude Code by default.');
 				targetAgents = [agents['claude-code']];
@@ -122,7 +132,7 @@ export default defineCommand({
 		}
 
 		if (isPlugin) {
-			await addPlugin(slug, { targetAgents, isGlobal, skipVerify, dryRun, overwrite });
+			await addPlugin(slug, { targetAgents, reportTargetAgents, isGlobal, skipVerify, dryRun, overwrite });
 		} else {
 			await addSkill(slug, { targetAgents, isGlobal, skipVerify, dryRun, overwrite });
 		}
@@ -131,6 +141,7 @@ export default defineCommand({
 
 interface AddOptions {
 	targetAgents: AgentConfig[];
+	reportTargetAgents?: string[];
 	isGlobal: boolean;
 	skipVerify: boolean;
 	dryRun: boolean;
@@ -354,7 +365,7 @@ async function addSkill(slug: string, options: AddOptions): Promise<void> {
  * Add a plugin (skill collection)
  */
 async function addPlugin(slug: string, options: AddOptions): Promise<void> {
-	const { targetAgents, isGlobal, skipVerify, dryRun, overwrite } = options;
+	const { targetAgents, reportTargetAgents, isGlobal, skipVerify, dryRun, overwrite } = options;
 
 	const installTargets = getPluginInstallTargets(targetAgents, isGlobal);
 
@@ -363,6 +374,11 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 		skipVerify,
 		dryRun,
 	});
+	const installTruth = dryRun ? null : await createPackInstallReporter(
+		(report) => reportPackInstallation(config, slug, report),
+		reportTargetAgents
+	);
+	let expectedSkillCount = 0;
 
 	logger.info(`Adding plugin: @${slug}`);
 	logger.info(`Target agents: ${targetAgents.map((a) => a.name).join(', ')}`);
@@ -379,6 +395,7 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 		// Step 1: Fetch manifest
 		logger.startSpinner('Fetching plugin manifest...');
 		const manifest = await fetchManifest(config, slug);
+		expectedSkillCount = manifest.skills.length;
 		logger.spinnerSuccess(`Fetched manifest for "${manifest.plugin.name}"`);
 
 		// Step 2: Verify manifest
@@ -389,7 +406,7 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			if (!verifyResult.valid) {
 				logger.spinnerError('Manifest verification failed');
 				logger.error(verifyResult.error || 'Unknown verification error');
-				process.exit(1);
+				throw new Error(verifyResult.error || 'Manifest verification failed');
 			}
 
 			if (verifyResult.error) {
@@ -435,19 +452,8 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			}
 		}
 
-		// Step 6: Report installation (non-blocking)
-		if (!dryRun && downloadResult.success > 0) {
-			try {
-				const reportResult = await reportInstallation(config, slug, 'cli');
-				if (reportResult.duplicate) {
-					logger.debug('Installation already recorded');
-				} else if (reportResult.success) {
-					logger.debug('Installation reported successfully');
-				}
-			} catch {
-				logger.debug('Failed to report installation (non-critical)');
-			}
-
+		// Step 6: Report per-skill telemetry independently of Pack truth.
+		if (!dryRun && installTruth && downloadResult.success > 0) {
 			// Report telemetry for each successfully installed skill
 			const newlyInstalledSkillSlugs = [
 				...new Set(downloadResult.results.filter((r) => r.success && !r.skipped).map((r) => r.slug)),
@@ -460,9 +466,29 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			}
 		}
 
+		let installOutcome = derivePackInstallOutcome(expectedSkillCount, 0, false);
+		if (!dryRun && downloadResult.failed === 0) {
+			const readback = await readbackPackInstall(
+				manifest.skills,
+				installTargets.map((target) => target.installDir)
+			);
+			installOutcome = derivePackInstallOutcome(
+				expectedSkillCount,
+				readback.installedSkillCount,
+				readback.readbackPassed
+			);
+			if (readback.failedSkillSlugs.length > 0) {
+				logger.warn(`Install readback failed for: ${readback.failedSkillSlugs.join(', ')}`);
+			}
+		}
+		if (!dryRun) {
+			const reported = await installTruth?.report(installOutcome);
+			if (reported === false) logger.debug('Failed to report installation truth (non-critical)');
+		}
+
 		// Final status
-		if (downloadResult.failed > 0) {
-			logger.warn(`Installation completed with ${downloadResult.failed} failures`);
+		if (!dryRun && installOutcome.status !== 'complete') {
+			logger.warn(`Installation did not complete: ${installOutcome.failedSkillCount} member failure${installOutcome.failedSkillCount === 1 ? '' : 's'}`);
 			process.exit(1);
 		} else if (dryRun) {
 			logger.success('Dry run complete - no files were written');
@@ -471,6 +497,7 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 		}
 	} catch (err) {
 		logger.stopSpinner();
+		await installTruth?.report(derivePackInstallOutcome(expectedSkillCount, 0, false));
 
 		if (err instanceof PluginApiError) {
 			if (err.statusCode === 404) {

--- a/packages/skillstore/src/commands/install.ts
+++ b/packages/skillstore/src/commands/install.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty';
 import { access } from 'node:fs/promises';
 import { getPluginConfig } from '../lib/plugin-config.js';
-import { fetchManifest, reportInstallation, reportSkillInstall, PluginApiError } from '../lib/plugin-api.js';
+import { fetchManifest, reportPackInstallation, reportSkillInstall, PluginApiError } from '../lib/plugin-api.js';
 import {
 	fetchSkillManifest,
 	downloadSkillZip,
@@ -17,6 +17,11 @@ import { CANONICAL_SKILLS_DIR } from '../lib/agents.js';
 import { extractSkillZip, getCanonicalSkillPath, linkSkillToDirectory } from '../lib/installer.js';
 import { addToLock, getLockEntry } from '../lib/skill-lock.js';
 import { lockVerifiedPackMembers } from '../lib/pack-lock.js';
+import {
+	createPackInstallReporter,
+	derivePackInstallOutcome,
+	readbackPackInstall,
+} from '../lib/pack-install-truth.js';
 
 /**
  * Normalize skill/plugin slug
@@ -262,6 +267,10 @@ async function installPlugin(
 		dryRun,
 	});
 	const targetConfig = getPluginConfig({ installDir: dir });
+	const installTruth = dryRun ? null : await createPackInstallReporter(
+		(report) => reportPackInstallation(config, slug, report)
+	);
+	let expectedSkillCount = 0;
 
 	logger.info(`Installing plugin: @${slug}`);
 	logger.info(`Canonical directory: ${CANONICAL_SKILLS_DIR}`);
@@ -275,6 +284,7 @@ async function installPlugin(
 		// Step 1: Fetch manifest
 		logger.startSpinner('Fetching plugin manifest...');
 		const manifest = await fetchManifest(config, slug);
+		expectedSkillCount = manifest.skills.length;
 		logger.spinnerSuccess(`Fetched manifest for "${manifest.plugin.name}"`);
 
 		// Step 2: Verify manifest
@@ -285,7 +295,7 @@ async function installPlugin(
 			if (!verifyResult.valid) {
 				logger.spinnerError('Manifest verification failed');
 				logger.error(verifyResult.error || 'Unknown verification error');
-				process.exit(1);
+				throw new Error(verifyResult.error || 'Manifest verification failed');
 			}
 
 			if (verifyResult.error) {
@@ -327,6 +337,7 @@ async function installPlugin(
 				for (const result of failedLinks) {
 					logger.error(result.error || `Failed to link ${result.path}`);
 				}
+				await installTruth?.report(derivePackInstallOutcome(expectedSkillCount, 0, false));
 				process.exit(1);
 			}
 			logger.spinnerSuccess(`Linked ${linkResults.length} skill${linkResults.length > 1 ? 's' : ''}`);
@@ -336,19 +347,8 @@ async function installPlugin(
 			}
 		}
 
-		// Step 6: Report installation (non-blocking)
-		if (!dryRun && downloadResult.success > 0) {
-			try {
-				const reportResult = await reportInstallation(config, slug, 'cli');
-				if (reportResult.duplicate) {
-					logger.debug('Installation already recorded');
-				} else if (reportResult.success) {
-					logger.debug('Installation reported successfully');
-				}
-			} catch {
-				logger.debug('Failed to report installation (non-critical)');
-			}
-
+		// Step 6: Report per-skill telemetry independently of Pack truth.
+		if (!dryRun && installTruth && downloadResult.success > 0) {
 			// Report telemetry for each successfully installed skill
 			const successfulSkills = downloadResult.results.filter(
 				(r) => r.success && !r.skipped
@@ -363,9 +363,26 @@ async function installPlugin(
 			}
 		}
 
+		let installOutcome = derivePackInstallOutcome(expectedSkillCount, 0, false);
+		if (!dryRun && downloadResult.failed === 0) {
+			const readback = await readbackPackInstall(manifest.skills, [targetConfig.installDir]);
+			installOutcome = derivePackInstallOutcome(
+				expectedSkillCount,
+				readback.installedSkillCount,
+				readback.readbackPassed
+			);
+			if (readback.failedSkillSlugs.length > 0) {
+				logger.warn(`Install readback failed for: ${readback.failedSkillSlugs.join(', ')}`);
+			}
+		}
+		if (!dryRun) {
+			const reported = await installTruth?.report(installOutcome);
+			if (reported === false) logger.debug('Failed to report installation truth (non-critical)');
+		}
+
 		// Final status
-		if (downloadResult.failed > 0) {
-			logger.warn(`Installation completed with ${downloadResult.failed} failures`);
+		if (!dryRun && installOutcome.status !== 'complete') {
+			logger.warn(`Installation did not complete: ${installOutcome.failedSkillCount} member failure${installOutcome.failedSkillCount === 1 ? '' : 's'}`);
 			process.exit(1);
 		} else if (dryRun) {
 			logger.success('Dry run complete - no files were written');
@@ -374,6 +391,7 @@ async function installPlugin(
 		}
 	} catch (err) {
 		logger.stopSpinner();
+		await installTruth?.report(derivePackInstallOutcome(expectedSkillCount, 0, false));
 
 		if (err instanceof PluginApiError) {
 			if (err.statusCode === 404) {

--- a/packages/skillstore/src/commands/plugin/install.ts
+++ b/packages/skillstore/src/commands/plugin/install.ts
@@ -1,11 +1,17 @@
 import { defineCommand } from 'citty';
 import { getPluginConfig } from '../../lib/plugin-config.js';
-import { fetchManifest, reportInstallation, PluginApiError } from '../../lib/plugin-api.js';
+import { fetchManifest, reportPackInstallation, PluginApiError } from '../../lib/plugin-api.js';
 import { verifyManifest } from '../../lib/plugin-verify.js';
 import { downloadAllSkills, printDownloadSummary } from '../../lib/plugin-download.js';
 import { logger } from '../../lib/plugin-logger.js';
 import { CANONICAL_SKILLS_DIR } from '../../lib/agents.js';
 import { linkSkillToDirectory } from '../../lib/installer.js';
+import { lockVerifiedPackMembers } from '../../lib/pack-lock.js';
+import {
+	createPackInstallReporter,
+	derivePackInstallOutcome,
+	readbackPackInstall,
+} from '../../lib/pack-install-truth.js';
 
 export default defineCommand({
 	meta: {
@@ -49,6 +55,10 @@ export default defineCommand({
 			dryRun,
 		});
 		const targetConfig = getPluginConfig({ installDir: dir });
+		const installTruth = dryRun ? null : await createPackInstallReporter(
+			(report) => reportPackInstallation(config, slug, report)
+		);
+		let expectedSkillCount = 0;
 
 		logger.info(`Installing plugin: ${slug}`);
 		logger.info(`Canonical directory: ${CANONICAL_SKILLS_DIR}`);
@@ -62,6 +72,7 @@ export default defineCommand({
 			// Step 1: Fetch manifest
 			logger.startSpinner('Fetching plugin manifest...');
 			const manifest = await fetchManifest(config, slug);
+			expectedSkillCount = manifest.skills.length;
 			logger.spinnerSuccess(`Fetched manifest for "${manifest.plugin.name}"`);
 
 			// Step 2: Verify manifest
@@ -72,7 +83,7 @@ export default defineCommand({
 				if (!verifyResult.valid) {
 					logger.spinnerError('Manifest verification failed');
 					logger.error(verifyResult.error || 'Unknown verification error');
-					process.exit(1);
+					throw new Error(verifyResult.error || 'Manifest verification failed');
 				}
 
 				if (verifyResult.error) {
@@ -115,29 +126,36 @@ export default defineCommand({
 					for (const result of failedLinks) {
 						logger.error(result.error || `Failed to link ${result.path}`);
 					}
+					await installTruth?.report(derivePackInstallOutcome(expectedSkillCount, 0, false));
 					process.exit(1);
 				}
 				logger.spinnerSuccess(`Linked ${linkResults.length} skill${linkResults.length > 1 ? 's' : ''}`);
-			}
-
-			// Step 6: Report installation (non-blocking)
-			if (!dryRun && downloadResult.success > 0) {
-				try {
-					const reportResult = await reportInstallation(config, slug, 'cli');
-					if (reportResult.duplicate) {
-						logger.debug('Installation already recorded');
-					} else if (reportResult.success) {
-						logger.debug('Installation reported successfully');
-					}
-				} catch {
-					// Don't fail on report error
-					logger.debug('Failed to report installation (non-critical)');
+				const lockResult = await lockVerifiedPackMembers(config, manifest.skills, downloadResult);
+				if (lockResult.skipped > 0) {
+					logger.warn(`${lockResult.skipped} pack member${lockResult.skipped > 1 ? 's were' : ' was'} installed but left unlocked`);
 				}
 			}
 
+			let installOutcome = derivePackInstallOutcome(expectedSkillCount, 0, false);
+			if (!dryRun && downloadResult.failed === 0) {
+				const readback = await readbackPackInstall(manifest.skills, [targetConfig.installDir]);
+				installOutcome = derivePackInstallOutcome(
+					expectedSkillCount,
+					readback.installedSkillCount,
+					readback.readbackPassed
+				);
+				if (readback.failedSkillSlugs.length > 0) {
+					logger.warn(`Install readback failed for: ${readback.failedSkillSlugs.join(', ')}`);
+				}
+			}
+			if (!dryRun) {
+				const reported = await installTruth?.report(installOutcome);
+				if (reported === false) logger.debug('Failed to report installation truth (non-critical)');
+			}
+
 			// Final status
-			if (downloadResult.failed > 0) {
-				logger.warn(`Installation completed with ${downloadResult.failed} failures`);
+			if (!dryRun && installOutcome.status !== 'complete') {
+				logger.warn(`Installation did not complete: ${installOutcome.failedSkillCount} member failure${installOutcome.failedSkillCount === 1 ? '' : 's'}`);
 				process.exit(1);
 			} else if (dryRun) {
 				logger.success('Dry run complete - no files were written');
@@ -146,6 +164,7 @@ export default defineCommand({
 			}
 		} catch (err) {
 			logger.stopSpinner();
+			await installTruth?.report(derivePackInstallOutcome(expectedSkillCount, 0, false));
 
 			if (err instanceof PluginApiError) {
 				if (err.statusCode === 404) {

--- a/packages/skillstore/src/index.ts
+++ b/packages/skillstore/src/index.ts
@@ -12,6 +12,7 @@ export {
 	downloadSkill,
 	downloadSkillFile,
 	reportInstallation,
+	reportPackInstallation,
 	PluginApiError,
 	type PluginManifest,
 	type ManifestSkill,
@@ -22,6 +23,13 @@ export {
 	type PluginListResponse,
 	type InstallReportResponse,
 } from './lib/plugin-api.js';
+
+export type {
+	PackInstallStatus,
+	InstallOsPlatform,
+	PackInstallOutcome,
+	PackInstallReport,
+} from './lib/pack-install-truth.js';
 
 // Re-export skill API for programmatic usage
 export {

--- a/packages/skillstore/src/lib/pack-install-truth.ts
+++ b/packages/skillstore/src/lib/pack-install-truth.ts
@@ -1,0 +1,292 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir, platform } from 'node:os';
+import { isAbsolute, join, normalize, resolve, sep } from 'node:path';
+import type { ManifestSkill } from './plugin-api.js';
+import { getCanonicalSkillPath, sanitizeName } from './installer.js';
+import { getLockEntry, type SkillLockEntry } from './skill-lock.js';
+import { CLI_VERSION } from './version.js';
+
+export type PackInstallStatus = 'complete' | 'partial' | 'error';
+export type InstallOsPlatform = 'darwin' | 'linux' | 'win32' | 'other';
+
+export interface PackInstallAttempt {
+	attemptId: string;
+	anonymousClientId: string;
+}
+
+export interface PackInstallOutcome {
+	status: PackInstallStatus;
+	expectedSkillCount: number;
+	installedSkillCount: number;
+	failedSkillCount: number;
+	readbackPassed: boolean;
+}
+
+export interface PackInstallReport extends PackInstallOutcome {
+	method: 'cli';
+	attemptId: string;
+	anonymousClientId: string;
+	cliVersion: string;
+	osPlatform: InstallOsPlatform;
+	targetAgents?: string[];
+}
+
+export interface PackInstallReadback {
+	installedSkillCount: number;
+	failedSkillCount: number;
+	readbackPassed: boolean;
+	failedSkillSlugs: string[];
+}
+
+export interface PackInstallReportResult {
+	success: boolean;
+	duplicate?: boolean;
+}
+
+export interface PackInstallAttemptReporter {
+	attemptId: string;
+	report: (outcome: PackInstallOutcome) => Promise<boolean>;
+}
+
+const anonymousClientIds = new Map<string, string>();
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function defaultConfigDirectory(): string {
+	const configured = process.env.SKILLSTORE_CONFIG_DIR?.trim();
+	if (configured) return configured;
+	const xdg = process.env.XDG_CONFIG_HOME?.trim();
+	return join(xdg || join(homedir(), '.config'), 'skillstore');
+}
+
+function isUuid(value: string): boolean {
+	return UUID_PATTERN.test(value.trim());
+}
+
+/**
+ * Return a random anonymous installation identifier persisted in the user's
+ * config directory. The value contains no host, account, path, or device data.
+ * When the directory is not writable, it remains stable for this CLI process.
+ */
+export async function getAnonymousClientId(configDirectory = defaultConfigDirectory()): Promise<string> {
+	const cached = anonymousClientIds.get(configDirectory);
+	if (cached) return cached;
+
+	const idPath = join(configDirectory, 'anonymous-client-id');
+	try {
+		const existing = (await readFile(idPath, 'utf8')).trim();
+		if (isUuid(existing)) {
+			anonymousClientIds.set(configDirectory, existing);
+			return existing;
+		}
+	} catch {
+		// Missing/unreadable state falls through to a new anonymous identifier.
+	}
+
+	const generated = randomUUID();
+	anonymousClientIds.set(configDirectory, generated);
+
+	try {
+		await mkdir(configDirectory, { recursive: true, mode: 0o700 });
+		try {
+			await writeFile(idPath, `${generated}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+			const concurrent = (await readFile(idPath, 'utf8')).trim();
+			if (isUuid(concurrent)) {
+				anonymousClientIds.set(configDirectory, concurrent);
+				return concurrent;
+			}
+		}
+	} catch {
+		// Telemetry must never make installation fail. Keep the in-process ID.
+	}
+
+	return generated;
+}
+
+export async function createPackInstallAttempt(): Promise<PackInstallAttempt> {
+	return {
+		attemptId: randomUUID(),
+		anonymousClientId: await getAnonymousClientId(),
+	};
+}
+
+export function isInstallTelemetryDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env.DO_NOT_TRACK === '1' || env.SKILLSTORE_TELEMETRY_DISABLED === '1';
+}
+
+export function getInstallOsPlatform(value = platform()): InstallOsPlatform {
+	return value === 'darwin' || value === 'linux' || value === 'win32' ? value : 'other';
+}
+
+export function derivePackInstallOutcome(
+	expectedSkillCount: number,
+	installedSkillCount: number,
+	readbackPassed: boolean
+): PackInstallOutcome {
+	const expected = Math.max(0, expectedSkillCount);
+	const installed = Math.max(0, Math.min(installedSkillCount, expected));
+	const failed = Math.max(0, expected - installed);
+	const complete = expected > 0 && installed === expected && failed === 0 && readbackPassed;
+	const status: PackInstallStatus = complete ? 'complete' : installed > 0 ? 'partial' : 'error';
+
+	return {
+		status,
+		expectedSkillCount: expected,
+		installedSkillCount: installed,
+		failedSkillCount: failed,
+		readbackPassed: complete,
+	};
+}
+
+export function createPackInstallReport(
+	attempt: PackInstallAttempt,
+	outcome: PackInstallOutcome,
+	targetAgents?: string[]
+): PackInstallReport {
+	const normalizedAgents = targetAgents
+		? [...new Set(targetAgents.map((agent) => agent.trim()).filter(Boolean))].slice(0, 32)
+		: undefined;
+	return {
+		method: 'cli',
+		attemptId: attempt.attemptId,
+		anonymousClientId: attempt.anonymousClientId,
+		...outcome,
+		cliVersion: CLI_VERSION,
+		osPlatform: getInstallOsPlatform(),
+		...(normalizedAgents && normalizedAgents.length > 0
+			? { targetAgents: normalizedAgents }
+			: {}),
+	};
+}
+
+/** Best-effort reporting must never replace the install command's exit result. */
+export async function reportPackInstallBestEffort(
+	report: PackInstallReport,
+	reporter: (report: PackInstallReport) => Promise<PackInstallReportResult>
+): Promise<boolean> {
+	try {
+		const result = await reporter(report);
+		return result.success || result.duplicate === true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Create one reporter per real CLI invocation. Repeated finalization calls use
+ * the same attempt ID and never emit a second request from this process.
+ */
+export async function createPackInstallReporter(
+	reporter: (report: PackInstallReport) => Promise<PackInstallReportResult>,
+	targetAgents?: string[]
+): Promise<PackInstallAttemptReporter | null> {
+	if (isInstallTelemetryDisabled()) return null;
+	const attempt = await createPackInstallAttempt();
+	let result: Promise<boolean> | undefined;
+	return {
+		attemptId: attempt.attemptId,
+		report(outcome) {
+			result ??= reportPackInstallBestEffort(
+				createPackInstallReport(attempt, outcome, targetAgents),
+				reporter
+			);
+			return result;
+		},
+	};
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function lockMatchesMember(lock: SkillLockEntry | undefined, member: ManifestSkill): boolean {
+	if (!lock) return false;
+	const authorVersion = hasOwn(member, 'authorVersion')
+		? member.authorVersion ?? null
+		: member.version ?? null;
+	const version = member.version ?? authorVersion;
+	const versionStatus = member.versionStatus || (authorVersion ? 'legacy_unknown' : 'missing');
+
+	return lock.slug === member.slug
+		&& lock.version === version
+		&& (lock.authorVersion ?? null) === authorVersion
+		&& (lock.skillstoreRevision ?? null) === (member.skillstoreRevision ?? null)
+		&& lock.versionStatus === versionStatus
+		&& (lock.treeHash ?? null) === (member.treeHash ?? null)
+		&& !!lock.zipHash;
+}
+
+interface ReadbackDependencies {
+	readPath: (path: string) => Promise<Uint8Array>;
+	readLockEntry: (slug: string) => Promise<SkillLockEntry | undefined>;
+}
+
+const defaultReadbackDependencies: ReadbackDependencies = {
+	readPath: async (path) => readFile(path),
+	readLockEntry: getLockEntry,
+};
+
+function getMemberArtifactPaths(member: ManifestSkill): string[] {
+	const paths = member.artifact?.files?.length
+		? member.artifact.files.map((file) => file.path)
+		: ['SKILL.md'];
+	return [...new Set(paths)];
+}
+
+function resolveReadbackPath(root: string, filePath: string): string {
+	if (!filePath || isAbsolute(filePath)) throw new Error('Invalid artifact path');
+	const normalizedPath = normalize(filePath);
+	if (normalizedPath === '..' || normalizedPath.startsWith(`..${sep}`)) {
+		throw new Error('Invalid artifact path');
+	}
+	const resolvedRoot = resolve(root);
+	const resolvedPath = resolve(resolvedRoot, normalizedPath);
+	if (resolvedPath !== resolvedRoot && resolvedPath.startsWith(`${resolvedRoot}${sep}`)) {
+		return resolvedPath;
+	}
+	throw new Error('Invalid artifact path');
+}
+
+/**
+ * Verify the durable post-install state. A member counts only when its
+ * canonical SKILL.md, every requested target link/copy, and matching lock entry
+ * can all be read back after writes finish.
+ */
+export async function readbackPackInstall(
+	members: ManifestSkill[],
+	targetDirectories: string[],
+	dependencies: ReadbackDependencies = defaultReadbackDependencies
+): Promise<PackInstallReadback> {
+	const uniqueTargetDirectories = [...new Set(targetDirectories)];
+	const failedSkillSlugs: string[] = [];
+
+	for (const member of members) {
+		try {
+			const canonicalRoot = getCanonicalSkillPath(member.slug);
+			for (const artifactPath of getMemberArtifactPaths(member)) {
+				const canonicalBytes = await dependencies.readPath(resolveReadbackPath(canonicalRoot, artifactPath));
+				for (const targetDirectory of uniqueTargetDirectories) {
+					const targetRoot = join(targetDirectory, sanitizeName(member.slug));
+					const targetBytes = await dependencies.readPath(resolveReadbackPath(targetRoot, artifactPath));
+					if (!Buffer.from(targetBytes).equals(Buffer.from(canonicalBytes))) {
+						throw new Error('Target content mismatch');
+					}
+				}
+			}
+			const lock = await dependencies.readLockEntry(member.slug);
+			if (!lockMatchesMember(lock, member)) throw new Error('Lock identity mismatch');
+		} catch {
+			failedSkillSlugs.push(member.slug);
+		}
+	}
+
+	const installedSkillCount = members.length - failedSkillSlugs.length;
+	return {
+		installedSkillCount,
+		failedSkillCount: failedSkillSlugs.length,
+		readbackPassed: members.length > 0 && failedSkillSlugs.length === 0,
+		failedSkillSlugs,
+	};
+}

--- a/packages/skillstore/src/lib/plugin-api.ts
+++ b/packages/skillstore/src/lib/plugin-api.ts
@@ -1,4 +1,5 @@
 import type { PluginConfig } from './plugin-config.js';
+import type { PackInstallReport } from './pack-install-truth.js';
 import {
 	getManifestUrl,
 	getInstallUrl,
@@ -338,6 +339,24 @@ export async function reportInstallation(
 	pluginSlug: string,
 	method: 'npm' | 'manual' | 'cli' = 'cli'
 ): Promise<InstallReportResponse> {
+	return postInstallation(config, pluginSlug, { method }, config.timeout);
+}
+
+/** Report the final durable result of one CLI Pack install attempt. */
+export async function reportPackInstallation(
+	config: PluginConfig,
+	pluginSlug: string,
+	report: PackInstallReport
+): Promise<InstallReportResponse> {
+	return postInstallation(config, pluginSlug, report, Math.min(config.timeout, 5000));
+}
+
+async function postInstallation(
+	config: PluginConfig,
+	pluginSlug: string,
+	body: { method: 'npm' | 'manual' | 'cli' } | PackInstallReport,
+	timeout: number
+): Promise<InstallReportResponse> {
 	const url = getInstallUrl(config, pluginSlug);
 
 	const response = await fetch(url, {
@@ -346,8 +365,8 @@ export async function reportInstallation(
 			'Content-Type': 'application/json',
 			Accept: 'application/json',
 		},
-		body: JSON.stringify({ method }),
-		signal: AbortSignal.timeout(config.timeout),
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(timeout),
 	});
 
 	// Accept both success and rate-limited responses

--- a/packages/skillstore/src/lib/version.ts
+++ b/packages/skillstore/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const CLI_VERSION = '0.1.10';

--- a/packages/skillstore/tests/install-command.test.ts
+++ b/packages/skillstore/tests/install-command.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
 	extractSkillZip: vi.fn(),
 	linkSkillToDirectory: vi.fn(),
 	addToLock: vi.fn(),
+	getLockEntry: vi.fn(),
 	reportSkillInstall: vi.fn(),
 }));
 
@@ -39,7 +40,7 @@ vi.mock('../src/lib/plugin-verify.js', () => ({
 
 vi.mock('../src/lib/plugin-api.js', () => ({
 	fetchManifest: vi.fn(),
-	reportInstallation: vi.fn(),
+	reportPackInstallation: vi.fn(),
 	reportSkillInstall: mocks.reportSkillInstall,
 	PluginApiError: class PluginApiError extends Error {},
 }));
@@ -76,6 +77,7 @@ vi.mock('../src/lib/installer.js', () => ({
 
 vi.mock('../src/lib/skill-lock.js', () => ({
 	addToLock: mocks.addToLock,
+	getLockEntry: mocks.getLockEntry,
 }));
 
 import installCommand from '../src/commands/install.js';
@@ -112,6 +114,7 @@ describe('install command', () => {
 			symlinkFailed: false,
 		});
 		mocks.addToLock.mockResolvedValue(undefined);
+		mocks.getLockEntry.mockResolvedValue(undefined);
 		mocks.reportSkillInstall.mockResolvedValue(undefined);
 	});
 

--- a/packages/skillstore/tests/pack-install-truth.test.ts
+++ b/packages/skillstore/tests/pack-install-truth.test.ts
@@ -1,0 +1,236 @@
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ManifestSkill } from '../src/lib/plugin-api.js';
+import type { SkillLockEntry } from '../src/lib/skill-lock.js';
+import { CLI_VERSION } from '../src/lib/version.js';
+import {
+	createPackInstallReporter,
+	derivePackInstallOutcome,
+	getAnonymousClientId,
+	isInstallTelemetryDisabled,
+	readbackPackInstall,
+	type PackInstallReport,
+} from '../src/lib/pack-install-truth.js';
+
+const originalDoNotTrack = process.env.DO_NOT_TRACK;
+const originalTelemetryDisabled = process.env.SKILLSTORE_TELEMETRY_DISABLED;
+const originalConfigDir = process.env.SKILLSTORE_CONFIG_DIR;
+
+afterEach(() => {
+	if (originalDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
+	else process.env.DO_NOT_TRACK = originalDoNotTrack;
+	if (originalTelemetryDisabled === undefined) delete process.env.SKILLSTORE_TELEMETRY_DISABLED;
+	else process.env.SKILLSTORE_TELEMETRY_DISABLED = originalTelemetryDisabled;
+	if (originalConfigDir === undefined) delete process.env.SKILLSTORE_CONFIG_DIR;
+	else process.env.SKILLSTORE_CONFIG_DIR = originalConfigDir;
+});
+
+describe('Pack install outcomes', () => {
+	it('keeps the reported CLI version aligned with the package version', async () => {
+		const packageJson = JSON.parse(
+			await readFile(new URL('../package.json', import.meta.url), 'utf8')
+		) as { version: string };
+		expect(CLI_VERSION).toBe(packageJson.version);
+	});
+
+	it('classifies only full durable readback as complete', () => {
+		expect(derivePackInstallOutcome(3, 3, true)).toEqual({
+			status: 'complete',
+			expectedSkillCount: 3,
+			installedSkillCount: 3,
+			failedSkillCount: 0,
+			readbackPassed: true,
+		});
+	});
+
+	it('classifies a final partial readback as partial', () => {
+		expect(derivePackInstallOutcome(3, 2, false)).toEqual({
+			status: 'partial',
+			expectedSkillCount: 3,
+			installedSkillCount: 2,
+			failedSkillCount: 1,
+			readbackPassed: false,
+		});
+	});
+
+	it('classifies zero installed members and empty Packs as error', () => {
+		expect(derivePackInstallOutcome(3, 0, false).status).toBe('error');
+		expect(derivePackInstallOutcome(0, 0, true)).toEqual({
+			status: 'error',
+			expectedSkillCount: 0,
+			installedSkillCount: 0,
+			failedSkillCount: 0,
+			readbackPassed: false,
+		});
+	});
+});
+
+describe('anonymous client identity and privacy', () => {
+	it('persists a stable random UUID without device-derived data', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'skillstore-client-id-'));
+		const first = await getAnonymousClientId(directory);
+		const second = await getAnonymousClientId(directory);
+
+		expect(second).toBe(first);
+		expect(first).toMatch(/^[0-9a-f-]{36}$/i);
+		expect((await readFile(join(directory, 'anonymous-client-id'), 'utf8')).trim()).toBe(first);
+	});
+
+	it('uses a stable in-process fallback when the config directory is not writable', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'skillstore-client-id-blocked-'));
+		const blocker = join(directory, 'file-not-directory');
+		await writeFile(blocker, 'blocked');
+		const impossibleDirectory = join(blocker, 'skillstore');
+
+		const first = await getAnonymousClientId(impossibleDirectory);
+		const second = await getAnonymousClientId(impossibleDirectory);
+
+		expect(second).toBe(first);
+		await expect(stat(join(impossibleDirectory, 'anonymous-client-id'))).rejects.toBeDefined();
+	});
+
+	it.each([
+		[{ DO_NOT_TRACK: '1' }, true],
+		[{ SKILLSTORE_TELEMETRY_DISABLED: '1' }, true],
+		[{}, false],
+	] as const)('applies the telemetry opt-out gate', (env, expected) => {
+		expect(isInstallTelemetryDisabled(env)).toBe(expected);
+	});
+
+	it('does not create an ID or reporter when telemetry is disabled', async () => {
+		const parent = await mkdtemp(join(tmpdir(), 'skillstore-dnt-'));
+		const configDirectory = join(parent, 'must-not-exist');
+		process.env.DO_NOT_TRACK = '1';
+		process.env.SKILLSTORE_CONFIG_DIR = configDirectory;
+		const reporter = vi.fn();
+
+		await expect(createPackInstallReporter(reporter)).resolves.toBeNull();
+		expect(reporter).not.toHaveBeenCalled();
+		await expect(stat(configDirectory)).rejects.toBeDefined();
+	});
+});
+
+describe('Pack install reporting', () => {
+	it('reports an attempt at most once with a stable idempotency key', async () => {
+		delete process.env.DO_NOT_TRACK;
+		delete process.env.SKILLSTORE_TELEMETRY_DISABLED;
+		process.env.SKILLSTORE_CONFIG_DIR = await mkdtemp(join(tmpdir(), 'skillstore-report-'));
+		const reports: PackInstallReport[] = [];
+		const reporter = vi.fn(async (report: PackInstallReport) => {
+			reports.push(report);
+			return { success: true };
+		});
+		const attempt = await createPackInstallReporter(reporter, ['codex', 'codex']);
+		const outcome = derivePackInstallOutcome(2, 2, true);
+
+		await expect(attempt?.report(outcome)).resolves.toBe(true);
+		await expect(attempt?.report(derivePackInstallOutcome(2, 0, false))).resolves.toBe(true);
+
+		expect(reporter).toHaveBeenCalledOnce();
+		expect(reports[0]).toMatchObject({
+			method: 'cli',
+			attemptId: attempt?.attemptId,
+			status: 'complete',
+			targetAgents: ['codex'],
+			cliVersion: '0.1.10',
+		});
+	});
+
+	it('contains reporting failures so they cannot replace the install result', async () => {
+		delete process.env.DO_NOT_TRACK;
+		delete process.env.SKILLSTORE_TELEMETRY_DISABLED;
+		process.env.SKILLSTORE_CONFIG_DIR = await mkdtemp(join(tmpdir(), 'skillstore-report-failure-'));
+		const attempt = await createPackInstallReporter(async () => {
+			throw new Error('network unavailable');
+		});
+
+		await expect(attempt?.report(derivePackInstallOutcome(1, 1, true))).resolves.toBe(false);
+	});
+});
+
+describe('Pack install readback', () => {
+	const members: ManifestSkill[] = [
+		{
+			slug: 'owner-one',
+			name: 'One',
+			version: '1.0.0',
+			authorVersion: '1.0.0',
+			skillstoreRevision: 2,
+			versionStatus: 'valid',
+			treeHash: 'a'.repeat(64),
+			contentHash: 'content-one',
+			downloadUrl: '/one',
+			artifact: {
+				files: [
+					{ path: 'SKILL.md', url: '/one/SKILL.md' },
+					{ path: 'references/guide.md', url: '/one/references/guide.md' },
+				],
+			},
+		},
+		{
+			slug: 'owner-two',
+			name: 'Two',
+			version: '2.0.0',
+			authorVersion: '2.0.0',
+			skillstoreRevision: 3,
+			versionStatus: 'valid',
+			treeHash: 'b'.repeat(64),
+			contentHash: 'content-two',
+			downloadUrl: '/two',
+		},
+	];
+
+	function lockFor(member: ManifestSkill): SkillLockEntry {
+		return {
+			slug: member.slug,
+			version: member.version ?? null,
+			authorVersion: member.authorVersion,
+			skillstoreRevision: member.skillstoreRevision,
+			versionStatus: member.versionStatus,
+			treeHash: member.treeHash,
+			zipHash: `zip-${member.slug}`,
+			source: 'skillstore',
+			installedAt: '2026-07-17T00:00:00.000Z',
+			updatedAt: '2026-07-17T00:00:00.000Z',
+		};
+	}
+
+	it('requires canonical files, every actual target directory, and matching locks', async () => {
+		const readPath = vi.fn(async () => new Uint8Array([1, 2, 3]));
+		const result = await readbackPackInstall(members, ['/targets/codex', '/targets/claude'], {
+			readPath,
+			readLockEntry: async (slug) => lockFor(members.find((member) => member.slug === slug)!),
+		});
+
+		expect(result).toEqual({
+			installedSkillCount: 2,
+			failedSkillCount: 0,
+			readbackPassed: true,
+			failedSkillSlugs: [],
+		});
+		expect(readPath.mock.calls.map(([path]) => path)).toEqual(expect.arrayContaining([
+			'/targets/codex/owner-one/SKILL.md',
+			'/targets/claude/owner-one/SKILL.md',
+			'/targets/codex/owner-one/references/guide.md',
+			'/targets/claude/owner-one/references/guide.md',
+			'/targets/codex/owner-two/SKILL.md',
+			'/targets/claude/owner-two/SKILL.md',
+		]));
+	});
+
+	it('counts only members whose final lock and filesystem state read back', async () => {
+		const result = await readbackPackInstall(members, ['/targets/codex'], {
+			readPath: async () => new Uint8Array([1, 2, 3]),
+			readLockEntry: async (slug) => slug === members[0].slug ? lockFor(members[0]) : undefined,
+		});
+
+		expect(result).toEqual({
+			installedSkillCount: 1,
+			failedSkillCount: 1,
+			readbackPassed: false,
+			failedSkillSlugs: ['owner-two'],
+		});
+	});
+});

--- a/packages/skillstore/tests/plugin-api.test.ts
+++ b/packages/skillstore/tests/plugin-api.test.ts
@@ -4,6 +4,7 @@ import {
 	fetchPluginInfo,
 	fetchPluginList,
 	reportInstallation,
+	reportPackInstallation,
 	downloadSkill,
 	downloadSkillFile,
 	reportSkillTelemetry,
@@ -17,6 +18,7 @@ import {
 	type TelemetryEvent,
 } from '../src/lib/plugin-api.js';
 import { getPluginConfig, type PluginConfig } from '../src/lib/plugin-config.js';
+import type { PackInstallReport } from '../src/lib/pack-install-truth.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -414,37 +416,72 @@ describe('plugin-api', () => {
 	});
 
 	describe('reportInstallation', () => {
-		it('should report installation with default method', async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: () => Promise.resolve({ success: true, installationId: 'inst-123' }),
-			});
-
-			const result = await reportInstallation(config, 'test-plugin');
-
-			expect(mockFetch).toHaveBeenCalledWith(
-				'https://api.test.com/packs/test-plugin/install',
-				expect.objectContaining({
-					method: 'POST',
-					body: JSON.stringify({ method: 'cli' }),
-				})
-			);
-			expect(result.success).toBe(true);
-		});
-
-		it('should report installation with custom method', async () => {
+		it('preserves the legacy SDK reporting contract', async () => {
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
 				json: () => Promise.resolve({ success: true }),
 			});
 
-			await reportInstallation(config, 'test-plugin', 'npm');
+			await reportInstallation(config, 'test-plugin', 'manual');
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://api.test.com/packs/test-plugin/install',
+				expect.objectContaining({ body: JSON.stringify({ method: 'manual' }) })
+			);
+		});
+	});
+
+	describe('reportPackInstallation', () => {
+		const completeReport: PackInstallReport = {
+			method: 'cli',
+			attemptId: '11111111-1111-4111-8111-111111111111',
+			anonymousClientId: '22222222-2222-4222-8222-222222222222',
+			status: 'complete',
+			expectedSkillCount: 2,
+			installedSkillCount: 2,
+			failedSkillCount: 0,
+			cliVersion: '0.1.10',
+			osPlatform: 'linux',
+			targetAgents: ['codex'],
+			readbackPassed: true,
+		};
+
+		it('should report the complete CLI installation truth payload', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ success: true, installationId: 'inst-123' }),
+			});
+
+			const result = await reportPackInstallation(config, 'test-plugin', completeReport);
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://api.test.com/packs/test-plugin/install',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify(completeReport),
+				})
+			);
+			expect(result.success).toBe(true);
+		});
+
+		it.each(['partial', 'error'] as const)('should preserve a %s outcome', async (status) => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ success: true }),
+			});
+
+			const report: PackInstallReport = {
+				...completeReport,
+				status,
+				installedSkillCount: status === 'partial' ? 1 : 0,
+				failedSkillCount: status === 'partial' ? 1 : 2,
+				readbackPassed: false,
+			};
+			await reportPackInstallation(config, 'test-plugin', report);
 
 			expect(mockFetch).toHaveBeenCalledWith(
 				expect.any(String),
-				expect.objectContaining({
-					body: JSON.stringify({ method: 'npm' }),
-				})
+					expect.objectContaining({ body: JSON.stringify(report) })
 			);
 		});
 
@@ -459,7 +496,7 @@ describe('plugin-api', () => {
 				json: () => Promise.resolve(response),
 			});
 
-			const result = await reportInstallation(config, 'test-plugin');
+			const result = await reportPackInstallation(config, 'test-plugin', completeReport);
 
 			expect(result.duplicate).toBe(true);
 		});


### PR DESCRIPTION
## Summary
- report one idempotent UUID attempt for every real CLI Pack install, with complete/partial/error based on final link, lockfile, and filesystem readback
- persist a random anonymous client ID without device fingerprinting, honor DO_NOT_TRACK and SKILLSTORE_TELEMETRY_DISABLED, and keep reporting best-effort
- cover all three Pack entry points while preserving the legacy SDK reporting API
- bump the package and CLI-reported version to 0.1.10 (no tag or release in this PR)

## Truth rules
- complete: every expected member is downloaded/written, linked to every actual target, locked with matching immutable identity, and all artifact files read back byte-for-byte
- partial: at least one, but not every, member passes the final durable readback
- error: zero members pass, or an earlier atomic phase fails; partial downloads that were not linked/locked report error

## Privacy
- anonymousClientId is a persisted random UUID, not a device fingerprint
- DO_NOT_TRACK=1 or SKILLSTORE_TELEMETRY_DISABLED=1 prevents ID generation/storage and all Pack telemetry
- no username, filesystem path, device ID, or contact data is reported

## Verification
- CI=true pnpm check
- CI=true pnpm build
- CI=true pnpm vitest run tests/*.test.ts
- 15 test files, 282 tests passed
- node dist/cli/index.js --version => 0.1.10

This PR intentionally does not merge, tag, or publish the CLI.