### PR TITLE
fix(submissions): bind processing to manifest scope

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -25,10 +25,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'CLI version to use'
+        description: 'Reserved compatibility input; this selection-plan rollout is pinned to CLI 2.15.0'
         required: false
         type: string
-        default: 'latest'
+        default: '2.15.0'
       max_parallel:
         description: 'Maximum parallel shards'
         required: false
@@ -60,6 +60,27 @@ on:
       outcome_reason:
         description: 'Machine-readable terminal outcome reason'
         value: ${{ jobs.merge-and-create-pr.outputs.outcome_reason }}
+      source_sha:
+        description: 'Immutable source commit used for discovery'
+        value: ${{ jobs.discover-and-plan.outputs.source_sha }}
+      scope:
+        description: 'Validated authoritative publication scope'
+        value: ${{ jobs.discover-and-plan.outputs.scope_path }}
+      physical_count:
+        description: 'Physical SKILL.md files observed'
+        value: ${{ jobs.discover-and-plan.outputs.physical_count }}
+      selected_count:
+        description: 'Skills in the authoritative selection plan'
+        value: ${{ jobs.discover-and-plan.outputs.selected_count }}
+      ignored_count:
+        description: 'Out-of-scope SKILL.md files ignored by authority'
+        value: ${{ jobs.discover-and-plan.outputs.ignored_count }}
+      identical_count:
+        description: 'Ignored identical local mirror groups'
+        value: ${{ jobs.discover-and-plan.outputs.identical_count }}
+      conflicting_count:
+        description: 'Conflicting ignored local mirror groups recorded as diagnostics'
+        value: ${{ jobs.discover-and-plan.outputs.conflicting_count }}
     secrets:
       APP_ID:
         required: true
@@ -98,6 +119,14 @@ jobs:
       repo: ${{ steps.clone.outputs.repo }}
       branch: ${{ steps.clone.outputs.branch }}
       github_url: ${{ steps.discover.outputs.github_url }}
+      source_sha: ${{ steps.clone.outputs.ref_sha }}
+      scope_path: ${{ steps.discover.outputs.scope_path }}
+      selection_plan: ${{ steps.discover.outputs.selection_plan }}
+      physical_count: ${{ steps.discover.outputs.physical_count }}
+      selected_count: ${{ steps.discover.outputs.skill_count }}
+      ignored_count: ${{ steps.discover.outputs.ignored_count }}
+      identical_count: ${{ steps.discover.outputs.identical_count }}
+      conflicting_count: ${{ steps.discover.outputs.conflicting_count }}
     steps:
       - name: Clear inherited discovery checkout
         run: |
@@ -137,6 +166,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/process-submission-shard.mjs"
+            "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
             "scripts/aggregate-submission-shards.mjs"
             "scripts/resolve-approved-submission.mjs"
@@ -178,17 +208,17 @@ jobs:
         id: clone
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUBMISSION_URL: ${{ inputs.github_url }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.github_url }}"
           REPOSITORY_ID=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
-            --github-url "$URL" --repository-only)
+            --github-url "$SUBMISSION_URL" --repository-only)
           OWNER_REPO=$(jq -er '"\(.owner)/\(.repo)"' <<< "$REPOSITORY_ID")
           DEFAULT_REF=$(gh api "repos/$OWNER_REPO" --jq '.default_branch')
           REFS_FILE="${RUNNER_TEMP:?}/submission-refs-${{ github.run_id }}-${{ github.run_attempt }}.txt"
           git ls-remote --heads --tags "https://github.com/$OWNER_REPO.git" > "$REFS_FILE"
           RESOLVED=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
-            --github-url "$URL" \
+            --github-url "$SUBMISSION_URL" \
             --default-ref "$DEFAULT_REF" \
             --refs-file "$REFS_FILE")
           rm -f "$REFS_FILE"
@@ -217,6 +247,7 @@ jobs:
           echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
           echo "repo=$REPO" >> "$GITHUB_OUTPUT"
           echo "branch=$REF" >> "$GITHUB_OUTPUT"
+          echo "ref_sha=$REF_SHA" >> "$GITHUB_OUTPUT"
           echo "skill_path=$SKILL_PATH" >> "$GITHUB_OUTPUT"
           echo "explicit_path=$EXPLICIT_PATH" >> "$GITHUB_OUTPUT"
           echo "normalized_url=$NORMALIZED_URL" >> "$GITHUB_OUTPUT"
@@ -227,30 +258,69 @@ jobs:
         id: discover
         env:
           SKILL_PATH: ${{ steps.clone.outputs.skill_path }}
+          SOURCE_DIR: ${{ steps.clone.outputs.source_dir }}
+          SOURCE_REPOSITORY: ${{ steps.clone.outputs.owner }}/${{ steps.clone.outputs.repo }}
+          SOURCE_SHA: ${{ steps.clone.outputs.ref_sha }}
         run: |
           set -euo pipefail
