### PR TITLE
fix(review): make deleted legacy packs terminal

### DIFF
--- a/.github/workflows/pack-review.yml
+++ b/.github/workflows/pack-review.yml
@@ -123,6 +123,25 @@ jobs:
               const responseText = await response.text();
               console.log(`Callback response: ${response.status} - ${responseText}`);
 
+              // A legacy review issue can outlive the Pack it referred to. The
+              // callback has already proved that no mutable Pack exists, so a
+              // structured Pack-not-found response is a terminal no-op rather
+              // than a retryable command failure. Keep every other 404/error
+              // fail-closed: an unexpected route or response must remain
+              // visible to reviewers.
+              let callbackError = null;
+              try {
+                callbackError = JSON.parse(responseText);
+              } catch {
+                // Non-JSON error bodies are never safe to downgrade.
+              }
+              const isMissingLegacyPack = response.status === 404
+                && callbackError?.message === 'Pack not found';
+              if (isMissingLegacyPack) {
+                core.notice(`Callback no-op: legacy Pack ${packId} no longer exists`);
+                return;
+              }
+
               if (!response.ok) {
                 core.setFailed(`Callback failed: ${response.status} - ${responseText}`);
                 // Add failure reaction

--- a/scripts/tests/pack-production-manual-publish.test.mjs
+++ b/scripts/tests/pack-production-manual-publish.test.mjs
@@ -469,4 +469,7 @@ test('legacy Pack review refuses guide replacement and marked v4 generation comm
   assert.match(workflow, /Pack Production v4 can only be published by the generation-bound production workflow/);
   assert.doesNotMatch(workflow, /const guideMatch =/);
   assert.match(workflow, /modifiedGuide: null/);
+  assert.match(workflow, /const isMissingLegacyPack = response\.status === 404/);
+  assert.match(workflow, /callbackError\?\.message === 'Pack not found'/);
+  assert.match(workflow, /Callback no-op: legacy Pack/);
 });


### PR DESCRIPTION
## Summary

- treat only the structured 404 Pack not found callback as a terminal no-op
- keep non-JSON 404s, authentication failures, issue mismatches, and all other callback errors fail-closed

## Why

Legacy review issues can outlive the Pack record they reference. Retrying such a command cannot recover the deleted record and should not present as a platform CI outage.

## Validation

- CI=true node --test scripts/tests/pack-production-manual-publish.test.mjs (11/11)
- git diff --check

Addresses Actions run 29577878798.