### PR TITLE
fix(governance): retain execution boundary runtime

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -509,6 +509,7 @@ jobs:
             ${{ runner.temp }}/execution-results.json
             ${{ runner.temp }}/post-inventory.json
             ${{ runner.temp }}/execution-proof/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -120,7 +120,9 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
   assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 2);
   assert.match(workflow, /fresh_canonical_audit_execution_complete/);
+  assert.equal((workflow.match(/include-hidden-files: true/g) || []).length, 2);
   assert.match(workflow, /name: fresh-canonical-audit-boundary-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
+  assert.match(workflow, /name: fresh-canonical-audit-execution-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /productionSmokeCompleted:true/);
   assert.match(workflow, /pre-inventory\.json/);
   assert.match(workflow, /skill govern-fresh-canonical-audit/);


### PR DESCRIPTION
## Summary
- preserve hidden `.github` files inside the execution evidence artifact
- enforce hidden-file retention for both dry-run and execute artifacts in the focused test

## Root cause
The first 10-row execute run 29619841184 completed governance, score/cache closure, and production smoke successfully. Its execution artifact re-uploaded the authenticated dry-run boundary, but `actions/upload-artifact@v6` again omitted the boundary’s hidden `.github` runtime files. Continuation dry-run 29620095528 correctly rejected that incomplete execution chain before any new production writes.

## Verification
- run 29619841184 is successful and production advanced exactly 10 rows
- continuation failure is in prior-chain checksum authentication before inventory/audit/execute
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- `git diff --check`
- production gate: broken pointer 0; supabase-db CPU 1.32%
