### PR TITLE
fix(governance): validate full cache recovery plan

### DIFF
--- a/scripts/close-fresh-canonical-audit-cache.mjs
+++ b/scripts/close-fresh-canonical-audit-cache.mjs
@@ -17,23 +17,71 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
+function nonNegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function planCounts(value) {
+  if (!value || typeof value !== 'object') return null;
+  const counts = {
+    resources: value.resources,
+    api: value.api,
+    page: value.page,
+    artifactPrefixes: value.artifactPrefixes,
+    artifacts: value.artifacts,
+    artifactListOperations: value.artifactListOperations,
+  };
+  return Object.values(counts).every(nonNegativeInteger) ? counts : null;
+}
+
+function resourcePlan(value, dependentResources) {
+  if (!value || typeof value !== 'object') return null;
+  const primary = planCounts(value.primary);
+  const dependentPacks = planCounts(value.dependentPacks);
+  const totalsBase = planCounts(value.totals);
+  const totals = totalsBase && nonNegativeInteger(value.totals?.listWrites)
+    && nonNegativeInteger(value.totals?.kvOperations)
+    ? { ...totalsBase, listWrites: value.totals.listWrites, kvOperations: value.totals.kvOperations }
+    : null;
+  if (!primary || !dependentPacks || !totals
+    || primary.resources !== 1 || dependentPacks.resources !== dependentResources
+    || totals.resources !== primary.resources + dependentPacks.resources
+    || totals.api !== primary.api + dependentPacks.api
+    || totals.page !== primary.page + dependentPacks.page
+    || totals.artifactPrefixes !== primary.artifactPrefixes + dependentPacks.artifactPrefixes
+    || totals.artifacts !== primary.artifacts + dependentPacks.artifacts
+    || totals.artifactListOperations !== (
+      primary.artifactListOperations + dependentPacks.artifactListOperations
+    )
+    || totals.listWrites !== 2
+    || totals.kvOperations !== (
+      totals.api + totals.page + totals.artifacts + totals.artifactListOperations + totals.listWrites
+    )
+    || totals.kvOperations > 850) {
+    return null;
+  }
+  return { primary, dependentPacks, totals };
+}
+
+function zeroWritePreflight(value) {
+  return value && typeof value === 'object'
+    && value.total === 0 && value.page === 0 && value.api === 0 && value.artifacts === 0
+    && value.listVersionBumped === false && nonNegativeInteger(value.listMaxStaleSeconds);
+}
+
 function parsePlan(body, slug) {
   const closure = body?.closure?.dependentPacks;
+  const plan = resourcePlan(body?.plan, closure?.all?.length);
   if (body?.preflight !== true || body?.type !== 'skills'
     || canonicalJson(body.slugs) !== canonicalJson([slug])
     || !Array.isArray(body.locales) || body.locales.length === 0
     || !closure || !Array.isArray(closure.all) || !Array.isArray(closure.warmable)
     || closure.overflow !== false || !Number.isSafeInteger(closure.cap)
-    || !body.plan || !Number.isSafeInteger(body?.plan?.totals?.kvOperations)
-    || body.plan.totals.kvOperations > 850
-    || body?.plan?.primary?.resources !== 1
-    || body?.plan?.primary?.api !== 253
-    || body?.plan?.primary?.page !== 231
-    || body?.plan?.primary?.artifactPrefixes !== 2
+    || !plan
     || body.locales.length !== 11
     || !/^[0-9a-f]{64}$/i.test(body?.planHash || '')
     || typeof body?.catalogEpoch !== 'string' || body.catalogEpoch.length === 0
-    || body?.invalidated?.total !== 0) {
+    || !zeroWritePreflight(body?.invalidated)) {
     fail(`invalid cache preflight contract for ${slug}`);
   }
   return {
@@ -41,7 +89,7 @@ function parsePlan(body, slug) {
     locales: body.locales,
     closure,
     catalogEpoch: body.catalogEpoch,
-    plan: body.plan,
+    plan,
     planHash: body.planHash,
     response: body,
   };
@@ -61,7 +109,8 @@ function verifyExecution(body, frozen) {
     || body?.invalidated?.artifacts !== frozen.plan.primary.artifacts
     || body?.invalidated?.total !== (
       frozen.plan.primary.api + frozen.plan.primary.page + frozen.plan.primary.artifacts
-    )) {
+    )
+    || body?.invalidated?.listMaxStaleSeconds !== 0) {
     fail(`invalid cache execution contract for ${frozen.slug}`);
   }
   if (frozen.closure.all.length > 0) {
@@ -69,7 +118,13 @@ function verifyExecution(body, frozen) {
       || canonicalJson(body?.dependentPacks?.anonymousWarmableSlugs) !== canonicalJson(frozen.closure.warmable)
       || body?.dependentPacks?.invalidated?.api !== frozen.plan.dependentPacks.api
       || body?.dependentPacks?.invalidated?.page !== frozen.plan.dependentPacks.page
-      || body?.dependentPacks?.invalidated?.artifacts !== frozen.plan.dependentPacks.artifacts) {
+      || body?.dependentPacks?.invalidated?.artifacts !== frozen.plan.dependentPacks.artifacts
+      || body?.dependentPacks?.invalidated?.total !== (
+        frozen.plan.dependentPacks.api + frozen.plan.dependentPacks.page
+        + frozen.plan.dependentPacks.artifacts
+      )
+      || body?.dependentPacks?.invalidated?.listVersionBumped !== true
+      || body?.dependentPacks?.invalidated?.listMaxStaleSeconds !== 0) {
       fail(`invalid dependent Pack closure for ${frozen.slug}`);
     }
   } else if (Object.hasOwn(body, 'dependentPacks')) {

--- a/scripts/tests/fresh-canonical-audit-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-recovery.test.mjs
@@ -118,9 +118,21 @@ function preflight(slug, packs = []) {
     plan: {
       primary: { resources: 1, api: 253, page: 231, artifactPrefixes: 2, artifacts: 0, artifactListOperations: 2 },
       dependentPacks: { resources: packs.length, api: packs.length * 33, page: packs.length * 66, artifactPrefixes: packs.length, artifacts: 0, artifactListOperations: packs.length },
-      totals: { resources: 1 + packs.length, kvOperations: packs.length ? 588 : 488 },
+      totals: {
+        resources: 1 + packs.length,
+        api: 253 + packs.length * 33,
+        page: 231 + packs.length * 66,
+        artifactPrefixes: 2 + packs.length,
+        artifacts: 0,
+        artifactListOperations: 2 + packs.length,
+        listWrites: 2,
+        kvOperations: packs.length ? 588 : 488,
+      },
     },
-    invalidated: { total: 0, api: 0, artifacts: 0 },
+    invalidated: {
+      total: 0, api: 0, page: 0, artifacts: 0,
+      listVersionBumped: false, listMaxStaleSeconds: 0,
+    },
   };
 }
 
@@ -130,11 +142,17 @@ function executed(plan) {
     catalogEpoch: plan.catalogEpoch,
     planHash: plan.planHash,
     closure: plan.closure, plan: plan.plan,
-    invalidated: { total: 484, api: 253, page: 231, artifacts: 0, listVersionBumped: true },
+    invalidated: {
+      total: 484, api: 253, page: 231, artifacts: 0,
+      listVersionBumped: true, listMaxStaleSeconds: 0,
+    },
     ...(plan.closure.dependentPacks.all.length ? { dependentPacks: {
       slugs: plan.closure.dependentPacks.all,
       anonymousWarmableSlugs: plan.closure.dependentPacks.warmable,
-      invalidated: { total: 99, api: 33, page: 66, artifacts: 0 },
+      invalidated: {
+        total: 99, api: 33, page: 66, artifacts: 0,
+        listVersionBumped: true, listMaxStaleSeconds: 0,
+      },
     } } : {}),
   };
 }
