### PR TITLE
fix(sync): bound cache invalidation fallback

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -915,8 +915,14 @@ jobs:
           CACHE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           CONTENT_TYPE: skills
           CURL_MAX_TIME: '30'
+          # Matrix max-parallel=3, so two item workers cap endpoint pressure at six.
+          FALLBACK_CONCURRENCY: '2'
+          FALLBACK_CURL_MAX_TIME: '30'
+          FALLBACK_MAX_ATTEMPTS: '2'
+          FALLBACK_RETRY_BASE_SECONDS: '2'
           MAX_ATTEMPTS: '3'
           MAX_ITEMS: '100'
+          MAX_RUNTIME_SECONDS: '1200'
           RETRY_BASE_SECONDS: '5'
           SITE_URL: https://skillstore.io
           SLUGS_FILE: ${{ runner.temp }}/cache-invalidation-shard.txt

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -9,9 +9,10 @@ MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 RETRY_BASE_SECONDS="${RETRY_BASE_SECONDS:-5}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
-FALLBACK_MAX_ATTEMPTS="${FALLBACK_MAX_ATTEMPTS:-4}"
-FALLBACK_RETRY_BASE_SECONDS="${FALLBACK_RETRY_BASE_SECONDS:-5}"
-FALLBACK_CURL_MAX_TIME="${FALLBACK_CURL_MAX_TIME:-90}"
+FALLBACK_MAX_ATTEMPTS="${FALLBACK_MAX_ATTEMPTS:-2}"
+FALLBACK_RETRY_BASE_SECONDS="${FALLBACK_RETRY_BASE_SECONDS:-2}"
+FALLBACK_CURL_MAX_TIME="${FALLBACK_CURL_MAX_TIME:-30}"
+FALLBACK_CONCURRENCY="${FALLBACK_CONCURRENCY:-2}"
 MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-1200}"
 CONTENT_TYPE="${CONTENT_TYPE:-}"
 SLUGS_STR="${SLUGS_STR:-}"
@@ -110,6 +111,13 @@ if ! [[ "$FALLBACK_MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
   [ "$FALLBACK_MAX_ATTEMPTS" -lt 1 ] ||
   [ "$FALLBACK_MAX_ATTEMPTS" -gt 10 ]; then
   echo "::error::FALLBACK_MAX_ATTEMPTS must be between 1 and 10" >&2
+  exit 1
+fi
+
+if ! [[ "$FALLBACK_CONCURRENCY" =~ ^[0-9]+$ ]] ||
+  [ "$FALLBACK_CONCURRENCY" -lt 1 ] ||
+  [ "$FALLBACK_CONCURRENCY" -gt 4 ]; then
+  echo "::error::FALLBACK_CONCURRENCY must be between 1 and 4" >&2
   exit 1
 fi
 
@@ -241,7 +249,11 @@ request_batch_once() {
       echo "    Cache invalidation response violated the requested contract" >&2
       return 76
       ;;
-    408|429|5[0-9][0-9])
+    408)
+      echo "    Transient HTTP $status timeout" >&2
+      return 78
+      ;;
+    429|5[0-9][0-9])
       echo "    Transient HTTP $status" >&2
       return 75
       ;;
@@ -258,7 +270,11 @@ request_batch_once() {
     ''|000)
       if [ "$curl_exit" -ne 0 ]; then
         case "$curl_exit" in
-          5|6|7|16|18|28|35|52|55|56|92)
+          28)
+            echo "    Transient curl timeout (exit $curl_exit)" >&2
+            return 78
+            ;;
+          5|6|7|16|18|35|52|55|56|92)
             echo "    Transient curl transport failure (exit $curl_exit)" >&2
             return 75
             ;;
