### PR TITLE
fix(governance): recover exact smoke-only closure

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Freeze, execute, or recover the authenticated 2026-07-18 partial execution'
+        description: 'Freeze, execute, or run one authenticated incident recovery'
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute, recover]
+        options: [dry-run, execute, recover, recover-smoke]
       cohort_path:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
@@ -169,7 +169,7 @@ jobs:
               --arg executeHeadSha "$execute_head_sha" \
               '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
               "$proof" >/dev/null
-          elif [ "$proof_schema" = 2 ]; then
+          elif [ "$proof_schema" = 2 ] && [ "$(jq -r .producerKind "$proof")" = fresh_canonical_audit_recovery ]; then
             jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
               --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
               --arg executeHeadSha "$execute_head_sha" \
@@ -182,6 +182,29 @@ jobs:
             test "$(jq -r .scoreTimestampEvidenceSha256 "$proof")" = "$(sha256sum "$recovery/score-timestamp-evidence.json" | awk '{print $1}')"
             test "$(jq -r .cacheClosureEvidenceSha256 "$proof")" = "$(sha256sum "$recovery/cache-closure-evidence.json" | awk '{print $1}')"
             test "$(jq -r .cacheReadbackSha256 "$proof")" = "$(sha256sum "$recovery/cache-readback.json" | awk '{print $1}')"
+            test "$(jq -r .smokeResultSha256 "$proof")" = "$(sha256sum "$recovery/smoke-result.json" | awk '{print $1}')"
+          elif [ "$proof_schema" = 2 ] && [ "$(jq -r .producerKind "$proof")" = fresh_canonical_audit_smoke_recovery ]; then
+            jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
+              --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
+              --arg executeHeadSha "$execute_head_sha" '
+              .status=="fresh_canonical_audit_execution_complete"
+              and .executeRunId==$executeRunId and .dryRunId==$dryRunId
+              and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha
+              and .failedExecuteRunId=="29671150631"
+              and .failedExecuteHeadSha=="88d62f4c32ec837ef30075b202b81a580b723259"
+              and .failedExecutionCli.version=="2.8.3"
+              and .failedExecutionCli.sha256=="296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f"
+              and .failedSmokeExpectedPublicCliVersion=="0.1.9"
+              and .recoveryRuntime.smokeCommit=="e368da730951aceca17a7e5d9d5a9adc0e3efc2a"
+              and .recoveryRuntime.publicCliVersion=="0.1.10"
+              and .recoveryRuntime.publicCliIntegrity=="sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=="
+              and .scoreFinalized==true and .timestampFinalized==true
+              and .cacheClosureCompleted==true and .packClosureCompleted==true
+              and .productionSmokeCompleted==true' "$proof" >/dev/null
+            recovery="$RUNNER_TEMP/previous-execution/recovery-evidence"
+            (cd "$recovery" && sha256sum --check SHA256SUMS)
+            test "$(jq -r .recoveryEvidenceManifestSha256 "$proof")" = "$(sha256sum "$recovery/SHA256SUMS" | awk '{print $1}')"
+            test "$(jq -r .boundaryManifestSha256 "$proof")" = "$(sha256sum "$execution_boundary/SHA256SUMS" | awk '{print $1}')"
             test "$(jq -r .smokeResultSha256 "$proof")" = "$(sha256sum "$recovery/smoke-result.json" | awk '{print $1}')"
           else
             echo '::error::unsupported fresh execution proof schema'; exit 1
@@ -541,8 +564,9 @@ jobs:
 
       - name: Verify every P0/P1 download, install, NPX, Pack, and MCP channel
         env:
-          SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0.1.9,skillstore@latest
-          SMOKE_EXPECTED_PUBLIC_CLI_VERSION: 0.1.9
+          SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0.1.10,skillstore@latest
+          SMOKE_EXPECTED_PUBLIC_CLI_VERSION: 0.1.10
+          SMOKE_EXPECTED_PUBLIC_CLI_INTEGRITY: sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw==
           SMOKE_EXPECTED_SIGNING_KEY_ID: EP0Myk7rTk_J0RdG1fvpkP
           SMOKE_EXPECTED_SIGNING_PUBLIC_KEY_X: 2tbC6eNY4T9sx4Pvuo_NwHlXGyWWz95WAtHyHUTqzs8
           SMOKE_EXPECT_INTERACTION_RECOVERY: true
