### PR TITLE
fix(ci): roll out translation-only Codex credential

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  PACK_PRODUCTION_CLI_VERSION: '2.14.2'
+  PACK_PRODUCTION_CLI_VERSION: '2.14.6'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 

--- a/.github/workflows/translate-packs.yml
+++ b/.github/workflows/translate-packs.yml
@@ -101,6 +101,7 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+          SKILLSTORE_TRANSLATION_CODEX_API_KEY: ${{ secrets.SKILLSTORE_TRANSLATION_CODEX_API_KEY }}
           SKILLSTORE_AGENT_ENV_MODE: strict
           SLUGS: ${{ steps.detect.outputs.slugs_csv }}
           CONCURRENCY: ${{ inputs.concurrency || '5' }}

--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -403,6 +403,8 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+          SKILLSTORE_TRANSLATION_CODEX_API_KEY: ${{ secrets.SKILLSTORE_TRANSLATION_CODEX_API_KEY }}
+          SKILLSTORE_AGENT_ENV_MODE: strict
           SLUGS: ${{ matrix.slugs }}
           OFFSET: ${{ matrix.offset }}
           LIMIT: ${{ matrix.limit }}
@@ -577,6 +579,8 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+          SKILLSTORE_TRANSLATION_CODEX_API_KEY: ${{ secrets.SKILLSTORE_TRANSLATION_CODEX_API_KEY }}
+          SKILLSTORE_AGENT_ENV_MODE: strict
           CONCURRENCY: ${{ inputs.concurrency || '8' }}
           # Audit translation cache ownership will move to its own exact
           # mutation manifest; never allow runner ambient secrets to invalidate here.

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -22,6 +22,7 @@ const ADMISSION_WORKFLOW = readFileSync(
 const SLO_WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/pack-production-slo.yml'), 'utf8');
 const GENERATE_CONTENT = readFileSync(join(REPO_ROOT, '.github/workflows/generate-content.yml'), 'utf8');
 const TRANSLATE_PACKS = readFileSync(join(REPO_ROOT, '.github/workflows/translate-packs.yml'), 'utf8');
+const TRANSLATE_SKILLS = readFileSync(join(REPO_ROOT, '.github/workflows/translate-skills.yml'), 'utf8');
 
 function section(start, end) {
   const startIndex = WORKFLOW.indexOf(start);
@@ -346,7 +347,7 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
     encoding: 'utf8',
     env: {
       PATH: process.env.PATH,
-      PACK_PRODUCTION_CLI_VERSION: '2.14.2',
+      PACK_PRODUCTION_CLI_VERSION: '2.14.6',
       PACK_EVALUATOR_PROXY_TOKEN: 'local-token-that-is-longer-than-thirty-two-bytes',
       PACK_DIAGNOSTICS_DIR: '/tmp',
       PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '0',
@@ -700,7 +701,7 @@ test('planning uses a read-only API and admits at most one artifact scenario', (
   assert.match(finalize, /if: needs\.plan\.outputs\.has_scenarios == 'true'/);
   assert.match(WORKFLOW, /group: generate-pack-production-v4/);
   assert.match(WORKFLOW, /cron: '17 19 \* \* 1,3,5'/);
-  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.2'/);
+  assert.match(WORKFLOW, /PACK_PRODUCTION_CLI_VERSION: '2\.14\.6'/);
   assert.doesNotMatch(WORKFLOW, /2\.12\.0|RELEASE BLOCKER/);
   assert.equal((WORKFLOW.match(/require-checksum: 'true'/g) ?? []).length, 1);
   assert.match(plan, /actions\/create-github-app-token@v3/);
@@ -821,4 +822,15 @@ test('production content is nonce-bound and never dispatches the legacy translat
   assert.match(TRANSLATE_PACKS, /github\.event\.client_payload\.cli_version/);
   assert.match(TRANSLATE_PACKS, /require-checksum: \$\{\{ github\.event\.client_payload\.source_generation_id/);
   assert.match(TRANSLATE_PACKS, /SKILLSTORE_AGENT_ENV_MODE: strict/);
+  assert.equal(
+    (TRANSLATE_PACKS.match(/SKILLSTORE_TRANSLATION_CODEX_API_KEY: \$\{\{ secrets\.SKILLSTORE_TRANSLATION_CODEX_API_KEY \}\}/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (TRANSLATE_SKILLS.match(/SKILLSTORE_TRANSLATION_CODEX_API_KEY: \$\{\{ secrets\.SKILLSTORE_TRANSLATION_CODEX_API_KEY \}\}/g) ?? []).length,
+    2,
+  );
+  assert.equal((TRANSLATE_SKILLS.match(/SKILLSTORE_AGENT_ENV_MODE: strict/g) ?? []).length, 2);
+  assert.doesNotMatch(TRANSLATE_PACKS, /HELM_API_KEY:\s*\$\{\{ secrets\.HELM_API_KEY \}\}/);
+  assert.doesNotMatch(TRANSLATE_SKILLS, /HELM_API_KEY:\s*\$\{\{ secrets\.HELM_API_KEY \}\}/);
 });


### PR DESCRIPTION
## Summary

- inject only the dedicated SKILLSTORE_TRANSLATION_CODEX_API_KEY into translation workflow parents
- keep strict agent isolation enabled for pack, skill, and audit translations
- pin Generate Pack to verified CLI 2.14.6 so generation-bound translation dispatches use the scoped credential implementation
- never expose the production HELM_API_KEY to translation agents

## Production setup

- created a separate Helm key with weekly request and spend caps, RPM/TPM limits, concurrency 5, reject-on-budget-exhaustion, and memory disabled
- stored it as the Marketplace SKILLSTORE_TRANSLATION_CODEX_API_KEY secret

## Validation

- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs (18/18)
- git diff --check

Completes the fix for Actions run 29578063948.