### PR TITLE
fix(pack): separate auxiliary preflight rejections

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -771,13 +771,16 @@ jobs:
                 elif .errorClass == "timeout" then "timeout"
                 else "preflight_failed" end
               ' "$PREFLIGHT_DIAGNOSTICS")
-              PREFLIGHT_STATUS=$(jq -r '.http.fatalStatus // .http.retryableStatus // empty' \
+              PREFLIGHT_STATUS=$(jq -r '.http.inferenceFatalStatus // .http.inferenceRetryableStatus // empty' \
+                "$PREFLIGHT_DIAGNOSTICS")
+              PREFLIGHT_AUXILIARY_REJECTED_COUNT=$(jq -r '.http.auxiliaryRejectedCount // 0' \
                 "$PREFLIGHT_DIAGNOSTICS")
               PREFLIGHT_ERROR_CATEGORY=$(sudo jq -rs '
                 [
                   .[]
                   | select(
                       .phase == "response"
+                      and (.path == "/v1/messages" or .path == "/v1/responses")
                       and (.status | type) == "number"
                       and .status >= 400 and .status < 500
                       and (.status != 408 and .status != 425 and .status != 429)
@@ -805,6 +808,7 @@ jobs:
                 --arg reason "$PREFLIGHT_REASON" \
                 --arg status "$PREFLIGHT_STATUS" \
                 --arg errorCategory "$PREFLIGHT_ERROR_CATEGORY" \
+                --argjson auxiliaryRejectedCount "$PREFLIGHT_AUXILIARY_REJECTED_COUNT" \
                 --arg diagnosticSha256 "$DIAGNOSTIC_SHA256" \
                 '{
                   schemaVersion: "marketplace.pack-production-infrastructure-failure/v1",
@@ -812,6 +816,7 @@ jobs:
                   reason: $reason,
                   status: (if $status == "" then null else ($status | tonumber) end),
                   errorCategory: (if $errorCategory == "" then null else $errorCategory end),
+                  auxiliaryRejectedCount: $auxiliaryRejectedCount,
                   diagnosticSha256: $diagnosticSha256
                 }' > "$INFRASTRUCTURE_FAILURE_FILE"
             fi

--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -86,6 +86,23 @@ activity_start_line() {
   printf '%s\n' "$((lines + 1))"
 }
 
+summarize_preflight_http_activity() {
+  jq -cs '
+    def inference_response:
+      .phase == "response" and
+      (.path == "/v1/messages" or .path == "/v1/responses") and
+      (.status | type) == "number";
+    [ .[] | select(inference_response) ] as $inference |
+    {
+      messages200: ([$inference[] | select(.path == "/v1/messages" and .status == 200)] | length),
+      responses200: ([$inference[] | select(.path == "/v1/responses" and .status == 200)] | length),
+      inferenceFatalStatus: ([$inference[] | select(.status >= 400 and .status < 500 and .status != 408 and .status != 425 and .status != 429) | .status] | first // null),
+      inferenceRetryableStatus: ([$inference[] | select(.status == 408 or .status == 425 or .status == 429 or .status >= 500) | .status] | last // null),
+      auxiliaryRejectedCount: ([.[] | select(.phase == "response" and .path == "not_allowed" and (.status == 401 or .status == 403))] | length)
+    }
+  '
+}
+
 monitor_preflight_http() {
   local command_pid="$1"
   local start_line="$2"
@@ -95,15 +112,11 @@ monitor_preflight_http() {
   while true; do
     if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && \
        sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
-      observed=$(sudo tail -n "+$start_line" "$PACK_EVALUATOR_ACTIVITY_FILE" 2>/dev/null | jq -cs '
-        [ .[] | select(.phase == "response") | .status | select(type == "number") ] as $statuses |
-        {
-          fatal: ([$statuses[] | select(. >= 400 and . < 500 and . != 408 and . != 425 and . != 429)] | first // null),
-          retryable: ([$statuses[] | select(. == 408 or . == 425 or . == 429 or . >= 500)] | last // null)
-        }
-      ' 2>/dev/null || printf '{"fatal":null,"retryable":null}')
-      HTTP_FATAL_STATUS=$(jq -r '.fatal // empty' <<< "$observed")
-      HTTP_RETRYABLE_STATUS=$(jq -r '.retryable // empty' <<< "$observed")
+      observed=$(sudo tail -n "+$start_line" "$PACK_EVALUATOR_ACTIVITY_FILE" 2>/dev/null | \
+        summarize_preflight_http_activity 2>/dev/null || \
+        printf '{"inferenceFatalStatus":null,"inferenceRetryableStatus":null}')
+      HTTP_FATAL_STATUS=$(jq -r '.inferenceFatalStatus // empty' <<< "$observed")
+      HTTP_RETRYABLE_STATUS=$(jq -r '.inferenceRetryableStatus // empty' <<< "$observed")
       if [ -n "$HTTP_FATAL_STATUS" ]; then
         sudo pkill -TERM -u packeval 2>/dev/null || true
         for _ in $(seq 1 20); do
@@ -484,14 +497,12 @@ fi
 if [ -n "${PACK_EVALUATOR_ACTIVITY_FILE:-}" ] && sudo test -f "$PACK_EVALUATOR_ACTIVITY_FILE"; then
   sudo tail -n "+$ACTIVITY_START_LINE" "$PACK_EVALUATOR_ACTIVITY_FILE" > "$ACTIVITY_SLICE" 2>/dev/null || true
 fi
-HTTP_EVIDENCE=$(jq -cs '
-  {
-    messages200: ([.[] | select(.phase == "response" and .path == "/v1/messages" and .status == 200)] | length),
-    responses200: ([.[] | select(.phase == "response" and .path == "/v1/responses" and .status == 200)] | length),
-    fatalStatus: ([.[] | select(.phase == "response" and (.status | type) == "number" and .status >= 400 and .status < 500 and .status != 408 and .status != 425 and .status != 429) | .status] | first // null),
-    retryableStatus: ([.[] | select(.phase == "response" and ((.status == 408) or (.status == 425) or (.status == 429) or (.status >= 500))) | .status] | last // null)
-  }
-' "$ACTIVITY_SLICE" 2>/dev/null || printf '{"messages200":0,"responses200":0,"fatalStatus":null,"retryableStatus":null}')
+HTTP_EVIDENCE=$(summarize_preflight_http_activity < "$ACTIVITY_SLICE" 2>/dev/null || \
+  printf '{"messages200":0,"responses200":0,"inferenceFatalStatus":null,"inferenceRetryableStatus":null,"auxiliaryRejectedCount":0}')
+AUXILIARY_REJECTED_COUNT=$(jq -r '.auxiliaryRejectedCount // 0' <<< "$HTTP_EVIDENCE")
+if [ "$AUXILIARY_REJECTED_COUNT" -gt 0 ]; then
+  echo "::warning::Pack evaluator proxy rejected $AUXILIARY_REJECTED_COUNT auxiliary request(s) outside the inference endpoints"
+fi
 
 jq -n \
   --arg outcome "$PREFLIGHT_OUTCOME" \

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -244,10 +244,12 @@ test('evaluate runs on a disposable VM with a user-separated job-local inference
     assert.match(evaluate, new RegExp(`"${category}"`));
   }
   assert.match(evaluate, /--arg errorCategory "\$PREFLIGHT_ERROR_CATEGORY"/);
+  assert.match(evaluate, /--argjson auxiliaryRejectedCount "\$PREFLIGHT_AUXILIARY_REJECTED_COUNT"/);
   assert.match(
     evaluate,
     /errorCategory: \(if \$errorCategory == "" then null else \$errorCategory end\)/,
   );
+  assert.match(evaluate, /auxiliaryRejectedCount: \$auxiliaryRejectedCount/);
   assert.doesNotMatch(evaluate, /--arg errorCategory "\$PREFLIGHT_REASON"/);
   assert.match(evaluate, /safe_execution_evidence\(\)/);
   assert.match(evaluate, /state_storage/);
@@ -357,6 +359,51 @@ test('evaluator preflight rejects a non-positive Claude output-token cap before 
   assert.match(result.stderr, /PACK_EVALUATOR_MAX_OUTPUT_TOKENS must be a positive integer/);
 });
 
+test('preflight HTTP monitoring separates inference failures from auxiliary rejections', () => {
+  const start = EVALUATOR_PREFLIGHT.indexOf('summarize_preflight_http_activity() {');
+  const end = EVALUATOR_PREFLIGHT.indexOf('\n}\n', start);
+  assert.ok(start >= 0 && end > start, 'HTTP activity summarizer must be extractable');
+  const summarizer = EVALUATOR_PREFLIGHT.slice(start, end + 3);
+  const summarize = (activities) => spawnSync(
+    'bash',
+    ['-c', `${summarizer}\nsummarize_preflight_http_activity`],
+    {
+      encoding: 'utf8',
+      input: `${activities.map((activity) => JSON.stringify(activity)).join('\n')}\n`,
+    },
+  );
+
+  const auxiliaryOnly = summarize([
+    { phase: 'response', path: '/v1/messages', status: 200 },
+    { phase: 'response', path: '/v1/responses', status: 200 },
+    { phase: 'response', path: 'not_allowed', status: 401, errorCategory: 'authentication_failed' },
+    { phase: 'response', path: '/v1/messages/count_tokens', status: 503 },
+    { phase: 'response', path: '/v1/responses/compact', status: 403 },
+  ]);
+  assert.equal(auxiliaryOnly.status, 0, auxiliaryOnly.stderr);
+  assert.deepEqual(JSON.parse(auxiliaryOnly.stdout), {
+    messages200: 1,
+    responses200: 1,
+    inferenceFatalStatus: null,
+    inferenceRetryableStatus: null,
+    auxiliaryRejectedCount: 1,
+  });
+
+  const inferenceFailures = summarize([
+    { phase: 'response', path: '/v1/messages', status: 401 },
+    { phase: 'response', path: '/v1/responses', status: 503 },
+    { phase: 'response', path: 'not_allowed', status: 403 },
+  ]);
+  assert.equal(inferenceFailures.status, 0, inferenceFailures.stderr);
+  assert.deepEqual(JSON.parse(inferenceFailures.stdout), {
+    messages200: 0,
+    responses200: 0,
+    inferenceFatalStatus: 401,
+    inferenceRetryableStatus: 503,
+    auxiliaryRejectedCount: 1,
+  });
+});
+
 test('preflight infrastructure evidence selects the last fatal response before category allowlisting', () => {
   const prefix = "PREFLIGHT_ERROR_CATEGORY=$(sudo jq -rs '\n";
   const suffix = "\n              ' \"$PROXY_ACTIVITY\" 2>/dev/null || true)";
@@ -372,16 +419,18 @@ test('preflight infrastructure evidence selects the last fatal response before c
   });
 
   const allowed = extract([
-    { phase: 'response', status: 403, errorCategory: 'model_not_allowed' },
-    { phase: 'response', status: 400, errorCategory: 'invalid_output_token_limit' },
-    { phase: 'response', status: 503, errorCategory: 'other' },
+    { phase: 'response', path: 'not_allowed', status: 401, errorCategory: 'authentication_failed' },
+    { phase: 'response', path: '/v1/responses', status: 403, errorCategory: 'model_not_allowed' },
+    { phase: 'response', path: '/v1/messages', status: 400, errorCategory: 'invalid_output_token_limit' },
+    { phase: 'response', path: '/v1/responses', status: 503, errorCategory: 'other' },
   ]);
   assert.equal(allowed.status, 0, allowed.stderr);
   assert.equal(allowed.stdout.trim(), 'invalid_output_token_limit');
 
   const rejected = extract([
-    { phase: 'response', status: 403, errorCategory: 'model_not_allowed' },
-    { phase: 'response', status: 400, errorCategory: 'attacker_supplied_category' },
+    { phase: 'response', path: 'not_allowed', status: 401, errorCategory: 'authentication_failed' },
+    { phase: 'response', path: '/v1/responses', status: 403, errorCategory: 'model_not_allowed' },
+    { phase: 'response', path: '/v1/messages', status: 400, errorCategory: 'attacker_supplied_category' },
   ]);
   assert.equal(rejected.status, 0, rejected.stderr);
   assert.equal(rejected.stdout, '');


### PR DESCRIPTION
## Summary

- classify only /v1/messages and /v1/responses activity as inference fatal/retryable
- keep every auxiliary/unknown path rejected by the local proxy
- preserve auxiliary rejection counts in sanitized diagnostics and emit a warning
- keep the exact Agent execution and runner trace gates unchanged

## Root cause

Run 29598122422 proved both inference contracts with 200 responses, then an Agent CLI auxiliary request received 401 on a non-allowed path. The monitor treated every 4xx on every path as an inference credential failure and terminated the valid preflight.

## Validation

- CI=true node --test scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-evaluator-bwrap-userns.test.mjs
- bash -n scripts/pack-evaluator-preflight.sh
- git diff --check

Unknown paths remain denied; this only prevents their denial from being mislabeled as an inference outage.