### PR TITLE
fix(governance): accept exact recovered boundary continuation

### DIFF
--- a/scripts/prepare-fresh-canonical-audit-batch.mjs
+++ b/scripts/prepare-fresh-canonical-audit-batch.mjs
@@ -9,9 +9,48 @@ const SHA256_RE = /^[0-9a-f]{64}$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const MAX_BATCH_SIZE = 10;
+const RECOVERY_PROOF_IDENTITY = Object.freeze({
+  executeRunId: '29668478921',
+  dryRunId: '29646612265',
+  failedExecuteRunId: '29666546406',
+  failedExecuteHeadSha: '3e7baf520a4d078047b53b95352156e3a3f74260',
+  workflowCommit: '7e58b46f1a1478773d6d1f5ef5eb4ae5d56d439c',
+  originalCliVersion: '2.8.0',
+  originalCliSha256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a',
+  failedCliVersion: '2.8.2',
+  failedCliSha256: '9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb',
+  cacheVersion: 'v7',
+  smokeCommit: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a',
+});
 const AUDIT_SCHEMA_PATH = 'schemas/skill-report.schema.json';
 
 function fail(message) { throw new Error(message); }
+function isSupportedExecutionProof(execution) {
+  if (execution?.schemaVersion === 1) return true;
+  if (execution?.schemaVersion !== 2
+    || execution.producerKind !== 'fresh_canonical_audit_recovery'
+    || execution.executeRunId !== RECOVERY_PROOF_IDENTITY.executeRunId
+    || execution.dryRunId !== RECOVERY_PROOF_IDENTITY.dryRunId
+    || execution.failedExecuteRunId !== RECOVERY_PROOF_IDENTITY.failedExecuteRunId
+    || execution.failedExecuteHeadSha !== RECOVERY_PROOF_IDENTITY.failedExecuteHeadSha
+    || execution.workflowCommit !== RECOVERY_PROOF_IDENTITY.workflowCommit
+    || execution.originalCli?.version !== RECOVERY_PROOF_IDENTITY.originalCliVersion
+    || execution.originalCli?.sha256 !== RECOVERY_PROOF_IDENTITY.originalCliSha256
+    || execution.failedExecutionCli?.version !== RECOVERY_PROOF_IDENTITY.failedCliVersion
+    || execution.failedExecutionCli?.sha256 !== RECOVERY_PROOF_IDENTITY.failedCliSha256
+    || execution.recoveryRuntime?.cacheVersion !== RECOVERY_PROOF_IDENTITY.cacheVersion
+    || execution.recoveryRuntime?.smokeCommit !== RECOVERY_PROOF_IDENTITY.smokeCommit) return false;
+  return [
+    execution.executionResultsSha256,
+    execution.postInventorySha256,
+    execution.boundaryManifestSha256,
+    execution.recoveryEvidenceManifestSha256,
+    execution.scoreTimestampEvidenceSha256,
+    execution.cacheClosureEvidenceSha256,
+    execution.cacheReadbackSha256,
+    execution.smokeResultSha256,
+  ].every((value) => typeof value === 'string' && SHA256_RE.test(value));
+}
 function git(root, args) {
   try {
     return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
@@ -60,21 +99,7 @@ export function prepareFreshCanonicalAuditBatch({
     const metadata = previousBoundary?.metadata;
     const selection = previousBoundary?.selection;
     const execution = previousBoundary?.executionProof;
-    const supportedExecutionProof = execution?.schemaVersion === 1
-      || (execution?.schemaVersion === 2
-        && execution.producerKind === 'fresh_canonical_audit_recovery'
-        && execution.failedExecuteRunId === '29623717000'
-        && execution.failedExecuteHeadSha === '15492b473b84a835e8b63083510ad1e59184b8db'
-        && [
-          execution.executionResultsSha256,
-          execution.postInventorySha256,
-          execution.boundaryManifestSha256,
-          execution.recoveryEvidenceManifestSha256,
-          execution.scoreTimestampEvidenceSha256,
-          execution.cacheClosureEvidenceSha256,
-          execution.cacheReadbackSha256,
-          execution.smokeResultSha256,
-        ].every((value) => typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)));
+    const supportedExecutionProof = isSupportedExecutionProof(execution);
     if (metadata?.status !== 'fresh_canonical_audit_frozen'
       || metadata.lastSelected !== cursor || selection?.lastSelected !== cursor
       || selection?.status !== 'lineage_unproven'

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -40,6 +40,54 @@ function inventory(row, revision = 0) {
   };
 }
 
+function exactRecoveryBoundary(row, cohortSha256) {
+  return {
+    metadata: {
+      status: 'fresh_canonical_audit_frozen', runId: '29646612265', lastSelected: row.slug,
+      cohortSha256,
+    },
+    selection: { status: 'lineage_unproven', lastSelected: row.slug },
+    executionProof: {
+      schemaVersion: 2,
+      producerKind: 'fresh_canonical_audit_recovery',
+      status: 'fresh_canonical_audit_execution_complete',
+      executeRunId: '29668478921',
+      dryRunId: '29646612265',
+      failedExecuteRunId: '29666546406',
+      failedExecuteHeadSha: '3e7baf520a4d078047b53b95352156e3a3f74260',
+      workflowCommit: '7e58b46f1a1478773d6d1f5ef5eb4ae5d56d439c',
+      lastSelected: row.slug,
+      cohortSha256,
+      executedCount: 1,
+      originalCli: {
+        version: '2.8.0',
+        sha256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a',
+      },
+      failedExecutionCli: {
+        version: '2.8.2',
+        sha256: '9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb',
+      },
+      recoveryRuntime: {
+        cacheVersion: 'v7',
+        smokeCommit: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a',
+      },
+      executionResultsSha256: '1'.repeat(64),
+      postInventorySha256: '2'.repeat(64),
+      boundaryManifestSha256: '3'.repeat(64),
+      recoveryEvidenceManifestSha256: '4'.repeat(64),
+      scoreTimestampEvidenceSha256: '5'.repeat(64),
+      cacheClosureEvidenceSha256: '6'.repeat(64),
+      cacheReadbackSha256: '7'.repeat(64),
+      smokeResultSha256: '8'.repeat(64),
+      scoreFinalized: true,
+      timestampFinalized: true,
+      cacheClosureCompleted: true,
+      packClosureCompleted: true,
+      productionSmokeCompleted: true,
+    },
+  };
+}
+
 test('prepares a bounded commit-addressed fresh audit batch', () => {
   const { root, row } = fixture();
   const result = prepareFreshCanonicalAuditBatch({
@@ -95,6 +143,25 @@ test('cursor requires both the immediately preceding boundary and a fully govern
     previousBoundary: {
       ...previousBoundary,
       executionProof: { ...previousBoundary.executionProof, productionSmokeCompleted: false },
+    },
+    cohortSha256,
+  }), /successfully closed previous execution/);
+
+  const recoveryBoundary = exactRecoveryBoundary(row, cohortSha256);
+  const recovered = prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1), previousBoundary: recoveryBoundary, cohortSha256,
+  });
+  assert.equal(recovered.count, 0);
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1),
+    previousBoundary: {
+      ...recoveryBoundary,
+      executionProof: {
+        ...recoveryBoundary.executionProof,
+        failedExecuteRunId: '29623717000',
+      },
     },
     cohortSha256,
   }), /successfully closed previous execution/);


### PR DESCRIPTION
## Summary
- bind schema-v2 continuation to recovery run 29668478921 and its exact incident/runtime identities
- reject stale or tampered recovery proofs
- add exact recovered-boundary continuation coverage

## Verification
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (4/4)
- exact production recovery artifact selects the next 10-Skill boundary through calel33-next-js-16-launchpad
- git diff --check

This only repairs dry-run continuation authentication. It does not dispatch governance, score, or cache writes.