### PR TITLE
fix(governance): authenticate first execution chain

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -136,14 +136,28 @@ jobs:
           gh run download "$PREVIOUS_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
             --name "fresh-canonical-audit-execution-$PREVIOUS_EXECUTE_RUN_ID" \
             --dir "$RUNNER_TEMP/previous-execution"
-          (cd "$RUNNER_TEMP/previous-execution/boundary" && sha256sum --check SHA256SUMS)
-          cmp "$RUNNER_TEMP/previous-boundary/SHA256SUMS" \
-            "$RUNNER_TEMP/previous-execution/boundary/SHA256SUMS"
+          execution_boundary="$RUNNER_TEMP/previous-execution/boundary"
+          cmp "$RUNNER_TEMP/previous-boundary/SHA256SUMS" "$execution_boundary/SHA256SUMS"
+          execute_head_sha=$(jq -r .headSha <<< "$execute_json")
+          legacy_hidden_pattern='  \./runtime/\.github/(actions/download-skillstore-cli/action\.yml|workflows/govern-fresh-canonical-audits\.yml)$'
+          if [ "$PREVIOUS_EXECUTE_RUN_ID" = '29619841184' ] \
+            && [ "$execute_head_sha" = '09cce5e8dac464d8e5f1d0a10446110bd95a9e3f' ]; then
+            # This one successful execution predates include-hidden-files on the
+            # execution artifact. The original dry-run boundary above is still
+            # fully authenticated, and its identical checksum manifest seals the
+            # two omitted runtime files. Validate every re-uploaded visible byte.
+            test "$(grep -Ec "$legacy_hidden_pattern" "$execution_boundary/SHA256SUMS")" = 2
+            test ! -e "$execution_boundary/runtime/.github/actions/download-skillstore-cli/action.yml"
+            test ! -e "$execution_boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
+            (cd "$execution_boundary" && grep -Ev "$legacy_hidden_pattern" SHA256SUMS | sha256sum --check -)
+          else
+            (cd "$execution_boundary" && sha256sum --check SHA256SUMS)
+          fi
           (cd "$RUNNER_TEMP/previous-execution/execution-proof" && sha256sum --check SHA256SUMS)
           proof="$RUNNER_TEMP/previous-execution/execution-proof/proof.json"
           jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
             --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
-            --arg executeHeadSha "$(jq -r .headSha <<< "$execute_json")" \
+            --arg executeHeadSha "$execute_head_sha" \
             '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
             "$proof" >/dev/null
           test "$(jq -r .cohortSha256 "$proof")" = "$(jq -r .cohortSha256 "$RUNNER_TEMP/previous-boundary/metadata.json")"

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -114,6 +114,10 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /fresh-audit-run\.json/);
   assert.match(workflow, /previous_boundary_run_id/);
   assert.match(workflow, /previous_execute_run_id/);
+  assert.match(workflow, /PREVIOUS_EXECUTE_RUN_ID" = '29619841184'/);
+  assert.match(workflow, /execute_head_sha" = '09cce5e8dac464d8e5f1d0a10446110bd95a9e3f'/);
+  assert.match(workflow, /grep -Ec "\$legacy_hidden_pattern"/);
+  assert.match(workflow, /grep -Ev "\$legacy_hidden_pattern" SHA256SUMS \| sha256sum --check -/);
   assert.equal((workflow.match(/sparse-checkout: ''/g) || []).length, 2);
   assert.equal((workflow.match(/sparse-checkout-cone-mode: false/g) || []).length, 2);
   assert.equal((workflow.match(/git sparse-checkout disable/g) || []).length, 2);


### PR DESCRIPTION
## Summary
- add a strictly bounded compatibility verifier for the one successful execution artifact created before hidden-file retention was enabled
- continue fully authenticating the original dry-run boundary and require byte-identical checksum manifests
- validate every visible execution-artifact byte while allowing exactly the two known omitted `.github` paths
- retain full checksum verification for every future execution artifact

## Root cause
First execute 29619841184 fully succeeded and advanced exactly 10 rows, but its artifact was uploaded before PR #2635 and therefore omitted two hidden boundary runtime files. Continuation dry-run 29620095528 failed safely while authenticating the previous chain, before inventory, audit, or execute. Historical artifacts are immutable, so this exact run/head requires a bounded compatibility path.

## Safety boundary
The exception requires both execute run `29619841184` and head SHA `09cce5e8dac464d8e5f1d0a10446110bd95a9e3f`. The original boundary is fully checksum-verified, both manifests must be byte-identical, exactly two named paths must be absent, and every other execution-boundary checksum must pass.

## Verification
- reproduced against downloaded boundary 29617992753 and execution 29619841184 artifacts
- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs`
- `git diff --check`
- production: 4875/5319 governed, revision0 444, broken pointer 0