@@ -289,6 +305,7 @@ invalidate_batch() {
   local max_attempts="$3"
   local retry_base_seconds="$4"
   local max_time="$5"
+  local stop_on_timeout="${6:-false}"
   local attempt
   local delay
   local request_status
@@ -305,6 +322,14 @@ invalidate_batch() {
 
     if [ "$request_status" -eq 0 ]; then
       return 0
+    fi
+
+    if [ "$request_status" -eq 78 ]; then
+      if [ "$stop_on_timeout" = "true" ]; then
+        echo "    Multi-item timeout will use the item-level fallback without another batch retry" >&2
+        return 78
+      fi
+      request_status=75
     fi
 
     if [ "$request_status" -ne 75 ]; then
@@ -347,6 +372,105 @@ SUCCESS_ITEMS_FILE="$WORK_DIR/success-items"
 record_success() {
   printf '%s\n' "$1" >> "$SUCCESS_ITEMS_FILE"
   SUCCESS=$((SUCCESS + 1))
+  echo "::notice::Cache invalidation completed for item: $1"
+}
+
+FALLBACK_PIDS=()
+FALLBACK_SLUGS=()
+FALLBACK_MARKERS=()
+
+wait_fallback_wave() {
+  local index
+  local marker
+  local pid
+  local slug
+
+  for index in "${!FALLBACK_PIDS[@]}"; do
+    pid="${FALLBACK_PIDS[$index]}"
+    slug="${FALLBACK_SLUGS[$index]}"
+    marker="${FALLBACK_MARKERS[$index]}"
+
+    # The marker, not a background exit status, is the completion evidence.
+    # wait remains inside a conditional so set -e cannot hide later failures.
+    if wait "$pid"; then
+      :
+    fi
+
+    if [ -f "$marker" ] && [ "$(cat "$marker")" = "success" ]; then
+      record_success "$slug"
+    else
+      echo "::error::Cache invalidation failed for item: $slug" >&2
+    fi
+  done
+
+  FALLBACK_PIDS=()
+  FALLBACK_SLUGS=()
+  FALLBACK_MARKERS=()
+}
+
+run_fallback_item() {
+  local body_file="$1"
+  local request_label="$2"
+  local marker="$3"
+
+  if invalidate_batch \
+    "$body_file" \
+    "$request_label" \
+    "$FALLBACK_MAX_ATTEMPTS" \
+    "$FALLBACK_RETRY_BASE_SECONDS" \
+    "$FALLBACK_CURL_MAX_TIME" \
+    false; then
+    printf 'success\n' > "$marker"
+    return 0
+  fi
+
+  printf 'failed\n' > "$marker"
+  return 1
+}
+
+fallback_batch_items() {
+  local batch_number="$1"
+  shift
+  local batch=("$@")
+  local body_file
+  local index
+  local marker
+  local remaining
+  local request_label
+  local slug
+
+  echo "::warning::Using ${#batch[@]} item-level fallback request(s), concurrency=$FALLBACK_CONCURRENCY" >&2
+  for index in "${!batch[@]}"; do
+    slug="${batch[$index]}"
+    body_file="$WORK_DIR/body-$batch_number-fallback-$index.json"
+    marker="$WORK_DIR/result-$batch_number-fallback-$index"
+    request_label="batch-$batch_number-fallback-$index"
+
+    if ! create_body "$body_file" "$slug"; then
+      return 1
+    fi
+
+    remaining=$(remaining_seconds)
+    if [ "$remaining" -lt 1 ]; then
+      printf 'failed\n' > "$marker"
+      echo "::error::No runtime budget remains for item: $slug" >&2
+      continue
+    fi
+
+    echo "    Fallback $((index + 1))/${#batch[@]}: $slug"
+    run_fallback_item "$body_file" "$request_label" "$marker" &
+    FALLBACK_PIDS+=("$!")
+    FALLBACK_SLUGS+=("$slug")
+    FALLBACK_MARKERS+=("$marker")
+
+    if [ "${#FALLBACK_PIDS[@]}" -ge "$FALLBACK_CONCURRENCY" ]; then
+      wait_fallback_wave
+    fi
+  done
+
+  if [ "${#FALLBACK_PIDS[@]}" -gt 0 ]; then
+    wait_fallback_wave
+  fi
 }
 
 finish_invalidation() {
@@ -378,6 +502,8 @@ BATCHES=$(((TOTAL + BATCH_SIZE - 1) / BATCH_SIZE))
 
 echo "Invalidating $TOTAL $CONTENT_TYPE item(s) in $BATCHES batch(es)"
 
+BATCH_TIMEOUT_DEGRADED=false
+
 for ((offset = 0; offset < TOTAL; offset += BATCH_SIZE)); do
   BATCH=("${SLUGS[@]:offset:BATCH_SIZE}")
   BATCH_NUMBER=$((offset / BATCH_SIZE + 1))
@@ -389,46 +515,40 @@ for ((offset = 0; offset < TOTAL; offset += BATCH_SIZE)); do
   fi
 
   echo "  Batch $BATCH_NUMBER/$BATCHES (${#BATCH[@]} items)"
-  if invalidate_batch \
-    "$BODY_FILE" \
-    "batch-$BATCH_NUMBER" \
-    "$MAX_ATTEMPTS" \
-    "$RETRY_BASE_SECONDS" \
-    "$CURL_MAX_TIME"; then
-    for slug in "${BATCH[@]}"; do
-      record_success "$slug"
-    done
-    continue
+  if [ "$BATCH_TIMEOUT_DEGRADED" = "true" ] && [ "${#BATCH[@]}" -gt 1 ]; then
+    echo "::warning::Skipping multi-item request for batch $BATCH_NUMBER/$BATCHES after an earlier batch timeout" >&2
+    batch_status=78
   else
-    batch_status=$?
+    if invalidate_batch \
+      "$BODY_FILE" \
+      "batch-$BATCH_NUMBER" \
+      "$MAX_ATTEMPTS" \
+      "$RETRY_BASE_SECONDS" \
+      "$CURL_MAX_TIME" \
+      "$([ "${#BATCH[@]}" -gt 1 ] && printf true || printf false)"; then
+      for slug in "${BATCH[@]}"; do
+        record_success "$slug"
+      done
+      continue
+    else
+      batch_status=$?
+    fi
   fi
-  if { [ "$batch_status" -ne 75 ] && [ "$batch_status" -ne 76 ]; } ||
+
+  if [ "$batch_status" -eq 78 ] && [ "${#BATCH[@]}" -gt 1 ]; then
+    BATCH_TIMEOUT_DEGRADED=true
+  fi
+
+  if { [ "$batch_status" -ne 75 ] && [ "$batch_status" -ne 76 ] && [ "$batch_status" -ne 78 ]; } ||
     [ "${#BATCH[@]}" -eq 1 ]; then
     echo "::error::Cache invalidation batch $BATCH_NUMBER/$BATCHES failed without a safe fallback" >&2
     continue
   fi
 
-  echo "::warning::Batch $BATCH_NUMBER/$BATCHES failed; falling back to ${#BATCH[@]} single-item request(s)" >&2
-  for index in "${!BATCH[@]}"; do
-    slug="${BATCH[$index]}"
-    FALLBACK_BODY_FILE="$WORK_DIR/body-$BATCH_NUMBER-fallback-$index.json"
-    if ! create_body "$FALLBACK_BODY_FILE" "$slug"; then
-      finish_invalidation || true
-      exit 1
-    fi
-
-    echo "    Fallback $((index + 1))/${#BATCH[@]}: $slug"
-    if invalidate_batch \
-      "$FALLBACK_BODY_FILE" \
-      "batch-$BATCH_NUMBER-fallback-$index" \
-      "$FALLBACK_MAX_ATTEMPTS" \
-      "$FALLBACK_RETRY_BASE_SECONDS" \
-      "$FALLBACK_CURL_MAX_TIME"; then
-      record_success "$slug"
-      continue
-    fi
-
-  done
+  if ! fallback_batch_items "$BATCH_NUMBER" "${BATCH[@]}"; then
+    finish_invalidation || true
+    exit 1
+  fi
 done
 
 if ! finish_invalidation; then

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -51,6 +51,9 @@ test('workflow matrix is artifact-backed, id-only, bounded, and max-parallel 3',
   assert.match(shardJob, /--shard-id "\$\{\{ matrix\.shard \}\}"/);
   assert.match(shardJob, /SLUGS_FILE: .*cache-invalidation-shard\.txt/);
   assert.match(shardJob, /MAX_ITEMS: ['"]100['"]/);
+  assert.match(shardJob, /FALLBACK_CONCURRENCY: ['"]2['"]/);
+  assert.match(shardJob, /FALLBACK_MAX_ATTEMPTS: ['"]2['"]/);
+  assert.match(shardJob, /MAX_RUNTIME_SECONDS: ['"]1200['"]/);
   assert.doesNotMatch(shardJob, /needs\.sync\.outputs\.synced_slugs/);
 });
 

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -23,12 +23,17 @@ const FAKE_CURL = `#!/usr/bin/env bash
 set -u
 
 count_file="$FAKE_CURL_LOG_DIR/count"
+count_lock="$FAKE_CURL_LOG_DIR/count.lock"
+while ! mkdir "$count_lock" 2>/dev/null; do
+  :
+done
 count=0
 if [ -f "$count_file" ]; then
   count=$(cat "$count_file")
 fi
 count=$((count + 1))
 printf '%s' "$count" > "$count_file"
+rmdir "$count_lock"
 
 response_file=""
 payload_arg=""
@@ -160,6 +165,7 @@ function runInvalidator({
   fallbackMaxAttempts = 2,
   fallbackRetryBaseSeconds = 1,
   fallbackCurlMaxTime = 9,
+  fallbackConcurrency = 1,
   results = 'http:200',
   contentType = 'skills',
   mktempFails = false,
@@ -200,6 +206,7 @@ function runInvalidator({
       FALLBACK_MAX_ATTEMPTS: String(fallbackMaxAttempts),
       FALLBACK_RETRY_BASE_SECONDS: String(fallbackRetryBaseSeconds),
       FALLBACK_CURL_MAX_TIME: String(fallbackCurlMaxTime),
+      FALLBACK_CONCURRENCY: String(fallbackConcurrency),
       CURL_CONNECT_TIMEOUT: '1',
       CURL_MAX_TIME: '2',
       GITHUB_OUTPUT: githubOutput,
@@ -317,8 +324,8 @@ test('temporary workspace failure fails closed before making an HTTP request', (
   assert.match(result.stderr, /Failed to create temporary workspace/);
 });
 
-test('retryable curl transport failures retry the same idempotent batch', () => {
-  for (const exitCode of [5, 6, 7, 16, 18, 28, 35, 52, 55, 56, 92]) {
+test('retryable non-timeout curl transport failures retry the same idempotent batch', () => {
+  for (const exitCode of [5, 6, 7, 16, 18, 35, 52, 55, 56, 92]) {
     const { result, payloads, sleeps } = runInvalidator({
       slugs: 'alpha,beta',
       results: `transport:${exitCode},http:200`,
@@ -468,7 +475,88 @@ test('status 000 with curl exit 28 uses transport retries within the finite budg
   assert.equal(payloads.length, 3);
   assert.ok(payloads.every((payload) => JSON.stringify(payload) === JSON.stringify(payloads[0])));
   assert.deepEqual(sleeps, ['1', '2']);
-  assert.match(result.stderr, /Transient curl transport failure \(exit 28\)/);
+  assert.match(result.stderr, /Transient curl timeout \(exit 28\)/);
+});
+
+test('a multi-item timeout skips batch retries and latches item fallback for later batches', () => {
+  const { result, payloads, sleeps, outputs } = runInvalidator({
+    slugs: 'alpha,beta,gamma,delta,epsilon,zeta',
+    batchSize: 2,
+    maxAttempts: 3,
+    fallbackConcurrency: 1,
+    results: 'transport:28,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.deepEqual(payloads.map((payload) => payload.slugs), [
+    ['alpha', 'beta'],
+    ['alpha'],
+    ['beta'],
+    ['gamma'],
+    ['delta'],
+    ['epsilon'],
+    ['zeta'],
+  ]);
+  assert.deepEqual(sleeps, []);
+  assert.match(result.stderr, /without another batch retry/);
+  assert.equal(
+    (result.stderr.match(/Skipping multi-item request/g) || []).length,
+    2,
+  );
+  assert.deepEqual(outputs, {
+    total_count: 6,
+    success_count: 6,
+    failed_count: 0,
+  });
+});
+
+test('parallel item fallback preserves one completion result for every requested item', () => {
+  const { result, payloads, outputs } = runInvalidator({
+    slugs: 'alpha,beta,gamma,delta',
+    batchSize: 4,
+    fallbackConcurrency: 2,
+    results: 'transport:28,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.deepEqual(payloads[0].slugs, ['alpha', 'beta', 'gamma', 'delta']);
+  assert.deepEqual(
+    payloads.slice(1).map((payload) => payload.slugs[0]).sort(),
+    ['alpha', 'beta', 'delta', 'gamma'],
+  );
+  assert.equal((result.stdout.match(/completed for item:/g) || []).length, 4);
+  assert.deepEqual(outputs, {
+    total_count: 4,
+    success_count: 4,
+    failed_count: 0,
+  });
+  assert.equal(outputs.total_count, outputs.success_count + outputs.failed_count);
+});
+
+test('the 78-item timeout shape completes through one batch probe and item evidence only', () => {
+  const slugs = Array.from({ length: 78 }, (_, index) => `sync-item-${index}`);
+  const { result, payloads, sleeps, outputs } = runInvalidator({
+    slugs: slugs.join(','),
+    batchSize: 10,
+    fallbackConcurrency: 2,
+    results: 'transport:28,http:200',
+  });
+
+  assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.equal(payloads.length, 79);
+  assert.deepEqual(payloads[0].slugs, slugs.slice(0, 10));
+  assert.ok(payloads.slice(1).every((payload) => payload.slugs.length === 1));
+  assert.deepEqual(
+    payloads.slice(1).map((payload) => payload.slugs[0]).sort(),
+    [...slugs].sort(),
+  );
+  assert.deepEqual(sleeps, []);
+  assert.equal((result.stdout.match(/completed for item:/g) || []).length, 78);
+  assert.deepEqual(outputs, {
+    total_count: 78,
+    success_count: 78,
+    failed_count: 0,
+  });
 });
 
 test('non-transient curl failures fail closed without retrying the failed batch', () => {
@@ -588,8 +676,12 @@ test('sync workflow uses an artifact-backed bounded invalidator and preserves do
   assert.match(invalidationJob, /BATCH_SIZE: ['"]10['"]/);
   assert.match(invalidationJob, /CONTENT_TYPE: skills/);
   assert.match(invalidationJob, /CURL_MAX_TIME: ['"]30['"]/);
+  assert.match(invalidationJob, /FALLBACK_CONCURRENCY: ['"]2['"]/);
+  assert.match(invalidationJob, /FALLBACK_CURL_MAX_TIME: ['"]30['"]/);
+  assert.match(invalidationJob, /FALLBACK_MAX_ATTEMPTS: ['"]2['"]/);
   assert.match(invalidationJob, /MAX_ATTEMPTS: ['"]3['"]/);
   assert.match(invalidationJob, /MAX_ITEMS: ['"]100['"]/);
+  assert.match(invalidationJob, /MAX_RUNTIME_SECONDS: ['"]1200['"]/);
   assert.match(invalidationJob, /run: \.\/scripts\/invalidate-cache\.sh/);
   assert.doesNotMatch(invalidationJob, /uses: \.\/\.github\/actions\/invalidate-cache/);
   assert.doesNotMatch(invalidationJob, /curl .*api\/cache\/invalidate/);
@@ -623,14 +715,24 @@ test('each cache invalidation shard has a hard runtime deadline below its own ti
     MAX_ATTEMPTS: readInteger('MAX_ATTEMPTS'),
     CURL_MAX_TIME: readInteger('CURL_MAX_TIME'),
     RETRY_BASE_SECONDS: readInteger('RETRY_BASE_SECONDS'),
+    FALLBACK_CONCURRENCY: readInteger('FALLBACK_CONCURRENCY'),
+    FALLBACK_MAX_ATTEMPTS: readInteger('FALLBACK_MAX_ATTEMPTS'),
+    FALLBACK_CURL_MAX_TIME: readInteger('FALLBACK_CURL_MAX_TIME'),
+    FALLBACK_RETRY_BASE_SECONDS: readInteger('FALLBACK_RETRY_BASE_SECONDS'),
     MAX_ITEMS: readInteger('MAX_ITEMS'),
+    MAX_RUNTIME_SECONDS: readInteger('MAX_RUNTIME_SECONDS'),
   };
   const expectedSettings = {
     BATCH_SIZE: 10,
     MAX_ATTEMPTS: 3,
     CURL_MAX_TIME: 30,
     RETRY_BASE_SECONDS: 5,
+    FALLBACK_CONCURRENCY: 2,
+    FALLBACK_MAX_ATTEMPTS: 2,
+    FALLBACK_CURL_MAX_TIME: 30,
+    FALLBACK_RETRY_BASE_SECONDS: 2,
     MAX_ITEMS: 100,
+    MAX_RUNTIME_SECONDS: 1200,
   };
   const violations = [];
 
@@ -648,26 +750,15 @@ test('each cache invalidation shard has a hard runtime deadline below its own ti
   }
   assert.deepEqual(violations, []);
 
-  const maxBatches = Math.ceil(settings.MAX_ITEMS / settings.BATCH_SIZE);
-  const retrySleepSeconds = settings.RETRY_BASE_SECONDS
-    * ((settings.MAX_ATTEMPTS - 1) * settings.MAX_ATTEMPTS / 2);
-  const worstSecondsPerBatch = settings.MAX_ATTEMPTS * settings.CURL_MAX_TIME
-    + retrySleepSeconds;
-  const worstCaseSeconds = maxBatches * worstSecondsPerBatch;
-
-  assert.equal(maxBatches, 10);
-  assert.equal(worstSecondsPerBatch, 105);
-  assert.equal(worstCaseSeconds, 1050);
-  assert.ok(worstCaseSeconds < timeoutMinutes * 60);
-
   const runtimeMatch = invalidator.match(
     /^MAX_RUNTIME_SECONDS="\$\{MAX_RUNTIME_SECONDS:-([0-9]+)\}"$/m,
   );
   assert.ok(runtimeMatch, 'invalidator must declare a fixed default runtime deadline');
   const maxRuntimeSeconds = Number(runtimeMatch[1]);
-  assert.ok(maxRuntimeSeconds <= 1200);
+  assert.equal(maxRuntimeSeconds, settings.MAX_RUNTIME_SECONDS);
   assert.ok(
-    maxRuntimeSeconds <= timeoutMinutes * 60 - 60,
-    'script deadline must leave at least one minute for setup and teardown',
+    maxRuntimeSeconds <= timeoutMinutes * 60 - 300,
+    'script deadline must leave five minutes for setup and teardown',
   );
+  assert.equal(3 * settings.FALLBACK_CONCURRENCY, 6, 'matrix-wide fallback pressure must stay capped');
 });


### PR DESCRIPTION
## Summary
- stop repeating multi-item requests after the first timeout and latch item-level fallback for remaining batches
- cap fallback concurrency and require an item-specific completion marker plus the existing strict response contract
- reserve five minutes for workflow teardown with an explicit 1200-second script deadline

## Safety
- keeps downstream aggregate, finalizer, and translation gates fail-closed
- does not count missing markers, timeouts, or invalid responses as success
- limits matrix-wide fallback pressure to six requests

## Validation
- `bash -n scripts/invalidate-cache.sh`
- `CI=true node --test scripts/tests/invalidate-cache.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` (34/34)
- 78-item timeout regression: one batch probe plus 78 item completion records
- `git diff --check`

Follow-up after merge: dispatch a new `sync-to-supabase.yml` run from `main` for the original synced slug artifact. A rerun of 29595605454 would use the old workflow SHA.
