### PR TITLE
fix(pack): scope evaluator HTTP circuit

### DIFF
--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -192,6 +192,7 @@ const INFRASTRUCTURE_ERROR_CATEGORIES = new Set([
   'model_not_allowed',
   'invalid_output_token_limit',
 ]);
+const INFERENCE_HTTP_PATHS = new Set(['/v1/messages', '/v1/responses']);
 const INTERRUPTED_SIGNALS = new Set(['SIGINT', 'SIGTERM', 'SIGHUP']);
 
 export function normalizeInterruptedSignal(value) {
@@ -286,13 +287,15 @@ export function deterministicHttpFailureFromActivity(contents) {
       continue;
     }
     if (!['response', 'circuit_open'].includes(activity?.phase)) continue;
+    const path = safeActivityToken(activity.path);
+    if (!INFERENCE_HTTP_PATHS.has(path)) continue;
     const status = Number(activity.status);
     if (!Number.isSafeInteger(status) || status < 400 || status >= 500 || [408, 425, 429].includes(status)) {
       continue;
     }
     return {
       status,
-      path: safeActivityToken(activity.path),
+      path,
       model: safeActivityToken(activity.model),
       requestNumber: Number.isSafeInteger(activity.requestNumber) ? activity.requestNumber : null,
       errorType: safeActivityToken(activity.errorType),

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -447,11 +447,20 @@ test('v4 causal stages are allowlisted as bounded evaluator progress', () => {
   );
 });
 
-test('deterministic HTTP activity excludes only bounded retryable statuses', () => {
+test('deterministic HTTP activity is scoped to exact inference paths', () => {
   const retryable = [408, 425, 429, 500, 503]
-    .map((status) => JSON.stringify({ phase: 'response', status }))
+    .map((status) => JSON.stringify({ phase: 'response', path: '/v1/messages', status }))
     .join('\n');
   assert.equal(deterministicHttpFailureFromActivity(retryable), null);
+  assert.equal(deterministicHttpFailureFromActivity([
+    { phase: 'response', path: 'not_allowed', status: 401 },
+    { phase: 'response', path: '/v1/messages/count_tokens', status: 403 },
+    { phase: 'circuit_open', path: '/v1/responses/compact', status: 422 },
+    { phase: 'response', status: 400 },
+  ].map((activity) => JSON.stringify(activity)).join('\n')), null);
+  assert.equal(deterministicHttpFailureFromActivity(JSON.stringify({
+    phase: 'response', path: '/v1/responses', status: 401,
+  }))?.path, '/v1/responses');
   const failure = deterministicHttpFailureFromActivity([
     retryable,
     JSON.stringify({
@@ -973,6 +982,40 @@ test('external proxy activity extends the idle deadline without exposing request
   assert.equal(result.status, 0);
   assert.equal(result.stalled, false);
   assert.equal(result.timedOut, false);
+});
+
+test('auxiliary proxy rejection does not terminate in-flight inference', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'pack-production-auxiliary-activity-'));
+  const activityFile = join(directory, 'proxy.activity');
+  const progressFile = join(directory, 'progress.ndjson');
+  writeFileSync(activityFile, [
+    { phase: 'response', requestNumber: 1, path: 'not_allowed', status: 401 },
+    { phase: 'started', requestNumber: 2, path: '/v1/messages', model: 'claude-sonnet-5' },
+    { phase: 'started', requestNumber: 3, path: '/v1/messages', model: 'claude-sonnet-5' },
+  ].map((activity) => JSON.stringify(activity)).join('\n'));
+  const result = await runEvaluatorProcess(
+    process.execPath,
+    ['-e', 'setTimeout(() => process.exit(0), 180)'],
+    {
+      cwd: directory,
+      env: process.env,
+      stdoutFile: join(directory, 'stdout.json'),
+      stderrFile: join(directory, 'run.log'),
+      progressFile,
+      externalActivityFile: activityFile,
+      label: 'executor-preflight',
+      heartbeatMs: 20,
+      idleTimeoutMs: 5_000,
+      timeoutMs: 1_000,
+      killGraceMs: 100,
+      onProgress: () => {},
+    },
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+  assert.equal(result.deterministicHttpFailure, null);
+  assert.doesNotMatch(readFileSync(progressFile, 'utf8'), /scenario\.deterministic_http_failure/);
 });
 
 test('mid-evaluation deterministic 4xx opens the circuit and terminates the scenario', async () => {


### PR DESCRIPTION
## Root cause
The evaluator has a second 500 ms activity scanner inside `runEvaluatorProcess()`. It still treated the auxiliary `not_allowed` 401 as a deterministic inference 4xx and sent SIGTERM while two real `/v1/messages` requests were in flight.

## Fix
- allow only exact `/v1/messages` and `/v1/responses` activity to open the internal deterministic HTTP circuit
- keep exact inference 4xx fatal and fail-closed
- add a process-level regression for auxiliary 401 followed by in-flight inference

## Preserved gates
- proxy allowlist unchanged
- inference preflight unchanged
- Agent execution evidence unchanged
- runner-trace gate unchanged
- mid-evaluation inference 4xx still terminates the evaluator

## Validation
- `CI=true node --test scripts/tests/pack-production.test.mjs scripts/tests/generate-packs-workflow.test.mjs scripts/tests/pack-evaluator-proxy.test.mjs`
- 71 passed, 1 Linux-only skip, 0 failed
- `git diff --check`
