### PR TITLE
fix(sync): rebind canonical tree hashes

### DIFF
--- a/skills/0nl1n1n/sitemapkit/skill-report.json
+++ b/skills/0nl1n1n/sitemapkit/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "b81153761f011d7bf956dcd6c890ee5d6eba8e3c9344bed728a94dd264878f18",
-    "tree_hash": "90d6db990c318eae4c3772a5d3db4286f9dc57426fe238bcba9775c17f66c6a2",
+    "tree_hash": "fc4938c93bc40aa3076e3ca0112652d3cec7ff10e890f73303f5326a12a74d50",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/ceeon/aippt/skill-report.json
+++ b/skills/ceeon/aippt/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "5e6955f556bc9b40d8ab555ca9188f02b52c4500e35108f93f047295376a002b",
-    "tree_hash": "42c09da92f8adea8322c7231433eea5cc0e1dcd715de71de9a1bf5bd51660b87",
+    "tree_hash": "867c9bc583bbfa9a3e38cd08f2cd4d1e5f11639705b4f3c4294bc504f6829e25",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/chipflow/context-tools/skill-report.json
+++ b/skills/chipflow/context-tools/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "1a839ce2b5a4a20537d74ebb1c736bdcfd7a0fee60b826370d4aa1834719c2e5",
-    "tree_hash": "8d1aca365e8020453adcd6b5e8c12c67bcf70eb25ca8a43e9fed10c529497fee",
+    "tree_hash": "b63255863cf22984b0457ebfee8e01a76f3a17526f5faa0e8108751e4fe43bd8",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [


### PR DESCRIPTION
## Summary

- rebind the canonical tree hashes for the three packages rejected by incremental sync
- preserve packaged bytes, content hashes, provenance, and fail-closed validation

## Root cause

PR #2621 refreshed the packaged trees, but these three reports retained tree hashes from an older monitor commit. Their SKILL.md content hashes were already correct.

## Validation

- CI=true node --test scripts/tests/rebind-skill-report-hashes.test.mjs
- direct canonical content/tree hash verification for all three packages
- git diff --check

Fixes the data mismatch reported by Actions run 29593149223.