@@ -871,4 +895,240 @@ jobs:
             echo "- Failed execute: \`$INCIDENT_FAILED_EXECUTE_RUN_ID\`"
             echo '- Reconstructed durable writes: `10/10`; next campaign cursor: `40/106`.'
             echo '- No governance RPC or score recalculation ran in recovery.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  recover-smoke-boundary:
+    if: inputs.mode == 'recover-smoke'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      INCIDENT_DRY_RUN_ID: '29669706395'
+      INCIDENT_DRY_RUN_SHA: '88d62f4c32ec837ef30075b202b81a580b723259'
+      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: 'sha256:12cfbdd4bcd38e38c93495c145c7e8d1f7254b50a236457d3112aa6b92055d2c'
+      INCIDENT_FAILED_EXECUTE_RUN_ID: '29671150631'
+      INCIDENT_FAILED_EXECUTE_SHA: '88d62f4c32ec837ef30075b202b81a580b723259'
+      INCIDENT_FAILED_ARTIFACT_DIGEST: 'sha256:2d52fc0097f9d7e4014c66e3af97081f519d00e391e9867eb345d756d1e3fcbf'
+      INCIDENT_EXECUTE_CLI_VERSION: '2.8.3'
+      INCIDENT_EXECUTE_CLI_SHA256: '296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f'
+      INCIDENT_FAILED_SMOKE_CLI_VERSION: '0.1.9'
+      RECOVERY_SMOKE_SHA: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a'
+      RECOVERY_PUBLIC_CLI_VERSION: '0.1.10'
+      RECOVERY_PUBLIC_CLI_INTEGRITY: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=='
+    steps:
+      - name: Checkout immutable smoke-recovery runtime
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Validate smoke-only incident inputs and public CLI identity
+        env:
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
+          START_AFTER: ${{ inputs.start_after }}
+          PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
+          PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
+          CLI_VERSION: ${{ inputs.cli_version }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          test "$DRY_RUN_ID" = "$INCIDENT_DRY_RUN_ID"
+          test "$FAILED_EXECUTE_RUN_ID" = "$INCIDENT_FAILED_EXECUTE_RUN_ID"
+          test "$CLI_VERSION" = "$INCIDENT_EXECUTE_CLI_VERSION"
+          test -z "$START_AFTER" && test -z "$PREVIOUS_BOUNDARY_RUN_ID" && test -z "$PREVIOUS_EXECUTE_RUN_ID"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$INCIDENT_DRY_RUN_SHA" "$GITHUB_SHA"
+          test "$(npm view "skillstore@$RECOVERY_PUBLIC_CLI_VERSION" version)" = "$RECOVERY_PUBLIC_CLI_VERSION"
+          test "$(npm view "skillstore@$RECOVERY_PUBLIC_CLI_VERSION" dist.integrity)" = "$RECOVERY_PUBLIC_CLI_INTEGRITY"
+          test "$(npm view skillstore@latest version)" = "$RECOVERY_PUBLIC_CLI_VERSION"
+          test "$(npm view skillstore@latest dist.integrity)" = "$RECOVERY_PUBLIC_CLI_INTEGRITY"
+
+      - name: Authenticate the exact failed smoke boundary without writes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/smoke-recovery-source"
+          recovery="$RUNNER_TEMP/fresh-smoke-recovery"
+          mkdir -p "$source/original-boundary" "$source/failed-execution" "$recovery/recovery-evidence"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_DRY_RUN_ID" > "$source/dry-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID" > "$source/failed-run.json"
+          jq -e --argjson id "$INCIDENT_DRY_RUN_ID" --arg sha "$INCIDENT_DRY_RUN_SHA" '
+            .id==$id and .name=="Govern Fresh Canonical Audits" and .event=="workflow_dispatch"
+            and .head_branch=="main" and .head_sha==$sha and .conclusion=="success" and .run_attempt==1
+          ' "$source/dry-run.json" >/dev/null
+          jq -e --argjson id "$INCIDENT_FAILED_EXECUTE_RUN_ID" --arg sha "$INCIDENT_FAILED_EXECUTE_SHA" '
+            .id==$id and .name=="Govern Fresh Canonical Audits" and .event=="workflow_dispatch"
+            and .head_branch=="main" and .head_sha==$sha and .conclusion=="failure" and .run_attempt==1
+          ' "$source/failed-run.json" >/dev/null
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_DRY_RUN_ID/artifacts" > "$source/dry-artifacts.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/artifacts" > "$source/failed-artifacts.json"
+          jq -e --arg name "fresh-canonical-audit-boundary-$INCIDENT_DRY_RUN_ID" \
+            --arg digest "$INCIDENT_BOUNDARY_ARTIFACT_DIGEST" '
+            [.artifacts[] | select(.name==$name and .expired==false and .digest==$digest)] | length==1
+          ' "$source/dry-artifacts.json" >/dev/null
+          jq -e --arg name "fresh-canonical-audit-execution-$INCIDENT_FAILED_EXECUTE_RUN_ID" \
+            --arg digest "$INCIDENT_FAILED_ARTIFACT_DIGEST" '
+            [.artifacts[] | select(.name==$name and .expired==false and .digest==$digest)] | length==1
+          ' "$source/failed-artifacts.json" >/dev/null
+          gh run download "$INCIDENT_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-boundary-$INCIDENT_DRY_RUN_ID" --dir "$source/original-boundary"
+          gh run download "$INCIDENT_FAILED_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-execution-$INCIDENT_FAILED_EXECUTE_RUN_ID" --dir "$source/failed-execution"
+          (cd "$source/original-boundary" && sha256sum --check SHA256SUMS)
+          (cd "$source/failed-execution/boundary" && sha256sum --check SHA256SUMS)
+          cmp "$source/original-boundary/SHA256SUMS" "$source/failed-execution/boundary/SHA256SUMS"
+          test ! -e "$source/failed-execution/execution-proof/proof.json"
+          test "$(jq -r .cliVersion "$source/original-boundary/metadata.json")" = "$INCIDENT_EXECUTE_CLI_VERSION"
+          test "$(jq -r .cliSha256 "$source/original-boundary/metadata.json")" = "$INCIDENT_EXECUTE_CLI_SHA256"
+          jq -e --slurpfile selected "$source/original-boundary/selected-cohort.json" '
+            length==$selected[0].count
+            and [.[].skillId]==[$selected[0].rows[].skillId]
+            and all(.[]; .artifactCreated==true and .artifactRevision==1)
+          ' "$source/failed-execution/execution-results.json" >/dev/null
+          jq -e --slurpfile selected "$source/original-boundary/selected-cohort.json" \
+            --slurpfile results "$source/failed-execution/execution-results.json" '
+            [$selected[0].rows[].skillId] as $ids |
+            ($results[0] | map({key:.skillId,value:.artifactVersionId}) | from_entries) as $versions |
+            [.rows[] | select(.id as $id | $ids | index($id))] as $rows |
+            ($rows|length)==($ids|length)
+            and all($rows[]; .artifact_revision==1 and .current_artifact_version_id==$versions[.id])
+          ' "$source/failed-execution/post-inventory.json" >/dev/null
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
+            > "$source/failed-jobs.json"
+          jq -e '
+            def job_rows:
+              if type=="object" and (.jobs|type)=="array" then .jobs
+              elif type=="array" and all(.[]; type=="object" and (.jobs|type)=="array") then [.[].jobs[]]
+              elif type=="array" then .
+              else error("unsupported jobs response") end;
+            job_rows as $jobs |
+            [$jobs[] | select(.name=="execute-boundary" and .conclusion=="failure")] | length==1
+            and ([$jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Fetch exact post-execution artifact and Pack evidence" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Verify every P0/P1 download, install, NPX, Pack, and MCP channel" and .conclusion=="failure")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Seal successful execute closure for the next cursor" and .conclusion=="skipped")] | length==1)
+            and ([$jobs[].steps[] | select(.name=="Upload execution and smoke evidence" and .conclusion=="success")] | length==1)
+          ' "$source/failed-jobs.json" >/dev/null
+          gh run view "$INCIDENT_FAILED_EXECUTE_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed \
+            > "$source/failed-smoke.log"
+          test "$(grep -Fc '[FAIL][P0]' "$source/failed-smoke.log")" = 1
+          test "$(grep -Fc '[PASS]' "$source/failed-smoke.log")" = 20
+          grep -F 'expected "0.1.9", got "0.1.10"' "$source/failed-smoke.log" >/dev/null
+          cp -a "$source/original-boundary" "$recovery/boundary"
+          cp "$source/failed-execution/execution-results.json" "$recovery/execution-results.json"
+          cp "$source/failed-execution/post-inventory.json" "$recovery/post-inventory.json"
+
+      - name: Verify production 10 of 10 readback without writes
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/smoke-recovery-source"
+          recovery="$RUNNER_TEMP/fresh-smoke-recovery"
+          jq '{schemaVersion:1,scopedSkillIds:[.rows[].skillId],rows:.rows}' \
+            "$source/original-boundary/selected-cohort.json" > "$recovery/scope.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$recovery/scope.json" \
+            --output "$recovery/recovery-evidence/production-readback.json"
+          jq -e --slurpfile results "$recovery/execution-results.json" '
+            ($results[0] | map({key:.skillId,value:.}) | from_entries) as $expected |
+            [.rows[] | select($expected[.id] != null)] as $rows |
+            ($rows|length)==10 and all($rows[];
+              .artifact_revision==1
+              and .current_artifact_version_id==$expected[.id].artifactVersionId
+              and .public_eligibility_audit_id==$expected[.id].auditId
+              and .current_quality_score_snapshot_id==$expected[.id].scoreSnapshotId)
+          ' "$recovery/recovery-evidence/production-readback.json" >/dev/null
+
+      - name: Generate GitHub App token for immutable smoke harness
+        id: smoke-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: skillstore
+
+      - name: Checkout pinned Skillstore structured smoke harness
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: aiskillstore/skillstore
+          token: ${{ steps.smoke-app-token.outputs.token }}
+          ref: ${{ env.RECOVERY_SMOKE_SHA }}
+          path: skillstore-smoke
+          fetch-depth: 1
+
+      - name: Verify corrected download, install, NPX, Pack, MCP, and CI channels
+        env:
+          SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0.1.10,skillstore@latest
+          SMOKE_EXPECTED_PUBLIC_CLI_VERSION: '0.1.10'
+          SMOKE_EXPECTED_PUBLIC_CLI_INTEGRITY: ${{ env.RECOVERY_PUBLIC_CLI_INTEGRITY }}
+          SMOKE_EXPECTED_SIGNING_KEY_ID: EP0Myk7rTk_J0RdG1fvpkP
+          SMOKE_EXPECTED_SIGNING_PUBLIC_KEY_X: 2tbC6eNY4T9sx4Pvuo_NwHlXGyWWz95WAtHyHUTqzs8
+          SMOKE_EXPECT_INTERACTION_RECOVERY: true
+          CI: true
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/fresh-smoke-recovery/recovery-evidence"
+          test "$(git -C skillstore-smoke rev-parse HEAD)" = "$RECOVERY_SMOKE_SHA"
+          sha256sum skillstore-smoke/scripts/smoke/production-smoke.mjs > "$evidence/smoke-runtime.sha256"
+          node skillstore-smoke/scripts/smoke/production-smoke.mjs \
+            --base-url https://skillstore.io --attempts 3 --retry-ms 3000 \
+            --result-file "$evidence/smoke-result.json" 2>&1 | tee "$evidence/smoke.log"
+
+      - name: Seal schema-v2 smoke-only recovery proof for the next cursor
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/smoke-recovery-source"
+          recovery="$RUNNER_TEMP/fresh-smoke-recovery"
+          evidence="$recovery/recovery-evidence"
+          cp "$source/"*.json "$evidence/"
+          cp "$source/failed-smoke.log" "$evidence/"
+          (cd "$evidence" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          proof="$recovery/execution-proof"
+          mkdir -p "$proof"
+          jq -n \
+            --arg executeRunId "$GITHUB_RUN_ID" --arg dryRunId "$INCIDENT_DRY_RUN_ID" \
+            --arg failedExecuteRunId "$INCIDENT_FAILED_EXECUTE_RUN_ID" \
+            --arg failedExecuteHeadSha "$INCIDENT_FAILED_EXECUTE_SHA" --arg workflowCommit "$GITHUB_SHA" \
+            --arg lastSelected "$(jq -r .lastSelected "$recovery/boundary/selected-cohort.json")" \
+            --arg cohortSha256 "$(jq -r .cohortSha256 "$recovery/boundary/metadata.json")" \
+            --arg executionResultsSha256 "$(sha256sum "$recovery/execution-results.json" | awk '{print $1}')" \
+            --arg postInventorySha256 "$(sha256sum "$recovery/post-inventory.json" | awk '{print $1}')" \
+            --arg boundaryManifestSha256 "$(sha256sum "$recovery/boundary/SHA256SUMS" | awk '{print $1}')" \
+            --arg recoveryEvidenceManifestSha256 "$(sha256sum "$evidence/SHA256SUMS" | awk '{print $1}')" \
+            --arg smokeResultSha256 "$(sha256sum "$evidence/smoke-result.json" | awk '{print $1}')" \
+            --arg failedExecutionCliVersion "$INCIDENT_EXECUTE_CLI_VERSION" \
+            --arg failedExecutionCliSha256 "$INCIDENT_EXECUTE_CLI_SHA256" \
+            --arg failedSmokeExpectedPublicCliVersion "$INCIDENT_FAILED_SMOKE_CLI_VERSION" \
+            --arg smokeCommit "$RECOVERY_SMOKE_SHA" --arg publicCliVersion "$RECOVERY_PUBLIC_CLI_VERSION" \
+            --arg publicCliIntegrity "$RECOVERY_PUBLIC_CLI_INTEGRITY" --argjson executedCount 10 \
+            '{schemaVersion:2,producerKind:"fresh_canonical_audit_smoke_recovery",status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,failedExecuteRunId:$failedExecuteRunId,failedExecuteHeadSha:$failedExecuteHeadSha,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,boundaryManifestSha256:$boundaryManifestSha256,recoveryEvidenceManifestSha256:$recoveryEvidenceManifestSha256,smokeResultSha256:$smokeResultSha256,failedExecutionCli:{version:$failedExecutionCliVersion,sha256:$failedExecutionCliSha256},failedSmokeExpectedPublicCliVersion:$failedSmokeExpectedPublicCliVersion,recoveryRuntime:{smokeCommit:$smokeCommit,publicCliVersion:$publicCliVersion,publicCliIntegrity:$publicCliIntegrity},scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
+            > "$proof/proof.json"
+          (cd "$proof" && sha256sum proof.json > SHA256SUMS)
+
+      - name: Upload smoke-only recovery evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: fresh-canonical-audit-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/fresh-smoke-recovery/boundary/
+            ${{ runner.temp }}/fresh-smoke-recovery/execution-results.json
+            ${{ runner.temp }}/fresh-smoke-recovery/post-inventory.json
+            ${{ runner.temp }}/fresh-smoke-recovery/recovery-evidence/
+            ${{ runner.temp }}/fresh-smoke-recovery/execution-proof/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish verified smoke-only recovery summary
+        run: |
+          {
+            echo '## Fresh canonical audit smoke closure recovered'
+            echo "- Frozen boundary: \`$INCIDENT_DRY_RUN_ID\`"
+            echo "- Failed execute: \`$INCIDENT_FAILED_EXECUTE_RUN_ID\`"
+            echo '- Durable governance, score, and cache readback: `10/10`.'
+            echo '- Recovery ran no governance RPC, score recalculation, or cache invalidation.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/prepare-fresh-canonical-audit-batch.mjs
+++ b/scripts/prepare-fresh-canonical-audit-batch.mjs
@@ -22,34 +22,62 @@ const RECOVERY_PROOF_IDENTITY = Object.freeze({
   cacheVersion: 'v7',
   smokeCommit: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a',
 });
+const SMOKE_RECOVERY_PROOF_IDENTITY = Object.freeze({
+  dryRunId: '29669706395',
+  failedExecuteRunId: '29671150631',
+  failedExecuteHeadSha: '88d62f4c32ec837ef30075b202b81a580b723259',
+  failedCliVersion: '2.8.3',
+  failedCliSha256: '296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f',
+  failedSmokeExpectedPublicCliVersion: '0.1.9',
+  smokeCommit: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a',
+  publicCliVersion: '0.1.10',
+  publicCliIntegrity: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw==',
+});
 const AUDIT_SCHEMA_PATH = 'schemas/skill-report.schema.json';
 
 function fail(message) { throw new Error(message); }
 function isSupportedExecutionProof(execution) {
   if (execution?.schemaVersion === 1) return true;
-  if (execution?.schemaVersion !== 2
-    || execution.producerKind !== 'fresh_canonical_audit_recovery'
-    || execution.executeRunId !== RECOVERY_PROOF_IDENTITY.executeRunId
-    || execution.dryRunId !== RECOVERY_PROOF_IDENTITY.dryRunId
-    || execution.failedExecuteRunId !== RECOVERY_PROOF_IDENTITY.failedExecuteRunId
-    || execution.failedExecuteHeadSha !== RECOVERY_PROOF_IDENTITY.failedExecuteHeadSha
-    || execution.workflowCommit !== RECOVERY_PROOF_IDENTITY.workflowCommit
-    || execution.originalCli?.version !== RECOVERY_PROOF_IDENTITY.originalCliVersion
-    || execution.originalCli?.sha256 !== RECOVERY_PROOF_IDENTITY.originalCliSha256
-    || execution.failedExecutionCli?.version !== RECOVERY_PROOF_IDENTITY.failedCliVersion
-    || execution.failedExecutionCli?.sha256 !== RECOVERY_PROOF_IDENTITY.failedCliSha256
-    || execution.recoveryRuntime?.cacheVersion !== RECOVERY_PROOF_IDENTITY.cacheVersion
-    || execution.recoveryRuntime?.smokeCommit !== RECOVERY_PROOF_IDENTITY.smokeCommit) return false;
-  return [
+  if (execution?.schemaVersion !== 2) return false;
+  const hashes = [
     execution.executionResultsSha256,
     execution.postInventorySha256,
     execution.boundaryManifestSha256,
     execution.recoveryEvidenceManifestSha256,
-    execution.scoreTimestampEvidenceSha256,
-    execution.cacheClosureEvidenceSha256,
-    execution.cacheReadbackSha256,
     execution.smokeResultSha256,
-  ].every((value) => typeof value === 'string' && SHA256_RE.test(value));
+  ];
+  if (!hashes.every((value) => typeof value === 'string' && SHA256_RE.test(value))) return false;
+  if (execution.producerKind === 'fresh_canonical_audit_recovery') {
+    return execution.executeRunId === RECOVERY_PROOF_IDENTITY.executeRunId
+      && execution.dryRunId === RECOVERY_PROOF_IDENTITY.dryRunId
+      && execution.failedExecuteRunId === RECOVERY_PROOF_IDENTITY.failedExecuteRunId
+      && execution.failedExecuteHeadSha === RECOVERY_PROOF_IDENTITY.failedExecuteHeadSha
+      && execution.workflowCommit === RECOVERY_PROOF_IDENTITY.workflowCommit
+      && execution.originalCli?.version === RECOVERY_PROOF_IDENTITY.originalCliVersion
+      && execution.originalCli?.sha256 === RECOVERY_PROOF_IDENTITY.originalCliSha256
+      && execution.failedExecutionCli?.version === RECOVERY_PROOF_IDENTITY.failedCliVersion
+      && execution.failedExecutionCli?.sha256 === RECOVERY_PROOF_IDENTITY.failedCliSha256
+      && execution.recoveryRuntime?.cacheVersion === RECOVERY_PROOF_IDENTITY.cacheVersion
+      && execution.recoveryRuntime?.smokeCommit === RECOVERY_PROOF_IDENTITY.smokeCommit
+      && [execution.scoreTimestampEvidenceSha256, execution.cacheClosureEvidenceSha256,
+        execution.cacheReadbackSha256]
+        .every((value) => typeof value === 'string' && SHA256_RE.test(value));
+  }
+  if (execution.producerKind === 'fresh_canonical_audit_smoke_recovery') {
+    return execution.dryRunId === SMOKE_RECOVERY_PROOF_IDENTITY.dryRunId
+      && execution.failedExecuteRunId === SMOKE_RECOVERY_PROOF_IDENTITY.failedExecuteRunId
+      && execution.failedExecuteHeadSha === SMOKE_RECOVERY_PROOF_IDENTITY.failedExecuteHeadSha
+      && execution.failedExecutionCli?.version === SMOKE_RECOVERY_PROOF_IDENTITY.failedCliVersion
+      && execution.failedExecutionCli?.sha256 === SMOKE_RECOVERY_PROOF_IDENTITY.failedCliSha256
+      && execution.failedSmokeExpectedPublicCliVersion
+        === SMOKE_RECOVERY_PROOF_IDENTITY.failedSmokeExpectedPublicCliVersion
+      && execution.recoveryRuntime?.smokeCommit === SMOKE_RECOVERY_PROOF_IDENTITY.smokeCommit
+      && execution.recoveryRuntime?.publicCliVersion
+        === SMOKE_RECOVERY_PROOF_IDENTITY.publicCliVersion
+      && execution.recoveryRuntime?.publicCliIntegrity
+        === SMOKE_RECOVERY_PROOF_IDENTITY.publicCliIntegrity;
+  }
+  return false;
 }
 function git(root, args) {
   try {

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -88,6 +88,49 @@ function exactRecoveryBoundary(row, cohortSha256) {
   };
 }
 
+function exactSmokeRecoveryBoundary(row, cohortSha256) {
+  return {
+    metadata: {
+      status: 'fresh_canonical_audit_frozen', runId: '29669706395', lastSelected: row.slug,
+      cohortSha256,
+    },
+    selection: { status: 'lineage_unproven', lastSelected: row.slug },
+    executionProof: {
+      schemaVersion: 2,
+      producerKind: 'fresh_canonical_audit_smoke_recovery',
+      status: 'fresh_canonical_audit_execution_complete',
+      executeRunId: 'future-smoke-recovery-run',
+      dryRunId: '29669706395',
+      failedExecuteRunId: '29671150631',
+      failedExecuteHeadSha: '88d62f4c32ec837ef30075b202b81a580b723259',
+      workflowCommit: 'f'.repeat(40),
+      lastSelected: row.slug,
+      cohortSha256,
+      executedCount: 1,
+      executionResultsSha256: '1'.repeat(64),
+      postInventorySha256: '2'.repeat(64),
+      boundaryManifestSha256: '3'.repeat(64),
+      recoveryEvidenceManifestSha256: '4'.repeat(64),
+      smokeResultSha256: '5'.repeat(64),
+      failedExecutionCli: {
+        version: '2.8.3',
+        sha256: '296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f',
+      },
+      failedSmokeExpectedPublicCliVersion: '0.1.9',
+      recoveryRuntime: {
+        smokeCommit: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a',
+        publicCliVersion: '0.1.10',
+        publicCliIntegrity: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw==',
+      },
+      scoreFinalized: true,
+      timestampFinalized: true,
+      cacheClosureCompleted: true,
+      packClosureCompleted: true,
+      productionSmokeCompleted: true,
+    },
+  };
+}
+
 test('prepares a bounded commit-addressed fresh audit batch', () => {
   const { root, row } = fixture();
   const result = prepareFreshCanonicalAuditBatch({
@@ -165,17 +208,36 @@ test('cursor requires both the immediately preceding boundary and a fully govern
     },
     cohortSha256,
   }), /successfully closed previous execution/);
+
+  const smokeRecoveryBoundary = exactSmokeRecoveryBoundary(row, cohortSha256);
+  const smokeRecovered = prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1), previousBoundary: smokeRecoveryBoundary, cohortSha256,
+  });
+  assert.equal(smokeRecovered.count, 0);
+  assert.throws(() => prepareFreshCanonicalAuditBatch({
+    repositoryRoot: root, cohort, startAfter: row.slug, batchSize: 1,
+    productionInventory: inventory(row, 1),
+    previousBoundary: {
+      ...smokeRecoveryBoundary,
+      executionProof: {
+        ...smokeRecoveryBoundary.executionProof,
+        failedSmokeExpectedPublicCliVersion: '0.1.10',
+      },
+    },
+    cohortSha256,
+  }), /successfully closed previous execution/);
 });
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute, recover\]/);
+  assert.match(workflow, /options: \[dry-run, execute, recover, recover-smoke\]/);
   assert.match(workflow, /default: '2\.8\.3'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
-  assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
+  assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 4);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
@@ -195,9 +257,9 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/sparse-checkout-cone-mode: false/g) || []).length, 2);
   assert.equal((workflow.match(/git sparse-checkout disable/g) || []).length, 2);
   assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
