### PR TITLE
fix(sync): restore pinned resolver runtime

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -42,6 +42,42 @@ jobs:
           # Full history needed to diff against last successful sync
           fetch-depth: 0
 
+      - name: Normalize pinned sync runtime checkout
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::workflow SHA is not an exact 40-character commit"
+            exit 1
+          fi
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::checkout SHA mismatch: expected=$EXPECTED_SHA actual=$checked_out_sha"
+            exit 1
+          fi
+          # Self-hosted runners can retain sparse-checkout state even when this
+          # job did not request it. The resolvers are pinned-tree readers, so
+          # restore their exact workflow-commit bytes before any plan is made.
+          git sparse-checkout disable
+          git reset --hard "$EXPECTED_SHA"
+          for required_path in \
+            scripts/resolve-manual-skills.mjs \
+            scripts/detect-changed-skills.mjs \
+            scripts/materialize-changed-skills.mjs \
+            .github/actions/download-skillstore-cli/action.yml; do
+            if [ ! -f "$required_path" ] || [ -L "$required_path" ]; then
+              echo "::error::required pinned runtime file is missing or not regular: $required_path"
+              exit 1
+            fi
+            expected_blob=$(git rev-parse "$EXPECTED_SHA:$required_path")
+            actual_blob=$(git hash-object "$required_path")
+            if [ "$actual_blob" != "$expected_blob" ]; then
+              echo "::error::runtime file does not match workflow commit: $required_path"
+              exit 1
+            fi
+          done
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -110,6 +110,25 @@ test('incremental detection resolves both sides from pinned Git trees', () => {
   assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
 });
 
+test('sync normalizes a retained sparse checkout before invoking pinned-tree resolvers', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const checkout = section(workflow, '      - name: Checkout repository', '      - name: Generate GitHub App Token');
+  const runtime = section(workflow, '      - name: Normalize pinned sync runtime checkout', '      - name: Generate GitHub App Token');
+  const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+
+  assert.match(checkout, /fetch-depth: 0/);
+  assert.match(runtime, /checked_out_sha=\$\(git rev-parse HEAD\)/);
+  assert.match(runtime, /git sparse-checkout disable[\s\S]*git reset --hard "\$EXPECTED_SHA"/);
+  assert.match(runtime, /scripts\/resolve-manual-skills\.mjs/);
+  assert.match(runtime, /scripts\/detect-changed-skills\.mjs/);
+  assert.match(runtime, /scripts\/materialize-changed-skills\.mjs/);
+  assert.match(runtime, /\.github\/actions\/download-skillstore-cli\/action\.yml/);
+  assert.match(runtime, /git rev-parse "\$EXPECTED_SHA:\$required_path"/);
+  assert.match(runtime, /git hash-object "\$required_path"/);
+  assert.ok(workflow.indexOf('      - name: Normalize pinned sync runtime checkout') < workflow.indexOf('      - name: Detect changed skills'));
+  assert.match(detect, /node \.\/scripts\/resolve-manual-skills\.mjs/);
+});
+
 test('sync materializes only the detected paths from the exact workflow commit', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const materialize = section(workflow, '      - name: Materialize changed skills', '      - name: Sync skills to Supabase');


### PR DESCRIPTION
## Root cause
A self-hosted runner retained sparse-checkout state, so manual sync planning could not load `scripts/resolve-manual-skills.mjs` even after checkout.

## Fix
- verify checkout is the exact workflow SHA
- disable retained sparse-checkout state and reset to that commit before planning
- fail closed unless all pinned resolver/materializer/downloader files exist as regular files and their blobs match the workflow commit

## Safety
No resolver, content hash, aggregate, cache, or downstream success gate is relaxed.

## Validation
- `CI=true node --test scripts/tests/resolve-manual-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` (14/14)
- `git diff --check`

Reproduction: Sync run 29602825858, `Detect changed skills`, missing `scripts/resolve-manual-skills.mjs`.
