### PR TITLE
feat(governance): recover and accelerate artifact campaign

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Freeze a no-write fresh-audit boundary, or execute one frozen boundary'
+        description: 'Freeze, execute, or recover the authenticated 2026-07-18 partial execution'
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute]
+        options: [dry-run, execute, recover]
       cohort_path:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
@@ -40,7 +40,12 @@ on:
         required: false
         default: ''
       dry_run_id:
-        description: 'Successful dry-run workflow run ID; execute only'
+        description: 'Successful dry-run workflow run ID; execute or recover only'
+        type: string
+        required: false
+        default: ''
+      failed_execute_run_id:
+        description: 'Failed execute run to authenticate; recover only'
         type: string
         required: false
         default: ''
@@ -93,10 +98,12 @@ jobs:
           START_AFTER: ${{ inputs.start_after }}
           PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
           PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
+          FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
           test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
+          test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
             [[ "$PREVIOUS_BOUNDARY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::cursor continuation requires numeric previous_boundary_run_id'; exit 1; }
             [[ "$PREVIOUS_EXECUTE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::cursor continuation requires numeric previous_execute_run_id'; exit 1; }
@@ -155,11 +162,30 @@ jobs:
           fi
           (cd "$RUNNER_TEMP/previous-execution/execution-proof" && sha256sum --check SHA256SUMS)
           proof="$RUNNER_TEMP/previous-execution/execution-proof/proof.json"
-          jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
-            --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
-            --arg executeHeadSha "$execute_head_sha" \
-            '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
-            "$proof" >/dev/null
+          proof_schema=$(jq -r .schemaVersion "$proof")
+          if [ "$proof_schema" = 1 ]; then
+            jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
+              --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
+              --arg executeHeadSha "$execute_head_sha" \
+              '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
+              "$proof" >/dev/null
+          elif [ "$proof_schema" = 2 ]; then
+            jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
+              --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
+              --arg executeHeadSha "$execute_head_sha" \
+              '.producerKind=="fresh_canonical_audit_recovery" and .status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .failedExecuteRunId=="29623717000" and .failedExecuteHeadSha=="15492b473b84a835e8b63083510ad1e59184b8db" and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
+              "$proof" >/dev/null
+            recovery="$RUNNER_TEMP/previous-execution/recovery-evidence"
+            (cd "$recovery" && sha256sum --check SHA256SUMS)
+            test "$(jq -r .recoveryEvidenceManifestSha256 "$proof")" = "$(sha256sum "$recovery/SHA256SUMS" | awk '{print $1}')"
+            test "$(jq -r .boundaryManifestSha256 "$proof")" = "$(sha256sum "$execution_boundary/SHA256SUMS" | awk '{print $1}')"
+            test "$(jq -r .scoreTimestampEvidenceSha256 "$proof")" = "$(sha256sum "$recovery/score-timestamp-evidence.json" | awk '{print $1}')"
+            test "$(jq -r .cacheClosureEvidenceSha256 "$proof")" = "$(sha256sum "$recovery/cache-closure-evidence.json" | awk '{print $1}')"
+            test "$(jq -r .cacheReadbackSha256 "$proof")" = "$(sha256sum "$recovery/cache-readback.json" | awk '{print $1}')"
+            test "$(jq -r .smokeResultSha256 "$proof")" = "$(sha256sum "$recovery/smoke-result.json" | awk '{print $1}')"
+          else
+            echo '::error::unsupported fresh execution proof schema'; exit 1
+          fi
           test "$(jq -r .cohortSha256 "$proof")" = "$(jq -r .cohortSha256 "$RUNNER_TEMP/previous-boundary/metadata.json")"
           test "$(jq -r .executedCount "$proof")" = "$(jq -r .count "$RUNNER_TEMP/previous-boundary/selected-cohort.json")"
           test "$(jq -r .executionResultsSha256 "$proof")" = "$(sha256sum "$RUNNER_TEMP/previous-execution/execution-results.json" | awk '{print $1}')"
@@ -377,12 +403,14 @@ jobs:
           CLI_VERSION: ${{ inputs.cli_version }}
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
           START_AFTER: ${{ inputs.start_after }}
+          FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
           test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
+          test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
 
       - name: Download and authenticate the successful frozen boundary
         env:
@@ -534,4 +562,267 @@ jobs:
             echo "- Frozen boundary: \`${{ inputs.dry_run_id }}\`"
             echo "- Executed: \`$(jq length "$RUNNER_TEMP/execution-results.json")\`"
             echo '- Canonical r1, independent v3 source audits, fresh scores, cache/Pack closure, and all production P0/P1 install channels passed.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  recover-boundary:
+    if: inputs.mode == 'recover'
+    concurrency:
+      group: production-skill-score-writes
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      INCIDENT_DRY_RUN_ID: '29622305779'
+      INCIDENT_DRY_RUN_SHA: '786debaf6d85644ad6b417cab08b7d98773bf94a'
+      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: 'sha256:2e7d739365a62c8940feb5dd657a621e26b7e5e9bacdf16b4297edb2ee63ccfd'
+      INCIDENT_FAILED_EXECUTE_RUN_ID: '29623717000'
+      INCIDENT_FAILED_EXECUTE_SHA: '15492b473b84a835e8b63083510ad1e59184b8db'
+      INCIDENT_FAILED_ARTIFACT_DIGEST: 'sha256:35c02b317b349750bcc35da7f27b1e07e0620dff5774bd35370b37d2df509220'
+      INCIDENT_CLI_VERSION: '2.8.0'
+      INCIDENT_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+      RECOVERY_EXPECTED_CACHE_VERSION: 'v6'
+      RECOVERY_SMOKE_SHA: '3bb1eb0eea6651a8965b106a9df406f1e73ab5f2'
+      RECOVERY_PUBLIC_CLI_VERSION: '0.1.10'
+      RECOVERY_PUBLIC_CLI_INTEGRITY: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=='
+    steps:
+      - name: Checkout immutable Marketplace recovery runtime
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Validate incident-only recovery inputs and external release gates
+        env:
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+          PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
+          PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
+          CLI_VERSION: ${{ inputs.cli_version }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          test "$DRY_RUN_ID" = "$INCIDENT_DRY_RUN_ID"
+          test "$FAILED_EXECUTE_RUN_ID" = "$INCIDENT_FAILED_EXECUTE_RUN_ID"
+          test "$CLI_VERSION" = "$INCIDENT_CLI_VERSION"
+          test -z "$START_AFTER" && test -z "$PREVIOUS_BOUNDARY_RUN_ID" && test -z "$PREVIOUS_EXECUTE_RUN_ID"
+          [[ "$RECOVERY_EXPECTED_CACHE_VERSION" =~ ^v[1-9][0-9]*$ ]] || {
+            echo '::error::pin the deployed Skill score-detail cache version before recovery'; exit 1;
+          }
+          [[ "$RECOVERY_SMOKE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo '::error::pin the merged Skillstore structured-smoke commit before recovery'; exit 1;
+          }
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$INCIDENT_DRY_RUN_SHA" "$GITHUB_SHA"
+          git merge-base --is-ancestor "$INCIDENT_FAILED_EXECUTE_SHA" "$GITHUB_SHA"
+          node --check scripts/verify-fresh-canonical-audit-recovery.mjs
+          node --check scripts/close-fresh-canonical-audit-cache.mjs
+
+      - name: Authenticate original boundary and failed execute run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/recovery-source"
+          mkdir -p "$evidence/original-boundary" "$evidence/failed-execution"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_DRY_RUN_ID" > "$evidence/dry-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID" > "$evidence/failed-run.json"
+          jq -e --argjson id "$INCIDENT_DRY_RUN_ID" --arg sha "$INCIDENT_DRY_RUN_SHA" '
+            .id==$id and .name=="Govern Fresh Canonical Audits" and .event=="workflow_dispatch"
+            and .head_branch=="main" and .head_sha==$sha and .conclusion=="success" and .run_attempt==1
+          ' "$evidence/dry-run.json" >/dev/null
+          jq -e --argjson id "$INCIDENT_FAILED_EXECUTE_RUN_ID" --arg sha "$INCIDENT_FAILED_EXECUTE_SHA" '
+            .id==$id and .name=="Govern Fresh Canonical Audits" and .event=="workflow_dispatch"
+            and .head_branch=="main" and .head_sha==$sha and .conclusion=="failure" and .run_attempt==1
+          ' "$evidence/failed-run.json" >/dev/null
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_DRY_RUN_ID/artifacts" > "$evidence/dry-artifacts.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/artifacts" > "$evidence/failed-artifacts.json"
+          jq -e --arg name "fresh-canonical-audit-boundary-$INCIDENT_DRY_RUN_ID" \
+            --arg digest "$INCIDENT_BOUNDARY_ARTIFACT_DIGEST" '
+            [.artifacts[] | select(.name==$name and .expired==false and .digest==$digest)] | length==1
+          ' "$evidence/dry-artifacts.json" >/dev/null
+          jq -e --arg name "fresh-canonical-audit-execution-$INCIDENT_FAILED_EXECUTE_RUN_ID" \
+            --arg digest "$INCIDENT_FAILED_ARTIFACT_DIGEST" '
+            [.artifacts[] | select(.name==$name and .expired==false and .digest==$digest)] | length==1
+          ' "$evidence/failed-artifacts.json" >/dev/null
+
+          gh run download "$INCIDENT_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-boundary-$INCIDENT_DRY_RUN_ID" --dir "$evidence/original-boundary"
+          gh run download "$INCIDENT_FAILED_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-execution-$INCIDENT_FAILED_EXECUTE_RUN_ID" --dir "$evidence/failed-execution"
+          (cd "$evidence/original-boundary" && sha256sum --check SHA256SUMS)
+          (cd "$evidence/failed-execution/boundary" && sha256sum --check SHA256SUMS)
+          diff -qr "$evidence/original-boundary" "$evidence/failed-execution/boundary"
+          test "$(jq -r .cliVersion "$evidence/original-boundary/metadata.json")" = "$INCIDENT_CLI_VERSION"
+          test "$(jq -r .cliSha256 "$evidence/original-boundary/metadata.json")" = "$INCIDENT_CLI_SHA256"
+          test "$(jq -r .runId "$evidence/original-boundary/metadata.json")" = "$INCIDENT_DRY_RUN_ID"
+          git show "$INCIDENT_FAILED_EXECUTE_SHA:.github/workflows/govern-fresh-canonical-audits.yml" \
+            | cmp - "$evidence/original-boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
+          git show "$INCIDENT_FAILED_EXECUTE_SHA:.github/actions/download-skillstore-cli/action.yml" \
+            | cmp - "$evidence/original-boundary/runtime/.github/actions/download-skillstore-cli/action.yml"
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
+            > "$evidence/failed-jobs.json"
+          jq -e '
+            [.jobs[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1
+            and ([.jobs[].steps[] | select(.name=="Checkout complete Marketplace history" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Normalize full checkout and verify governance runtime" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.0" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="skipped")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="skipped")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
+          ' "$evidence/failed-jobs.json" >/dev/null
+
+      - name: Fetch exact scoped post-inventory
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          boundary="$RUNNER_TEMP/recovery-source/original-boundary"
+          recovery="$RUNNER_TEMP/fresh-recovery"
+          mkdir -p "$recovery/recovery-evidence"
+          jq '{schemaVersion:1,scopedSkillIds:[.rows[].skillId],rows:.rows}' \
+            "$boundary/selected-cohort.json" > "$recovery/scope.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$recovery/scope.json" --output "$recovery/post-inventory.json"
+
+      - name: Reconstruct and verify every durable governance result without writes
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/verify-fresh-canonical-audit-recovery.mjs \
+            --boundary "$RUNNER_TEMP/recovery-source/original-boundary/fresh-boundary.json" \
+            --post-inventory "$RUNNER_TEMP/fresh-recovery/post-inventory.json" \
+            --failed-run "$RUNNER_TEMP/recovery-source/failed-run.json" \
+            --output-dir "$RUNNER_TEMP/fresh-recovery/recovery-evidence"
+          cp "$RUNNER_TEMP/fresh-recovery/recovery-evidence/execution-results.json" \
+            "$RUNNER_TEMP/fresh-recovery/execution-results.json"
+          jq -r '.rows[].slug' "$RUNNER_TEMP/recovery-source/original-boundary/selected-cohort.json" \
+            | sort -u > "$RUNNER_TEMP/fresh-recovery/recovery-evidence/slugs.txt"
+          test "$(wc -l < "$RUNNER_TEMP/fresh-recovery/recovery-evidence/slugs.txt" | tr -d ' ')" = 10
+
+      - name: Close exact cache and dependent Pack closure one Skill at a time
+        env:
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+        run: |
+          set -euo pipefail
+          node scripts/close-fresh-canonical-audit-cache.mjs \
+            --slugs-file "$RUNNER_TEMP/fresh-recovery/recovery-evidence/slugs.txt" \
+            --site-url https://skillstore.io \
+            --output "$RUNNER_TEMP/fresh-recovery/recovery-evidence/cache-closure-evidence.json"
+
+      - name: Verify every recovered production score cache readback
+        run: |
+          set -euo pipefail
+          node scripts/score-cache-closure.mjs readback \
+            --expected-score-evidence "$RUNNER_TEMP/fresh-recovery/recovery-evidence/expected-score-evidence.json" \
+            --evidence "$RUNNER_TEMP/fresh-recovery/recovery-evidence/cache-readback.json" \
+            --site-url https://skillstore.io \
+            --expected-cache-version "$RECOVERY_EXPECTED_CACHE_VERSION" \
+            --concurrency 1 --attempts 3 --timeout-ms 30000
+
+      - name: Generate GitHub App token for immutable smoke harness
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: skillstore
+
+      - name: Checkout pinned Skillstore structured smoke harness
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: aiskillstore/skillstore
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ env.RECOVERY_SMOKE_SHA }}
+          path: skillstore-smoke
+          fetch-depth: 1
+
+      - name: Verify download, install, NPX, Pack, MCP, and CI channels
+        env:
+          SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0.1.10,skillstore@latest
+          SMOKE_EXPECTED_PUBLIC_CLI_VERSION: '0.1.10'
+          SMOKE_EXPECTED_PUBLIC_CLI_INTEGRITY: ${{ env.RECOVERY_PUBLIC_CLI_INTEGRITY }}
+          SMOKE_EXPECTED_SIGNING_KEY_ID: EP0Myk7rTk_J0RdG1fvpkP
+          SMOKE_EXPECTED_SIGNING_PUBLIC_KEY_X: 2tbC6eNY4T9sx4Pvuo_NwHlXGyWWz95WAtHyHUTqzs8
+          SMOKE_EXPECT_INTERACTION_RECOVERY: true
+          CI: true
+        run: |
+          set -euo pipefail
+          test "$(git -C skillstore-smoke rev-parse HEAD)" = "$RECOVERY_SMOKE_SHA"
+          sha256sum skillstore-smoke/scripts/smoke/production-smoke.mjs \
+            > "$RUNNER_TEMP/fresh-recovery/recovery-evidence/smoke-runtime.sha256"
+          node skillstore-smoke/scripts/smoke/production-smoke.mjs \
+            --base-url https://skillstore.io --attempts 3 --retry-ms 3000 \
+            --result-file "$RUNNER_TEMP/fresh-recovery/recovery-evidence/smoke-result.json" \
+            2>&1 | tee "$RUNNER_TEMP/fresh-recovery/recovery-evidence/smoke.log"
+
+      - name: Seal schema-v2 recovery proof for the next cursor
+        run: |
+          set -euo pipefail
+          recovery="$RUNNER_TEMP/fresh-recovery"
+          evidence="$recovery/recovery-evidence"
+          boundary="$RUNNER_TEMP/recovery-source/original-boundary"
+          cp -a "$boundary" "$recovery/boundary"
+          cp "$RUNNER_TEMP/recovery-source/"*.json "$evidence/"
+          cp scripts/verify-fresh-canonical-audit-recovery.mjs "$evidence/"
+          cp scripts/close-fresh-canonical-audit-cache.mjs "$evidence/"
+          (cd "$evidence" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          proof="$recovery/execution-proof"
+          mkdir -p "$proof"
+          jq -n \
+            --arg executeRunId "$GITHUB_RUN_ID" --arg dryRunId "$INCIDENT_DRY_RUN_ID" \
+            --arg failedExecuteRunId "$INCIDENT_FAILED_EXECUTE_RUN_ID" \
+            --arg failedExecuteHeadSha "$INCIDENT_FAILED_EXECUTE_SHA" --arg workflowCommit "$GITHUB_SHA" \
+            --arg lastSelected "$(jq -r .lastSelected "$boundary/selected-cohort.json")" \
+            --arg cohortSha256 "$(jq -r .cohortSha256 "$boundary/metadata.json")" \
+            --arg executionResultsSha256 "$(sha256sum "$recovery/execution-results.json" | awk '{print $1}')" \
+            --arg postInventorySha256 "$(sha256sum "$recovery/post-inventory.json" | awk '{print $1}')" \
+            --arg boundaryManifestSha256 "$(sha256sum "$boundary/SHA256SUMS" | awk '{print $1}')" \
+            --arg recoveryEvidenceManifestSha256 "$(sha256sum "$evidence/SHA256SUMS" | awk '{print $1}')" \
+            --arg scoreTimestampEvidenceSha256 "$(sha256sum "$evidence/score-timestamp-evidence.json" | awk '{print $1}')" \
+            --arg cacheClosureEvidenceSha256 "$(sha256sum "$evidence/cache-closure-evidence.json" | awk '{print $1}')" \
+            --arg cacheReadbackSha256 "$(sha256sum "$evidence/cache-readback.json" | awk '{print $1}')" \
+            --arg smokeResultSha256 "$(sha256sum "$evidence/smoke-result.json" | awk '{print $1}')" \
+            --arg originalCliVersion "$INCIDENT_CLI_VERSION" --arg originalCliSha256 "$INCIDENT_CLI_SHA256" \
+            --arg cacheVersion "$RECOVERY_EXPECTED_CACHE_VERSION" --arg smokeCommit "$RECOVERY_SMOKE_SHA" \
+            --arg publicCliVersion "$RECOVERY_PUBLIC_CLI_VERSION" --arg publicCliIntegrity "$RECOVERY_PUBLIC_CLI_INTEGRITY" \
+            --argjson executedCount 10 \
+            '{schemaVersion:2,producerKind:"fresh_canonical_audit_recovery",status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,failedExecuteRunId:$failedExecuteRunId,failedExecuteHeadSha:$failedExecuteHeadSha,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,boundaryManifestSha256:$boundaryManifestSha256,recoveryEvidenceManifestSha256:$recoveryEvidenceManifestSha256,scoreTimestampEvidenceSha256:$scoreTimestampEvidenceSha256,cacheClosureEvidenceSha256:$cacheClosureEvidenceSha256,cacheReadbackSha256:$cacheReadbackSha256,smokeResultSha256:$smokeResultSha256,originalCli:{version:$originalCliVersion,sha256:$originalCliSha256},recoveryRuntime:{cacheVersion:$cacheVersion,smokeCommit:$smokeCommit,publicCliVersion:$publicCliVersion,publicCliIntegrity:$publicCliIntegrity},scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
+            > "$proof/proof.json"
+          (cd "$proof" && sha256sum proof.json > SHA256SUMS)
+
+      - name: Upload recovery execution and smoke evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: fresh-canonical-audit-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/fresh-recovery/boundary/
+            ${{ runner.temp }}/fresh-recovery/execution-results.json
+            ${{ runner.temp }}/fresh-recovery/post-inventory.json
+            ${{ runner.temp }}/fresh-recovery/recovery-evidence/
+            ${{ runner.temp }}/fresh-recovery/execution-proof/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish verified recovery summary
+        run: |
+          {
+            echo '## Fresh canonical audit execution recovered'
+            echo "- Frozen boundary: \`$INCIDENT_DRY_RUN_ID\`"
+            echo "- Failed execute: \`$INCIDENT_FAILED_EXECUTE_RUN_ID\`"
+            echo '- Reconstructed durable writes: `10/10`; next campaign cursor: `30/106`.'
+            echo '- No governance RPC or score recalculation ran in recovery.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/close-fresh-canonical-audit-cache.mjs
+++ b/scripts/close-fresh-canonical-audit-cache.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  throw new Error(`Fresh canonical audit cache recovery: ${message}`);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function parsePlan(body, slug) {
+  const closure = body?.closure?.dependentPacks;
+  if (body?.preflight !== true || body?.type !== 'skills'
+    || canonicalJson(body.slugs) !== canonicalJson([slug])
+    || !Array.isArray(body.locales) || body.locales.length === 0
+    || !closure || !Array.isArray(closure.all) || !Array.isArray(closure.warmable)
+    || closure.overflow !== false || !Number.isSafeInteger(closure.cap)
+    || !body.plan || !Number.isSafeInteger(body?.plan?.totals?.kvOperations)
+    || body.plan.totals.kvOperations > 850
+    || body?.plan?.primary?.resources !== 1
+    || body?.plan?.primary?.api !== 253
+    || body?.plan?.primary?.page !== 231
+    || body?.plan?.primary?.artifactPrefixes !== 2
+    || body.locales.length !== 11
+    || !/^[0-9a-f]{64}$/i.test(body?.planHash || '')
+    || typeof body?.catalogEpoch !== 'string' || body.catalogEpoch.length === 0
+    || body?.invalidated?.total !== 0) {
+    fail(`invalid cache preflight contract for ${slug}`);
+  }
+  return {
+    slug,
+    locales: body.locales,
+    closure,
+    catalogEpoch: body.catalogEpoch,
+    plan: body.plan,
+    planHash: body.planHash,
+    response: body,
+  };
+}
+
+function verifyExecution(body, frozen) {
+  if (body?.preflight !== false || body?.type !== 'skills'
+    || canonicalJson(body.slugs) !== canonicalJson([frozen.slug])
+    || canonicalJson(body.locales) !== canonicalJson(frozen.locales)
+    || body.catalogEpoch !== frozen.catalogEpoch
+    || body.planHash !== frozen.planHash
+    || canonicalJson(body.closure) !== canonicalJson({ dependentPacks: frozen.closure })
+    || canonicalJson(body.plan) !== canonicalJson(frozen.plan)
+    || body?.invalidated?.listVersionBumped !== true
+    || body?.invalidated?.api !== frozen.plan.primary.api
+    || body?.invalidated?.page !== frozen.plan.primary.page
+    || body?.invalidated?.artifacts !== frozen.plan.primary.artifacts
+    || body?.invalidated?.total !== (
+      frozen.plan.primary.api + frozen.plan.primary.page + frozen.plan.primary.artifacts
+    )) {
+    fail(`invalid cache execution contract for ${frozen.slug}`);
+  }
+  if (frozen.closure.all.length > 0) {
+    if (canonicalJson(body?.dependentPacks?.slugs) !== canonicalJson(frozen.closure.all)
+      || canonicalJson(body?.dependentPacks?.anonymousWarmableSlugs) !== canonicalJson(frozen.closure.warmable)
+      || body?.dependentPacks?.invalidated?.api !== frozen.plan.dependentPacks.api
+      || body?.dependentPacks?.invalidated?.page !== frozen.plan.dependentPacks.page
+      || body?.dependentPacks?.invalidated?.artifacts !== frozen.plan.dependentPacks.artifacts) {
+      fail(`invalid dependent Pack closure for ${frozen.slug}`);
+    }
+  } else if (Object.hasOwn(body, 'dependentPacks')) {
+    fail(`unexpected dependent Pack result for ${frozen.slug}`);
+  }
+}
+
+async function request({ body, endpoint, fetchImpl, secret, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'skillstore-fresh-audit-recovery',
+      },
+      body: JSON.stringify(body),
+    });
+    const payload = await response.json().catch(() => null);
+    return { ok: response.ok, status: response.status, payload };
+  } catch (error) {
+    return { ok: false, status: 0, payload: null, error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function preflight(options, slug, maxAttempts, sleepImpl) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = await request({ ...options, body: {
+      type: 'skills', slugs: [slug], preflight: true,
+      invalidateApi: true, invalidateLists: true, invalidateArtifacts: true,
+      invalidateDependentPacks: true,
+    } });
+    if (response.ok) return parsePlan(response.payload, slug);
+    if (attempt === maxAttempts) {
+      fail(`cache preflight returned HTTP ${response.status} for ${slug}${response.error ? `: ${response.error}` : ''}`);
+    }
+    await sleepImpl(attempt * 5_000);
+  }
+  fail(`cache preflight attempts exhausted for ${slug}`);
+}
+
+export async function closeFreshAuditCaches({
+  endpoint = 'https://skillstore.io/api/cache/invalidate',
+  fetchImpl = fetch,
+  maxAttempts = 4,
+  interSkillDelayMs = 1_100,
+  secret,
+  sleepImpl = sleep,
+  slugs,
+  timeoutMs = 90_000,
+}) {
+  if (!secret) fail('cache invalidation secret is required');
+  if (!Number.isSafeInteger(interSkillDelayMs) || interSkillDelayMs < 1_100) {
+    fail('inter-Skill delay must be at least 1100ms');
+  }
+  const requested = [...new Set(slugs.map((slug) => String(slug).trim()).filter(Boolean))].sort();
+  if (requested.length === 0 || requested.length !== slugs.length) fail('exact unique slug set is required');
+  const results = [];
+  for (const slug of requested) {
+    let frozen = await preflight({ endpoint, fetchImpl, secret, timeoutMs }, slug, maxAttempts, sleepImpl);
+    let completed = null;
+    let transportFailures = 0;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const response = await request({ endpoint, fetchImpl, secret, timeoutMs, body: {
+        type: 'skills', slugs: [slug], locales: frozen.locales,
+        invalidateApi: true, invalidateLists: true, invalidateArtifacts: true,
+        invalidateDependentPacks: true,
+        expectedDependentPacks: frozen.closure.all,
+        expectedWarmableDependentPacks: frozen.closure.warmable,
+        expectedPlanHash: frozen.planHash,
+      } });
+      if (response.ok) {
+        verifyExecution(response.payload, frozen);
+        completed = { attempt, execution: response.payload, preflight: frozen.response, slug };
+        break;
+      }
+      if (response.status === 0) {
+        transportFailures += 1;
+        if (transportFailures > 1) {
+          fail(`ambiguous cache execution repeated for ${slug}`);
+        }
+        await sleepImpl(35_000);
+        continue;
+      }
+      if (response.status === 409 && [
+        'Dependent pack closure changed; run preflight again',
+        'Cache invalidation plan changed; run preflight again',
+      ].includes(response.payload?.message)) {
+        frozen = await preflight({ endpoint, fetchImpl, secret, timeoutMs }, slug, maxAttempts, sleepImpl);
+      } else if (attempt === maxAttempts) {
+        fail(`cache execution returned HTTP ${response.status} for ${slug}${response.error ? `: ${response.error}` : ''}`);
+      }
+      if (attempt < maxAttempts) await sleepImpl(attempt * 5_000);
+    }
+    if (!completed) fail(`cache closure attempts exhausted for ${slug}`);
+    results.push(completed);
+    if (results.length < requested.length) await sleepImpl(interSkillDelayMs);
+  }
+  return {
+    schemaVersion: 1,
+    status: 'fresh_canonical_audit_cache_closed',
+    requestedCount: requested.length,
+    closedCount: results.length,
+    slugs: requested,
+    results,
+  };
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith('--')) fail(`missing ${name}`);
+  return args[index + 1];
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const slugs = readFileSync(option(args, '--slugs-file'), 'utf8').split(/\r?\n/).filter(Boolean);
+  const output = resolve(option(args, '--output'));
+  const result = await closeFreshAuditCaches({
+    endpoint: `${option(args, '--site-url').replace(/\/$/, '')}/api/cache/invalidate`,
+    secret: process.env.CACHE_INVALIDATE_SECRET,
+    slugs,
+  });
+  mkdirSync(resolve(output, '..'), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1] || '')).href) {
+  main().catch((error) => {
+    process.stderr.write(`fresh canonical audit cache recovery failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/fetch-artifact-version-inventory.mjs
+++ b/scripts/fetch-artifact-version-inventory.mjs
@@ -20,6 +20,10 @@ const SELECT = [
   'public_eligibility_audit_id',
   'published_at',
   'updated_at',
+  'quality_score',
+  'quality_tier',
+  'quality_score_calculated_at',
+  'current_quality_score_snapshot_id',
 ].join(',');
 const ARTIFACT_SELECT = [
   'id',

--- a/scripts/finalize-artifact-governance-campaign.mjs
+++ b/scripts/finalize-artifact-governance-campaign.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  throw new Error(`Artifact governance campaign finalizer: ${message}`);
+}
+
+async function post({ endpoint, fetchImpl, secret, body }) {
+  const response = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'skillstore-artifact-governance-finalizer',
+    },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) fail(`catalog epoch ${body.action} failed with HTTP ${response.status}`);
+  return payload;
+}
+
+export async function activateCampaignCache({
+  campaignProofSha256,
+  endpoint = 'https://skillstore.io/api/cache/catalog-epoch',
+  expectedEpoch,
+  fetchImpl = fetch,
+  readbackAttempts = 6,
+  secret,
+  sleepImpl = sleep,
+}) {
+  if (!secret || typeof expectedEpoch !== 'string' || expectedEpoch.length === 0
+    || !/^[0-9a-f]{64}$/.test(campaignProofSha256 || '')
+    || !Number.isSafeInteger(readbackAttempts) || readbackAttempts < 1) {
+    fail('invalid activation inputs');
+  }
+  const nextEpoch = `g-${campaignProofSha256.slice(0, 32)}`;
+  const before = await post({ endpoint, fetchImpl, secret, body: { action: 'read' } });
+  const freshTransition = before?.epoch === expectedEpoch && before?.converged === true;
+  const ambiguousCommittedTransition = before?.epoch === nextEpoch;
+  if (before?.changed !== false || (!freshTransition && !ambiguousCommittedTransition)) {
+    fail(`catalog epoch drifted before activation: expected ${expectedEpoch}, got ${before?.epoch}`);
+  }
+  const bump = await post({
+    endpoint,
+    fetchImpl,
+    secret,
+    body: { action: 'bump', expectedEpoch, nextEpoch },
+  });
+  if (bump?.changed !== true || bump?.previousEpoch !== expectedEpoch
+    || bump?.epoch !== nextEpoch || bump?.converged !== true) {
+    fail('catalog epoch bump returned an invalid transition');
+  }
+
+  let readback = null;
+  for (let attempt = 1; attempt <= readbackAttempts; attempt += 1) {
+    readback = await post({ endpoint, fetchImpl, secret, body: { action: 'read' } });
+    if (readback?.epoch === bump.epoch && readback?.changed === false
+      && readback?.converged === true) break;
+    if (attempt < readbackAttempts) await sleepImpl(attempt * 1_000);
+  }
+  if (readback?.epoch !== bump.epoch || readback?.changed !== false
+    || readback?.converged !== true) {
+    fail(`catalog epoch ${bump.epoch} did not converge`);
+  }
+  return {
+    schemaVersion: 1,
+    status: 'artifact_governance_catalog_activated',
+    campaignProofSha256,
+    previousEpoch: expectedEpoch,
+    epoch: bump.epoch,
+    readbackVerified: true,
+  };
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith('--')) fail(`missing ${name}`);
+  return args[index + 1];
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const siteUrl = option(args, '--site-url').replace(/\/$/, '');
+  const output = resolve(option(args, '--output'));
+  const result = await activateCampaignCache({
+    campaignProofSha256: option(args, '--campaign-proof-sha256'),
+    endpoint: `${siteUrl}/api/cache/catalog-epoch`,
+    expectedEpoch: option(args, '--expected-epoch'),
+    secret: process.env.CACHE_INVALIDATE_SECRET,
+  });
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1] || '')).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/fresh-canonical-audit-campaign.mjs
+++ b/scripts/fresh-canonical-audit-campaign.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+
+function fail(message) {
+  throw new Error(`Fresh canonical audit campaign: ${message}`);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+export const CAMPAIGN_STATES = Object.freeze([
+  'PLANNED',
+  'EVIDENCE_READY',
+  'AUDIT_READY',
+  'COMMIT_READY',
+  'DB_WRITTEN_NEEDS_SCORE',
+  'COMMITTED_SCORED',
+  'CACHE_PENDING',
+  'ACTIVATED_VERIFIED',
+  'CAMPAIGN_SEALED',
+]);
+
+const CAMPAIGN_TRANSITIONS = new Map([
+  ['PLANNED', new Set(['EVIDENCE_READY'])],
+  ['EVIDENCE_READY', new Set(['AUDIT_READY', 'COMMIT_READY'])],
+  ['AUDIT_READY', new Set(['COMMIT_READY'])],
+  ['COMMIT_READY', new Set(['DB_WRITTEN_NEEDS_SCORE', 'COMMITTED_SCORED'])],
+  ['DB_WRITTEN_NEEDS_SCORE', new Set(['COMMITTED_SCORED'])],
+  ['COMMITTED_SCORED', new Set(['CACHE_PENDING'])],
+  ['CACHE_PENDING', new Set(['ACTIVATED_VERIFIED'])],
+  ['ACTIVATED_VERIFIED', new Set(['CAMPAIGN_SEALED'])],
+]);
+
+function requireDigest(value, label) {
+  if (!/^[0-9a-f]{64}$/.test(value || '')) fail(`invalid ${label}`);
+  return value;
+}
+
+export function immutableEvidenceKeys({
+  algorithmVersion = 'v1',
+  commit,
+  path,
+  sourceDigest,
+  treeHash,
+}) {
+  if (!/^[a-z0-9][a-z0-9.-]*$/.test(algorithmVersion)
+    || !/^[0-9a-f]{40}$/.test(commit || '')
+    || typeof path !== 'string' || !path || path.startsWith('/') || path.includes('..')) {
+    fail('invalid immutable evidence identity');
+  }
+  requireDigest(sourceDigest, 'source digest');
+  requireDigest(treeHash, 'tree hash');
+  const pathHash = sha256(path);
+  return {
+    source: `source/${algorithmVersion}/${commit}/${pathHash}/${treeHash}.tar.zst`,
+    evidence: `evidence/${algorithmVersion}/${sourceDigest}.json`,
+  };
+}
+
+export function immutableFreshAuditKey({
+  campaignId,
+  model,
+  policyVersion,
+  promptVersion,
+  scannerVersion,
+  subjectDigest,
+}) {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(campaignId || '')) fail('invalid campaign identity');
+  for (const [label, value] of Object.entries({ model, policyVersion, promptVersion, scannerVersion })) {
+    if (typeof value !== 'string' || !value || value.includes('/')) fail(`invalid ${label}`);
+  }
+  requireDigest(subjectDigest, 'audit subject digest');
+  return `fresh-audit/${campaignId}/${subjectDigest}/${scannerVersion}/${policyVersion}/${model}/${promptVersion}.json`;
+}
+
+export function buildCampaignManifest({ campaignId, cohortSha256, rows, shardSize = 10 }) {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(campaignId || '') || !/^[0-9a-f]{64}$/.test(cohortSha256 || '')) {
+    fail('invalid campaign identity');
+  }
+  if (!Number.isSafeInteger(shardSize) || shardSize < 1 || shardSize > 10 || !Array.isArray(rows) || rows.length === 0) {
+    fail('invalid campaign rows or shard size');
+  }
+  const ordered = [...rows].sort((left, right) => left.slug.localeCompare(right.slug, 'en', { sensitivity: 'variant' }));
+  if (new Set(ordered.map((row) => row.slug)).size !== ordered.length) fail('duplicate campaign slug');
+  const shards = [];
+  for (let offset = 0; offset < ordered.length; offset += shardSize) {
+    const shardRows = ordered.slice(offset, offset + shardSize);
+    const index = shards.length;
+    shards.push({
+      index,
+      shardId: `${campaignId}-${String(index).padStart(4, '0')}`,
+      startExclusive: offset === 0 ? null : ordered[offset - 1].slug,
+      endInclusive: shardRows.at(-1).slug,
+      count: shardRows.length,
+      rowsSha256: sha256(shardRows),
+      slugs: shardRows.map((row) => row.slug),
+    });
+  }
+  const items = ordered.map((row) => ({
+    slug: row.slug,
+    inputSha256: sha256(row),
+    requiresFreshAudit: row.requiresFreshAudit !== false,
+    shardId: shards.find((shard) => shard.slugs.includes(row.slug)).shardId,
+  }));
+  const base = {
+    schemaVersion: 1,
+    campaignId,
+    cohortSha256,
+    totalCount: ordered.length,
+    shardSize,
+    shards,
+    items,
+  };
+  return { ...base, manifestSha256: sha256(base) };
+}
+
+export function createCampaignLedger(manifest) {
+  if (manifest?.schemaVersion !== 1 || !Array.isArray(manifest.items)) {
+    fail('unsupported campaign manifest');
+  }
+  return manifest.items.map((item) => ({
+    campaignId: manifest.campaignId,
+    slug: item.slug,
+    shardId: item.shardId,
+    state: 'PLANNED',
+    inputSha256: item.inputSha256,
+    outputSha256: null,
+    attempt: 0,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+  }));
+}
+
+export function transitionCampaignItem(entry, {
+  fromInputSha256,
+  outputSha256,
+  to,
+  attempt,
+  leaseOwner = null,
+  leaseExpiresAt = null,
+}) {
+  if (!entry || !CAMPAIGN_STATES.includes(entry.state)
+    || !CAMPAIGN_TRANSITIONS.get(entry.state)?.has(to)) {
+    fail(`invalid campaign transition ${entry?.state || 'unknown'} -> ${to}`);
+  }
+  if (entry.inputSha256 !== requireDigest(fromInputSha256, 'transition input digest')) {
+    fail(`stale campaign input for ${entry.slug}`);
+  }
+  requireDigest(outputSha256, 'transition output digest');
+  if (!Number.isSafeInteger(attempt) || attempt !== entry.attempt + 1) {
+    fail(`invalid campaign attempt for ${entry.slug}`);
+  }
+  if ((leaseOwner === null) !== (leaseExpiresAt === null)) fail('incomplete campaign lease');
+  if (leaseExpiresAt !== null && !Number.isFinite(Date.parse(leaseExpiresAt))) {
+    fail('invalid campaign lease expiry');
+  }
+  return {
+    ...entry,
+    state: to,
+    inputSha256: outputSha256,
+    outputSha256,
+    attempt,
+    leaseOwner,
+    leaseExpiresAt,
+  };
+}
+
+export function assignFreshAuditLanes(manifest, laneCount = 2) {
+  if (manifest?.schemaVersion !== 1 || !Array.isArray(manifest.items)
+    || !Number.isSafeInteger(laneCount) || laneCount < 1 || laneCount > 3) {
+    fail('invalid Fresh audit lane request');
+  }
+  const lanes = Array.from({ length: laneCount }, (_, index) => ({ index, slugs: [] }));
+  manifest.items
+    .filter((item) => item.requiresFreshAudit)
+    .sort((left, right) => left.slug.localeCompare(right.slug, 'en', { sensitivity: 'variant' }))
+    .forEach((item, index) => lanes[index % laneCount].slugs.push(item.slug));
+  return lanes.map((lane) => ({
+    ...lane,
+    count: lane.slugs.length,
+    slugsSha256: sha256(lane.slugs),
+  }));
+}
+
+export function finalizeCampaign({ manifest, ledger }) {
+  if (manifest?.schemaVersion !== 1 || !Array.isArray(manifest.shards) || !Array.isArray(ledger)) {
+    fail('unsupported campaign evidence');
+  }
+  const byShard = new Map();
+  for (const entry of ledger) {
+    if (byShard.has(entry?.shardId)) fail(`duplicate ledger shard ${entry?.shardId}`);
+    byShard.set(entry?.shardId, entry);
+  }
+  for (const shard of manifest.shards) {
+    const entry = byShard.get(shard.shardId);
+    if (entry?.status !== 'fresh_canonical_audit_execution_complete'
+      || entry.count !== shard.count || entry.endInclusive !== shard.endInclusive
+      || !/^[0-9a-f]{64}$/.test(entry.proofSha256 || '')) {
+      fail(`incomplete shard ${shard.shardId}`);
+    }
+  }
+  if (byShard.size !== manifest.shards.length) fail('ledger contains an unknown shard');
+  return {
+    schemaVersion: 1,
+    status: 'fresh_canonical_audit_campaign_complete',
+    campaignId: manifest.campaignId,
+    manifestSha256: manifest.manifestSha256,
+    completedCount: manifest.totalCount,
+    finalCursor: manifest.shards.at(-1).endInclusive,
+    ledgerSha256: sha256([...ledger].sort((a, b) => a.shardId.localeCompare(b.shardId))),
+  };
+}

--- a/scripts/prepare-fresh-canonical-audit-batch.mjs
+++ b/scripts/prepare-fresh-canonical-audit-batch.mjs
@@ -60,12 +60,28 @@ export function prepareFreshCanonicalAuditBatch({
     const metadata = previousBoundary?.metadata;
     const selection = previousBoundary?.selection;
     const execution = previousBoundary?.executionProof;
+    const supportedExecutionProof = execution?.schemaVersion === 1
+      || (execution?.schemaVersion === 2
+        && execution.producerKind === 'fresh_canonical_audit_recovery'
+        && execution.failedExecuteRunId === '29623717000'
+        && execution.failedExecuteHeadSha === '15492b473b84a835e8b63083510ad1e59184b8db'
+        && [
+          execution.executionResultsSha256,
+          execution.postInventorySha256,
+          execution.boundaryManifestSha256,
+          execution.recoveryEvidenceManifestSha256,
+          execution.scoreTimestampEvidenceSha256,
+          execution.cacheClosureEvidenceSha256,
+          execution.cacheReadbackSha256,
+          execution.smokeResultSha256,
+        ].every((value) => typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)));
     if (metadata?.status !== 'fresh_canonical_audit_frozen'
       || metadata.lastSelected !== cursor || selection?.lastSelected !== cursor
       || selection?.status !== 'lineage_unproven'
       || typeof metadata.runId !== 'string' || !metadata.runId
       || !cohortSha256 || metadata.cohortSha256 !== cohortSha256
       || execution?.status !== 'fresh_canonical_audit_execution_complete'
+      || !supportedExecutionProof
       || execution.dryRunId !== metadata.runId
       || execution.lastSelected !== cursor || execution.cohortSha256 !== cohortSha256
       || typeof execution.executeRunId !== 'string' || !execution.executeRunId

--- a/scripts/tests/artifact-governance-campaign-finalizer.test.mjs
+++ b/scripts/tests/artifact-governance-campaign-finalizer.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { activateCampaignCache } from '../finalize-artifact-governance-campaign.mjs';
+
+test('campaign activation performs one compare-and-swap epoch bump and verifies readback', async () => {
+  const requests = [];
+  let epoch = 'epoch-1';
+  const result = await activateCampaignCache({
+    campaignProofSha256: 'a'.repeat(64),
+    expectedEpoch: epoch,
+    secret: 'secret',
+    sleepImpl: async () => {},
+    fetchImpl: async (_url, init) => {
+      const body = JSON.parse(init.body);
+      requests.push(body);
+      if (body.action === 'read') {
+        return new Response(JSON.stringify({ action: 'read', epoch, changed: false, converged: true }));
+      }
+      assert.equal(body.expectedEpoch, 'epoch-1');
+      assert.equal(body.nextEpoch, `g-${'a'.repeat(32)}`);
+      epoch = body.nextEpoch;
+      return new Response(JSON.stringify({
+        action: 'bump', previousEpoch: 'epoch-1', epoch, changed: true, converged: true,
+      }));
+    },
+  });
+
+  assert.equal(result.epoch, `g-${'a'.repeat(32)}`);
+  assert.deepEqual(requests, [
+    { action: 'read' },
+    { action: 'bump', expectedEpoch: 'epoch-1', nextEpoch: `g-${'a'.repeat(32)}` },
+    { action: 'read' },
+  ]);
+});
+
+test('campaign activation refuses epoch drift without a bump request', async () => {
+  const requests = [];
+  await assert.rejects(activateCampaignCache({
+    campaignProofSha256: 'a'.repeat(64),
+    expectedEpoch: 'epoch-1',
+    secret: 'secret',
+    fetchImpl: async (_url, init) => {
+      requests.push(JSON.parse(init.body));
+      return new Response(JSON.stringify({ action: 'read', epoch: 'epoch-2', changed: false, converged: true }));
+    },
+  }), /catalog epoch drifted before activation/);
+  assert.deepEqual(requests, [{ action: 'read' }]);
+});
+
+test('campaign activation replays an ambiguously committed CAS and repairs its KV mirror', async () => {
+  const requests = [];
+  const nextEpoch = `g-${'a'.repeat(32)}`;
+  let converged = false;
+  const result = await activateCampaignCache({
+    campaignProofSha256: 'a'.repeat(64),
+    expectedEpoch: 'epoch-1',
+    secret: 'secret',
+    sleepImpl: async () => {},
+    fetchImpl: async (_url, init) => {
+      const body = JSON.parse(init.body);
+      requests.push(body);
+      if (body.action === 'read') {
+        return new Response(JSON.stringify({
+          action: 'read', epoch: nextEpoch, changed: false, converged,
+        }));
+      }
+      assert.deepEqual(body, { action: 'bump', expectedEpoch: 'epoch-1', nextEpoch });
+      converged = true;
+      return new Response(JSON.stringify({
+        action: 'bump', previousEpoch: 'epoch-1', epoch: nextEpoch,
+        changed: true, replayed: true, converged: true,
+      }));
+    },
+  });
+
+  assert.equal(result.epoch, nextEpoch);
+  assert.equal(result.readbackVerified, true);
+  assert.deepEqual(requests, [
+    { action: 'read' },
+    { action: 'bump', expectedEpoch: 'epoch-1', nextEpoch },
+    { action: 'read' },
+  ]);
+});

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -75,7 +75,7 @@ test('cursor requires both the immediately preceding boundary and a fully govern
     },
     selection: { status: 'lineage_unproven', lastSelected: row.slug },
     executionProof: {
-      status: 'fresh_canonical_audit_execution_complete', executeRunId: '456',
+      schemaVersion: 1, status: 'fresh_canonical_audit_execution_complete', executeRunId: '456',
       dryRunId: '123', lastSelected: row.slug, cohortSha256,
       scoreFinalized: true, timestampFinalized: true, cacheClosureCompleted: true,
       packClosureCompleted: true, productionSmokeCompleted: true,
@@ -102,9 +102,9 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute\]/);
+  assert.match(workflow, /options: \[dry-run, execute, recover\]/);
   assert.match(workflow, /default: '2\.8\.0'/);
-  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 2);
+  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 3);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
@@ -122,9 +122,9 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/sparse-checkout-cone-mode: false/g) || []).length, 2);
   assert.equal((workflow.match(/git sparse-checkout disable/g) || []).length, 2);
   assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
-  assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 2);
+  assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 3);
   assert.match(workflow, /fresh_canonical_audit_execution_complete/);
-  assert.equal((workflow.match(/include-hidden-files: true/g) || []).length, 2);
+  assert.equal((workflow.match(/include-hidden-files: true/g) || []).length, 3);
   assert.match(workflow, /name: fresh-canonical-audit-boundary-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /name: fresh-canonical-audit-execution-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /productionSmokeCompleted:true/);
@@ -136,4 +136,12 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0\.1\.9,skillstore@latest/);
   assert.match(workflow, /production-smoke\.mjs/);
   assert.match(workflow, /MCP channel/);
+  assert.match(workflow, /recover-boundary:/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29622305779'/);
+  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: '29623717000'/);
+  assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);
+  assert.match(workflow, /scripts\/verify-fresh-canonical-audit-recovery\.mjs/);
+  assert.match(workflow, /scripts\/close-fresh-canonical-audit-cache\.mjs/);
+  const recovery = workflow.slice(workflow.indexOf('  recover-boundary:'));
+  assert.doesNotMatch(recovery, /skill govern-fresh-canonical-audit|recalculate-scores|record_fresh_canonical_audit/);
 });

--- a/scripts/tests/fresh-canonical-audit-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-recovery.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { closeFreshAuditCaches } from '../close-fresh-canonical-audit-cache.mjs';
+import {
+  assignFreshAuditLanes,
+  buildCampaignManifest,
+  createCampaignLedger,
+  finalizeCampaign,
+  immutableEvidenceKeys,
+  immutableFreshAuditKey,
+  transitionCampaignItem,
+} from '../fresh-canonical-audit-campaign.mjs';
+import { verifyRecoveryState } from '../verify-fresh-canonical-audit-recovery.mjs';
+
+const ids = {
+  skill: '11111111-1111-4111-8111-111111111111',
+  oldAudit: '22222222-2222-4222-8222-222222222222',
+  audit: '33333333-3333-4333-8333-333333333333',
+  artifact: '44444444-4444-4444-8444-444444444444',
+  snapshot: '55555555-5555-4555-8555-555555555555',
+};
+const commit = 'a'.repeat(40);
+const content = 'b'.repeat(64);
+const tree = 'c'.repeat(64);
+const auditContent = `v3:${commit}:${content}:${tree}:path:payload`;
+const failedRun = {
+  id: 29623717000,
+  head_sha: '15492b473b84a835e8b63083510ad1e59184b8db',
+  conclusion: 'failure', event: 'workflow_dispatch', head_branch: 'main', run_attempt: 1,
+  run_started_at: '2026-07-18T00:43:26Z', updated_at: '2026-07-18T00:47:35Z',
+};
+
+function fixture() {
+  const candidate = {
+    row: { slug: 'owner-skill', skillId: ids.skill, marketplaceCommit: commit,
+      path: 'skills/owner/skill', canonicalArtifact: { contentHash: content, treeHash: tree } },
+    expectedSkill: { published_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-02T00:00:00Z' },
+    expectedLatestAudit: { id: ids.oldAudit, version: 4 },
+    auditId: ids.audit,
+    rpcPayload: { p_audit_payload: { content_hash: auditContent } },
+  };
+  const skill = {
+    id: ids.skill, slug: 'owner-skill', status: 'approved', public_eligible: true,
+    artifact_revision: 1, current_artifact_version_id: ids.artifact,
+    content_hash: content, tree_hash: tree, marketplace_commit_sha: commit,
+    plugin_path: 'skills/owner/skill', public_eligibility_audit_id: ids.audit,
+    current_quality_score_snapshot_id: ids.snapshot, quality_score: 88, quality_tier: 'silver',
+    quality_score_calculated_at: '2026-07-18T00:44:12Z',
+    published_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-02T00:00:00Z',
+  };
+  return {
+    boundary: { schemaVersion: 1, status: 'fresh_canonical_audit_frozen', candidates: [candidate] },
+    inventory: { schemaVersion: 2, rows: [skill], artifacts: [{
+      id: ids.artifact, skill_id: ids.skill, artifact_revision: 1, change_kind: 'initial',
+      previous_version_id: null, content_hash: content, tree_hash: tree,
+      marketplace_commit_sha: commit, source_path: 'skills/owner/skill', created_at: '2026-07-18T00:44:04Z',
+    }], observations: [{
+      id: '66666666-6666-4666-8666-666666666666',
+      skill_id: ids.skill,
+      artifact_version_id: ids.artifact,
+      marketplace_commit_sha: commit,
+      source_path: 'skills/owner/skill',
+      created_at: '2026-07-18T00:44:04Z',
+    }] },
+    audits: [{ id: ids.audit, skill_id: ids.skill, version: 5, content_hash: auditContent,
+      analysis_status: 'ok', derived_from_audit_id: null, derivation_kind: null,
+      subject_marketplace_commit_sha: commit, subject_content_hash: content,
+      subject_tree_hash: tree, subject_plugin_path: 'skills/owner/skill',
+      created_at: '2026-07-18T00:44:04Z' }],
+    snapshots: [{ id: ids.snapshot, skill_id: ids.skill, scorer_version: '1.9.0',
+      composite_score: 88, quality_tier: 'silver', calculated_at: '2026-07-18T00:44:12Z',
+      created_at: '2026-07-18T00:44:12Z', score_inputs: {
+        skill: { updatedAt: '2026-07-02T00:00:00Z' },
+      }, score_subject: {
+        auditId: ids.audit, auditVersion: 5, auditContentHash: auditContent,
+        contentHash: content, treeHash: tree, marketplaceCommitSha: commit, pluginPath: 'skills/owner/skill',
+      } }],
+    breakdowns: [{
+      skill_id: ids.skill, score_snapshot_id: ids.snapshot, stale_at: null, stale_reason: null,
+      calculated_at: '2026-07-18T00:44:12Z', scorer_version: '1.9.0', composite_score: 88,
+    }],
+    failedRun,
+  };
+}
+
+test('reconstructs deterministic execution results only from exact incident-bound durable state', () => {
+  const result = verifyRecoveryState(fixture());
+  assert.deepEqual(result.executionResults, [{
+    slug: 'owner-skill', skillId: ids.skill, artifactVersionId: ids.artifact,
+    artifactRevision: 1, artifactCreated: true, auditId: ids.audit,
+    auditVersion: 5, scoreSnapshotId: ids.snapshot, scoreBreakdownVerified: true,
+  }]);
+  assert.equal(result.recoveryEvidence.verifiedCount, 1);
+  assert.equal(result.expectedScoreEvidence.scores[0].qualityScore, 88);
+});
+
+test('rejects later mutation, wrong snapshot binding, or a different failed run', () => {
+  const later = fixture();
+  later.inventory.artifacts[0].created_at = '2026-07-18T00:48:00Z';
+  assert.throws(() => verifyRecoveryState(later), /artifact evidence mismatch/);
+  const snapshot = fixture();
+  snapshot.snapshots[0].score_subject.auditId = ids.oldAudit;
+  assert.throws(() => verifyRecoveryState(snapshot), /score subject mismatch/);
+  const run = fixture();
+  run.failedRun.run_attempt = 2;
+  assert.throws(() => verifyRecoveryState(run), /failed run identity/);
+});
+
+function preflight(slug, packs = []) {
+  const planHash = Buffer.from(`${slug}:${packs.join(',')}`)
+    .toString('hex').padEnd(64, '0').slice(0, 64);
+  return {
+    preflight: true, type: 'skills', slugs: [slug],
+    locales: ['en', 'zh-hans', 'zh-hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'ru', 'ar'],
+    catalogEpoch: 'epoch-test',
+    planHash,
+    closure: { dependentPacks: { all: packs, warmable: packs, overflow: false, cap: 100 } },
+    plan: {
+      primary: { resources: 1, api: 253, page: 231, artifactPrefixes: 2, artifacts: 0, artifactListOperations: 2 },
+      dependentPacks: { resources: packs.length, api: packs.length * 33, page: packs.length * 66, artifactPrefixes: packs.length, artifacts: 0, artifactListOperations: packs.length },
+      totals: { resources: 1 + packs.length, kvOperations: packs.length ? 588 : 488 },
+    },
+    invalidated: { total: 0, api: 0, artifacts: 0 },
+  };
+}
+
+function executed(plan) {
+  return {
+    preflight: false, type: 'skills', slugs: plan.slugs, locales: plan.locales,
+    catalogEpoch: plan.catalogEpoch,
+    planHash: plan.planHash,
+    closure: plan.closure, plan: plan.plan,
+    invalidated: { total: 484, api: 253, page: 231, artifacts: 0, listVersionBumped: true },
+    ...(plan.closure.dependentPacks.all.length ? { dependentPacks: {
+      slugs: plan.closure.dependentPacks.all,
+      anonymousWarmableSlugs: plan.closure.dependentPacks.warmable,
+      invalidated: { total: 99, api: 33, page: 66, artifacts: 0 },
+    } } : {}),
+  };
+}
+
+test('closes cache one Skill at a time and binds execution to exact Pack closure', async () => {
+  const requests = [];
+  const plans = new Map();
+  const result = await closeFreshAuditCaches({
+    secret: 'secret', slugs: ['beta', 'alpha'], sleepImpl: async () => {},
+    fetchImpl: async (_url, init) => {
+      const body = JSON.parse(init.body);
+      requests.push(body);
+      if (body.preflight) {
+        const plan = preflight(body.slugs[0], body.slugs[0] === 'alpha' ? ['pack-a'] : []);
+        plans.set(body.slugs[0], plan);
+        return new Response(JSON.stringify(plan), { status: 200 });
+      }
+      return new Response(JSON.stringify(executed(plans.get(body.slugs[0]))), { status: 200 });
+    },
+  });
+  assert.equal(result.closedCount, 2);
+  assert.deepEqual(result.slugs, ['alpha', 'beta']);
+  assert(requests.every((request) => request.slugs.length === 1));
+  assert.deepEqual(requests[1].expectedDependentPacks, ['pack-a']);
+  assert.equal(requests[1].expectedPlanHash, plans.get('alpha').planHash);
+});
+
+test('retries an aborted per-Skill execution and refreshes an explicit closure drift', async () => {
+  let preflights = 0;
+  let executes = 0;
+  let activePlan;
+  const result = await closeFreshAuditCaches({
+    secret: 'secret', slugs: ['alpha'], sleepImpl: async () => {},
+    fetchImpl: async (_url, init) => {
+      const body = JSON.parse(init.body);
+      if (body.preflight) {
+        preflights += 1;
+        activePlan = preflight('alpha', preflights === 1 ? ['pack-a'] : ['pack-b']);
+        return new Response(JSON.stringify(activePlan), { status: 200 });
+      }
+      executes += 1;
+      if (executes === 1) throw new Error('The operation was aborted.');
+      if (executes === 2) return new Response(JSON.stringify({
+        message: 'Dependent pack closure changed; run preflight again',
+      }), { status: 409 });
+      return new Response(JSON.stringify(executed(activePlan)), { status: 200 });
+    },
+  });
+  assert.equal(result.closedCount, 1);
+  assert.equal(preflights, 2);
+  assert.equal(executes, 3);
+  assert.deepEqual(result.results[0].preflight.closure.dependentPacks.all, ['pack-b']);
+});
+
+test('campaign manifest and finalizer are deterministic and reject partial ledgers', () => {
+  const rows = [{ slug: 'beta' }, { slug: 'alpha' }, { slug: 'gamma' }];
+  const manifest = buildCampaignManifest({ campaignId: 'fresh-2026', cohortSha256: 'f'.repeat(64), rows, shardSize: 2 });
+  assert.deepEqual(manifest.shards.map((shard) => shard.slugs), [['alpha', 'beta'], ['gamma']]);
+  const ledger = manifest.shards.map((shard) => ({
+    shardId: shard.shardId, status: 'fresh_canonical_audit_execution_complete',
+    count: shard.count, endInclusive: shard.endInclusive, proofSha256: 'e'.repeat(64),
+  }));
+  assert.equal(finalizeCampaign({ manifest, ledger }).completedCount, 3);
+  assert.throws(() => finalizeCampaign({ manifest, ledger: ledger.slice(0, 1) }), /incomplete shard/);
+});
+
+test('campaign ledger enforces hashed state transitions and deterministic audit lanes', () => {
+  const manifest = buildCampaignManifest({
+    campaignId: 'fresh-2026',
+    cohortSha256: 'f'.repeat(64),
+    rows: [
+      { slug: 'delta', requiresFreshAudit: false },
+      { slug: 'charlie' },
+      { slug: 'bravo' },
+      { slug: 'alpha' },
+    ],
+    shardSize: 2,
+  });
+  assert.deepEqual(
+    assignFreshAuditLanes(manifest, 2).map((lane) => lane.slugs),
+    [['alpha', 'charlie'], ['bravo']]
+  );
+  const ledger = createCampaignLedger(manifest);
+  const planned = ledger.find((entry) => entry.slug === 'alpha');
+  const evidence = transitionCampaignItem(planned, {
+    fromInputSha256: planned.inputSha256,
+    outputSha256: 'a'.repeat(64),
+    to: 'EVIDENCE_READY',
+    attempt: 1,
+  });
+  assert.equal(evidence.state, 'EVIDENCE_READY');
+  assert.throws(() => transitionCampaignItem(evidence, {
+    fromInputSha256: planned.inputSha256,
+    outputSha256: 'b'.repeat(64),
+    to: 'COMMIT_READY',
+    attempt: 2,
+  }), /stale campaign input/);
+});
+
+test('immutable evidence and Fresh audit keys bind source and campaign identity', () => {
+  const keys = immutableEvidenceKeys({
+    commit: 'a'.repeat(40),
+    path: 'skills/owner/skill',
+    sourceDigest: 'b'.repeat(64),
+    treeHash: 'c'.repeat(64),
+  });
+  assert.match(keys.source, /^source\/v1\/[0-9a-f]{40}\/[0-9a-f]{64}\/[0-9a-f]{64}\.tar\.zst$/);
+  assert.equal(keys.evidence, `evidence/v1/${'b'.repeat(64)}.json`);
+  assert.equal(immutableFreshAuditKey({
+    campaignId: 'fresh-2026',
+    model: 'sol-high',
+    policyVersion: 'policy-v3',
+    promptVersion: 'prompt-v2',
+    scannerVersion: 'scanner-v1',
+    subjectDigest: 'd'.repeat(64),
+  }), `fresh-audit/fresh-2026/${'d'.repeat(64)}/scanner-v1/policy-v3/sol-high/prompt-v2.json`);
+});

--- a/scripts/verify-fresh-canonical-audit-recovery.mjs
+++ b/scripts/verify-fresh-canonical-audit-recovery.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function fail(message) {
+  throw new Error(`Fresh canonical audit recovery: ${message}`);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameTimestamp(left, right) {
+  return typeof left === 'string' && typeof right === 'string'
+    && Number.isFinite(Date.parse(left)) && Date.parse(left) === Date.parse(right);
+}
+
+function withinRun(value, failedRun) {
+  const time = Date.parse(value);
+  const start = Date.parse(failedRun.run_started_at || failedRun.created_at);
+  const end = Date.parse(failedRun.updated_at);
+  return Number.isFinite(time) && Number.isFinite(start) && Number.isFinite(end)
+    && time >= start && time <= end;
+}
+
+function uniqueBy(rows, key, label) {
+  const result = new Map();
+  for (const row of rows) {
+    if (!row || typeof row[key] !== 'string' || result.has(row[key])) fail(`duplicate or invalid ${label}`);
+    result.set(row[key], row);
+  }
+  return result;
+}
+
+function latestAuditsBySkill(rows, skillIds) {
+  const result = new Map();
+  for (const row of rows.filter((item) => skillIds.includes(item?.skill_id))) {
+    const current = result.get(row.skill_id);
+    if (!current || row.version > current.version
+      || (row.version === current.version && Date.parse(row.created_at) > Date.parse(current.created_at))) {
+      result.set(row.skill_id, row);
+    }
+  }
+  return result;
+}
+
+export function verifyRecoveryState({ boundary, inventory, audits, snapshots, breakdowns, failedRun }) {
+  if (boundary?.schemaVersion !== 1 || boundary?.status !== 'fresh_canonical_audit_frozen'
+    || !Array.isArray(boundary.candidates) || boundary.candidates.length === 0) {
+    fail('unsupported frozen boundary');
+  }
+  if (failedRun?.id !== 29623717000 || failedRun?.head_sha !== '15492b473b84a835e8b63083510ad1e59184b8db'
+    || failedRun?.conclusion !== 'failure' || failedRun?.event !== 'workflow_dispatch'
+    || failedRun?.head_branch !== 'main' || failedRun?.run_attempt !== 1) {
+    fail('failed run identity does not match the incident boundary');
+  }
+  if (inventory?.schemaVersion !== 2 || !Array.isArray(inventory.rows) || !Array.isArray(inventory.artifacts)) {
+    fail('unsupported post-inventory');
+  }
+
+  const candidates = boundary.candidates;
+  const candidateSlugs = candidates.map((candidate) => candidate?.row?.slug);
+  const candidateIds = candidates.map((candidate) => candidate?.row?.skillId);
+  if (new Set(candidateSlugs).size !== candidates.length || new Set(candidateIds).size !== candidates.length) {
+    fail('boundary contains duplicate Skill identity');
+  }
+  const skillsById = uniqueBy(
+    inventory.rows.filter((row) => candidateIds.includes(row.id)), 'id', 'post-inventory Skill id'
+  );
+  const artifactsBySkill = uniqueBy(
+    inventory.artifacts.filter((row) => candidateIds.includes(row.skill_id)), 'skill_id', 'artifact Skill id'
+  );
+  const observationsBySkill = uniqueBy(
+    inventory.observations.filter((row) => candidateIds.includes(row.skill_id)),
+    'skill_id',
+    'observation Skill id'
+  );
+  const auditsBySkill = latestAuditsBySkill(audits, candidateIds);
+  const snapshotsById = uniqueBy(snapshots, 'id', 'score snapshot id');
+  const breakdownsBySkill = uniqueBy(breakdowns, 'skill_id', 'score breakdown Skill id');
+  if ([skillsById, artifactsBySkill, observationsBySkill, auditsBySkill, breakdownsBySkill]
+    .some((map) => map.size !== candidates.length)) {
+    fail('recovery evidence does not cover the exact frozen cohort');
+  }
+
+  const executionResults = [];
+  const scoreEvidence = [];
+  const rows = [];
+  for (const candidate of candidates) {
+    const { row, expectedSkill, expectedLatestAudit, rpcPayload, auditId } = candidate;
+    const skill = skillsById.get(row.skillId);
+    const artifact = artifactsBySkill.get(row.skillId);
+    const observation = observationsBySkill.get(row.skillId);
+    const audit = auditsBySkill.get(row.skillId);
+    const snapshot = snapshotsById.get(skill?.current_quality_score_snapshot_id);
+    const breakdown = breakdownsBySkill.get(row.skillId);
+    const expectedAuditContentHash = rpcPayload?.p_audit_payload?.content_hash;
+    const subject = snapshot?.score_subject;
+
+    if (!skill || skill.slug !== row.slug || skill.artifact_revision !== 1
+      || !UUID_RE.test(skill.current_artifact_version_id || '')
+      || skill.current_artifact_version_id !== artifact?.id
+      || skill.content_hash !== row.canonicalArtifact.contentHash
+      || skill.tree_hash !== row.canonicalArtifact.treeHash
+      || skill.marketplace_commit_sha !== row.marketplaceCommit || skill.plugin_path !== row.path
+      || skill.public_eligible !== true || skill.status !== 'approved'
+      || skill.public_eligibility_audit_id !== auditId
+      || !sameTimestamp(skill.published_at, expectedSkill.published_at)
+      || !sameTimestamp(skill.updated_at, expectedSkill.updated_at)) {
+      fail(`canonical Skill or finalized timestamp mismatch for ${row.slug}`);
+    }
+    if (artifact?.artifact_revision !== 1 || artifact?.change_kind !== 'initial'
+      || artifact?.previous_version_id !== null || artifact?.content_hash !== row.canonicalArtifact.contentHash
+      || artifact?.tree_hash !== row.canonicalArtifact.treeHash
+      || artifact?.marketplace_commit_sha !== row.marketplaceCommit || artifact?.source_path !== row.path
+      || !withinRun(artifact?.created_at, failedRun)) {
+      fail(`artifact evidence mismatch for ${row.slug}`);
+    }
+    if (observation?.artifact_version_id !== artifact.id
+      || observation?.marketplace_commit_sha !== row.marketplaceCommit
+      || observation?.source_path !== row.path
+      || !withinRun(observation?.created_at, failedRun)) {
+      fail(`artifact observation mismatch for ${row.slug}`);
+    }
+    if (audit?.id !== auditId || audit?.version !== expectedLatestAudit.version + 1
+      || audit?.content_hash !== expectedAuditContentHash
+      || audit?.analysis_status !== 'ok' || audit?.derived_from_audit_id !== null
+      || audit?.derivation_kind !== null
+      || audit?.subject_marketplace_commit_sha !== row.marketplaceCommit
+      || audit?.subject_content_hash !== row.canonicalArtifact.contentHash
+      || audit?.subject_tree_hash !== row.canonicalArtifact.treeHash
+      || audit?.subject_plugin_path !== row.path
+      || !withinRun(audit?.created_at, failedRun)) {
+      fail(`fresh audit evidence mismatch for ${row.slug}`);
+    }
+    if (!snapshot || snapshot.skill_id !== row.skillId || !withinRun(snapshot.created_at, failedRun)
+      || snapshot.scorer_version !== '1.9.0' || typeof snapshot.composite_score !== 'number'
+      || subject?.auditId !== auditId || subject?.auditVersion !== audit.version
+      || subject?.auditContentHash !== audit.content_hash
+      || subject?.contentHash !== row.canonicalArtifact.contentHash
+      || subject?.treeHash !== row.canonicalArtifact.treeHash
+      || subject?.marketplaceCommitSha !== row.marketplaceCommit || subject?.pluginPath !== row.path
+      || !sameTimestamp(snapshot?.score_inputs?.skill?.updatedAt, expectedSkill.updated_at)
+      || breakdown?.score_snapshot_id !== snapshot.id || breakdown?.stale_at !== null
+      || breakdown?.stale_reason !== null || breakdown?.scorer_version !== snapshot.scorer_version
+      || breakdown?.composite_score !== snapshot.composite_score
+      || !sameTimestamp(breakdown?.calculated_at, snapshot.calculated_at)) {
+      fail(`score subject mismatch for ${row.slug}`);
+    }
+    if (snapshots.some((item) => item.skill_id === row.skillId
+      && Date.parse(item.created_at) > Date.parse(snapshot.created_at))) {
+      fail(`later score snapshot exists for ${row.slug}`);
+    }
+    if (skill.quality_score !== snapshot.composite_score || skill.quality_tier !== snapshot.quality_tier
+      || !sameTimestamp(skill.quality_score_calculated_at, snapshot.calculated_at)) {
+      fail(`current score pointer mismatch for ${row.slug}`);
+    }
+
+    executionResults.push({
+      slug: row.slug,
+      skillId: row.skillId,
+      artifactVersionId: artifact.id,
+      artifactRevision: 1,
+      artifactCreated: true,
+      auditId: audit.id,
+      auditVersion: audit.version,
+      scoreSnapshotId: snapshot.id,
+      scoreBreakdownVerified: true,
+    });
+    scoreEvidence.push({
+      calculatedAt: skill.quality_score_calculated_at,
+      qualityScore: skill.quality_score,
+      qualityTier: skill.quality_tier,
+      slug: row.slug,
+      snapshotId: snapshot.id,
+    });
+    rows.push({
+      slug: row.slug,
+      skillId: row.skillId,
+      artifactVersionId: artifact.id,
+      artifactCreatedAt: artifact.created_at,
+      auditId: audit.id,
+      auditVersion: audit.version,
+      auditCreatedAt: audit.created_at,
+      scoreSnapshotId: snapshot.id,
+      scoreSnapshotCreatedAt: snapshot.created_at,
+      publishedAtFinalized: true,
+      updatedAtFinalized: true,
+    });
+  }
+
+  return {
+    executionResults,
+    expectedScoreEvidence: { schemaVersion: 1, scores: scoreEvidence },
+    recoveryEvidence: {
+      schemaVersion: 1,
+      status: 'fresh_canonical_audit_durable_writes_verified',
+      failedExecuteRunId: String(failedRun.id),
+      failedExecuteHeadSha: failedRun.head_sha,
+      verifiedCount: rows.length,
+      selectedSlugsCanonicalSha256Input: canonicalJson([...candidateSlugs].sort()),
+      rows,
+    },
+  };
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith('--')) fail(`missing ${name}`);
+  return args[index + 1];
+}
+
+async function fetchRows({ table, select, filter, supabaseUrl, serviceKey }) {
+  if (!/^https:\/\//.test(supabaseUrl || '') || !serviceKey) fail('Supabase read credentials are required');
+  const url = new URL(`/rest/v1/${table}`, supabaseUrl);
+  url.searchParams.set('select', select);
+  url.searchParams.set(...filter);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Accept-Profile': 'skillstore',
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+    },
+  });
+  if (!response.ok) fail(`${table} read failed: HTTP ${response.status}`);
+  const rows = await response.json();
+  if (!Array.isArray(rows)) fail(`${table} read returned a non-array`);
+  return rows;
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const boundary = JSON.parse(readFileSync(option(args, '--boundary'), 'utf8'));
+  const inventory = JSON.parse(readFileSync(option(args, '--post-inventory'), 'utf8'));
+  const failedRun = JSON.parse(readFileSync(option(args, '--failed-run'), 'utf8'));
+  const outputDir = resolve(option(args, '--output-dir'));
+  const ids = boundary.candidates.map((candidate) => candidate.row.skillId);
+  const common = {
+    supabaseUrl: process.env.SUPABASE_URL,
+    serviceKey: process.env.SUPABASE_SERVICE_KEY,
+  };
+  const [audits, snapshots, breakdowns] = await Promise.all([
+    fetchRows({ ...common, table: 'skill_security_audit',
+      select: 'id,skill_id,version,content_hash,analysis_status,derived_from_audit_id,derivation_kind,subject_marketplace_commit_sha,subject_content_hash,subject_tree_hash,subject_plugin_path,created_at', filter: ['skill_id', `in.(${ids.join(',')})`] }),
+    fetchRows({ ...common, table: 'skill_quality_score_snapshots',
+      select: 'id,skill_id,scorer_version,score_subject,score_inputs,breakdown,composite_score,quality_tier,calculated_at,created_at',
+      filter: ['skill_id', `in.(${ids.join(',')})`] }),
+    fetchRows({ ...common, table: 'skill_quality_breakdown',
+      select: 'skill_id,score_snapshot_id,stale_at,stale_reason,calculated_at,scorer_version,composite_score',
+      filter: ['skill_id', `in.(${ids.join(',')})`] }),
+  ]);
+  const result = verifyRecoveryState({
+    boundary,
+    inventory,
+    audits,
+    snapshots,
+    breakdowns,
+    failedRun,
+  });
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(resolve(outputDir, 'execution-results.json'), `${JSON.stringify(result.executionResults, null, 2)}\n`);
+  writeFileSync(resolve(outputDir, 'expected-score-evidence.json'), `${JSON.stringify(result.expectedScoreEvidence, null, 2)}\n`);
+  writeFileSync(resolve(outputDir, 'score-timestamp-evidence.json'), `${JSON.stringify(result.recoveryEvidence, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1] || '')).href) {
+  main().catch((error) => {
+    process.stderr.write(`fresh canonical audit recovery verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add incident-bounded cache-only recovery for failed execute 29623717000; never rerun governance RPC or scoring
- verify the exact 10-row artifact/audit/score/timestamp chain and close cache sequentially per Skill
- add deterministic campaign manifests, resumable ledger primitives, 2-3 audit lanes, and one Postgres-authoritative cache epoch finalizer
- pin production Skillstore smoke SHA 3bb1eb0eea6651a8965b106a9df406f1e73ab5f2

## Verification
- CI=true node --test focused artifact governance/cache/recovery/finalizer suite: 42 passed
- Node syntax checks for all new scripts
- workflow YAML parsed successfully
- git diff --check

## Safety
- recovery is readback/cache/smoke/proof only; no governance RPC, rescore, or Generate Pack
- cursor advances only after checksum-bound schema-v2 recovery proof
- DB CPU >=80% or broken pointer !=0 remains a hard stop