-          SOURCE_DIR="${{ steps.clone.outputs.source_dir }}"
           DISCOVERY=$(node "$GITHUB_WORKSPACE/scripts/discover-submission-skills.mjs" \
             --source-dir "$SOURCE_DIR" \
             --skill-path "$SKILL_PATH" \
             --explicit-path "${{ steps.clone.outputs.explicit_path }}" \
-            --repository "${{ steps.clone.outputs.owner }}/${{ steps.clone.outputs.repo }}" \
+            --repository "$SOURCE_REPOSITORY" \
             --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json")
+          FULL_PLAN=$(jq -ce --arg repository "$SOURCE_REPOSITORY" --arg sourceCommit "$SOURCE_SHA" \
+            '{schemaVersion: 1, repository: $repository, sourceCommit: $sourceCommit, scope: .scope, skills: .skills}' <<< "$DISCOVERY")
+          PLAN_FILE="${RUNNER_TEMP:?}/selection-plan-${{ github.run_id }}-${{ github.run_attempt }}.json"
+          printf '%s\n' "$FULL_PLAN" > "$PLAN_FILE"
+          node "$GITHUB_WORKSPACE/scripts/submission-selection-plan.mjs" --input "$PLAN_FILE" --output "$PLAN_FILE"
+          FULL_PLAN=$(tr -d '\n' < "$PLAN_FILE")
+          rm -f "$PLAN_FILE"
           SKILLS_JSON=$(jq -cer '[.skills[].slug]' <<< "$DISCOVERY")
           SKILL_COUNT=$(jq -er '.skills | length' <<< "$DISCOVERY")
-          echo "github_url=${{ steps.clone.outputs.normalized_url }}" >> "$GITHUB_OUTPUT"
+          SCOPE_PATH=$(jq -er '.scope.path' <<< "$DISCOVERY")
+          SCOPE_REASON=$(jq -er '.scope.reason' <<< "$DISCOVERY")
+          PHYSICAL_COUNT=$(jq -er '.stats.physicalSkillFiles' <<< "$DISCOVERY")
+          IGNORED_COUNT=$(jq -er '.stats.ignoredSkillFiles' <<< "$DISCOVERY")
+          IDENTICAL_MIRRORS=$(jq -er '.stats.identicalMirrorGroups' <<< "$DISCOVERY")
+          CONFLICTING_MIRRORS=$(jq -er '.stats.conflictingMirrorGroups' <<< "$DISCOVERY")
+          # CLI always receives the repository root. The immutable selection
+          # plan, not an untrusted tree URL, carries the authority scope.
+          printf 'github_url=https://github.com/%s/%s\n' "${{ steps.clone.outputs.owner }}" "${{ steps.clone.outputs.repo }}" >> "$GITHUB_OUTPUT"
           echo "skills_json=$SKILLS_JSON" >> "$GITHUB_OUTPUT"
           echo "skill_count=$SKILL_COUNT" >> "$GITHUB_OUTPUT"
-          echo "📊 Discovered $SKILL_COUNT skill(s)"
+          echo "scope_path=$SCOPE_PATH" >> "$GITHUB_OUTPUT"
+          echo "selection_plan=$FULL_PLAN" >> "$GITHUB_OUTPUT"
+          echo "physical_count=$PHYSICAL_COUNT" >> "$GITHUB_OUTPUT"
+          echo "ignored_count=$IGNORED_COUNT" >> "$GITHUB_OUTPUT"
+          echo "identical_count=$IDENTICAL_MIRRORS" >> "$GITHUB_OUTPUT"
+          echo "conflicting_count=$CONFLICTING_MIRRORS" >> "$GITHUB_OUTPUT"
+          echo "📊 Selected $SKILL_COUNT public skill(s) from ${SCOPE_PATH:-repository root}; ignored $IGNORED_COUNT of $PHYSICAL_COUNT physical SKILL.md files"
+          annotation_escape() { sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g'; }
+          ANNOTATION=$(printf 'reason=%s scope=%s selected=%s ignored=%s identical_mirror_groups=%s conflicting_mirror_groups=%s' "$SCOPE_REASON" "${SCOPE_PATH:-.}" "$SKILL_COUNT" "$IGNORED_COUNT" "$IDENTICAL_MIRRORS" "$CONFLICTING_MIRRORS" | annotation_escape)
+          echo "::notice title=DISCOVERY_SCOPE_SELECTED::$ANNOTATION"
+          {
+            echo "## Skill discovery scope"
+            echo
+            echo "| Metric | Value |"
+            echo "|---|---:|"
+            echo "| Source commit | \`${{ steps.clone.outputs.ref_sha }}\` |"
+            echo "| Scope reason | \`$SCOPE_REASON\` |"
+            echo "| Selected scope | \`${SCOPE_PATH:-.}\` |"
+            echo "| Physical SKILL.md files | $PHYSICAL_COUNT |"
+            echo "| Selected public skills | $SKILL_COUNT |"
+            echo "| Ignored out-of-scope SKILL.md files | $IGNORED_COUNT |"
+            echo "| Identical mirror groups | $IDENTICAL_MIRRORS |"
+            echo "| Conflicting ignored mirror groups | $CONFLICTING_MIRRORS |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Plan processing strategy
         id: plan
         env:
-          SKILL_COUNT: ${{ steps.discover.outputs.skill_count }}
-          SKILLS_JSON: ${{ steps.discover.outputs.skills_json }}
+          FULL_SELECTION_PLAN: ${{ steps.discover.outputs.selection_plan }}
           EXPLICIT_PATH: ${{ steps.clone.outputs.explicit_path }}
         run: |
-          COUNT=$SKILL_COUNT
+          COUNT=$(jq -er '.skills | length' <<< "$FULL_SELECTION_PLAN")
           THRESHOLD=${{ env.SHARD_THRESHOLD }}
           MAX_SHARDS=${{ env.MAX_SHARDS }}
 
@@ -260,7 +330,8 @@ jobs:
               exit 1
             fi
             echo "No skills found; planning one explicit no-op shard"
-            echo 'matrix={"include":[{"shard":0,"slugs":""}]}' >> $GITHUB_OUTPUT
+            MATRIX=$(jq -ce '{include: [{shard: 0, selection_plan: .}]}' <<< "$FULL_SELECTION_PLAN")
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
             echo "is_sharded=false" >> $GITHUB_OUTPUT
             echo "shard_count=1" >> $GITHUB_OUTPUT
             exit 0
@@ -268,8 +339,8 @@ jobs:
 
           if [ "$COUNT" -lt "$THRESHOLD" ]; then
             echo "📦 Simple mode: $COUNT skills (below threshold $THRESHOLD)"
-            ESCAPED_SLUGS=$(echo "$SKILLS_JSON" | jq -r 'join(",")')
-            echo "matrix={\"include\":[{\"shard\":0,\"slugs\":\"$ESCAPED_SLUGS\"}]}" >> $GITHUB_OUTPUT
+            MATRIX=$(jq -ce '{include: [{shard: 0, selection_plan: .}]}' <<< "$FULL_SELECTION_PLAN")
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
             echo "is_sharded=false" >> $GITHUB_OUTPUT
             echo "shard_count=1" >> $GITHUB_OUTPUT
           else
@@ -286,27 +357,16 @@ jobs:
             BASE_SIZE=$((COUNT / SHARDS))
             REMAINDER=$((COUNT % SHARDS))
 
-            MATRIX='{"include":['
-            CURRENT_IDX=0
-
-            for i in $(seq 0 $((SHARDS - 1))); do
-              if [ $i -lt $REMAINDER ]; then
-                THIS_SIZE=$((BASE_SIZE + 1))
-              else
-                THIS_SIZE=$BASE_SIZE
-              fi
-
-              SHARD_SLUGS=$(echo "$SKILLS_JSON" | jq -r ".[$CURRENT_IDX:$((CURRENT_IDX + THIS_SIZE))] | join(\",\")")
-              CURRENT_IDX=$((CURRENT_IDX + THIS_SIZE))
-
-              [ $i -gt 0 ] && MATRIX+=','
-              MATRIX+="{\"shard\":$i,\"slugs\":\"$SHARD_SLUGS\"}"
-
-              echo "  Shard $i: $THIS_SIZE skills"
-            done
-            MATRIX+=']}'
-
-            echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+            MATRIX=$(jq -nce --argjson plan "$FULL_SELECTION_PLAN" --argjson shards "$SHARDS" '
+              ($plan.skills | length) as $count |
+              ($count / $shards | floor) as $base |
+              ($count % $shards) as $remainder |
+              {include: [range(0; $shards) as $index |
+                ($base + (if $index < $remainder then 1 else 0 end)) as $size |
+                ($index * $base + (if $index < $remainder then $index else $remainder end)) as $start |
+                {shard: $index, selection_plan: ($plan | .skills = .skills[$start:($start + $size)])}
+              ]}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
             echo "is_sharded=true" >> $GITHUB_OUTPUT
             echo "shard_count=$SHARDS" >> $GITHUB_OUTPUT
           fi
@@ -330,7 +390,6 @@ jobs:
       matrix: ${{ fromJSON(needs.discover-and-plan.outputs.matrix) }}
     steps:
       - name: Generate GitHub App Token
-        if: matrix.slugs != ''
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -395,6 +454,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/process-submission-shard.mjs"
+            "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
             "scripts/aggregate-submission-shards.mjs"
             "scripts/resolve-approved-submission.mjs"
@@ -417,13 +477,13 @@ jobs:
           done
 
       - name: Download Skillstore CLI
-        if: matrix.slugs != ''
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: ${{ inputs.cli_version }}
+          # Rollout pin: selection-plan processing requires the exact 2.15.0 contract.
+          version: '2.15.0'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.14.3
+          minimum-version: 2.15.0
           require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}
@@ -433,15 +493,21 @@ jobs:
           SKILLSTORE_AGENTS: ${{ secrets.SKILLSTORE_AGENTS }}
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          SLUGS: ${{ matrix.slugs }}
+          SELECTION_PLAN_JSON: ${{ toJSON(matrix.selection_plan) }}
+          NORMALIZED_GITHUB_URL: ${{ needs.discover-and-plan.outputs.github_url }}
           MODEL: ${{ inputs.model }}
         run: |
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
+          INPUT_PLAN="${RUNNER_TEMP:?}/selection-plan-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}.json"
+          cleanup_input_plan() { rm -f "$INPUT_PLAN"; }
+          trap cleanup_input_plan EXIT
+          umask 077
+          printf '%s\n' "$SELECTION_PLAN_JSON" > "$INPUT_PLAN"
           node "$GITHUB_WORKSPACE/scripts/process-submission-shard.mjs" \
             --cli "$GITHUB_WORKSPACE/skillstore-cli" \
-            --github-url "${{ needs.discover-and-plan.outputs.github_url }}" \
-            --slugs "$SLUGS" \
+            --github-url "$NORMALIZED_GITHUB_URL" \
+            --selection-plan "$INPUT_PLAN" \
             --result-dir "$RESULT_DIR" \
             --marketplace-repo "${{ github.repository }}" \
             --shard-index "${{ matrix.shard }}" \
@@ -450,8 +516,6 @@ jobs:
 
       - name: Create mode-preserving shard archive
         if: always()
-        env:
-          PLANNED_SLUGS: ${{ matrix.slugs }}
         run: |
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
@@ -463,10 +527,20 @@ jobs:
             echo "::error::Shard process step did not produce a diagnostic manifest"
             exit 1
           }
-          printf '%s\n' "$PLANNED_SLUGS" > "$RESULT_DIR/planned-slugs.csv"
+          PLAN_EVIDENCE=()
+          if [ -f "$RESULT_DIR/selection-plan.json" ] && jq -e . "$RESULT_DIR/selection-plan.json" >/dev/null; then
+            jq -r '[.skills[].slug] | join(",")' "$RESULT_DIR/selection-plan.json" > "$RESULT_DIR/planned-slugs.csv"
+            PLAN_EVIDENCE+=(selection-plan.json)
+          else
+            # Preserve the untrusted bytes separately; do not let malformed
+            # plan JSON prevent artifact upload or overwrite valid evidence.
+            jq -r '[.planned[]] | join(",")' "$MANIFEST_FILE" > "$RESULT_DIR/planned-slugs.csv"
+            test -f "$RESULT_DIR/selection-plan.invalid.json" || : > "$RESULT_DIR/selection-plan.invalid.json"
+            PLAN_EVIDENCE+=(selection-plan.invalid.json)
+          fi
           SHARD_ARCHIVE_NAME="process-shard-${{ github.run_attempt }}-${{ matrix.shard }}.tar.gz"
           tar -C "$RESULT_DIR" -czf "$RESULT_DIR/$SHARD_ARCHIVE_NAME" \
-            pending "$(basename "$LOG_FILE")" planned-slugs.csv shard-manifest.json
+            pending "$(basename "$LOG_FILE")" planned-slugs.csv shard-manifest.json "${PLAN_EVIDENCE[@]}"
 
       - name: Upload shard results
         if: always()
@@ -480,14 +554,22 @@ jobs:
       - name: Enforce shard terminal status
         if: always()
         env:
-          PLANNED_SLUGS: ${{ matrix.slugs }}
+          EXPECTED_SELECTION_PLAN_JSON: ${{ toJSON(matrix.selection_plan) }}
         run: |
           set -euo pipefail
           RESULT_DIR="/tmp/submission-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}"
+          EXPECTED_PLAN="${RUNNER_TEMP:?}/expected-selection-plan-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}.json"
+          cleanup_expected_plan() { rm -f "$EXPECTED_PLAN"; }
+          trap cleanup_expected_plan EXIT
+          umask 077
+          printf '%s\n' "$EXPECTED_SELECTION_PLAN_JSON" > "$EXPECTED_PLAN"
+          node "$GITHUB_WORKSPACE/scripts/submission-selection-plan.mjs" --input "$EXPECTED_PLAN" --output "$EXPECTED_PLAN"
+          PLANNED_SLUGS=$(jq -r '[.skills[].slug] | join(",")' "$EXPECTED_PLAN")
           node "$GITHUB_WORKSPACE/scripts/submission-shard-contract.mjs" \
             --manifest "$RESULT_DIR/shard-manifest.json" \
             --expected-index "${{ matrix.shard }}" \
             --expected-slugs "$PLANNED_SLUGS" \
+            --expected-selection-plan "$EXPECTED_PLAN" \
             --pending-root "$RESULT_DIR/pending" \
             --require-success
 
@@ -552,6 +634,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/process-submission-shard.mjs"
+            "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
             "scripts/aggregate-submission-shards.mjs"
             "scripts/resolve-approved-submission.mjs"

--- a/scripts/aggregate-submission-shards.mjs
+++ b/scripts/aggregate-submission-shards.mjs
@@ -16,9 +16,9 @@ import { pathToFileURL } from 'node:url';
 import { resolveApprovedSubmission } from './resolve-approved-submission.mjs';
 import {
   parseCanonicalShardIndex,
-  parseSlugCsv,
   readAndValidateSubmissionShardManifest,
 } from './submission-shard-contract.mjs';
+import { validateSelectionPlan } from './submission-selection-plan.mjs';
 
 function fail(message) {
   throw new Error(message);
@@ -43,14 +43,56 @@ function parseMatrix(json, expectedCount) {
     fail(`matrix contains ${matrix.include.length} shard(s), expected ${expectedCount}`);
   }
   const entries = new Map();
+  // The union of these immutable shard subplans is the frozen full submission
+  // plan; callers deliberately do not pass a separate mutable full-plan file.
+  let identity = null;
+  const slugs = new Set();
+  const paths = new Set();
+  const foldedPaths = new Set();
   for (const [position, entry] of matrix.include.entries()) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail(`matrix entry ${position} must be an object`);
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)
+      || JSON.stringify(Object.keys(entry).sort()) !== JSON.stringify(['selection_plan', 'shard'])) {
+      fail(`matrix entry ${position} must contain only shard and selection_plan`);
+    }
     if (typeof entry.shard !== 'number') fail(`matrix entry ${position} shard must be a canonical JSON integer`);
     const shard = parseCanonicalShardIndex(entry.shard, `matrix entry ${position} shard`);
     if (entries.has(shard)) fail(`matrix contains duplicate canonical shard index ${shard}`);
-    entries.set(shard, parseSlugCsv(entry.slugs, `matrix shard ${shard} slugs`));
+    const plan = validateSelectionPlan(entry.selection_plan);
+    const planIdentity = JSON.stringify({ repository: plan.repository, sourceCommit: plan.sourceCommit, scope: plan.scope });
+    if (identity !== null && identity !== planIdentity) fail(`matrix shard ${shard} selection plan identity does not match other shards`);
+    identity = planIdentity;
+    for (const skill of plan.skills) {
+      if (slugs.has(skill.slug)) fail(`matrix selection plans contain duplicate slug ${skill.slug}`);
+      if (paths.has(skill.path)) fail(`matrix selection plans contain duplicate path ${skill.path}`);
+      const foldedPath = skill.path.normalize('NFC').toLocaleLowerCase('en-US');
+      if (foldedPaths.has(foldedPath)) fail(`matrix selection plans contain NFC/case-fold path collision ${skill.path}`);
+      slugs.add(skill.slug);
+      paths.add(skill.path);
+      foldedPaths.add(foldedPath);
+    }
+    entries.set(shard, plan);
   }
   return entries;
