### PR TITLE
fix(governance): freeze audit schema with source batch

### DIFF
--- a/scripts/prepare-fresh-canonical-audit-batch.mjs
+++ b/scripts/prepare-fresh-canonical-audit-batch.mjs
@@ -9,6 +9,7 @@ const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const MAX_BATCH_SIZE = 10;
+const AUDIT_SCHEMA_PATH = 'schemas/skill-report.schema.json';
 
 function fail(message) { throw new Error(message); }
 function git(root, args) {
@@ -89,6 +90,9 @@ export function prepareFreshCanonicalAuditBatch({
     git(repositoryRoot, ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/SKILL.md`]);
     git(repositoryRoot, ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/skill-report.json`]);
   }
+  for (const commit of new Set(selected.map((row) => row.marketplaceCommit))) {
+    git(repositoryRoot, ['cat-file', '-e', `${commit}:${AUDIT_SCHEMA_PATH}`]);
+  }
   const grouped = new Map();
   for (const row of selected) {
     if (!grouped.has(row.marketplaceCommit)) grouped.set(row.marketplaceCommit, []);
@@ -99,7 +103,7 @@ export function prepareFreshCanonicalAuditBatch({
     .map(([marketplaceCommit, group]) => ({
       marketplaceCommit,
       count: group.length,
-      paths: group.map((row) => row.path),
+      paths: [AUDIT_SCHEMA_PATH, ...group.map((row) => row.path)],
       slugs: group.map((row) => row.slug),
     }));
   return {

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -12,8 +12,10 @@ function fixture() {
   execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.com']);
   execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
   mkdirSync(join(root, 'skills', 'owner', 'skill'), { recursive: true });
+  mkdirSync(join(root, 'schemas'), { recursive: true });
   writeFileSync(join(root, 'skills', 'owner', 'skill', 'SKILL.md'), '---\nname: skill\n---\n');
   writeFileSync(join(root, 'skills', 'owner', 'skill', 'skill-report.json'), '{}\n');
+  writeFileSync(join(root, 'schemas', 'skill-report.schema.json'), '{}\n');
   execFileSync('git', ['-C', root, 'add', '.']);
   execFileSync('git', ['-C', root, 'commit', '-qm', 'fixture']);
   const commit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
@@ -48,6 +50,7 @@ test('prepares a bounded commit-addressed fresh audit batch', () => {
   });
   assert.equal(result.count, 1);
   assert.equal(result.groups[0].marketplaceCommit, row.marketplaceCommit);
+  assert.deepEqual(result.groups[0].paths, ['schemas/skill-report.schema.json', row.path]);
   assert.equal(result.remaining, 0);
 });
 


### PR DESCRIPTION
## Summary
- include the historical `schemas/skill-report.schema.json` in every immutable fresh-audit materialization group
- fail closed during planning if a selected historical commit lacks that schema
- lock the schema path into the focused batch-plan test

## Root cause
Fresh dry-run 29614456685 selected and materialized the first cohort correctly, but only archived Skill directories. The pinned CLI 2.8.0 resolves its fallback schema from `<audit cwd>/schemas/skill-report.schema.json`; all four selected audits therefore failed schema validation before any production write. All 19 distinct commits in the frozen 106-row cohort contain the schema, and the historical schema keys match the CLI 2.8.0 contract.

## Verification
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- all 19 frozen cohort commits contain `schemas/skill-report.schema.json`
- `git diff --check`
- production gate: broken pointer 0; supabase-db CPU 4.82%
