### PR TITLE
fix(governance): recover exact cache closure incident

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.8.2'
+        default: '2.8.3'
 
 permissions:
   actions: read
@@ -101,7 +101,7 @@ jobs:
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.8.2' || { echo '::error::workflow is pinned to CLI 2.8.2'; exit 1; }
+          test "$CLI_VERSION" = '2.8.3' || { echo '::error::workflow is pinned to CLI 2.8.3'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
@@ -173,7 +173,7 @@ jobs:
             jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
               --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
               --arg executeHeadSha "$execute_head_sha" \
-              '.producerKind=="fresh_canonical_audit_recovery" and .status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .failedExecuteRunId=="29623717000" and .failedExecuteHeadSha=="15492b473b84a835e8b63083510ad1e59184b8db" and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
+              '.producerKind=="fresh_canonical_audit_recovery" and .status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .failedExecuteRunId=="29666546406" and .failedExecuteHeadSha=="3e7baf520a4d078047b53b95352156e3a3f74260" and .originalCli.version=="2.8.0" and .originalCli.sha256=="ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a" and .failedExecutionCli.version=="2.8.2" and .failedExecutionCli.sha256=="9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb" and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
               "$proof" >/dev/null
             recovery="$RUNNER_TEMP/previous-execution/recovery-evidence"
             (cd "$recovery" && sha256sum --check SHA256SUMS)
@@ -248,21 +248,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.8.2
+      - name: Download exact fresh-governance CLI 2.8.3
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.2'
-          minimum-version: '2.8.2'
+          version: '2.8.3'
+          minimum-version: '2.8.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
+          audited='296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.2 digest TODO before any run'; exit 1; }
-          test "$actual" = "$audited" || { echo '::error::CLI 2.8.2 digest mismatch'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.3 digest TODO before any run'; exit 1; }
+          test "$actual" = "$audited" || { echo '::error::CLI 2.8.3 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -337,7 +337,7 @@ jobs:
           done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
           jq -n \
             --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
-            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.2' \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.3' \
             --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
@@ -407,7 +407,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
-          test "$CLI_VERSION" = '2.8.2' || { echo '::error::workflow is pinned to CLI 2.8.2'; exit 1; }
+          test "$CLI_VERSION" = '2.8.3' || { echo '::error::workflow is pinned to CLI 2.8.3'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
@@ -464,12 +464,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.8.2
+      - name: Download exact audited CLI 2.8.3
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.2'
-          minimum-version: '2.8.2'
+          version: '2.8.3'
+          minimum-version: '2.8.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -477,10 +477,10 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          audited='9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
+          audited='296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.2 digest TODO'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.3 digest TODO'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else
@@ -602,16 +602,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
-      INCIDENT_DRY_RUN_ID: '29622305779'
-      INCIDENT_DRY_RUN_SHA: '786debaf6d85644ad6b417cab08b7d98773bf94a'
-      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: 'sha256:2e7d739365a62c8940feb5dd657a621e26b7e5e9bacdf16b4297edb2ee63ccfd'
-      INCIDENT_FAILED_EXECUTE_RUN_ID: '29623717000'
-      INCIDENT_FAILED_EXECUTE_SHA: '15492b473b84a835e8b63083510ad1e59184b8db'
-      INCIDENT_FAILED_ARTIFACT_DIGEST: 'sha256:35c02b317b349750bcc35da7f27b1e07e0620dff5774bd35370b37d2df509220'
-      INCIDENT_CLI_VERSION: '2.8.0'
-      INCIDENT_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+      INCIDENT_DRY_RUN_ID: '29646612265'
+      INCIDENT_DRY_RUN_SHA: '11101c85a06aaec0d8f0deda0a4aac82cf24899b'
+      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: 'sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b'
+      INCIDENT_FAILED_EXECUTE_RUN_ID: '29666546406'
+      INCIDENT_FAILED_EXECUTE_SHA: '3e7baf520a4d078047b53b95352156e3a3f74260'
+      INCIDENT_FAILED_ARTIFACT_DIGEST: 'sha256:d35558237279c275c3dd0d7169f8f0ae718719c050e7d2055dd8ac32d344b526'
+      INCIDENT_BOUNDARY_CLI_VERSION: '2.8.0'
+      INCIDENT_BOUNDARY_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+      INCIDENT_EXECUTE_CLI_VERSION: '2.8.2'
+      INCIDENT_EXECUTE_CLI_SHA256: '9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
       RECOVERY_EXPECTED_CACHE_VERSION: 'v7'
-      RECOVERY_SMOKE_SHA: '3bb1eb0eea6651a8965b106a9df406f1e73ab5f2'
+      RECOVERY_SMOKE_SHA: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a'
       RECOVERY_PUBLIC_CLI_VERSION: '0.1.10'
       RECOVERY_PUBLIC_CLI_INTEGRITY: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=='
     steps:
@@ -634,7 +636,7 @@ jobs:
           test "$GITHUB_REF_NAME" = main
           test "$DRY_RUN_ID" = "$INCIDENT_DRY_RUN_ID"
           test "$FAILED_EXECUTE_RUN_ID" = "$INCIDENT_FAILED_EXECUTE_RUN_ID"
-          test "$CLI_VERSION" = "$INCIDENT_CLI_VERSION"
+          test "$CLI_VERSION" = '2.8.3'
           test -z "$START_AFTER" && test -z "$PREVIOUS_BOUNDARY_RUN_ID" && test -z "$PREVIOUS_EXECUTE_RUN_ID"
           [[ "$RECOVERY_EXPECTED_CACHE_VERSION" =~ ^v[1-9][0-9]*$ ]] || {
             echo '::error::pin the deployed Skill score-detail cache version before recovery'; exit 1;
@@ -684,13 +686,19 @@ jobs:
           (cd "$evidence/original-boundary" && sha256sum --check SHA256SUMS)
           (cd "$evidence/failed-execution/boundary" && sha256sum --check SHA256SUMS)
           diff -qr "$evidence/original-boundary" "$evidence/failed-execution/boundary"
-          test "$(jq -r .cliVersion "$evidence/original-boundary/metadata.json")" = "$INCIDENT_CLI_VERSION"
-          test "$(jq -r .cliSha256 "$evidence/original-boundary/metadata.json")" = "$INCIDENT_CLI_SHA256"
+          test "$(jq -r .cliVersion "$evidence/original-boundary/metadata.json")" = "$INCIDENT_BOUNDARY_CLI_VERSION"
+          test "$(jq -r .cliSha256 "$evidence/original-boundary/metadata.json")" = "$INCIDENT_BOUNDARY_CLI_SHA256"
           test "$(jq -r .runId "$evidence/original-boundary/metadata.json")" = "$INCIDENT_DRY_RUN_ID"
-          git show "$INCIDENT_FAILED_EXECUTE_SHA:.github/workflows/govern-fresh-canonical-audits.yml" \
+          git show "$INCIDENT_DRY_RUN_SHA:.github/workflows/govern-fresh-canonical-audits.yml" \
             | cmp - "$evidence/original-boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
-          git show "$INCIDENT_FAILED_EXECUTE_SHA:.github/actions/download-skillstore-cli/action.yml" \
+          git show "$INCIDENT_DRY_RUN_SHA:.github/actions/download-skillstore-cli/action.yml" \
             | cmp - "$evidence/original-boundary/runtime/.github/actions/download-skillstore-cli/action.yml"
+          git show "$INCIDENT_DRY_RUN_SHA:scripts/prepare-fresh-canonical-audit-batch.mjs" \
+            | cmp - "$evidence/original-boundary/runtime/scripts/prepare-fresh-canonical-audit-batch.mjs"
+          git show "$INCIDENT_FAILED_EXECUTE_SHA:.github/workflows/govern-fresh-canonical-audits.yml" \
+            > "$evidence/failed-workflow.yml"
+          test "$(grep -Fc "$INCIDENT_EXECUTE_CLI_VERSION" "$evidence/failed-workflow.yml")" -ge 1
+          test "$(grep -Fc "$INCIDENT_EXECUTE_CLI_SHA256" "$evidence/failed-workflow.yml")" -ge 1
 
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
             > "$evidence/failed-jobs.json"
@@ -701,7 +709,7 @@ jobs:
             and ([.jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
             and ([.jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
             and ([.jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.0" and .conclusion=="success")] | length==1)
+            and ([.jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
             and ([.jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
             and ([.jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
             and ([.jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
@@ -805,6 +813,7 @@ jobs:
           boundary="$RUNNER_TEMP/recovery-source/original-boundary"
           cp -a "$boundary" "$recovery/boundary"
           cp "$RUNNER_TEMP/recovery-source/"*.json "$evidence/"
+          cp "$RUNNER_TEMP/recovery-source/failed-workflow.yml" "$evidence/"
           cp scripts/verify-fresh-canonical-audit-recovery.mjs "$evidence/"
           cp scripts/close-fresh-canonical-audit-cache.mjs "$evidence/"
           (cd "$evidence" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
@@ -824,11 +833,12 @@ jobs:
             --arg cacheClosureEvidenceSha256 "$(sha256sum "$evidence/cache-closure-evidence.json" | awk '{print $1}')" \
             --arg cacheReadbackSha256 "$(sha256sum "$evidence/cache-readback.json" | awk '{print $1}')" \
             --arg smokeResultSha256 "$(sha256sum "$evidence/smoke-result.json" | awk '{print $1}')" \
-            --arg originalCliVersion "$INCIDENT_CLI_VERSION" --arg originalCliSha256 "$INCIDENT_CLI_SHA256" \
+            --arg originalCliVersion "$INCIDENT_BOUNDARY_CLI_VERSION" --arg originalCliSha256 "$INCIDENT_BOUNDARY_CLI_SHA256" \
+            --arg failedExecutionCliVersion "$INCIDENT_EXECUTE_CLI_VERSION" --arg failedExecutionCliSha256 "$INCIDENT_EXECUTE_CLI_SHA256" \
             --arg cacheVersion "$RECOVERY_EXPECTED_CACHE_VERSION" --arg smokeCommit "$RECOVERY_SMOKE_SHA" \
             --arg publicCliVersion "$RECOVERY_PUBLIC_CLI_VERSION" --arg publicCliIntegrity "$RECOVERY_PUBLIC_CLI_INTEGRITY" \
             --argjson executedCount 10 \
-            '{schemaVersion:2,producerKind:"fresh_canonical_audit_recovery",status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,failedExecuteRunId:$failedExecuteRunId,failedExecuteHeadSha:$failedExecuteHeadSha,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,boundaryManifestSha256:$boundaryManifestSha256,recoveryEvidenceManifestSha256:$recoveryEvidenceManifestSha256,scoreTimestampEvidenceSha256:$scoreTimestampEvidenceSha256,cacheClosureEvidenceSha256:$cacheClosureEvidenceSha256,cacheReadbackSha256:$cacheReadbackSha256,smokeResultSha256:$smokeResultSha256,originalCli:{version:$originalCliVersion,sha256:$originalCliSha256},recoveryRuntime:{cacheVersion:$cacheVersion,smokeCommit:$smokeCommit,publicCliVersion:$publicCliVersion,publicCliIntegrity:$publicCliIntegrity},scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
+            '{schemaVersion:2,producerKind:"fresh_canonical_audit_recovery",status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,failedExecuteRunId:$failedExecuteRunId,failedExecuteHeadSha:$failedExecuteHeadSha,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,boundaryManifestSha256:$boundaryManifestSha256,recoveryEvidenceManifestSha256:$recoveryEvidenceManifestSha256,scoreTimestampEvidenceSha256:$scoreTimestampEvidenceSha256,cacheClosureEvidenceSha256:$cacheClosureEvidenceSha256,cacheReadbackSha256:$cacheReadbackSha256,smokeResultSha256:$smokeResultSha256,originalCli:{version:$originalCliVersion,sha256:$originalCliSha256},failedExecutionCli:{version:$failedExecutionCliVersion,sha256:$failedExecutionCliSha256},recoveryRuntime:{cacheVersion:$cacheVersion,smokeCommit:$smokeCommit,publicCliVersion:$publicCliVersion,publicCliIntegrity:$publicCliIntegrity},scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
             > "$proof/proof.json"
           (cd "$proof" && sha256sum proof.json > SHA256SUMS)
 
@@ -853,6 +863,6 @@ jobs:
             echo '## Fresh canonical audit execution recovered'
             echo "- Frozen boundary: \`$INCIDENT_DRY_RUN_ID\`"
             echo "- Failed execute: \`$INCIDENT_FAILED_EXECUTE_RUN_ID\`"
-            echo '- Reconstructed durable writes: `10/10`; next campaign cursor: `30/106`.'
+            echo '- Reconstructed durable writes: `10/10`; next campaign cursor: `40/106`.'
             echo '- No governance RPC or score recalculation ran in recovery.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -103,13 +103,14 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover\]/);
-  assert.match(workflow, /default: '2\.8\.2'/);
+  assert.match(workflow, /default: '2\.8\.3'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
+  assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
-  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 3);
+  assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
@@ -142,8 +143,11 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /production-smoke\.mjs/);
   assert.match(workflow, /MCP channel/);
   assert.match(workflow, /recover-boundary:/);
-  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29622305779'/);
-  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: '29623717000'/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29646612265'/);
+  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: '29666546406'/);
+  assert.match(workflow, /INCIDENT_BOUNDARY_CLI_VERSION: '2\.8\.0'/);
+  assert.match(workflow, /INCIDENT_EXECUTE_CLI_VERSION: '2\.8\.2'/);
+  assert.match(workflow, /failedExecutionCli:\{version:\$failedExecutionCliVersion,sha256:\$failedExecutionCliSha256\}/);
   assert.match(workflow, /RECOVERY_EXPECTED_CACHE_VERSION: 'v7'/);
   assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);
   assert.match(workflow, /scripts\/verify-fresh-canonical-audit-recovery\.mjs/);

--- a/scripts/tests/fresh-canonical-audit-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-recovery.test.mjs
@@ -24,10 +24,10 @@ const content = 'b'.repeat(64);
 const tree = 'c'.repeat(64);
 const auditContent = `v3:${commit}:${content}:${tree}:path:payload`;
 const failedRun = {
-  id: 29623717000,
-  head_sha: '15492b473b84a835e8b63083510ad1e59184b8db',
+  id: 29666546406,
+  head_sha: '3e7baf520a4d078047b53b95352156e3a3f74260',
   conclusion: 'failure', event: 'workflow_dispatch', head_branch: 'main', run_attempt: 1,
-  run_started_at: '2026-07-18T00:43:26Z', updated_at: '2026-07-18T00:47:35Z',
+  run_started_at: '2026-07-19T00:11:42Z', updated_at: '2026-07-19T00:16:10Z',
 };
 
 function fixture() {
@@ -45,7 +45,7 @@ function fixture() {
     content_hash: content, tree_hash: tree, marketplace_commit_sha: commit,
     plugin_path: 'skills/owner/skill', public_eligibility_audit_id: ids.audit,
     current_quality_score_snapshot_id: ids.snapshot, quality_score: 88, quality_tier: 'silver',
-    quality_score_calculated_at: '2026-07-18T00:44:12Z',
+    quality_score_calculated_at: '2026-07-19T00:12:55Z',
     published_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-02T00:00:00Z',
   };
   return {
@@ -53,23 +53,23 @@ function fixture() {
     inventory: { schemaVersion: 2, rows: [skill], artifacts: [{
       id: ids.artifact, skill_id: ids.skill, artifact_revision: 1, change_kind: 'initial',
       previous_version_id: null, content_hash: content, tree_hash: tree,
-      marketplace_commit_sha: commit, source_path: 'skills/owner/skill', created_at: '2026-07-18T00:44:04Z',
+      marketplace_commit_sha: commit, source_path: 'skills/owner/skill', created_at: '2026-07-19T00:12:45Z',
     }], observations: [{
       id: '66666666-6666-4666-8666-666666666666',
       skill_id: ids.skill,
       artifact_version_id: ids.artifact,
       marketplace_commit_sha: commit,
       source_path: 'skills/owner/skill',
-      created_at: '2026-07-18T00:44:04Z',
+      created_at: '2026-07-19T00:12:45Z',
     }] },
     audits: [{ id: ids.audit, skill_id: ids.skill, version: 5, content_hash: auditContent,
       analysis_status: 'ok', derived_from_audit_id: null, derivation_kind: null,
       subject_marketplace_commit_sha: commit, subject_content_hash: content,
       subject_tree_hash: tree, subject_plugin_path: 'skills/owner/skill',
-      created_at: '2026-07-18T00:44:04Z' }],
-    snapshots: [{ id: ids.snapshot, skill_id: ids.skill, scorer_version: '1.9.0',
-      composite_score: 88, quality_tier: 'silver', calculated_at: '2026-07-18T00:44:12Z',
-      created_at: '2026-07-18T00:44:12Z', score_inputs: {
+      created_at: '2026-07-19T00:12:45Z' }],
+    snapshots: [{ id: ids.snapshot, skill_id: ids.skill, scorer_version: '1.9.1',
+      composite_score: 88, quality_tier: 'silver', calculated_at: '2026-07-19T00:12:55Z',
+      created_at: '2026-07-19T00:12:55Z', score_inputs: {
         skill: { updatedAt: '2026-07-02T00:00:00Z' },
       }, score_subject: {
         auditId: ids.audit, auditVersion: 5, auditContentHash: auditContent,
@@ -77,7 +77,7 @@ function fixture() {
       } }],
     breakdowns: [{
       skill_id: ids.skill, score_snapshot_id: ids.snapshot, stale_at: null, stale_reason: null,
-      calculated_at: '2026-07-18T00:44:12Z', scorer_version: '1.9.0', composite_score: 88,
+      calculated_at: '2026-07-19T00:12:55Z', scorer_version: '1.9.1', composite_score: 88,
     }],
     failedRun,
   };
@@ -96,7 +96,7 @@ test('reconstructs deterministic execution results only from exact incident-boun
 
 test('rejects later mutation, wrong snapshot binding, or a different failed run', () => {
   const later = fixture();
-  later.inventory.artifacts[0].created_at = '2026-07-18T00:48:00Z';
+  later.inventory.artifacts[0].created_at = '2026-07-19T00:17:00Z';
   assert.throws(() => verifyRecoveryState(later), /artifact evidence mismatch/);
   const snapshot = fixture();
   snapshot.snapshots[0].score_subject.auditId = ids.oldAudit;

--- a/scripts/verify-fresh-canonical-audit-recovery.mjs
+++ b/scripts/verify-fresh-canonical-audit-recovery.mjs
@@ -57,7 +57,7 @@ export function verifyRecoveryState({ boundary, inventory, audits, snapshots, br
     || !Array.isArray(boundary.candidates) || boundary.candidates.length === 0) {
     fail('unsupported frozen boundary');
   }
-  if (failedRun?.id !== 29623717000 || failedRun?.head_sha !== '15492b473b84a835e8b63083510ad1e59184b8db'
+  if (failedRun?.id !== 29666546406 || failedRun?.head_sha !== '3e7baf520a4d078047b53b95352156e3a3f74260'
     || failedRun?.conclusion !== 'failure' || failedRun?.event !== 'workflow_dispatch'
     || failedRun?.head_branch !== 'main' || failedRun?.run_attempt !== 1) {
     fail('failed run identity does not match the incident boundary');
@@ -142,7 +142,7 @@ export function verifyRecoveryState({ boundary, inventory, audits, snapshots, br
       fail(`fresh audit evidence mismatch for ${row.slug}`);
     }
     if (!snapshot || snapshot.skill_id !== row.skillId || !withinRun(snapshot.created_at, failedRun)
-      || snapshot.scorer_version !== '1.9.0' || typeof snapshot.composite_score !== 'number'
+      || snapshot.scorer_version !== '1.9.1' || typeof snapshot.composite_score !== 'number'
       || subject?.auditId !== auditId || subject?.auditVersion !== audit.version
       || subject?.auditContentHash !== audit.content_hash
       || subject?.contentHash !== row.canonicalArtifact.contentHash


### PR DESCRIPTION
## Summary

- authenticate only dry-run 29646612265 and failed execute 29666546406 by exact run, SHA, artifact digest, boundary bytes, job steps, and CLI identities
- reconstruct 10/10 durable artifact, audit, score snapshot, breakdown, and timestamp results entirely by readback
- run only per-Skill cache closure with exact plan hashes; no governance RPC and no rescore
- retain schema-v2 proof, SHA256SUMS, cache readback, and the full P0/P1 download/install/NPX/Pack/MCP smoke
- pin future Fresh governance to released CLI 2.8.3 with Linux SHA256 296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f

## Safety

The recovery job contains no govern-fresh-canonical-audit command, score recalculation, or record_fresh_canonical_audit RPC. It accepts only the exact incident identities and fails closed on any later score snapshot, artifact/audit timestamp outside the failed run, changed current pointer, cache plan drift that cannot be re-preflighted, or smoke failure.

## Tests

- CI=true node --test scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/fresh-canonical-audit-governance.test.mjs (11/11)
- node --check recovery and cache-only helpers
- Skillstore CLI 2.8.3 focused suite (73/73) and check (0 errors)
- live Skillstore production smoke passed every P0/P1 channel
