### PR TITLE
fix(pack): retain bounded preflight trace diagnostics

### DIFF
--- a/scripts/pack-evaluator-preflight.sh
+++ b/scripts/pack-evaluator-preflight.sh
@@ -226,6 +226,49 @@ safe_runner_trace_evidence() {
   ' "$source" 2>/dev/null || printf 'null\n'
 }
 
+safe_runner_trace_diagnostics() {
+  local source="$1"
+  jq -c '
+    def bounded_boolean: . == null or (type == "boolean");
+    def bounded_count: . == null or (type == "number" and . >= 0 and . <= 1000000);
+    def failure_reason: . as $reason | $reason == null or ([
+      "invalid-bindings", "unsupported-agent", "malformed-stream-json",
+      "missing-result-event", "duplicate-result-event", "agent-result-error",
+      "agent-execution-failed", "missing-skill-use", "malformed-skill-use",
+      "unknown-skill-use", "missing-skill-result", "failed-skill-result",
+      "unknown-tool-result", "duplicate-tool-result", "out-of-order-skill-result",
+      "missing-bound-skill", "unknown"
+    ] | index($reason) != null);
+    .runnerTraceDiagnostics as $diagnostics
+    | if (
+        ($diagnostics | type) == "object"
+        and $diagnostics.schemaVersion == "marketplace.pack-executor-preflight-diagnostics/v1"
+        and (["passed", "failed", "unknown"] | index($diagnostics.cliOutcome) != null)
+        and ($diagnostics.verification | type) == "object"
+        and ($diagnostics.verification.passed | bounded_boolean)
+        and ($diagnostics.verification.verdictCount | bounded_count)
+        and ($diagnostics.verification.errorCount | bounded_count)
+        and ($diagnostics.verification.usedSkill | bounded_boolean)
+        and ($diagnostics.verification.usedSkillCount | bounded_count)
+        and ($diagnostics.verification.taskCompleted | bounded_boolean)
+        and ($diagnostics.verification.envBlocked | bounded_boolean)
+        and ($diagnostics.traceCount | bounded_count)
+        and ($diagnostics.tracesTruncated | type) == "boolean"
+        and ($diagnostics.traces | type) == "array"
+        and ($diagnostics.traces | length) <= 4
+        and all($diagnostics.traces[];
+          (.schemaValid | type) == "boolean"
+          and (["claude", "codex", "gemini", "unknown"] | index(.agent) != null)
+          and (["claude-stream-json-v1", "unsupported-agent", "unknown"] | index(.source) != null)
+          and (.deterministic | bounded_boolean)
+          and (.eventCount | bounded_count)
+          and (.eventsTruncated | type) == "boolean"
+          and (.failureReason | failure_reason)
+        )
+      ) then $diagnostics else null end
+  ' "$source" 2>/dev/null || printf 'null\n'
+}
+
 safe_outer_execution() {
   local source="$1"
   jq -c '
@@ -334,6 +377,7 @@ HTTP_FATAL_STATUS=''
 HTTP_RETRYABLE_STATUS=''
 FINAL_EXECUTION_EVIDENCE='[]'
 FINAL_RUNNER_TRACE_EVIDENCE='null'
+FINAL_RUNNER_TRACE_DIAGNOSTICS='null'
 FINAL_OUTER_EXECUTION='{}'
 
 for ATTEMPT in 1 2; do
@@ -393,6 +437,7 @@ for ATTEMPT in 1 2; do
   STDERR_SHA256=$(sha256sum "$CLI_STDERR" | awk '{print $1}')
   FINAL_EXECUTION_EVIDENCE=$(safe_execution_evidence "$CLI_STDOUT")
   FINAL_RUNNER_TRACE_EVIDENCE=$(safe_runner_trace_evidence "$CLI_STDOUT")
+  FINAL_RUNNER_TRACE_DIAGNOSTICS=$(safe_runner_trace_diagnostics "$CLI_STDOUT")
   FINAL_OUTER_EXECUTION=$(safe_outer_execution "$CLI_STDOUT")
 
   if [ -n "$HTTP_FATAL_STATUS" ]; then
@@ -510,6 +555,7 @@ jq -n \
   --argjson commandAttempts "$COMMAND_ATTEMPTS" \
   --argjson executionEvidence "$FINAL_EXECUTION_EVIDENCE" \
   --argjson runnerTraceEvidence "$FINAL_RUNNER_TRACE_EVIDENCE" \
+  --argjson runnerTraceDiagnostics "$FINAL_RUNNER_TRACE_DIAGNOSTICS" \
   --argjson outerExecution "$FINAL_OUTER_EXECUTION" \
   --argjson http "$HTTP_EVIDENCE" \
   --arg cleanupOutcome "$CLEANUP_OUTCOME" \
@@ -526,6 +572,7 @@ jq -n \
     outerExecution: $outerExecution,
     agentExecutionEvidence: $executionEvidence,
     runnerTraceEvidence: $runnerTraceEvidence,
+    runnerTraceDiagnostics: $runnerTraceDiagnostics,
     http: $http,
     cleanup: { outcome: $cleanupOutcome, retryOutcome: $retryCleanupOutcome },
     proofBinding: {

--- a/scripts/pack-production.mjs
+++ b/scripts/pack-production.mjs
@@ -194,6 +194,24 @@ const INFRASTRUCTURE_ERROR_CATEGORIES = new Set([
 ]);
 const INFERENCE_HTTP_PATHS = new Set(['/v1/messages', '/v1/responses']);
 const INTERRUPTED_SIGNALS = new Set(['SIGINT', 'SIGTERM', 'SIGHUP']);
+const RUNNER_TRACE_FAILURE_REASONS = new Set([
+  'invalid-bindings',
+  'unsupported-agent',
+  'malformed-stream-json',
+  'missing-result-event',
+  'duplicate-result-event',
+  'agent-result-error',
+  'agent-execution-failed',
+  'missing-skill-use',
+  'malformed-skill-use',
+  'unknown-skill-use',
+  'missing-skill-result',
+  'failed-skill-result',
+  'unknown-tool-result',
+  'duplicate-tool-result',
+  'out-of-order-skill-result',
+  'missing-bound-skill',
+]);
 
 export function normalizeInterruptedSignal(value) {
   if (!INTERRUPTED_SIGNALS.has(value)) fail('Evaluator interruption signal is not allowlisted');
@@ -1925,6 +1943,48 @@ export function exactExecutorPreflightClosure(raw, expectedBindings) {
   return exactExecutorPreflightClosureFromEvidence(raw, evidence, expectedBindings);
 }
 
+export function projectExecutorPreflightDiagnostics(raw) {
+  const traces = Array.isArray(raw?.runnerUsageTraces) ? raw.runnerUsageTraces : null;
+  const usedSkills = Array.isArray(raw?.verification?.usedSkills)
+    ? raw.verification.usedSkills
+    : null;
+  const boundedInteger = (value) => Number.isSafeInteger(value) && value >= 0 && value <= 1_000_000
+    ? value
+    : null;
+  const boundedBoolean = (value) => typeof value === 'boolean' ? value : null;
+  return {
+    schemaVersion: 'marketplace.pack-executor-preflight-diagnostics/v1',
+    cliOutcome: raw?.outcome === 'passed' || raw?.outcome === 'failed' ? raw.outcome : 'unknown',
+    verification: {
+      passed: boundedBoolean(raw?.verification?.passed),
+      verdictCount: boundedInteger(raw?.verification?.verdictCount),
+      errorCount: boundedInteger(raw?.verification?.errorCount),
+      usedSkill: boundedBoolean(raw?.verification?.usedSkill),
+      usedSkillCount: usedSkills ? Math.min(usedSkills.length, 1_000) : null,
+      taskCompleted: boundedBoolean(raw?.verification?.taskCompleted),
+      envBlocked: boundedBoolean(raw?.verification?.envBlocked),
+    },
+    traceCount: traces ? Math.min(traces.length, 1_000) : null,
+    tracesTruncated: Boolean(traces && traces.length > 4),
+    traces: (traces ?? []).slice(0, 4).map((trace) => {
+      const events = Array.isArray(trace?.events) ? trace.events : null;
+      return {
+        schemaValid: trace?.schemaVersion === 'skillstore.runner-skill-trace/v1',
+        agent: ['claude', 'codex', 'gemini'].includes(trace?.agent) ? trace.agent : 'unknown',
+        source: ['claude-stream-json-v1', 'unsupported-agent'].includes(trace?.source)
+          ? trace.source
+          : 'unknown',
+        deterministic: boundedBoolean(trace?.deterministic),
+        eventCount: events ? Math.min(events.length, 1_000) : null,
+        eventsTruncated: Boolean(events && events.length > 1_000),
+        failureReason: trace?.failureReason == null
+          ? null
+          : RUNNER_TRACE_FAILURE_REASONS.has(trace.failureReason) ? trace.failureReason : 'unknown',
+      };
+    }),
+  };
+}
+
 export async function executorPreflight(args) {
   const cli = resolve(required(args, 'cli'));
   const expectedCliVersion = required(args, 'expected-cli-version');
@@ -2067,6 +2127,7 @@ export async function executorPreflight(args) {
     },
     agentExecutionEvidence,
     runnerTraceEvidence: closure?.runnerTraceEvidence ?? null,
+    runnerTraceDiagnostics: projectExecutorPreflightDiagnostics(raw),
     verdictCount: Number.isSafeInteger(raw?.verification?.verdictCount)
       ? raw.verification.verdictCount
       : 0,

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -334,6 +334,8 @@ test('extracted evaluator preflight is valid bounded bash', () => {
   assert.match(EVALUATOR_PREFLIGHT, /--skill-a "\$PREFLIGHT_SKILL_A"/);
   assert.match(EVALUATOR_PREFLIGHT, /--skill-b "\$PREFLIGHT_SKILL_B"/);
   assert.match(EVALUATOR_PREFLIGHT, /safe_runner_trace_evidence\(\)/);
+  assert.match(EVALUATOR_PREFLIGHT, /safe_runner_trace_diagnostics\(\)/);
+  assert.match(EVALUATOR_PREFLIGHT, /runnerTraceDiagnostics: \$runnerTraceDiagnostics/);
   assert.match(EVALUATOR_PREFLIGHT, /proofBinding:/);
   assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_ENV_MODE=strict/);
   assert.match(EVALUATOR_PREFLIGHT, /SKILLSTORE_AGENT_SANDBOX_MODE=bwrap/);
@@ -507,6 +509,30 @@ test('invalid trace and outer summaries project explicit JSON fallbacks', () => 
   const report = join(directory, 'report.json');
   writeFileSync(report, JSON.stringify({
     runnerTraceEvidence: { schemaVersion: 'attacker-schema', bindingDigest: 'private path' },
+    runnerTraceDiagnostics: {
+      schemaVersion: 'marketplace.pack-executor-preflight-diagnostics/v1',
+      cliOutcome: 'failed',
+      verification: {
+        passed: false,
+        verdictCount: 1,
+        errorCount: 0,
+        usedSkill: true,
+        usedSkillCount: 2,
+        taskCompleted: true,
+        envBlocked: false,
+      },
+      traceCount: 1,
+      tracesTruncated: false,
+      traces: [{
+        schemaValid: false,
+        agent: 'claude',
+        source: 'claude-stream-json-v1',
+        deterministic: true,
+        eventCount: 2,
+        eventsTruncated: false,
+        failureReason: 'private attacker reason',
+      }],
+    },
     outerExecution: {
       durationMs: 430001,
       rawStderr: 'private process detail',
@@ -514,15 +540,17 @@ test('invalid trace and outer summaries project explicit JSON fallbacks', () => 
   }));
   const script = [
     extractFunction('safe_runner_trace_evidence'),
+    extractFunction('safe_runner_trace_diagnostics'),
     extractFunction('safe_outer_execution'),
     'trace=$(safe_runner_trace_evidence "$1")',
+    'diagnostics=$(safe_runner_trace_diagnostics "$1")',
     'outer=$(safe_outer_execution "$1")',
-    'jq -cn --argjson trace "$trace" --argjson outer "$outer" "{trace: \\$trace, outer: \\$outer}"',
+    'jq -cn --argjson trace "$trace" --argjson diagnostics "$diagnostics" --argjson outer "$outer" "{trace: \\$trace, diagnostics: \\$diagnostics, outer: \\$outer}"',
   ].join('\n');
   const result = spawnSync('bash', ['-c', script, 'invalid-projection', report], { encoding: 'utf8' });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), { trace: null, outer: {} });
+  assert.deepEqual(JSON.parse(result.stdout), { trace: null, diagnostics: null, outer: {} });
   assert.doesNotMatch(result.stdout, /private|rawStderr|attacker/);
 });
 

--- a/scripts/tests/pack-production.test.mjs
+++ b/scripts/tests/pack-production.test.mjs
@@ -34,6 +34,7 @@ import {
   normalizeInfrastructureFailure,
   planTrustedPersistence,
   prepareScenarioRuntime,
+  projectExecutorPreflightDiagnostics,
   projectExecutorPreflightEvidence,
   readExactPublicPack,
   runEvaluatorProcess,
@@ -766,6 +767,36 @@ test('executor preflight preserves the validated attempt schema for the shell pr
   const wrongTrace = structuredClone(report);
   wrongTrace.runnerUsageTraces[0].events[1].contentHash = 'f'.repeat(64);
   assert.equal(exactExecutorPreflightClosure(wrongTrace, bindings), null);
+
+  const diagnostics = projectExecutorPreflightDiagnostics(wrongJudge);
+  assert.deepEqual(diagnostics, {
+    schemaVersion: 'marketplace.pack-executor-preflight-diagnostics/v1',
+    cliOutcome: 'passed',
+    verification: {
+      passed: true,
+      verdictCount: 1,
+      errorCount: 0,
+      usedSkill: true,
+      usedSkillCount: 1,
+      taskCompleted: true,
+      envBlocked: false,
+    },
+    traceCount: 1,
+    tracesTruncated: false,
+    traces: [{
+      schemaValid: true,
+      agent: 'claude',
+      source: 'claude-stream-json-v1',
+      deterministic: true,
+      eventCount: 2,
+      eventsTruncated: false,
+      failureReason: null,
+    }],
+  });
+  assert.doesNotMatch(
+    JSON.stringify(diagnostics),
+    /contentHash|bindingDigest|canonicalSkillId|private/,
+  );
 });
 
 test('executor preflight retains bounded failed Agent evidence outside the pass closure', () => {


### PR DESCRIPTION
## Problem
When executor preflight fails, the pass-only trace projection becomes `null`. The current sanitized artifact cannot distinguish Judge verification failure from trace schema/coverage failure, so the next repair would otherwise be guesswork.

## Change
- project only bounded verification booleans/counts and up to four allowlisted trace summaries
- allowlist all failure reasons and agent/source values
- retain no raw IDs, hashes, paths, events, prompts, outputs, or unbounded strings

## Safety
The runner-trace, Judge, proxy, inference, execution-evidence, and fail-closed pass gates are unchanged. This PR adds diagnostics only.

## Validation
- `CI=true node --test scripts/tests/pack-production.test.mjs scripts/tests/generate-packs-workflow.test.mjs` (61 passed, 1 Linux-only skip)
- `bash -n scripts/pack-evaluator-preflight.sh`
- `git diff --check`

Follow-up: run one production canary and use the bounded projection to identify the exact failed subgate.
