### PR TITLE
fix(validation): rebind report auto-fix hashes

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -625,8 +625,85 @@ jobs:
             exit 1
           fi
 
-      - name: Commit auto-fixed skill-report.json files locally
+      - name: Rebind reports to auto-fixed skill-report artifacts
         if: steps.validate-skill-reports.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true' && steps.revalidate.outcome == 'success'
+        working-directory: ${{ env.WORK_DIR }}
+        run: |
+          set -euo pipefail
+          CHANGED_REPORTS="$RUNNER_TEMP/auto-fixed-report-paths-${{ github.run_id }}.bin"
+          CHANGED_SKILLS="$RUNNER_TEMP/auto-fixed-report-skill-paths-${{ github.run_id }}.bin"
+
+          if ! git diff --no-renames --quiet --diff-filter=D HEAD -- \
+            'skills/**/skill-report.json' 'pending/**/skill-report.json'; then
+            echo "::error::skill-report.json auto-fix deleted a report; refusing to publish an unbound artifact"
+            exit 1
+          fi
+
+          git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD -- \
+            'skills/**/skill-report.json' 'pending/**/skill-report.json' > "$CHANGED_REPORTS"
+          if [ ! -s "$CHANGED_REPORTS" ]; then
+            echo "::error::skill-report.json auto-fix reported success without a changed report artifact"
+            exit 1
+          fi
+
+          while IFS= read -r -d '' report_path; do
+            case "$report_path" in
+              skills/*/skill-report.json|pending/*/skill-report.json)
+                printf '%s\0' "${report_path%/skill-report.json}/SKILL.md"
+                ;;
+              *)
+                echo "::error::Unexpected auto-fixed report path: $report_path"
+                exit 1
+                ;;
+            esac
+          done < "$CHANGED_REPORTS" | LC_ALL=C sort -z -u > "$CHANGED_SKILLS"
+
+          node scripts/rebind-skill-report-hashes.mjs \
+            --repo-root "$PWD" \
+            --skill-paths-file "$CHANGED_SKILLS"
+
+      - name: Verify skill-report hash contract after auto-fix
+        if: steps.validate-skill-reports.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true' && steps.revalidate.outcome == 'success'
+        id: revalidate-report-hash-contract
+        working-directory: ${{ env.WORK_DIR }}
+        run: |
+          set -euo pipefail
+          CHANGED_SKILLS="$RUNNER_TEMP/auto-fixed-report-skill-paths-${{ github.run_id }}.bin"
+          test -s "$CHANGED_SKILLS" || {
+            echo "::error::Missing affected SKILL.md list for report hash contract validation"
+            exit 1
+          }
+
+          node --input-type=module - "$CHANGED_SKILLS" <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync } from 'node:fs';
+          import { dirname } from 'node:path';
+          import { calculateCanonicalTreeHash } from './scripts/resolve-approved-submission.mjs';
+
+          const pathsFile = process.argv[2];
+          const skillPaths = [...new Set(readFileSync(pathsFile, 'utf8').split('\\0').filter(Boolean))].sort();
+          if (skillPaths.length === 0) throw new Error('no affected SKILL.md paths were provided');
+
+          for (const skillPath of skillPaths) {
+            const skillDirectory = dirname(skillPath);
+            const reportPath = `${skillDirectory}/skill-report.json`;
+            const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+            const contentHash = createHash('sha256').update(readFileSync(skillPath)).digest('hex');
+            const treeHash = calculateCanonicalTreeHash(process.cwd(), skillDirectory);
+            if (typeof report?.meta?.source_url !== 'string' || !report.meta.source_url.startsWith('https://github.com/')) {
+              throw new Error(`${reportPath} has invalid source_url lineage`);
+            }
+            if (typeof report?.meta?.source_ref !== 'string' || report.meta.source_ref.trim() === '') {
+              throw new Error(`${reportPath} has invalid source_ref lineage`);
+            }
+            if (report?.meta?.content_hash !== contentHash) throw new Error(`${reportPath} content_hash does not match SKILL.md raw bytes`);
+            if (report?.meta?.tree_hash !== treeHash) throw new Error(`${reportPath} tree_hash does not match the canonical skill tree`);
+          }
+          console.log(`Verified report hash contract for ${skillPaths.length} auto-fixed artifact(s)`);
+          NODE
+
+      - name: Commit auto-fixed skill-report.json files locally
+        if: steps.validate-skill-reports.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true' && steps.revalidate.outcome == 'success' && steps.revalidate-report-hash-contract.outcome == 'success'
         working-directory: ${{ env.WORK_DIR }}
         run: |
           set -euo pipefail
@@ -704,7 +781,7 @@ jobs:
           exit 1
 
       - name: Publish validated auto-fixes
-        if: success() && env.AUTO_FIX_ENABLED == 'true' && (steps.revalidate-skill-md.outcome == 'success' || steps.revalidate.outcome == 'success')
+        if: success() && env.AUTO_FIX_ENABLED == 'true' && (steps.revalidate-skill-md.outcome == 'success' || (steps.revalidate.outcome == 'success' && steps.revalidate-report-hash-contract.outcome == 'success'))
         working-directory: ${{ env.WORK_DIR }}
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/tests/validate-marketplace-autofix.test.mjs
+++ b/scripts/tests/validate-marketplace-autofix.test.mjs
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
 
 const workflow = readFileSync('.github/workflows/validate-marketplace.yml', 'utf8');
 
