### PR TITLE
fix(cache): align recovery readback with skill detail v7

### DIFF
--- a/.github/workflows/recover-score-cache-closure.yml
+++ b/.github/workflows/recover-score-cache-closure.yml
@@ -329,7 +329,7 @@ jobs:
           test "$(jq -r '.scores | length' "$expected")" -eq "$count"
           invalidation_target="$RUNNER_TEMP/cache-invalidation-slugs.txt"
           if [ "$SCOPE" = approved-catalog-cache ]; then
-            # The deployed Skill detail v6 / recommendation v3 / page-build
+            # The deployed Skill detail v7 / recommendation v3 / page-build
             # generations make every old per-Skill key unreachable. One exact
             # invalidation still bumps the shared Skill-list generation without
             # issuing millions of redundant KV deletes for the full catalog.
@@ -377,7 +377,7 @@ jobs:
             --expected-score-evidence "$RUNNER_TEMP/cache-closure-expected-score-evidence.json" \
             --evidence "$RUNNER_TEMP/cache-readback.json" \
             --site-url https://skillstore.io \
-            --expected-cache-version v6 \
+            --expected-cache-version v7 \
             --concurrency 16 \
             --attempts 3 \
             --timeout-ms 30000

--- a/scripts/tests/score-cache-closure.test.mjs
+++ b/scripts/tests/score-cache-closure.test.mjs
@@ -349,7 +349,7 @@ test('manual recovery is file-backed, fixed-CLI, bounded, and red on any remaini
   assert.match(RECOVERY, /listVersionBumped:\$listVersionBumped/);
   assert.match(RECOVERY, /List-generation invalidation slugs:/);
   assert.match(RECOVERY, /batch-size: '30'\n\s+concurrency: \$\{\{ needs\.plan\.outputs\.scope == 'approved-catalog-cache' && '4' \|\| '1' \}\}/);
-  assert.match(RECOVERY, /--expected-cache-version v6/);
+  assert.match(RECOVERY, /--expected-cache-version v7/);
   assert.match(RECOVERY, /--concurrency 16/);
   assert.match(RECOVERY, /Require complete score and cache recovery/);
   assert.match(RECOVERY, /freeze-score-evidence/);


### PR DESCRIPTION
## Summary
- update the manual score/cache recovery workflow to require Skill detail cache v7
- update the workflow contract test to pin the same expected version

## Rollout dependency
Merge only after the Skillstore v7 deployment is live and verified. The recovery workflow is manual, so it must not be dispatched during the transition window.

## Verification
- `CI=true node --test scripts/tests/score-cache-closure.test.mjs` — 17/17 passed
- `git diff --check` — passed