@@ -160,6 +178,37 @@ test('closes cache one Skill at a time and binds execution to exact Pack closure
   assert(requests.every((request) => request.slugs.length === 1));
   assert.deepEqual(requests[1].expectedDependentPacks, ['pack-a']);
   assert.equal(requests[1].expectedPlanHash, plans.get('alpha').planHash);
+});
+
+test('accepts evolved cache-key counts only when the full bounded plan reconciles', async () => {
+  const evolved = preflight('alpha');
+  evolved.plan.primary.api = 260;
+  evolved.plan.totals.api = 260;
+  evolved.plan.totals.kvOperations = 495;
+  const execution = executed(evolved);
+  execution.invalidated.api = 260;
+  execution.invalidated.total = 491;
+  let calls = 0;
+  const result = await closeFreshAuditCaches({
+    secret: 'secret', slugs: ['alpha'], sleepImpl: async () => {},
+    fetchImpl: async () => {
+      calls += 1;
+      return new Response(JSON.stringify(calls === 1 ? evolved : execution), { status: 200 });
+    },
+  });
+  assert.equal(result.closedCount, 1);
+
+  const malformed = preflight('alpha');
+  malformed.plan.totals.kvOperations += 1;
+  let malformedCalls = 0;
+  await assert.rejects(closeFreshAuditCaches({
+    secret: 'secret', slugs: ['alpha'], sleepImpl: async () => {},
+    fetchImpl: async () => {
+      malformedCalls += 1;
+      return new Response(JSON.stringify(malformed), { status: 200 });
+    },
+  }), /invalid cache preflight contract/);
+  assert.equal(malformedCalls, 1);
 });
 
 test('retries an aborted per-Skill execution and refreshes an explicit closure drift', async () => {


### PR DESCRIPTION
## Summary

- replace brittle fixed cache-key counts with full structural plan validation
- require every primary/dependent/total count to reconcile, listWrites=2, and exact kvOperations arithmetic within the 850-operation cap
- require complete zero-write preflight evidence and exact execution count/readback contracts
- retain exact catalog epoch, plan hash, closure, locales, and one-Skill scope binding

## Incident

Recovery 29668285613 passed source authentication and 10/10 durable DB readback, then rejected the first HTTP 200 preflight before cache execution because the recovery helper fixed historical API/page/prefix counts. No cache mutation occurred and all subsequent steps were skipped.

## Tests

- CI=true node --test fresh governance and recovery suites (12/12)
- evolved cache counts are accepted only when the complete plan reconciles
- a one-operation arithmetic mismatch fails before execution