-  assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 3);
+  assert.equal((workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g) || []).length, 4);
   assert.match(workflow, /fresh_canonical_audit_execution_complete/);
-  assert.equal((workflow.match(/include-hidden-files: true/g) || []).length, 3);
+  assert.equal((workflow.match(/include-hidden-files: true/g) || []).length, 4);
   assert.match(workflow, /name: fresh-canonical-audit-boundary-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /name: fresh-canonical-audit-execution-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /productionSmokeCompleted:true/);
@@ -206,7 +268,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /production-skill-score-writes/);
   assert.match(workflow, /CACHE_INVALIDATE_SECRET/);
   assert.match(workflow, /expected.*Pack|post-execution artifact and Pack evidence/i);
-  assert.match(workflow, /SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0\.1\.9,skillstore@latest/);
+  assert.doesNotMatch(workflow, /SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0\.1\.9,skillstore@latest/);
+  assert.match(workflow, /SMOKE_PUBLIC_CLI_PACKAGES: skillstore@0\.1\.10,skillstore@latest/);
   assert.match(workflow, /production-smoke\.mjs/);
   assert.match(workflow, /MCP channel/);
   assert.match(workflow, /recover-boundary:/);
@@ -218,6 +281,11 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /RECOVERY_EXPECTED_CACHE_VERSION: 'v7'/);
   assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);
   assert.match(workflow, /scripts\/verify-fresh-canonical-audit-recovery\.mjs/);