+}
+
+function readArchiveSelectionPlan(root, expectedPlan, shardIndex) {
+  const expectedPath = join(root, 'selection-plan.json');
+  if (!existsSync(expectedPath)) fail(`shard ${shardIndex} archive is missing root selection-plan.json`);
+  const evidenceStat = lstatSync(expectedPath);
+  if (evidenceStat.isSymbolicLink() || !evidenceStat.isFile()) {
+    fail(`shard ${shardIndex} archive root selection-plan.json must be a regular file`);
+  }
+  let plan;
+  try {
+    plan = JSON.parse(readFileSync(expectedPath, 'utf8'));
+  } catch (error) {
+    fail(`shard ${shardIndex} archive selection plan is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const normalized = validateSelectionPlan(plan);
+  if (JSON.stringify(normalized) !== JSON.stringify(expectedPlan)) {
+    fail(`shard ${shardIndex} archive selection plan does not match matrix selection plan`);
+  }
+  return normalized;
 }
 
 function collectFiles(root, predicate) {
@@ -183,9 +225,12 @@ function aggregate(config) {
     const root = extractArchive(archive);
     const pendingRoot = join(root, 'pending');
     const manifestPath = join(root, 'shard-manifest.json');
+    const expectedPlan = matrix.get(index);
+    readArchiveSelectionPlan(root, expectedPlan, index);
     const manifest = readAndValidateSubmissionShardManifest(manifestPath, {
       expectedIndex: index,
-      expectedPlanned: matrix.get(index),
+      expectedPlanned: expectedPlan.skills.map(({ slug }) => slug),
+      expectedSelectionPlan: expectedPlan,
       pendingRoot,
       requireSuccess: true,
     });

--- a/scripts/discover-submission-skills.mjs
+++ b/scripts/discover-submission-skills.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
-import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { validatePortablePath } from './submission-selection-plan.mjs';
 
 const SKIP_DIRECTORIES = new Set(['node_modules', '.git', '.venv', 'venv', 'dist', 'build', '__pycache__', '.cache']);
+const PROJECT_LOCAL_SKILL_ROOTS = ['.agents/skills', '.claude/skills', '.codex/skills'];
 const REPOSITORY = /^[a-z0-9_-]+\/[a-z0-9._-]+$/;
 const CANONICAL_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -27,14 +30,18 @@ function slugify(value) {
 }
 
 function repositoryPath(value, label) {
-  if (typeof value !== 'string' || value === '' || value !== value.normalize('NFC') || value.includes('\\')) {
-    fail(`${label} must be a non-empty NFC POSIX repository-relative path`);
+  return validatePortablePath(value, label);
+}
+
+function publicationPath(value, label) {
+  if (typeof value !== 'string' || value === '' || value !== value.normalize('NFC')) {
+    fail(`${label} must be a non-empty NFC string`);
   }
-  const segments = value.split('/');
-  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
-    fail(`${label} contains an empty or unsafe path segment`);
-  }
-  return segments.join('/');
+  if (value.startsWith('/') || value.includes('\\')) fail(`${label} must be repository-relative POSIX path`);
+  const withoutPrefix = value.startsWith('./') ? value.slice(2) : value;
+  const normalized = withoutPrefix.replace(/\/+$/g, '');
+  if (normalized === '') fail(`${label} must not resolve to the repository root`);
+  return repositoryPath(normalized, label);
 }
 
 function canonicalRepository(value, label) {
@@ -129,19 +136,186 @@ function topLevelName(skillMdPath, content) {
   return name;
 }
 
-function collectSkillFiles(root) {
+function collectSkillFiles(root, { strict = false } = {}) {
   const files = [];
   function walk(directory) {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const seenNames = new Set();
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'variant' }))) {
+      if (strict) {
+        // Validate every traversed tree entry before opening it. This makes the
+        // plan portable across case-insensitive and Windows checkouts.
+        validatePortablePath(entry.name, `publication tree entry ${entry.name}`);
+        const folded = entry.name.normalize('NFC').toLocaleLowerCase('en-US');
+        if (seenNames.has(folded)) fail(`publication tree contains NFC/case-fold collision: ${entry.name}`);
+        seenNames.add(folded);
+      }
       if (entry.isDirectory() && !SKIP_DIRECTORIES.has(entry.name)) {
         walk(join(directory, entry.name));
       } else if (entry.isFile() && entry.name === 'SKILL.md') {
         files.push(join(directory, entry.name));
+      } else if (strict && entry.isSymbolicLink()) {
+        fail(`symbolic links are not allowed in the selected publication scope: ${join(directory, entry.name)}`);
       }
     }
   }
   walk(root);
   return files.sort();
+}
+
+function resolveContainedPath(sourceRoot, relativePath, label, { directory = true } = {}) {
+  const normalized = relativePath === '.' ? '.' : repositoryPath(relativePath, label);
+  const segments = normalized === '.' ? [] : normalized.split('/');
+  let current = sourceRoot;
+  for (const segment of segments) {
+    current = join(current, segment);
+    let stat;
+    try { stat = lstatSync(current); } catch { fail(`${label} does not exist: ${relativePath}`); }
+    if (stat.isSymbolicLink()) fail(`${label} contains a symbolic link: ${relativePath}`);
+  }
+  let resolved;
+  try { resolved = realpathSync(current); } catch { fail(`${label} cannot be resolved: ${relativePath}`); }
+  if (resolved !== sourceRoot && !resolved.startsWith(`${sourceRoot}${sep}`)) fail(`${label} escapes source repository: ${relativePath}`);
+  const final = lstatSync(current);
+  if (directory && !final.isDirectory()) fail(`${label} must be a real directory: ${relativePath}`);
+  if (!directory && !final.isFile()) fail(`${label} must be a regular file: ${relativePath}`);
+  return current;
+}
+
+function codexPluginScope(sourceRoot) {
+  let pluginDirectory;
+  try { pluginDirectory = lstatSync(join(sourceRoot, '.codex-plugin')); } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+  if (!pluginDirectory.isDirectory() || pluginDirectory.isSymbolicLink()) fail('Codex plugin directory must be a real directory');
+  try { lstatSync(join(sourceRoot, '.codex-plugin', 'plugin.json')); } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+  const manifestPath = resolveContainedPath(sourceRoot, '.codex-plugin/plugin.json', 'Codex plugin manifest', { directory: false });
+  let stat;
+  try { stat = lstatSync(manifestPath); } catch (error) { if (error?.code === 'ENOENT') return null; throw error; }
+  if (!stat.isFile() || stat.isSymbolicLink()) fail('Codex plugin manifest must be a regular file');
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    fail(`cannot parse Codex plugin manifest: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) fail('Codex plugin manifest must be an object');
+  if (!Object.hasOwn(manifest, 'skills')) return null;
+  if (typeof manifest.skills !== 'string') fail('Codex plugin skills must be one repository-relative directory path');
+  return publicationPath(manifest.skills, 'Codex plugin skills path');
+}
+
+function resolvePublicationScope(sourceRoot, skillPath, explicitPath) {
+  if (explicitPath) {
+    const path = skillPath === '.' ? '.' : repositoryPath(skillPath, 'skillPath');
+    resolveContainedPath(sourceRoot, path, 'explicit skill path');
+    return { reason: 'explicit_path', path };
+  }
+  const manifestScope = codexPluginScope(sourceRoot);
+  if (manifestScope !== null) {
+    resolveContainedPath(sourceRoot, manifestScope, 'declared publication scope');
+    return { reason: 'codex_plugin_manifest', path: manifestScope };
+  }
+  const conventional = join(sourceRoot, 'skills');
+  try {
+    const stat = lstatSync(conventional);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) fail('conventional publication scope must be a real directory: skills');
+    resolveContainedPath(sourceRoot, 'skills', 'conventional publication scope');
+    return { reason: 'conventional_skills', path: 'skills' };
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return { reason: 'repository_fallback', path: '.' };
+}
+
+function canonicalTreeHash(skillDir) {
+  const entries = [];
+  function walk(directory) {
+    const seenNames = new Set();
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'variant' }))) {
+      validatePortablePath(entry.name, `mirrored skill tree entry ${entry.name}`);
+      const folded = entry.name.normalize('NFC').toLocaleLowerCase('en-US');
+      if (seenNames.has(folded)) fail(`mirrored skill tree contains NFC/case-fold collision: ${entry.name}`);
+      seenNames.add(folded);
+      const absolute = join(directory, entry.name);
+      const relativePath = posixRelative(skillDir, absolute);
+      const stat = lstatSync(absolute);
+      if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile())) {
+        fail(`unsupported file type in mirrored skill tree: ${relativePath}`);
+      }
+      if (entry.isDirectory()) {
+        walk(absolute);
+        continue;
+      }
+      if (relativePath === 'skill-report.json' || entry.name === '.DS_Store' || entry.name.endsWith('~') || entry.name.endsWith('.tmp') || entry.name.endsWith('.temp')) continue;
+      const bytes = readFileSync(absolute);
+      entries.push({
+        path: relativePath,
+        mode: (stat.mode & 0o111) === 0 ? '100644' : '100755',
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+        size: bytes.byteLength,
+      });
+    }
+  }
+  walk(skillDir);
+  const serialized = entries
+    .sort((a, b) => a.path.localeCompare(b.path, 'en', { sensitivity: 'variant' }))
+    .map((entry) => JSON.stringify(entry))
+    .join('\n');
+  return createHash('sha256').update(serialized).digest('hex');
+}
+
+function projectLocalMirrorIdentity(relativeDirectory) {
+  const root = PROJECT_LOCAL_SKILL_ROOTS.find((candidate) => relativeDirectory.startsWith(`${candidate}/`));
+  if (!root) return null;
+  return { root, logicalPath: relativeDirectory.slice(root.length + 1) };
+}
+
+function mirrorDiagnostics(sourceRoot, physicalSkillFiles, selectedSkillFiles, includeSelected) {
+  const selected = new Set(selectedSkillFiles);
+  const groups = new Map();
+  for (const file of physicalSkillFiles) {
+    if (!includeSelected && selected.has(file)) continue;
+    const directory = dirname(file);
+    const relativeDirectory = posixRelative(sourceRoot, directory);
+    const identity = projectLocalMirrorIdentity(relativeDirectory);
+    if (!identity) continue;
+    let slug;
+    try {
+      slug = slugify(topLevelName(posixRelative(sourceRoot, file), readFileSync(file, 'utf8')) ?? basename(directory));
+    } catch {
+      continue;
+    }
+    if (slug === '') continue;
+    const key = `${slug}\0${identity.logicalPath}`;
+    const rows = groups.get(key) ?? [];
+    let treeHash = null;
+    try {
+      treeHash = canonicalTreeHash(directory);
+    } catch {
+      // This path is outside the authoritative publication scope. Keep the
+      // diagnostic conservative without allowing ignored local files to block it.
+    }
+    rows.push({ path: relativeDirectory, treeHash });
+    groups.set(key, rows);
+  }
+  return [...groups.entries()]
+    .filter(([, rows]) => rows.length > 1)
+    .map(([key, rows]) => {
+      const slug = key.split('\0', 1)[0];
+      const hashes = [...new Set(rows.map(({ treeHash }) => treeHash))];
+      const fullyInspected = hashes.every((hash) => typeof hash === 'string');
+      return {
+        slug,
+        paths: rows.map(({ path }) => path).sort(),
+        identical: fullyInspected && hashes.length === 1,
+        treeHash: fullyInspected && hashes.length === 1 ? hashes[0] : null,
+      };
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug, 'en', { sensitivity: 'variant' }));
 }
 
 export function discoverSubmissionSkills({
@@ -151,8 +325,9 @@ export function discoverSubmissionSkills({
   repository = '',
   slugAliasRegistry = { schemaVersion: 1, aliases: [] },
 }) {
-  const sourceRoot = resolve(sourceDir);
-  const searchRoot = resolve(sourceRoot, skillPath);
+  const sourceRoot = realpathSync(resolve(sourceDir));
+  const scope = resolvePublicationScope(sourceRoot, skillPath, explicitPath);
+  const searchRoot = scope.path === '.' ? sourceRoot : resolve(sourceRoot, scope.path);
   const relativeSearch = relative(sourceRoot, searchRoot);
   if (relativeSearch === '..' || relativeSearch.startsWith(`..${sep}`)) fail(`skill path escapes source repository: ${skillPath}`);
   let searchStat;
@@ -160,7 +335,13 @@ export function discoverSubmissionSkills({
     searchStat = lstatSync(searchRoot);
   } catch {
     if (explicitPath) fail(`explicit skill path does not exist: ${skillPath}`);
-    return { schemaVersion: 1, explicitPath, skillPath, skills: [] };
+    return { schemaVersion: 2, explicitPath, skillPath, scope, stats: {
+      physicalSkillFiles: 0,
+      selectedSkillFiles: 0,
+      ignoredSkillFiles: 0,
+      identicalMirrorGroups: 0,
+      conflictingMirrorGroups: 0,
+    }, mirrorGroups: [], skills: [] };
   }
   if (!searchStat.isDirectory() || searchStat.isSymbolicLink()) fail(`skill search root must be a real directory: ${skillPath || '.'}`);
 
@@ -170,14 +351,32 @@ export function discoverSubmissionSkills({
     : '';
   const repositoryAliases = aliases.filter((alias) => alias.repository === canonicalRepo);
   const aliasByPath = new Map(repositoryAliases.map((alias) => [alias.path, alias]));
-  const normalizedSkillPath = skillPath === '' ? '' : repositoryPath(skillPath, 'skillPath');
-  const scopedAliases = repositoryAliases.filter((alias) => isWithinScope(alias.path, normalizedSkillPath));
+  const normalizedSkillPath = scope.path === '.' ? '' : scope.path;
+  const scopedAliases = explicitPath && scope.path === '.'
+    ? []
+    : repositoryAliases.filter((alias) => isWithinScope(alias.path, normalizedSkillPath));
   const consumedAliases = new Set();
 
-  const skillFiles = collectSkillFiles(searchRoot);
+  const physicalSkillFiles = collectSkillFiles(sourceRoot);
+  let skillFiles;
+  // A root-level blob URL names only repository-root SKILL.md. Do not walk
+  // unrelated nested content: it is outside this explicit authority boundary.
+  if (explicitPath && scope.path === '.') {
+    const rootSkill = join(sourceRoot, 'SKILL.md');
+    try {
+      const stat = lstatSync(rootSkill);
+      if (stat.isSymbolicLink() || !stat.isFile()) fail('root-level explicit SKILL.md must be a regular file');
+      skillFiles = [rootSkill];
+    } catch (error) {
+      if (error?.code === 'ENOENT') skillFiles = [];
+      else throw error;
+    }
+  } else {
+    skillFiles = collectSkillFiles(searchRoot, { strict: true });
+  }
   if (explicitPath && skillFiles.length === 0) fail(`explicit skill path contains no SKILL.md: ${skillPath}`);
   const skills = [];
-  const seen = new Set();
+  const seen = new Map();
   for (const file of skillFiles) {
     const directory = dirname(file);
     const relativeFile = posixRelative(sourceRoot, file);
@@ -195,13 +394,47 @@ export function discoverSubmissionSkills({
       slug = alias.baseSlug;
       consumedAliases.add(alias.path);
     }
-    if (seen.has(slug)) fail(`duplicate discovered skill slug: ${slug}`);
-    seen.add(slug);
+    const previous = seen.get(slug);
+    if (previous) {
+      const previousIdentity = projectLocalMirrorIdentity(previous.path);
+      const currentIdentity = projectLocalMirrorIdentity(relativeDirectory);
+      const approvedMirror = scope.reason === 'repository_fallback'
+        && previousIdentity !== null
+        && currentIdentity !== null
+        && previousIdentity.logicalPath === currentIdentity.logicalPath;
+      if (!approvedMirror) fail(`duplicate discovered skill slug: ${slug}`);
+      const previousHash = canonicalTreeHash(previous.directory);
+      const currentHash = canonicalTreeHash(directory);
+      if (previousHash !== currentHash) fail(`conflicting project-local mirror slug: ${slug}`);
+      continue;
+    }
+    seen.set(slug, { path: relativeDirectory, directory });
     skills.push({ slug, path: relativeDirectory });
   }
   const unconsumed = scopedAliases.filter((alias) => !consumedAliases.has(alias.path));
   if (unconsumed.length > 0) fail(`slug alias scope contains unconsumed paths: ${unconsumed.map((alias) => alias.path).join(', ')}`);
-  return { schemaVersion: 1, explicitPath, skillPath, skills };
+  const mirrorGroups = mirrorDiagnostics(
+    sourceRoot,
+    physicalSkillFiles,
+    skillFiles,
+    scope.reason === 'repository_fallback',
+  );
+  const identicalMirrorGroups = mirrorGroups.filter(({ identical }) => identical).length;
+  return {
+    schemaVersion: 2,
+    explicitPath,
+    skillPath,
+    scope,
+    stats: {
+      physicalSkillFiles: physicalSkillFiles.length,
+      selectedSkillFiles: skills.length,
+      ignoredSkillFiles: physicalSkillFiles.length - skills.length,
+      identicalMirrorGroups,
+      conflictingMirrorGroups: mirrorGroups.length - identicalMirrorGroups,
+    },
+    mirrorGroups,
+    skills,
+  };
 }
 
 function main() {

--- a/scripts/process-submission-shard.mjs
+++ b/scripts/process-submission-shard.mjs
@@ -14,7 +14,8 @@ import {
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { parseCanonicalShardIndex, parseSlugCsv } from './submission-shard-contract.mjs';
+import { parseCanonicalShardIndex } from './submission-shard-contract.mjs';
+import { parseSelectionPlan } from './submission-selection-plan.mjs';
 
 function fail(message) {
   throw new Error(message);
@@ -127,7 +128,8 @@ function buildAttempt(number, requested, execution, result) {
 }
 
 async function processShard(config) {
-  const planned = parseSlugCsv(config.slugs, 'planned slugs');
+  const selectionPlan = parseSelectionPlan(readFileSync(config.selectionPlan, 'utf8'));
+  const planned = selectionPlan.skills.map(({ slug }) => slug);
   const shardIndex = parseCanonicalShardIndex(config.shardIndex);
   const pendingRoot = join(config.resultDir, 'pending');
   const manifestPath = join(config.resultDir, 'shard-manifest.json');
@@ -135,6 +137,7 @@ async function processShard(config) {
 
   rmSync(config.resultDir, { recursive: true, force: true });
   mkdirSync(pendingRoot, { recursive: true });
+  writeFileSync(join(config.resultDir, 'selection-plan.json'), `${JSON.stringify(selectionPlan)}\n`, { mode: 0o600 });
 
   if (planned.length === 0) {
     writeFileSync(logPath, 'No skills planned; explicit no-op.\n', { mode: 0o600 });
@@ -143,6 +146,7 @@ async function processShard(config) {
       shardIndex,
       status: 'succeeded',
       reasonCode: 'no_skills_planned',
+      selectionPlan,
       planned: [],
       succeeded: [],
       failed: [],
@@ -163,6 +167,7 @@ async function processShard(config) {
 
   const baseArgs = [
     'skill', 'process', config.githubUrl,
+    '--selection-plan', join(config.resultDir, 'selection-plan.json'),
     '--slugs', planned.join(','),
     '--output', config.resultDir,
     '--marketplace-repo', config.marketplaceRepo,
@@ -214,6 +219,7 @@ async function processShard(config) {
     shardIndex,
     status,
     reasonCode: status === 'succeeded' ? 'processed_all_planned' : 'processing_failed',
+    selectionPlan,
     planned,
     succeeded,
     failed,
@@ -229,7 +235,7 @@ async function main() {
   const config = {
     cli: option(args, '--cli'),
     githubUrl: option(args, '--github-url'),
-    slugs: option(args, '--slugs'),
+    selectionPlan: option(args, '--selection-plan'),
     resultDir: option(args, '--result-dir'),
     marketplaceRepo: option(args, '--marketplace-repo'),
     shardIndex: option(args, '--shard-index'),
@@ -243,9 +249,23 @@ async function main() {
   try {
     manifest = await processShard(config);
   } catch (error) {
-    const planned = parseSlugCsv(config.slugs, 'planned slugs');
+    let planned = [];
+    let selectionPlan = null;
+    try {
+      selectionPlan = parseSelectionPlan(readFileSync(config.selectionPlan, 'utf8'));
+      planned = selectionPlan.skills.map(({ slug }) => slug);
+    } catch {
+      // The diagnostic manifest below records the stable processing failure.
+    }
     const shardIndex = parseCanonicalShardIndex(config.shardIndex);
     mkdirSync(join(config.resultDir, 'pending'), { recursive: true });
+    if (existsSync(config.selectionPlan)) {
+      writeFileSync(
+        join(config.resultDir, 'selection-plan.invalid.json'),
+        readFileSync(config.selectionPlan),
+        { mode: 0o600 },
+      );
+    }
     const manifestPath = join(config.resultDir, 'shard-manifest.json');
     const logPath = join(config.resultDir, `process-output-${shardIndex}.log`);
     const message = error instanceof Error ? error.message : String(error);
@@ -255,6 +275,7 @@ async function main() {
       shardIndex,
       status: 'failed',
       reasonCode: 'process_step_failed',
+      selectionPlan,
       planned,
       succeeded: [],
       failed: planned,

--- a/scripts/resolve-submission-source.mjs
+++ b/scripts/resolve-submission-source.mjs
@@ -24,7 +24,8 @@ function decodePathSegment(raw) {
   } catch {
     fail(`GitHub URL contains invalid percent encoding: ${raw}`);
   }
-  if (decoded === '' || decoded === '.' || decoded === '..' || decoded.includes('\\') || decoded.includes('\0')) {
+  if (decoded === '' || decoded !== decoded.normalize('NFC') || /[\u0000-\u001f\u007f-\u009f]/u.test(decoded)
+    || decoded === '.' || decoded === '..' || decoded.startsWith('-') || decoded.includes('\\')) {
     fail(`GitHub URL contains an unsafe path segment: ${raw}`);
   }
   return decoded;
@@ -148,8 +149,10 @@ export function resolveSubmissionSource({ githubUrl, defaultRef, refsText }) {
     ref: selected.name,
     refType: selected.type,
     refSha: selected.sha,
-    skillPath: skillPath.join('/'),
-    explicitPath: skillPath.length > 0,
+    // A blob URL is always an explicit authority selection, including a
+    // root-level SKILL.md. Keep '.' as a transport-safe root sentinel.
+    skillPath: mode === 'blob' && skillPath.length === 0 ? '.' : skillPath.join('/'),
+    explicitPath: mode === 'blob' || skillPath.length > 0,
     normalizedUrl: normalizedTreeUrl(owner, repo, selected.name, skillPath),
   };
 }

--- a/scripts/submission-selection-plan.mjs
+++ b/scripts/submission-selection-plan.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const REPOSITORY = /^[a-z0-9][a-z0-9_.-]*\/[a-z0-9][a-z0-9_.-]*$/;
+const COMMIT = /^[0-9a-f]{40,64}$/;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/u;
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+
+function fail(message) { throw new Error(message); }
+
+function option(args, name, { required = true } = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    if (required) fail(`missing required option ${name}`);
+    return null;
+  }
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+export function validatePortablePath(value, label, { rootSentinel = false } = {}) {
+  if (rootSentinel && value === '.') return value;
+  if (typeof value !== 'string' || value === '' || value !== value.normalize('NFC')
+    || CONTROL.test(value) || /[<>:"|?*\\$'"`;%]/u.test(value) || value.startsWith('/') || value.startsWith('-')) {
+    fail(`${label} must be a non-empty NFC, control-free, repository-relative POSIX path`);
+  }
+  for (const segment of value.split('/')) {
+    if (segment === '' || segment === '.' || segment === '..' || segment.startsWith('-')
+      || segment.endsWith('.') || segment.endsWith(' ') || WINDOWS_RESERVED.test(segment)) {
+      fail(`${label} contains an unsafe path segment or non-portable path segment`);
+    }
+  }
+  return value;
+}
+
+function validateSkills(skills) {
+  if (!Array.isArray(skills)) fail('selection plan skills must be an array');
+  const slugs = new Set();
+  const paths = new Set();
+  const foldedPaths = new Set();
+  for (const [index, skill] of skills.entries()) {
+    if (!skill || typeof skill !== 'object' || Array.isArray(skill)
+      || JSON.stringify(Object.keys(skill).sort()) !== JSON.stringify(['path', 'slug'])) {
+      fail(`selection plan skill ${index} must contain only slug and path`);
+    }
+    if (typeof skill.slug !== 'string' || !SLUG.test(skill.slug) || slugs.has(skill.slug)) {
+      fail(`selection plan has invalid or duplicate slug at skill ${index}`);
+    }
+    const path = validatePortablePath(skill.path, `selection plan skill ${index}.path`, { rootSentinel: true });
+    if (paths.has(path)) fail(`selection plan has duplicate path ${path}`);
+    const foldedPath = path.normalize('NFC').toLocaleLowerCase('en-US');
+    if (foldedPaths.has(foldedPath)) fail(`selection plan has an NFC/case-fold path collision at ${path}`);
+    slugs.add(skill.slug);
+    paths.add(path);
+    foldedPaths.add(foldedPath);
+  }
+  return skills.map(({ slug, path }) => ({ slug, path }));
+}
+
+export function validateSelectionPlan(plan) {
+  if (!plan || typeof plan !== 'object' || Array.isArray(plan)
+    || JSON.stringify(Object.keys(plan).sort()) !== JSON.stringify(['repository', 'schemaVersion', 'scope', 'skills', 'sourceCommit'])) {
+    fail('selection plan has unknown or missing fields');
+  }
+  if (plan.schemaVersion !== 1) fail('selection plan schemaVersion must be 1');
+  if (typeof plan.repository !== 'string' || !REPOSITORY.test(plan.repository)) fail('selection plan repository must be canonical owner/repo');
+  if (typeof plan.sourceCommit !== 'string' || !COMMIT.test(plan.sourceCommit)) fail('selection plan sourceCommit must be a lowercase commit');
+  if (!plan.scope || typeof plan.scope !== 'object' || Array.isArray(plan.scope)
+    || JSON.stringify(Object.keys(plan.scope).sort()) !== JSON.stringify(['path', 'reason'])) {
+    fail('selection plan scope must contain only path and reason');
+  }
+  const scope = {
+    path: validatePortablePath(plan.scope.path, 'selection plan scope.path', { rootSentinel: true }),
+    reason: plan.scope.reason,
+  };
+  if (!['explicit_path', 'codex_plugin_manifest', 'conventional_skills', 'repository_fallback'].includes(scope.reason)) {
+    fail('selection plan scope.reason is invalid');
+  }
+  const skills = validateSkills(plan.skills);
+  for (const { path } of skills) {
+    if (scope.path !== '.' && path !== scope.path && !path.startsWith(`${scope.path}/`)) {
+      fail(`selection plan skill path escapes scope: ${path}`);
+    }
+  }
+  return { schemaVersion: 1, repository: plan.repository, sourceCommit: plan.sourceCommit, scope, skills };
+}
+
+export function parseSelectionPlan(text) {
+  let plan;
+  try { plan = JSON.parse(text); } catch (error) { fail(`cannot parse selection plan: ${error instanceof Error ? error.message : String(error)}`); }
+  return validateSelectionPlan(plan);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const input = readFileSync(option(args, '--input'), 'utf8');
+  const plan = parseSelectionPlan(input);
+  const output = option(args, '--output', { required: false });
+  const serialized = `${JSON.stringify(plan)}\n`;
+  if (output === null) process.stdout.write(serialized);
+  else writeFileSync(output, serialized, { mode: 0o600 });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try { main(); } catch (error) {
+    console.error(`::error::Selection plan validation failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/submission-shard-contract.mjs
+++ b/scripts/submission-shard-contract.mjs
@@ -7,6 +7,7 @@ import {
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { validateSelectionPlan } from './submission-selection-plan.mjs';
 
 const CANONICAL_INDEX = /^(0|[1-9][0-9]*)$/;
 const SLUG = /^[a-z0-9][a-z0-9-]*$/;
@@ -147,6 +148,7 @@ function validateAttempt(attempt, planned, expectedNumber) {
 export function validateSubmissionShardManifest(manifest, {
   expectedIndex = null,
   expectedPlanned = null,
+  expectedSelectionPlan = null,
   pendingRoot = null,
   requireSuccess = false,
 } = {}) {
@@ -164,6 +166,13 @@ export function validateSubmissionShardManifest(manifest, {
   const failed = validateSlugArray(manifest.failed, 'manifest.failed');
   assertPartition(planned, succeeded, failed, 'manifest');
   if (expectedPlanned !== null) assertSameSet(planned, expectedPlanned, 'manifest planned slugs do not match matrix');
+  if (!Object.hasOwn(manifest, 'selectionPlan')) fail('manifest selectionPlan is required');
+  const selectionPlan = validateSelectionPlan(manifest.selectionPlan);
+  assertSameSet(selectionPlan.skills.map(({ slug }) => slug), planned, 'manifest selection plan does not match planned slugs');
+  if (expectedSelectionPlan !== null) {
+    const expected = validateSelectionPlan(expectedSelectionPlan);
+    assert.deepEqual(selectionPlan, expected, 'manifest selection plan does not match matrix selection plan');
+  }
 
   if (!Array.isArray(manifest.failureCategories)) fail('manifest.failureCategories must be an array');
   for (const category of manifest.failureCategories) {
@@ -220,10 +229,17 @@ function main() {
   const manifestPath = option(args, '--manifest');
   const expectedIndex = option(args, '--expected-index');
   const expectedSlugs = parseSlugCsv(option(args, '--expected-slugs'), 'expected slugs');
+  let expectedSelectionPlan;
+  try {
+    expectedSelectionPlan = JSON.parse(readFileSync(option(args, '--expected-selection-plan'), 'utf8'));
+  } catch (error) {
+    fail(`cannot read expected selection plan: ${error instanceof Error ? error.message : String(error)}`);
+  }
   const pendingRoot = option(args, '--pending-root');
   const manifest = readAndValidateSubmissionShardManifest(manifestPath, {
     expectedIndex,
     expectedPlanned: expectedSlugs,
+    expectedSelectionPlan,
     pendingRoot,
     requireSuccess: args.includes('--require-success'),
   });

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -24,6 +24,7 @@ const runtimeFiles = [
   'scripts/resolve-submission-source.mjs',
   'scripts/discover-submission-skills.mjs',
   'scripts/process-submission-shard.mjs',
+  'scripts/submission-selection-plan.mjs',
   'scripts/submission-shard-contract.mjs',
   'scripts/aggregate-submission-shards.mjs',
   'scripts/resolve-approved-submission.mjs',
@@ -93,6 +94,7 @@ function createFixture() {
     'scripts/resolve-submission-source.mjs': 'export const source = true;\n',
     'scripts/discover-submission-skills.mjs': 'export const discover = true;\n',
     'scripts/process-submission-shard.mjs': 'export const process = true;\n',
+    'scripts/submission-selection-plan.mjs': 'export const selectionPlan = true;\n',
     'scripts/submission-shard-contract.mjs': 'export const contract = true;\n',
     'scripts/aggregate-submission-shards.mjs': "import './resolve-approved-submission.mjs';\n",
     'scripts/resolve-approved-submission.mjs': 'export const resolve = true;\n',
@@ -197,8 +199,15 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/submission-shard-contract\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
-  assert.match(reusable, /minimum-version: 2\.14\.3/);
+  assert.match(reusable, /minimum-version: 2\.15\.0/);
+  assert.match(reusable, /Rollout pin: selection-plan processing requires the exact 2\.15\.0 contract/);
+  assert.match(reusable, /trap cleanup_input_plan EXIT/);
   assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
+  assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);
+  assert.match(reusable, /SELECTION_PLAN_JSON:/);
+  assert.match(readFileSync('scripts/process-submission-shard.mjs', 'utf8'), /'--selection-plan', join\(config\.resultDir, 'selection-plan\.json'\)/);
+  assert.equal((reusable.match(/"scripts\/submission-selection-plan\.mjs"/g) ?? []).length, 3,
+    'discovery, processing, and aggregation immutable runtime lists must all include the plan validator');
   assert.match(
     readFileSync('scripts/aggregate-submission-shards.mjs', 'utf8'),
     /from '\.\/resolve-approved-submission\.mjs'/,

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -40,6 +40,28 @@ function runNode(script, args, options = {}) {
   });
 }
 
+function writeSelectionPlan(root, skills, { scope = 'skills' } = {}) {
+  const path = join(root, 'selection-plan.json');
+  writeFileSync(path, `${JSON.stringify({
+    schemaVersion: 1,
+    repository: 'example/source',
+    sourceCommit: 'a'.repeat(40),
+    scope: { path: scope, reason: scope === '.' ? 'explicit_path' : 'conventional_skills' },
+    skills,
+  })}\n`);
+  return path;
+}
+
+function selectionPlanFor(skills) {
+  return {
+    schemaVersion: 1,
+    repository: 'example/source',
+    sourceCommit: 'a'.repeat(40),
+    scope: { path: 'skills', reason: 'conventional_skills' },
+    skills: skills.map((slug) => ({ slug, path: `skills/${slug}` })),
+  };
+}
+
 function writePendingSkill(root, slug, extraFiles = []) {
   const pendingDir = `pending/${slug}`;
   const absoluteDir = join(root, pendingDir);
@@ -71,6 +93,7 @@ function successfulManifest(index, planned, { reasonCode = 'processed_all_planne
     shardIndex: index,
     status: 'succeeded',
     reasonCode: noOp ? 'no_skills_planned' : reasonCode,
+    selectionPlan: selectionPlanFor(planned),
     planned,
     succeeded: planned,
     failed: [],
@@ -93,6 +116,7 @@ function failedManifest(index, planned, status = 'failed') {
     shardIndex: index,
     status,
     reasonCode: status === 'failed' ? 'processing_failed' : `processing_${status}`,
+    selectionPlan: selectionPlanFor(planned),
     planned,
     succeeded: [],
     failed: planned,
@@ -112,6 +136,7 @@ function failedManifest(index, planned, status = 'failed') {
 function createShardArchive(artifactsDir, {
   rawIndex,
   manifest,
+  selectionPlan = manifest?.selectionPlan,
   slugs = manifest?.succeeded ?? [],
   nested = '',
   omitManifest = false,
@@ -124,10 +149,11 @@ function createShardArchive(artifactsDir, {
     if (!omitManifest) {
       writeFileSync(join(fixtureRoot, 'shard-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
     }
+    writeFileSync(join(fixtureRoot, 'selection-plan.json'), `${JSON.stringify(selectionPlan)}\n`);
     const archiveDir = join(artifactsDir, nested);
     mkdirSync(archiveDir, { recursive: true });
     const archive = join(archiveDir, `process-shard-1-${rawIndex}.tar.gz`);
-    const entries = ['pending'];
+    const entries = ['pending', 'selection-plan.json'];
     if (!omitManifest) entries.push('shard-manifest.json');
     const tar = spawnSync('tar', ['-C', fixtureRoot, '-czf', archive, ...entries], { encoding: 'utf8' });
     assert.equal(tar.status, 0, tar.stderr);
@@ -158,14 +184,23 @@ function createRawEntryArchive(artifactsDir, entryName) {
   return archive;
 }
 
-function runAggregate(root, matrix, expectedCount = matrix.include.length) {
+function matrixWithSelectionPlans(matrix) {
+  return {
+    include: matrix.include.map((entry) => entry.selection_plan ? entry : {
+      shard: entry.shard,
+      selection_plan: selectionPlanFor(entry.slugs === '' ? [] : entry.slugs.split(',')),
+    }),
+  };
+}
+
+function runAggregate(root, matrix, expectedCount = matrix.include.length, { normalizeLegacyMatrix = true } = {}) {
   const approvalPlan = join(root, 'approval-plan.json');
   const mergedResults = join(root, 'merged');
   const summary = join(root, 'summary.json');
   const result = runNode(aggregateShardsScript, [
     '--artifacts-dir', join(root, 'artifacts'),
     '--run-attempt', '1',
-    '--matrix-json', JSON.stringify(matrix),
+    '--matrix-json', JSON.stringify(normalizeLegacyMatrix ? matrixWithSelectionPlans(matrix) : matrix),
     '--expected-count', String(expectedCount),
     '--approval-plan', approvalPlan,
     '--merged-results', mergedResults,
@@ -180,6 +215,9 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/process-submission-shard\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
+  assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);
+  assert.match(reusable, /PLAN_EVIDENCE=\(\)/);
+  assert.match(reusable, /selection-plan\.invalid\.json/);
   assert.match(reusable, /git add -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
   assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
   assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);
@@ -193,6 +231,7 @@ test('real CLI two-round failure produces a failed manifest and cannot aggregate
   const argsLog = join(root, 'args.txt');
   const aliases = join(root, 'aliases.json');
   const resultDir = join(root, 'result');
+  const selectionPlan = writeSelectionPlan(root, [{ slug: 'broken-skill', path: 'skills/broken-skill' }]);
   writeFileSync(aliases, '{"schemaVersion":1,"aliases":[]}\n');
   writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\nprintf '%s\\n' "$*" >> "$FAKE_ARGS"\necho "fixture CLI failure $count" >&2\nexit 23\n`);
   chmodSync(fakeCli, 0o755);
@@ -200,7 +239,7 @@ test('real CLI two-round failure produces a failed manifest and cannot aggregate
   const processing = runNode(processShardScript, [
     '--cli', fakeCli,
     '--github-url', 'https://github.com/example/source',
-    '--slugs', 'broken-skill',
+    '--selection-plan', selectionPlan,
     '--result-dir', resultDir,
     '--marketplace-repo', 'aiskillstore/marketplace',
     '--shard-index', '0',
@@ -211,8 +250,13 @@ test('real CLI two-round failure produces a failed manifest and cannot aggregate
   assert.equal(readFileSync(state, 'utf8').trim(), '2');
   const attempts = readFileSync(argsLog, 'utf8').trim().split('\n');
   assert.equal(attempts.length, 2);
-  for (const args of attempts) assert.match(args, new RegExp(`--slug-aliases-file ${aliases.replaceAll('/', '\\/')}`));
+  for (const args of attempts) {
+    assert.match(args, new RegExp(`--slug-aliases-file ${aliases.replaceAll('/', '\\/')}`));
+    assert.match(args, /--selection-plan .*selection-plan\.json/);
+    assert.match(args, /--slugs broken-skill/);
+  }
   const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.deepEqual(JSON.parse(readFileSync(join(resultDir, 'selection-plan.json'), 'utf8')), JSON.parse(readFileSync(selectionPlan, 'utf8')));
   assert.equal(manifest.status, 'failed');
   assert.deepEqual(manifest.planned, ['broken-skill']);
   assert.deepEqual(manifest.succeeded, []);
@@ -223,6 +267,7 @@ test('real CLI two-round failure produces a failed manifest and cannot aggregate
     '--manifest', join(resultDir, 'shard-manifest.json'),
     '--expected-index', '0',
     '--expected-slugs', 'broken-skill',
+    '--expected-selection-plan', selectionPlan,
     '--pending-root', join(resultDir, 'pending'),
     '--require-success',
   ]);
@@ -247,6 +292,7 @@ test('a successful retry closes the manifest only after every planned result exi
   const state = join(root, 'calls.txt');
   const sourceFixture = join(root, 'source-fixture');
   const resultDir = join(root, 'result');
+  const selectionPlan = writeSelectionPlan(root, [{ slug: 'recoverable', path: 'skills/recoverable' }]);
   mkdirSync(join(sourceFixture, 'pending'), { recursive: true });
   writePendingSkill(sourceFixture, 'recoverable');
   writeFileSync(fakeCli, `#!/usr/bin/env bash\nset -eu\ncount=0\n[ ! -f "$FAKE_STATE" ] || count=$(cat "$FAKE_STATE")\ncount=$((count + 1))\nprintf '%s\\n' "$count" > "$FAKE_STATE"\nif [ "$count" -eq 1 ]; then\n  echo 'first attempt fails' >&2\n  exit 23\nfi\noutput=''\nwhile [ "$#" -gt 0 ]; do\n  if [ "$1" = '--output' ]; then output="$2"; break; fi\n  shift\ndone\ntest -n "$output"\nmkdir -p "$output/pending"\ncp -R "$FIXTURE_PENDING/recoverable" "$output/pending/recoverable"\n`);
@@ -255,7 +301,7 @@ test('a successful retry closes the manifest only after every planned result exi
   const processing = runNode(processShardScript, [
     '--cli', fakeCli,
     '--github-url', 'https://github.com/example/source',
-    '--slugs', 'recoverable',
+    '--selection-plan', selectionPlan,
     '--result-dir', resultDir,
     '--marketplace-repo', 'aiskillstore/marketplace',
     '--shard-index', '0',
@@ -263,6 +309,7 @@ test('a successful retry closes the manifest only after every planned result exi
   ], { env: { FAKE_STATE: state, FIXTURE_PENDING: join(sourceFixture, 'pending') } });
   assert.equal(processing.status, 0, processing.stderr);
   const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.deepEqual(JSON.parse(readFileSync(join(resultDir, 'selection-plan.json'), 'utf8')), JSON.parse(readFileSync(selectionPlan, 'utf8')));
   assert.equal(manifest.status, 'succeeded');
   assert.equal(manifest.reasonCode, 'processed_all_planned');
   assert.deepEqual(manifest.succeeded, ['recoverable']);
@@ -273,10 +320,55 @@ test('a successful retry closes the manifest only after every planned result exi
     '--manifest', join(resultDir, 'shard-manifest.json'),
     '--expected-index', '0',
     '--expected-slugs', 'recoverable',
+    '--expected-selection-plan', selectionPlan,
     '--pending-root', join(resultDir, 'pending'),
     '--require-success',
   ]);
   assert.equal(terminal.status, 0, terminal.stderr);
+}));
+
+test('the shard contract rejects a serialized selection plan whose paths do not match the shard slugs', () => withTempDirectory((root) => {
+  const manifest = successfulManifest(0, ['alpha']);
+  manifest.selectionPlan = {
+    schemaVersion: 1,
+    repository: 'example/source',
+    sourceCommit: 'a'.repeat(40),
+    scope: { path: 'skills', reason: 'conventional_skills' },
+    skills: [{ slug: 'beta', path: 'skills/beta' }],
+  };
+  const manifestPath = join(root, 'shard-manifest.json');
+  const expectedPlan = writeSelectionPlan(root, [{ slug: 'alpha', path: 'skills/alpha' }]);
+  writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`);
+  mkdirSync(join(root, 'pending'));
+  const result = runNode(shardContractScript, [
+    '--manifest', manifestPath,
+    '--expected-index', '0',
+    '--expected-slugs', 'alpha',
+    '--expected-selection-plan', expectedPlan,
+    '--pending-root', join(root, 'pending'),
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /selection plan does not match planned slugs/);
+}));
+
+test('an invalid selection plan still produces an uploadable diagnostic manifest and raw-plan evidence', () => withTempDirectory((root) => {
+  const plan = join(root, 'tampered-plan.json');
+  const resultDir = join(root, 'result');
+  writeFileSync(plan, '{not-json\n');
+  const result = runNode(processShardScript, [
+    '--cli', join(root, 'not-invoked'),
+    '--github-url', 'https://github.com/example/source',
+    '--selection-plan', plan,
+    '--result-dir', resultDir,
+    '--marketplace-repo', 'aiskillstore/marketplace',
+    '--shard-index', '0',
+    '--retry-delay-ms', '0',
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(readFileSync(join(resultDir, 'selection-plan.invalid.json'), 'utf8'), '{not-json\n');
+  const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.equal(manifest.reasonCode, 'process_step_failed');
+  assert.equal(manifest.selectionPlan, null);
 }));
 
 test('aggregation accepts root and nested archives only when manifests and pending results agree', () => withTempDirectory((root) => {
@@ -305,6 +397,73 @@ test('aggregation accepts root and nested archives only when manifests and pendi
   assert.deepEqual(plan.skills.map(({ pendingDir }) => pendingDir), ['pending/alpha', 'pending/beta']);
   assert.equal(JSON.parse(readFileSync(aggregate.summary, 'utf8')).status, 'has_results');
 }));
+
+test('aggregation rejects legacy slug-only matrix entries and path-bound plan drift', () => withTempDirectory((root) => {
+  const artifacts = join(root, 'artifacts');
+  mkdirSync(artifacts);
+  const manifest = successfulManifest(0, ['alpha']);
+  manifest.selectionPlan.skills[0].path = 'skills/other-alpha';
+  createShardArchive(artifacts, {
+    rawIndex: '0',
+    manifest,
+    selectionPlan: selectionPlanFor(['alpha']),
+    slugs: ['alpha'],
+  });
+  const matrix = { include: [{ shard: 0, slugs: 'alpha' }] };
+  const legacy = runAggregate(root, matrix, 1, { normalizeLegacyMatrix: false });
+  assert.notEqual(legacy.result.status, 0);
+  assert.match(legacy.result.stderr, /selection_plan/);
+  const drift = runAggregate(root, matrix);
+  assert.notEqual(drift.result.status, 0);
+  assert.match(drift.result.stderr, /selection plan does not match matrix selection plan/);
+}));
+
+test('aggregation requires archive selection-plan evidence to exactly match the matrix plan', () => withTempDirectory((root) => {
+  const artifacts = join(root, 'artifacts');
+  mkdirSync(artifacts);
+  const tamperedPlan = { ...selectionPlanFor(['alpha']), skills: [{ slug: 'alpha', path: 'skills/tampered-alpha' }] };
+  createShardArchive(artifacts, {
+    rawIndex: '0',
+    manifest: successfulManifest(0, ['alpha']),
+    selectionPlan: tamperedPlan,
+    slugs: ['alpha'],
+  });
+  const matrix = { include: [{ shard: 0, selection_plan: selectionPlanFor(['alpha']) }] };
+  const aggregate = runAggregate(root, matrix);
+  assert.notEqual(aggregate.result.status, 0);
+  assert.match(aggregate.result.stderr, /archive selection plan does not match matrix selection plan/);
+}));
+
+for (const fixture of [
+  {
+    name: 'mixed source commits',
+    plans: [selectionPlanFor(['alpha']), { ...selectionPlanFor(['beta']), sourceCommit: 'b'.repeat(40) }],
+    expected: /identity does not match/,
+  },
+  {
+    name: 'mixed scopes',
+    plans: [selectionPlanFor(['alpha']), { ...selectionPlanFor(['beta']), scope: { path: '.', reason: 'explicit_path' }, skills: [{ slug: 'beta', path: 'beta' }] }],
+    expected: /identity does not match/,
+  },
+  {
+    name: 'duplicate slugs',
+    plans: [selectionPlanFor(['alpha']), selectionPlanFor(['alpha'])],
+    expected: /duplicate slug/,
+  },
+  {
+    name: 'duplicate paths',
+    plans: [selectionPlanFor(['alpha']), { ...selectionPlanFor(['beta']), skills: [{ slug: 'beta', path: 'skills/alpha' }] }],
+    expected: /duplicate path/,
+  },
+]) {
+  test(`aggregation rejects matrix selection plans with ${fixture.name}`, () => withTempDirectory((root) => {
+    mkdirSync(join(root, 'artifacts'));
+    const matrix = { include: fixture.plans.map((selection_plan, shard) => ({ shard, selection_plan })) };
+    const aggregate = runAggregate(root, matrix);
+    assert.notEqual(aggregate.result.status, 0);
+    assert.match(aggregate.result.stderr, fixture.expected);
+  }));
+}
 
 test('aggregation preserves printable UTF-8 archive paths without weakening path validation', () => withTempDirectory((root) => {
   const artifacts = join(root, 'artifacts');

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test } from 'node:test';
@@ -8,6 +8,7 @@ import {
   discoverSubmissionSkills,
   validateSlugAliasRegistry,
 } from '../discover-submission-skills.mjs';
+import { validateSelectionPlan } from '../submission-selection-plan.mjs';
 
 const MAIN_SHA = '1'.repeat(40);
 const READY_SHA = '2'.repeat(40);
@@ -84,6 +85,246 @@ test('repository URLs use the exact default head and unsafe encoded paths are re
   }), /unsafe path segment/);
 });
 
+test('root SKILL.md blob keeps the explicit root sentinel and cannot be overridden by a manifest', () => {
+  const result = resolveSubmissionSource({
+    githubUrl: 'https://github.com/example/repo/blob/main/SKILL.md',
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main']),
+  });
+  assert.equal(result.skillPath, '.');
+  assert.equal(result.explicitPath, true);
+});
+
+test('a root SKILL.md blob selects only the root skill and ignores nested repository skills', () => withDirectory((root) => {
+  mkdirSync(join(root, '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'nested'), { recursive: true });
+  mkdirSync(join(root, 'skills', '-unsafe'), { recursive: true });
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'fixture', skills: './skills/' }));
+  writeFileSync(join(root, 'SKILL.md'), '---\nname: root-blob\n---\n');
+  writeFileSync(join(root, 'skills', 'nested', 'SKILL.md'), '---\nname: nested\n---\n');
+  writeFileSync(join(root, 'skills', '-unsafe', 'SKILL.md'), '---\nname: ignored-invalid-path\n---\n');
+  symlinkSync(join(root, 'outside'), join(root, 'skills', 'nested', 'untrusted-link'));
+  const result = discoverSubmissionSkills({ sourceDir: root, skillPath: '.', explicitPath: true });
+  assert.deepEqual(result.scope, { reason: 'explicit_path', path: '.' });
+  assert.deepEqual(result.skills, [{ slug: 'root-blob', path: '.' }]);
+  assert.equal(result.stats.physicalSkillFiles, 3);
+  assert.equal(result.stats.selectedSkillFiles, 1);
+  assert.equal(result.stats.ignoredSkillFiles, 2);
+}));
+
+test('a frozen Hyperframes-shaped fixture produces one authoritative 19-skill plan and only ignored identical mirrors', () => withDirectory((root) => {
+  const publicSlugs = [
+    'embedded-captions', 'faceless-explainer', 'figma', 'general-video',
+    'hyperframes-animation', 'hyperframes-cli', 'hyperframes-core', 'hyperframes-creative',
+    'hyperframes-keyframes', 'hyperframes-registry', 'hyperframes', 'media-use',
+    'motion-graphics', 'music-to-video', 'pr-to-video', 'product-launch-video',
+    'remotion-to-hyperframes', 'slideshow', 'talking-head-recut',
+  ];
+  const localMirrors = ['captions-overlay', 'changelog-video', 'cut-the-curve', 'motion-doctrine', 'oversized-cursor', 'seam-craft'];
+  mkdirSync(join(root, '.codex-plugin'), { recursive: true });
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'hyperframes-fixture', skills: './skills/' }));
+  for (const slug of publicSlugs) {
+    mkdirSync(join(root, 'skills', slug), { recursive: true });
+    writeFileSync(join(root, 'skills', slug, 'SKILL.md'), `---\nname: ${slug}\n---\n`);
+  }
+  for (const slug of localMirrors) {
+    for (const host of ['.agents', '.claude']) {
+      mkdirSync(join(root, host, 'skills', slug, 'scripts'), { recursive: true });
+      writeFileSync(join(root, host, 'skills', slug, 'SKILL.md'), `---\nname: ${slug}\n---\n`);
+      writeFileSync(join(root, host, 'skills', slug, 'scripts', 'run.mjs'), 'export const fixture = true;\n');
+    }
+  }
+  const result = discoverSubmissionSkills({ sourceDir: root, repository: 'heygen-com/hyperframes' });
+  assert.deepEqual(result.stats, {
+    physicalSkillFiles: 31,
+    selectedSkillFiles: 19,
+    ignoredSkillFiles: 12,
+    identicalMirrorGroups: 6,
+    conflictingMirrorGroups: 0,
+  });
+  assert.deepEqual(result.skills.map(({ slug }) => slug), publicSlugs);
+  const plan = validateSelectionPlan({
+    schemaVersion: 1,
+    repository: 'heygen-com/hyperframes',
+    sourceCommit: MAIN_SHA,
+    scope: result.scope,
+    skills: result.skills,
+  });
+  assert.equal(plan.skills.length, 19);
+  assert.equal([plan].length, 1, '19 skills remain a single shard below the workflow threshold');
+}));
+
+for (const unsafe of ['bad\npath', 'bad\rpath', 'bad\u0001path', 'bad\u0085path', 'bad\u007fpath', '-leading', '../escape', '/absolute', 'quote;$(touch p)', 'windows:stream', 'CON.txt']) {
+  test(`selection plans reject unsafe path ${JSON.stringify(unsafe)}`, () => {
+    assert.throws(() => validateSelectionPlan({
+      schemaVersion: 1,
+      repository: 'example/repo',
+      sourceCommit: MAIN_SHA,
+      scope: { path: 'skills', reason: 'conventional_skills' },
+      skills: [{ slug: 'demo', path: unsafe }],
+    }));
+  });
+}
+
+test('selection plan repository accepts canonical punctuation but rejects leading punctuation', () => {
+  const base = {
+    schemaVersion: 1,
+    sourceCommit: MAIN_SHA,
+    scope: { path: 'skills', reason: 'conventional_skills' },
+    skills: [{ slug: 'demo', path: 'skills/demo' }],
+  };
+  assert.equal(validateSelectionPlan({ ...base, repository: 'owner.name/repo_name' }).repository, 'owner.name/repo_name');
+  for (const repository of ['-owner/repo', 'owner/-repo', '.owner/repo', 'owner/.repo']) {
+    assert.throws(() => validateSelectionPlan({ ...base, repository }));
+  }
+});
+
+test('repository-root discovery honors the Codex plugin publication scope and reports ignored mirrors', () => withDirectory((root) => {
+  mkdirSync(join(root, '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'public-one'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'public-two'), { recursive: true });
+  mkdirSync(join(root, '.agents', 'skills', 'local-only', 'scripts'), { recursive: true });
+  mkdirSync(join(root, '.claude', 'skills', 'local-only', 'scripts'), { recursive: true });
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({
+    name: 'fixture',
+    skills: './skills/',
+  }));
+  writeFileSync(join(root, 'skills', 'public-one', 'SKILL.md'), '---\nname: public-one\n---\n');
+  writeFileSync(join(root, 'skills', 'public-two', 'SKILL.md'), '---\nname: public-two\n---\n');
+  for (const host of ['.agents', '.claude']) {
+    writeFileSync(join(root, host, 'skills', 'local-only', 'SKILL.md'), '---\nname: local-only\n---\n');
+    writeFileSync(join(root, host, 'skills', 'local-only', 'scripts', 'run.mjs'), 'export const local = true;\n');
+  }
+
+  const result = discoverSubmissionSkills({
+    sourceDir: root,
+    repository: 'example/repository',
+  });
+
+  assert.deepEqual(result.scope, { reason: 'codex_plugin_manifest', path: 'skills' });
+  assert.deepEqual(result.skills, [
+    { slug: 'public-one', path: 'skills/public-one' },
+    { slug: 'public-two', path: 'skills/public-two' },
+  ]);
+  assert.deepEqual(result.stats, {
+    physicalSkillFiles: 4,
+    selectedSkillFiles: 2,
+    ignoredSkillFiles: 2,
+    identicalMirrorGroups: 1,
+    conflictingMirrorGroups: 0,
+  });
+  assert.equal(result.mirrorGroups.length, 1);
+  assert.deepEqual(result.mirrorGroups[0].paths, [
+    '.agents/skills/local-only',
+    '.claude/skills/local-only',
+  ]);
+  assert.equal(result.mirrorGroups[0].identical, true);
+  assert.match(result.mirrorGroups[0].treeHash, /^[0-9a-f]{64}$/);
+}));
+
+test('repository-root discovery falls back to the conventional skills directory', () => withDirectory((root) => {
+  mkdirSync(join(root, 'skills', 'public-skill'), { recursive: true });
+  mkdirSync(join(root, '.agents', 'skills', 'local-only'), { recursive: true });
+  writeFileSync(join(root, 'skills', 'public-skill', 'SKILL.md'), '# Public\n');
+  writeFileSync(join(root, '.agents', 'skills', 'local-only', 'SKILL.md'), '# Local\n');
+
+  const result = discoverSubmissionSkills({ sourceDir: root });
+
+  assert.deepEqual(result.scope, { reason: 'conventional_skills', path: 'skills' });
+  assert.deepEqual(result.skills, [{ slug: 'public-skill', path: 'skills/public-skill' }]);
+}));
+
+test('legacy repository fallback collapses only complete identical project-local mirrors', () => withDirectory((root) => {
+  for (const host of ['.agents', '.claude']) {
+    mkdirSync(join(root, host, 'skills', 'mirrored', 'scripts'), { recursive: true });
+    writeFileSync(join(root, host, 'skills', 'mirrored', 'SKILL.md'), '---\nname: mirrored\n---\n');
+    writeFileSync(join(root, host, 'skills', 'mirrored', 'scripts', 'run.mjs'), 'export const value = 1;\n');
+  }
+
+  const result = discoverSubmissionSkills({ sourceDir: root });
+
+  assert.deepEqual(result.scope, { reason: 'repository_fallback', path: '.' });
+  assert.deepEqual(result.skills, [{ slug: 'mirrored', path: '.agents/skills/mirrored' }]);
+  assert.deepEqual(result.stats, {
+    physicalSkillFiles: 2,
+    selectedSkillFiles: 1,
+    ignoredSkillFiles: 1,
+    identicalMirrorGroups: 1,
+    conflictingMirrorGroups: 0,
+  });
+}));
+
+test('legacy repository fallback rejects project-local mirrors with different complete trees', () => withDirectory((root) => {
+  for (const host of ['.agents', '.claude']) {
+    mkdirSync(join(root, host, 'skills', 'mirrored', 'scripts'), { recursive: true });
+    writeFileSync(join(root, host, 'skills', 'mirrored', 'SKILL.md'), '---\nname: mirrored\n---\n');
+  }
+  writeFileSync(join(root, '.agents', 'skills', 'mirrored', 'scripts', 'run.mjs'), 'export const value = 1;\n');
+  writeFileSync(join(root, '.claude', 'skills', 'mirrored', 'scripts', 'run.mjs'), 'export const value = 2;\n');
+
+  assert.throws(
+    () => discoverSubmissionSkills({ sourceDir: root }),
+    /conflicting project-local mirror slug: mirrored/,
+  );
+}));
+
+test('an authority-scoped submission records a three-way partial local mirror as ignored diagnostics', () => withDirectory((root) => {
+  mkdirSync(join(root, 'skills', 'public'), { recursive: true });
+  writeFileSync(join(root, 'skills', 'public', 'SKILL.md'), '---\nname: public\n---\n');
+  for (const host of ['.agents', '.claude', '.codex']) {
+    mkdirSync(join(root, host, 'skills', 'local', 'scripts'), { recursive: true });
+    writeFileSync(join(root, host, 'skills', 'local', 'SKILL.md'), '---\nname: local\n---\n');
+    writeFileSync(join(root, host, 'skills', 'local', 'scripts', 'run.mjs'), host === '.codex' ? 'export const value = 2;\n' : 'export const value = 1;\n');
+  }
+  const result = discoverSubmissionSkills({ sourceDir: root });
+  assert.deepEqual(result.skills, [{ slug: 'public', path: 'skills/public' }]);
+  assert.equal(result.stats.conflictingMirrorGroups, 1);
+  assert.equal(result.stats.ignoredSkillFiles, 3);
+  assert.equal(result.mirrorGroups[0].identical, false);
+}));
+
+test('an explicit project-local path wins over repository publication manifests', () => withDirectory((root) => {
+  mkdirSync(join(root, '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'public-skill'), { recursive: true });
+  mkdirSync(join(root, '.agents', 'skills', 'local-only'), { recursive: true });
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({
+    name: 'fixture',
+    skills: './skills/',
+  }));
+  writeFileSync(join(root, 'skills', 'public-skill', 'SKILL.md'), '# Public\n');
+  writeFileSync(join(root, '.agents', 'skills', 'local-only', 'SKILL.md'), '---\nname: local-only\n---\n');
+
+  const result = discoverSubmissionSkills({
+    sourceDir: root,
+    skillPath: '.agents/skills/local-only',
+    explicitPath: true,
+  });
+
+  assert.deepEqual(result.scope, { reason: 'explicit_path', path: '.agents/skills/local-only' });
+  assert.deepEqual(result.skills, [{ slug: 'local-only', path: '.agents/skills/local-only' }]);
+}));
+
+test('repository-root discovery rejects an unsafe or missing manifest scope', () => withDirectory((root) => {
+  mkdirSync(join(root, '.codex-plugin'), { recursive: true });
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({
+    name: 'fixture',
+    skills: '../outside',
+  }));
+  assert.throws(
+    () => discoverSubmissionSkills({ sourceDir: root }),
+    /Codex plugin skills path/,
+  );
+
+  writeFileSync(join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({
+    name: 'fixture',
+    skills: './missing/',
+  }));
+  assert.throws(
+    () => discoverSubmissionSkills({ sourceDir: root }),
+    /declared publication scope does not exist/,
+  );
+}));
+
 test('explicit paths with no SKILL.md fail while a repository-level empty scan remains an explicit no-op candidate', () => withDirectory((root) => {
   mkdirSync(join(root, 'empty'));
   assert.throws(() => discoverSubmissionSkills({
@@ -92,9 +333,18 @@ test('explicit paths with no SKILL.md fail while a repository-level empty scan r
     explicitPath: true,
   }), /contains no SKILL\.md/);
   assert.deepEqual(discoverSubmissionSkills({ sourceDir: root }), {
-    schemaVersion: 1,
+    schemaVersion: 2,
     explicitPath: false,
     skillPath: '',
+    scope: { reason: 'repository_fallback', path: '.' },
+    stats: {
+      physicalSkillFiles: 0,
+      selectedSkillFiles: 0,
+      ignoredSkillFiles: 0,
+      identicalMirrorGroups: 0,
+      conflictingMirrorGroups: 0,
+    },
+    mirrorGroups: [],
     skills: [],
   });
 }));


### PR DESCRIPTION
## Summary
- prefer explicit path, Codex plugin manifest scope, then conventional skills directory
- ignore authority-scope local mirrors while reporting physical/selected/ignored diagnostics
- freeze repository, source SHA, scope and exact slug/path plans through matrix, shard evidence and aggregation
- pin the verified Skillstore CLI 2.15.0 release
- harden untrusted path/output handling and root SKILL blob selection

## Incident
Fixes the discovery failure in run 29677315177, where Hyperframes public skills were mixed with project-local .agents/.claude mirrors.

## Verification
- Marketplace focused tests: 74 passed
- workflow YAML parsed successfully
- Hyperframes SHA 458df4c41294655f76e551100a9b634114209bb9: 31 physical, 19 selected, 12 ignored, 6 identical mirror groups, 0 conflicts
- Skillstore CLI 2.15.0 release run 29680709490 verified checksum, version and all three contract flags
- architecture/security/QA final reviews: SHIP

## Canary
After merge, create a new repository-dispatch run. Do not re-run 29677315177 because it is bound to the old workflow SHA.