### PR TITLE
fix(governance): pin cache-safe CLI 2.8.2

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.8.0'
+        default: '2.8.2'
 
 permissions:
   actions: read
@@ -101,7 +101,7 @@ jobs:
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
+          test "$CLI_VERSION" = '2.8.2' || { echo '::error::workflow is pinned to CLI 2.8.2'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
@@ -248,21 +248,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.8.0
+      - name: Download exact fresh-governance CLI 2.8.2
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.0'
-          minimum-version: '2.8.0'
+          version: '2.8.2'
+          minimum-version: '2.8.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+          audited='9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO before any run'; exit 1; }
-          test "$actual" = "$audited" || { echo '::error::CLI 2.8.0 digest mismatch'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.2 digest TODO before any run'; exit 1; }
+          test "$actual" = "$audited" || { echo '::error::CLI 2.8.2 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -337,7 +337,7 @@ jobs:
           done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
           jq -n \
             --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
-            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.0' \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.2' \
             --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
@@ -407,7 +407,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
-          test "$CLI_VERSION" = '2.8.0' || { echo '::error::workflow is pinned to CLI 2.8.0'; exit 1; }
+          test "$CLI_VERSION" = '2.8.2' || { echo '::error::workflow is pinned to CLI 2.8.2'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
@@ -441,21 +441,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.8.0
+      - name: Download exact audited CLI 2.8.2
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.0'
-          minimum-version: '2.8.0'
+          version: '2.8.2'
+          minimum-version: '2.8.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
         run: |
           set -euo pipefail
-          audited='ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+          audited='9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.0 digest TODO'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.2 digest TODO'; exit 1; }
           test "$expected" = "$audited" && test "$actual" = "$audited"
 
       - name: Rematerialize exact source and overlay only frozen fresh reports

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -103,8 +103,9 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover\]/);
-  assert.match(workflow, /default: '2\.8\.0'/);
-  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 3);
+  assert.match(workflow, /default: '2\.8\.2'/);
+  assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
+  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 1);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);


### PR DESCRIPTION
## Summary
- pin Fresh governance dry-run and execute lanes to the audited CLI 2.8.2 binary
- preserve the original 2.8.0 identity only for the sealed historical recovery incident
- audit Linux SHA-256 9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb

## Incident
Execute run 29648706248 failed on a no-write cache preflight HTTP 413 before governance RPCs or scoring. CLI 2.8.2 recursively bisects multi-Skill 413 preflights and remains fail-closed for one-Skill 413 responses.

## Verification
- CLI release run 29650097560 passed build, binary test, checksum, and release
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (4/4)
- git diff --check