+  assert.match(workflow, /recover-smoke-boundary:/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29669706395'/);
+  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: '29671150631'/);
+  assert.match(workflow, /fresh_canonical_audit_smoke_recovery/);
+  assert.match(workflow, /Recovery ran no governance RPC, score recalculation, or cache invalidation/);
   assert.match(workflow, /scripts\/close-fresh-canonical-audit-cache\.mjs/);
   assert.match(workflow, /def job_rows:/);
   assert.match(workflow, /elif type=="array" and all\(\.\[\]; type=="object" and \(\.jobs\|type\)=="array"\)/);


### PR DESCRIPTION
## Summary
- update normal Fresh execute smoke from public CLI 0.1.9 to the released 0.1.10 identity
- add an incident-only recover-smoke path for dry-run 29669706395 / failed execute 29671150631
- authenticate the exact artifacts and 10/10 production readback, then run only smoke and seal continuation proof
- accept only the exact schema-v2 smoke-recovery identity in future cursor continuation

## Safety
- recovery contains no governance RPC, score recalculation, or cache invalidation
- worker remains stopped
- failed execute artifact digest: sha256:2d52fc0097f9d7e4014c66e3af97081f519d00e391e9867eb345d756d1e3fcbf

## Verification
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (4/4)
- node --check scripts/prepare-fresh-canonical-audit-batch.mjs
- Ruby YAML parse
- git diff --check