### PR TITLE
fix(governance): normalize recovery jobs payload

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -703,19 +703,25 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
             > "$evidence/failed-jobs.json"
           jq -e '
-            [.jobs[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1
-            and ([.jobs[].steps[] | select(.name=="Checkout complete Marketplace history" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Normalize full checkout and verify governance runtime" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="skipped")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="skipped")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
+            def job_rows:
+              if type=="object" and (.jobs|type)=="array" then .jobs
+              elif type=="array" and all(.[]; type=="object" and (.jobs|type)=="array") then [.[].jobs[]]
+              elif type=="array" then .
+              else error("unsupported jobs response") end;
+            job_rows as $jobs |
+            [$jobs[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1
+            and ([$jobs[].steps[] | select(.name=="Checkout complete Marketplace history" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Normalize full checkout and verify governance runtime" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="skipped")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="skipped")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
           ' "$evidence/failed-jobs.json" >/dev/null
 
       - name: Fetch exact scoped post-inventory

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -152,6 +152,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);
   assert.match(workflow, /scripts\/verify-fresh-canonical-audit-recovery\.mjs/);
   assert.match(workflow, /scripts\/close-fresh-canonical-audit-cache\.mjs/);
+  assert.match(workflow, /def job_rows:/);
+  assert.match(workflow, /elif type=="array" and all\(\.\[\]; type=="object" and \(\.jobs\|type\)=="array"\)/);
   const recovery = workflow.slice(workflow.indexOf('  recover-boundary:'));
   assert.doesNotMatch(recovery, /skill govern-fresh-canonical-audit|recalculate-scores|record_fresh_canonical_audit/);
 });


### PR DESCRIPTION
## Summary

- normalize the failed-run jobs payload from the standard object, paginated object array, or direct job array shapes
- preserve every exact run/job/step conclusion assertion
- keep recovery fail-closed before cache closure for unsupported payloads

## Incident

Recovery run 29668079351 authenticated both source artifacts and their checksums, then failed before DB readback because the hosted GitHub CLI emitted an array-shaped jobs payload. Every production/cache/smoke step was skipped, so production side effects were zero.

## Tests

- jq identity filter passes the live failed-run payload in all three supported envelope shapes
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs scripts/tests/fresh-canonical-audit-recovery.test.mjs (11/11)
