### PR TITLE
fix(governance): normalize recovery jobs envelope

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -701,21 +701,24 @@ jobs:
           test "$(grep -Fc "$INCIDENT_EXECUTE_CLI_SHA256" "$evidence/failed-workflow.yml")" -ge 1
 
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
+            | jq -f scripts/normalize-actions-jobs-envelope.jq \
+            | jq -s 'if length > 0 and all(.[]; type == "array") then add else error("invalid Actions jobs page stream") end' \
             > "$evidence/failed-jobs.json"
           jq -e '
-            [.jobs[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1
-            and ([.jobs[].steps[] | select(.name=="Checkout complete Marketplace history" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Normalize full checkout and verify governance runtime" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="skipped")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="skipped")] | length==1)
-            and ([.jobs[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
+            type=="array"
+            and ([.[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1)
+            and ([.[].steps[] | select(.name=="Checkout complete Marketplace history" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Normalize full checkout and verify governance runtime" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
+            and ([.[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
+            and ([.[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="skipped")] | length==1)
+            and ([.[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="skipped")] | length==1)
+            and ([.[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
           ' "$evidence/failed-jobs.json" >/dev/null
 
       - name: Fetch exact scoped post-inventory

--- a/scripts/normalize-actions-jobs-envelope.jq
+++ b/scripts/normalize-actions-jobs-envelope.jq
@@ -1,0 +1,12 @@
+if type == "object" and (.jobs | type) == "array" then
+  .jobs
+elif type == "array" then
+  .
+else
+  error("unexpected Actions jobs API envelope")
+end
+| if all(.[]; type == "object") then
+    .
+  else
+    error("Actions jobs API entries must be objects")
+  end

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -152,6 +152,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);
   assert.match(workflow, /scripts\/verify-fresh-canonical-audit-recovery\.mjs/);
   assert.match(workflow, /scripts\/close-fresh-canonical-audit-cache\.mjs/);
+  assert.match(workflow, /jq -f scripts\/normalize-actions-jobs-envelope\.jq/);
+  assert.match(workflow, /type=="array"[\s\S]*?\.\[\] \| select\(\.name=="execute-boundary"/);
   const recovery = workflow.slice(workflow.indexOf('  recover-boundary:'));
   assert.doesNotMatch(recovery, /skill govern-fresh-canonical-audit|recalculate-scores|record_fresh_canonical_audit/);
 });

--- a/scripts/tests/fresh-canonical-audit-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-recovery.test.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { closeFreshAuditCaches } from '../close-fresh-canonical-audit-cache.mjs';
 import {
@@ -29,6 +31,17 @@ const failedRun = {
   conclusion: 'failure', event: 'workflow_dispatch', head_branch: 'main', run_attempt: 1,
   run_started_at: '2026-07-19T00:11:42Z', updated_at: '2026-07-19T00:16:10Z',
 };
+
+const jobsEnvelopeFilter = fileURLToPath(
+  new URL('../normalize-actions-jobs-envelope.jq', import.meta.url),
+);
+
+function normalizeJobsEnvelope(value) {
+  return JSON.parse(execFileSync('jq', ['-c', '-f', jobsEnvelopeFilter], {
+    encoding: 'utf8',
+    input: JSON.stringify(value),
+  }));
+}
 
 function fixture() {
   const candidate = {
@@ -104,6 +117,14 @@ test('rejects later mutation, wrong snapshot binding, or a different failed run'
   const run = fixture();
   run.failedRun.run_attempt = 2;
   assert.throws(() => verifyRecoveryState(run), /failed run identity/);
+});
+
+test('normalizes both Actions jobs API envelopes and rejects unknown shapes', () => {
+  const jobs = [{ id: 1, name: 'execute-boundary', steps: [] }];
+  assert.deepEqual(normalizeJobsEnvelope({ total_count: 1, jobs }), jobs);
+  assert.deepEqual(normalizeJobsEnvelope(jobs), jobs);
+  assert.throws(() => normalizeJobsEnvelope({ total_count: 1, items: jobs }));
+  assert.throws(() => normalizeJobsEnvelope(['not-a-job']));
 });
 
 function preflight(slug, packs = []) {


### PR DESCRIPTION
## Summary

- normalize both object and array GitHub Actions jobs API envelopes before exact incident authentication
- retain fail-closed checks for the single failed execute job and every required step conclusion
- add regression coverage for both accepted envelopes and rejected unknown/non-job shapes

## Production evidence

- failed bounded recovery: https://github.com/aiskillstore/marketplace/actions/runs/29668079351
- root error: `Cannot index array with string "jobs"`
- no cache closure or production smoke step ran before the failure

## Tests

- `CI=true node --test scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/fresh-canonical-audit-governance.test.mjs` (12/12)
- live Jobs API normalization and exact failed-job assertion passed
- `git diff --check`