@@ -19,6 +21,8 @@ function runBlock(stepName) {
 }
 
 const rebind = runBlock('Rebind reports to auto-fixed SKILL.md artifacts');
+const rebindReport = runBlock('Rebind reports to auto-fixed skill-report artifacts');
+const verifyReportHashContract = runBlock('Verify skill-report hash contract after auto-fix');
 const commitSkill = runBlock('Commit auto-fixed SKILL.md artifacts locally');
 const commitReport = runBlock('Commit auto-fixed skill-report.json files locally');
 const publish = runBlock('Publish validated auto-fixes');
@@ -29,6 +33,70 @@ test('auto-fix binds final artifact hashes before creating local commits', () =>
   assert.match(rebind, /--skill-paths-file/);
   assert.doesNotMatch(commitSkill, /git push|gh pr create/);
   assert.doesNotMatch(commitReport, /git push|git pull|git reset|git cherry-pick/);
+});
+
+test('report auto-fix rebinds every changed report and verifies its hash contract before commit', () => {
+  assert.match(rebindReport, /git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD/);
+  assert.match(rebindReport, /skills\/\*\/skill-report\.json/);
+  assert.match(rebindReport, /pending\/\*\/skill-report\.json/);
+  assert.match(rebindReport, /scripts\/rebind-skill-report-hashes\.mjs/);
+  assert.match(rebindReport, /--skill-paths-file/);
+  assert.match(rebindReport, /--diff-filter=D/);
+  assert.match(verifyReportHashContract, /content_hash does not match SKILL\.md raw bytes/);
+  assert.match(verifyReportHashContract, /tree_hash does not match the canonical skill tree/);
+  assert.match(
+    workflow,
+    /Commit auto-fixed skill-report\.json files locally\n        if: [^\n]*steps\.revalidate-report-hash-contract\.outcome == 'success'/,
+  );
+});
+
+test('report auto-fix restores erased hashes without changing source lineage', () => {
+  const root = mkdtempSync(join(tmpdir(), 'validate-autofix-report-rebind-'));
+  const skillDirectory = 'pending/example/fixture';
+  const absoluteDirectory = join(root, skillDirectory);
+  const skillPath = join(absoluteDirectory, 'SKILL.md');
+  const reportPath = join(absoluteDirectory, 'skill-report.json');
+  const pathsFile = join(root, 'affected-skills.bin');
+  try {
+    mkdirSync(absoluteDirectory, { recursive: true });
+    writeFileSync(skillPath, '---\nname: fixture\ndescription: Auto-fixed fixture\n---\n');
+    writeFileSync(reportPath, `${JSON.stringify({
+      meta: {
+        slug: 'example-fixture',
+        source_type: 'community',
+        source_url: 'https://github.com/example/source/tree/main/fixture',
+        source_ref: 'main',
+        content_hash: 'a'.repeat(64),
+        tree_hash: 'b'.repeat(64),
+      },
+      security_audit: { is_blocked: false, safe_to_publish: true },
+    }, null, 2)}\n`);
+
+    // Model the report-only AI repair dropping both identity hashes.
+    const autoFixed = JSON.parse(readFileSync(reportPath, 'utf8'));
+    delete autoFixed.meta.content_hash;
+    delete autoFixed.meta.tree_hash;
+    writeFileSync(reportPath, `${JSON.stringify(autoFixed, null, 2)}\n`);
+    writeFileSync(pathsFile, Buffer.from(`${skillDirectory}/SKILL.md\0`));
+
+    const result = spawnSync(process.execPath, [
+      'scripts/rebind-skill-report-hashes.mjs',
+      '--repo-root', root,
+      '--skill-paths-file', pathsFile,
+    ], { cwd: process.cwd(), encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+
+    const rebound = JSON.parse(readFileSync(reportPath, 'utf8'));
+    assert.equal(rebound.meta.source_url, 'https://github.com/example/source/tree/main/fixture');
+    assert.equal(rebound.meta.source_ref, 'main');
+    assert.equal(
+      rebound.meta.content_hash,
+      createHash('sha256').update(readFileSync(skillPath)).digest('hex'),
+    );
+    assert.equal(rebound.meta.tree_hash, calculateCanonicalTreeHash(root, skillDirectory));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('publishing updates only the original trusted PR head and fails closed on races', () => {


### PR DESCRIPTION
## Root cause
The report AI auto-fix can produce a schema-valid `skill-report.json` while deleting `meta.content_hash` and `meta.tree_hash`. PR #2634 demonstrated this: the original shard artifact had correct hashes, the auto-fix commit removed them, and post-merge approval correctly failed closed in run 29621478057.

## Fix
- collect every auto-fixed `skills/**/skill-report.json` and `pending/**/skill-report.json`
- fail closed if an auto-fix deletes a report
- map each changed report to its sibling `SKILL.md`
- run the existing lineage-preserving hash rebinder
- independently recompute and verify content/tree hashes plus source lineage before commit or publish

## Safety
Approval validation is not weakened. Auto-fixes cannot be committed or pushed unless the final artifact hash contract passes.

## Validation
- `CI=true node --test scripts/tests/rebind-skill-report-hashes.test.mjs scripts/tests/validate-marketplace-autofix.test.mjs` (9/9)
- YAML parse
- extracted shell blocks: `bash -n`
- `git diff --check`
