### PR TITLE
fix(governance): normalize fresh audit checkout

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -69,6 +69,21 @@ jobs:
         with:
           fetch-depth: 0
           clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize full checkout and verify governance runtime
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          for path in \
+            .github/actions/download-skillstore-cli/action.yml \
+            scripts/prepare-fresh-canonical-audit-batch.mjs \
+            scripts/fetch-artifact-version-inventory.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing fresh governance runtime"; exit 1; }
+          done
 
       - name: Validate dry-run inputs and governance runtime
         env:
@@ -324,6 +339,21 @@ jobs:
         with:
           fetch-depth: 0
           clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize full checkout and verify governance runtime
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          for path in \
+            .github/actions/download-skillstore-cli/action.yml \
+            scripts/prepare-fresh-canonical-audit-batch.mjs \
+            scripts/fetch-artifact-version-inventory.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing fresh governance runtime"; exit 1; }
+          done
 
       - name: Validate execute inputs
         env:

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -108,6 +108,11 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /fresh-audit-run\.json/);
   assert.match(workflow, /previous_boundary_run_id/);
   assert.match(workflow, /previous_execute_run_id/);
+  assert.equal((workflow.match(/sparse-checkout: ''/g) || []).length, 2);
+  assert.equal((workflow.match(/sparse-checkout-cone-mode: false/g) || []).length, 2);
+  assert.equal((workflow.match(/git sparse-checkout disable/g) || []).length, 2);
+  assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
+  assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 2);
   assert.match(workflow, /fresh_canonical_audit_execution_complete/);
   assert.match(workflow, /productionSmokeCompleted:true/);
   assert.match(workflow, /pre-inventory\.json/);


### PR DESCRIPTION
## Summary
- clear inherited sparse-checkout state in both fresh canonical governance jobs
- verify the exact workflow SHA and required runtime files before dry-run or execute
- lock the checkout hardening contract with the focused governance test

## Root cause
Run 29612965001 checked out commit f4ae82af78e9403ed4f860d15e8ffbaa78aa22fb, whose Git tree contains `governance/fresh-canonical-audit/remaining-lineage.json`. The persistent self-hosted workspace retained sparse-checkout state, so the cohort was absent from the worktree even though `actions/checkout` succeeded. The run failed in input validation before any production write step.

## Verification
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- `git diff --check`
- production read-only gate: broken pointer 0, supabase-db CPU 12.74%
