### PR TITLE
fix(governance): retain hidden boundary runtime

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -314,6 +314,7 @@ jobs:
         with:
           name: fresh-canonical-audit-boundary-${{ github.run_id }}
           path: ${{ runner.temp }}/fresh-canonical-boundary/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -120,6 +120,7 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
   assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 2);
   assert.match(workflow, /fresh_canonical_audit_execution_complete/);
+  assert.match(workflow, /name: fresh-canonical-audit-boundary-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /productionSmokeCompleted:true/);
   assert.match(workflow, /pre-inventory\.json/);
   assert.match(workflow, /skill govern-fresh-canonical-audit/);


### PR DESCRIPTION
## Summary
- preserve `.github` runtime evidence when uploading the strict Fresh Canonical boundary
- lock `include-hidden-files: true` into the focused workflow contract test

## Root cause
Dry-run 29615683122 completed successfully with a valid 10-row boundary and no production writes. `actions/upload-artifact@v6` omitted hidden `.github` paths by default even though `SHA256SUMS` sealed them. The resident worker correctly rejected the incomplete artifact before execute.

## Verification
- downloaded artifact proves both sealed `./runtime/.github/...` files are absent while their checksums are present
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- `git diff --check`
- production gate: broken pointer 0; supabase-db CPU 4.04%
