### PR TITLE
fix(validation): parse NUL-delimited report paths

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -681,7 +681,7 @@ jobs:
           import { calculateCanonicalTreeHash } from './scripts/resolve-approved-submission.mjs';
 
           const pathsFile = process.argv[2];
-          const skillPaths = [...new Set(readFileSync(pathsFile, 'utf8').split('\\0').filter(Boolean))].sort();
+          const skillPaths = [...new Set(readFileSync(pathsFile, 'utf8').split('\0').filter(Boolean))].sort();
           if (skillPaths.length === 0) throw new Error('no affected SKILL.md paths were provided');
 
           for (const skillPath of skillPaths) {

--- a/scripts/tests/validate-marketplace-autofix.test.mjs
+++ b/scripts/tests/validate-marketplace-autofix.test.mjs
@@ -44,6 +44,8 @@ test('report auto-fix rebinds every changed report and verifies its hash contrac
   assert.match(rebindReport, /--diff-filter=D/);
   assert.match(verifyReportHashContract, /content_hash does not match SKILL\.md raw bytes/);
   assert.match(verifyReportHashContract, /tree_hash does not match the canonical skill tree/);
+  assert.ok(verifyReportHashContract.includes(String.raw`.split('\0')`));
+  assert.ok(!verifyReportHashContract.includes(String.raw`.split('\\0')`));
   assert.match(
     workflow,
     /Commit auto-fixed skill-report\.json files locally\n        if: [^\n]*steps\.revalidate-report-hash-contract\.outcome == 'success'/,


### PR DESCRIPTION
## Root cause
The post-auto-fix hash verifier split the NUL-delimited path file on the two-character string `\\0`, leaving a trailing NUL in each filesystem path. Run 29622349667 therefore failed after the report hash rebinder had already succeeded.

## Fix
Split on the actual JavaScript NUL delimiter and add regression assertions that reject the double-escaped form.

## Validation
- `CI=true node --test scripts/tests/rebind-skill-report-hashes.test.mjs scripts/tests/validate-marketplace-autofix.test.mjs` (9/9)
- YAML parse
- `git diff --check`
