### PR TITLE
fix(governance): run fresh audit from materialized root

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -239,14 +239,16 @@ jobs:
             count=$(jq -r .count <<< "$group")
             model_args=()
             test -z "$MODEL" || model_args=(--model "$MODEL")
-            "$GITHUB_WORKSPACE/skillstore-cli" skill audit \
-              "$RUNNER_TEMP/materialized/$commit/skills" --slugs "$slugs" \
-              --checkpoint-file "$RUNNER_TEMP/audit-$commit.checkpoint.json" \
-              --correlation-id "$GITHUB_RUN_ID-$commit" \
-              --fresh-run-manifest-file "$RUNNER_TEMP/fresh-audit-manifests/$commit.json" \
-              --fresh-run-nonce "$run_nonce" --fresh-run-id "$GITHUB_RUN_ID" \
-              --fresh-run-started-at "$run_started_at" --fresh-selected-count "$count" \
-              "${model_args[@]}"
+            (
+              cd "$RUNNER_TEMP/materialized/$commit"
+              "$GITHUB_WORKSPACE/skillstore-cli" skill audit skills --slugs "$slugs" \
+                --checkpoint-file "$RUNNER_TEMP/audit-$commit.checkpoint.json" \
+                --correlation-id "$GITHUB_RUN_ID-$commit" \
+                --fresh-run-manifest-file "$RUNNER_TEMP/fresh-audit-manifests/$commit.json" \
+                --fresh-run-nonce "$run_nonce" --fresh-run-id "$GITHUB_RUN_ID" \
+                --fresh-run-started-at "$run_started_at" --fresh-selected-count "$count" \
+                "${model_args[@]}"
+            )
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/selected-cohort.json")
           jq -s --arg nonce "$run_nonce" --arg runId "$GITHUB_RUN_ID" --arg startedAt "$run_started_at" '
             if length == 0 or any(.runNonce != $nonce or .runId != $runId or .startedAt != $startedAt or .status != "fresh_audit_run_complete") then error("fresh audit group manifest mismatch") else {

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -104,6 +104,9 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 2);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /skill audit/);
+  assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
+  assert.match(workflow, /skill audit skills --slugs "\$slugs"/);
+  assert.doesNotMatch(workflow, /skill audit \\\n\s+"\$RUNNER_TEMP\/materialized\/\$commit\/skills"/);
   assert.match(workflow, /fresh-run-manifest-file/);
   assert.match(workflow, /fresh-audit-run\.json/);
   assert.match(workflow, /previous_boundary_run_id/);


### PR DESCRIPTION
## Summary
- run CLI 2.8.0 from each immutable materialized commit root and pass the relative `skills` directory
- retain absolute checkpoint and manifest evidence paths
- add a focused contract preventing the broken absolute skills-path invocation

## Root cause
Fresh dry-run 29614177891 proved the checkout fix and selected the first 10-row cohort, then failed before production writes. CLI 2.8.0 uses `path.join(process.cwd(), skillsDir)`, so an absolute `$RUNNER_TEMP/.../skills` argument was incorrectly prefixed with `$GITHUB_WORKSPACE`. Running from the frozen commit root with `skills` preserves the immutable input and matches the released CLI contract.

## Verification
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- `git diff --check`
