### PR TITLE
fix(governance): pin fresh audits to CLI 2.8.4

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.8.3'
+        default: '2.8.4'
 
 permissions:
   actions: read
@@ -101,7 +101,7 @@ jobs:
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.8.3' || { echo '::error::workflow is pinned to CLI 2.8.3'; exit 1; }
+          test "$CLI_VERSION" = '2.8.4' || { echo '::error::workflow is pinned to CLI 2.8.4'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
@@ -271,21 +271,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.8.3
+      - name: Download exact fresh-governance CLI 2.8.4
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.3'
-          minimum-version: '2.8.3'
+          version: '2.8.4'
+          minimum-version: '2.8.4'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f'
+          audited='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.3 digest TODO before any run'; exit 1; }
-          test "$actual" = "$audited" || { echo '::error::CLI 2.8.3 digest mismatch'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.4 digest TODO before any run'; exit 1; }
+          test "$actual" = "$audited" || { echo '::error::CLI 2.8.4 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -360,7 +360,7 @@ jobs:
           done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
           jq -n \
             --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
-            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.3' \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.4' \
             --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
@@ -430,7 +430,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
-          test "$CLI_VERSION" = '2.8.3' || { echo '::error::workflow is pinned to CLI 2.8.3'; exit 1; }
+          test "$CLI_VERSION" = '2.8.4' || { echo '::error::workflow is pinned to CLI 2.8.4'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
@@ -487,12 +487,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.8.3
+      - name: Download exact audited CLI 2.8.4
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.3'
-          minimum-version: '2.8.3'
+          version: '2.8.4'
+          minimum-version: '2.8.4'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -500,10 +500,10 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          audited='296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f'
+          audited='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.3 digest TODO'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.4 digest TODO'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -232,12 +232,13 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.8\.3'/);
+  assert.match(workflow, /default: '2\.8\.4'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
-  assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 4);
+  assert.equal((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length, 2);
+  assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);


### PR DESCRIPTION
## Summary
- pin future Fresh dry-run and execute jobs to released CLI 2.8.4
- bind both phases to audited Linux SHA256 282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb
- preserve the exact CLI 2.8.3 identities used by the sealed historical recovery evidence

## Incident boundary
Dry-run 29675314474 uploaded no artifacts, never dispatched execute, and made no production writes. CLI 2.8.4 runs evaluators only from disposable source copies so scratch files cannot contaminate canonical hashes.

## Verification
- release run 29680264293 succeeded; Linux asset checksum independently verified
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (4/4)