### PR TITLE
fix: make scoped source monitor updates fail closed

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: string
         default: ''
+      expected_upstream_commit:
+        description: 'Expected 40-character upstream commit for an explicit slug-scoped update PR'
+        required: false
+        type: string
+        default: ''
       checkout_cache_dir:
         description: 'Persistent upstream checkout cache directory on self-hosted runners'
         required: false
@@ -157,6 +162,7 @@ jobs:
           REQUIRED_RUNTIME_FILES=(
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/monitor-skill-sources.yml"
+            "scripts/verify-source-monitor-selection.mjs"
           )
           {
             echo "expected_workflow_sha=$EXPECTED_WORKFLOW_SHA"
@@ -187,7 +193,7 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: latest
+          version: 2.15.0
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
           minimum-version: 2.14.5
@@ -223,6 +229,7 @@ jobs:
           DELETE_ARCHIVED: ${{ inputs.delete_archived || false }}
           MIN_MISSING_AGE_HOURS: ${{ inputs.min_missing_age_hours || 24 }}
           MODEL: ${{ inputs.model || '' }}
+          EXPECTED_UPSTREAM_COMMIT: ${{ inputs.expected_upstream_commit || '' }}
         run: |
           set -euo pipefail
 
@@ -270,9 +277,25 @@ jobs:
           fi
 
           if [ "$DRY_RUN" != "true" ]; then
-            CMD+=(--write)
-            if [ "$CREATE_PR" = "true" ]; then
+            if [ "$CREATE_PR" = "true" ] && [ -n "$SLUGS" ]; then
+              if [ -z "$EXPECTED_UPSTREAM_COMMIT" ]; then
+                echo "::error::A slug-scoped update PR requires expected_upstream_commit"
+                exit 1
+              fi
+              if ! [[ "$EXPECTED_UPSTREAM_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::expected_upstream_commit must be a lowercase 40-character Git SHA"
+                exit 1
+              fi
+              if [ "$ARCHIVE_MISSING" != "false" ] || [ "$CONFIRM_ARCHIVE" != "false" ] || [ "$DELETE_ARCHIVED" != "false" ]; then
+                echo "::error::A slug-scoped update PR cannot archive or delete skills"
+                exit 1
+              fi
               CMD+=(--updateLocal)
+            else
+              CMD+=(--write)
+              if [ "$CREATE_PR" = "true" ]; then
+                CMD+=(--updateLocal)
+              fi
             fi
           fi
 
@@ -307,6 +330,25 @@ jobs:
           echo "Delete archived: $DELETE_ARCHIVED"
           echo "Command: ${CMD[*]}"
           "${CMD[@]}" 2>&1 | tee "source-monitor-results/stdout-${GITHUB_RUN_ID}.jsonl"
+
+          if [ -n "$SLUGS" ]; then
+            VERIFY_SELECTION=(
+              node "$GITHUB_WORKSPACE/scripts/verify-source-monitor-selection.mjs"
+              --requested "$SLUGS"
+              --jsonl "$JSONL_FILE"
+            )
+            if [ -n "$EXPECTED_UPSTREAM_COMMIT" ]; then
+              VERIFY_SELECTION+=(--expected-upstream-commit "$EXPECTED_UPSTREAM_COMMIT")
+            fi
+            if [ "$DRY_RUN" != "true" ] && [ "$CREATE_PR" = "true" ]; then
+              VERIFY_SELECTION+=(
+                --require-local-updates
+                --summary "$SUMMARY_FILE"
+                --repository-root "$GITHUB_WORKSPACE"
+              )
+            fi
+            "${VERIFY_SELECTION[@]}"
+          fi
 
           echo "jsonl_file=$JSONL_FILE" >> "$GITHUB_OUTPUT"
           echo "summary_file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
@@ -415,6 +457,7 @@ jobs:
         env:
           DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
           CREATE_PR: ${{ github.event_name == 'schedule' && 'true' || inputs.create_pr }}
+          SLUGS: ${{ inputs.slugs || '' }}
           CONCURRENCY: ${{ inputs.concurrency || 8 }}
           WRITE_CONCURRENCY: ${{ inputs.write_concurrency || 2 }}
           MAX_UPDATES_PER_RUN: ${{ inputs.max_updates_per_run || 100 }}
@@ -422,7 +465,7 @@ jobs:
           ARCHIVE_MISSING: ${{ inputs.archive_missing || false }}
           DELETE_ARCHIVED: ${{ inputs.delete_archived || false }}
         run: |
-          if [ "$DRY_RUN" != "true" ]; then
+          if [ "$DRY_RUN" != "true" ] && { [ "$CREATE_PR" != "true" ] || [ -z "$SLUGS" ]; }; then
             WRITES="enabled"
           else
             WRITES="disabled"

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
+      - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
@@ -44,6 +45,7 @@ on:
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/tests/**"
+      - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
       - ".github/workflows/sync-audit-compute.yml"
@@ -75,6 +77,7 @@ jobs:
           sparse-checkout: |
             .github
             scripts
+            schemas
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/schemas/skill-report.schema.json
+++ b/schemas/skill-report.schema.json
@@ -62,6 +62,29 @@
         "provenance": {
           "$ref": "#/$defs/AnalysisProvenance",
           "description": "Reproducibility record: which model actually produced the report and the full fallback chain"
+        },
+        "upstream_version_raw": {
+          "type": ["string", "null"],
+          "description": "Author-supplied upstream version before normalization"
+        },
+        "upstream_version_normalized": {
+          "type": ["string", "null"],
+          "description": "Normalized upstream version used for version governance"
+        },
+        "upstream_version_source": {
+          "type": "string",
+          "enum": ["metadata.version", "version", "conflict", "none"],
+          "description": "Authoritative field from which the upstream version was derived"
+        },
+        "upstream_version_status": {
+          "type": "string",
+          "enum": ["valid", "missing", "invalid", "conflict", "not_bumped", "regressed"],
+          "description": "Version-governance result for the observed upstream version"
+        },
+        "upstream_commit_sha": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{40}$",
+          "description": "Immutable upstream Git commit used to build this report"
         }
       }
     },

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -515,9 +515,9 @@ test('download action invalidates stale local CLI cache entries', () => {
 	assert.match(action, /cache-hit=false/, 'stale local cache must flip cache-hit back to false');
 });
 
-test('source monitor warns and falls back when checkout-cache support is unavailable', () => {
+test('source monitor pins its audited CLI contract and falls back when checkout-cache support is unavailable', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /version: latest/, 'source monitor must always download the latest CLI');
+	assert.match(workflow, /version: 2\.15\.0/, 'source monitor must download the audited CLI contract version');
 	assert.doesNotMatch(workflow, /cli_version:/, 'source monitor must not expose a fixed CLI version input');
 	assert.doesNotMatch(workflow, /inputs\.cli_version/, 'source monitor must not consume a fixed CLI version input');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');

--- a/scripts/tests/skill-report-upstream-schema.test.mjs
+++ b/scripts/tests/skill-report-upstream-schema.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 const schema = JSON.parse(readFileSync('schemas/skill-report.schema.json', 'utf8'));
+const testWorkflow = readFileSync('.github/workflows/test-recalculate-scores.yml', 'utf8');
 const meta = schema.properties.meta;
 
 test('strict report schema declares the complete CLI upstream metadata contract', () => {
@@ -21,4 +22,13 @@ test('strict report schema declares the complete CLI upstream metadata contract'
   });
   assert.deepEqual(meta.properties.upstream_commit_sha.type, ['string', 'null']);
   assert.equal(meta.properties.upstream_commit_sha.pattern, '^[a-f0-9]{40}$');
+});
+
+test('script unit workflow checks out and watches the report schema fixture', () => {
+  assert.match(testWorkflow, /sparse-checkout: \|[\s\S]*\n\s+schemas\n/);
+  assert.equal(
+    (testWorkflow.match(/- "schemas\/skill-report\.schema\.json"/g) ?? []).length,
+    2,
+    'pull_request and push must both run schema contract tests when the fixture changes',
+  );
 });

--- a/scripts/tests/skill-report-upstream-schema.test.mjs
+++ b/scripts/tests/skill-report-upstream-schema.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const schema = JSON.parse(readFileSync('schemas/skill-report.schema.json', 'utf8'));
+const meta = schema.properties.meta;
+
+test('strict report schema declares the complete CLI upstream metadata contract', () => {
+  assert.equal(meta.additionalProperties, false);
+  assert.deepEqual(meta.properties.upstream_version_raw.type, ['string', 'null']);
+  assert.deepEqual(meta.properties.upstream_version_normalized.type, ['string', 'null']);
+  assert.deepEqual(meta.properties.upstream_version_source, {
+    type: 'string',
+    enum: ['metadata.version', 'version', 'conflict', 'none'],
+    description: 'Authoritative field from which the upstream version was derived',
+  });
+  assert.deepEqual(meta.properties.upstream_version_status, {
+    type: 'string',
+    enum: ['valid', 'missing', 'invalid', 'conflict', 'not_bumped', 'regressed'],
+    description: 'Version-governance result for the observed upstream version',
+  });
+  assert.deepEqual(meta.properties.upstream_commit_sha.type, ['string', 'null']);
+  assert.equal(meta.properties.upstream_commit_sha.pattern, '^[a-f0-9]{40}$');
+});

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import {
+  chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -18,6 +20,7 @@ const workflow = readFileSync('.github/workflows/monitor-skill-sources.yml', 'ut
 const runtimeFiles = [
   '.github/actions/download-skillstore-cli/action.yml',
   '.github/workflows/monitor-skill-sources.yml',
+  'scripts/verify-source-monitor-selection.mjs',
 ];
 
 function run(command, args, options = {}) {
@@ -70,6 +73,7 @@ function createFixture() {
   const files = {
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
+    'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
     'README.md': 'fixture\n',
   };
   for (const [path, content] of Object.entries(files)) {
@@ -168,9 +172,198 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
   assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /fetch-depth: 1/);
   assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /version: 2\.15\.0/);
   assert.match(workflow, /minimum-version: 2\.14\.5/);
   assert.match(workflow, /require-checksum: true/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);
   assert.match(workflow, /name: Upload monitor evidence\n\s+if: always\(\)/);
   for (const file of runtimeFiles) assert.match(workflow, new RegExp(file.replaceAll('.', '\\.')));
+});
+
+test('source monitor verifies every explicit requested slug before later workflow steps', () => {
+  const monitor = extractRunBlock('Run source monitor');
+  assert.match(monitor, /A slug-scoped update PR requires expected_upstream_commit/);
+  assert.match(monitor, /if \[ "\$CREATE_PR" = "true" \] && \[ -n "\$SLUGS" \]; then/);
+  assert.match(monitor, /CMD\+=\(--updateLocal\)/);
+  assert.match(monitor, /if \[ -n "\$SLUGS" \]; then/);
+  assert.match(monitor, /node "\$GITHUB_WORKSPACE\/scripts\/verify-source-monitor-selection\.mjs"/);
+  assert.match(monitor, /--requested "\$SLUGS"/);
+  assert.match(monitor, /--jsonl "\$JSONL_FILE"/);
+  assert.match(monitor, /--expected-upstream-commit "\$EXPECTED_UPSTREAM_COMMIT"/);
+  assert.ok(
+    monitor.indexOf('verify-source-monitor-selection.mjs') < monitor.indexOf('jsonl_file=$JSONL_FILE'),
+    'explicit selection verification must run before publishing step outputs',
+  );
+});
+
+test('final summary reports scoped local updates as no-write while scheduled scans keep writes enabled', () => {
+  const summary = extractRunBlock('Final summary').replaceAll('${{ github.run_id }}', '1234');
+  const cases = [
+    {
+      name: 'scoped local update PR',
+      env: { DRY_RUN: 'false', CREATE_PR: 'true', SLUGS: 'owner-one' },
+      expected: '- Supabase writes: disabled',
+    },
+    {
+      name: 'scheduled full scan',
+      env: { DRY_RUN: 'false', CREATE_PR: 'true', SLUGS: '' },
+      expected: '- Supabase writes: enabled',
+    },
+  ];
+
+  for (const fixture of cases) {
+    const root = mkdtempSync(join(tmpdir(), 'source-monitor-summary-'));
+    try {
+      const output = join(root, 'summary.md');
+      run('bash', ['-c', summary], {
+        env: {
+          ...process.env,
+          ...fixture.env,
+          GITHUB_STEP_SUMMARY: output,
+          CONCURRENCY: '8',
+          WRITE_CONCURRENCY: '2',
+          MAX_UPDATES_PER_RUN: '100',
+          CHECKOUT_CACHE_DIR: '/tmp/source-monitor-cache',
+          ARCHIVE_MISSING: 'false',
+          DELETE_ARCHIVED: 'false',
+        },
+      });
+      assert.match(readFileSync(output, 'utf8'), new RegExp(fixture.expected), fixture.name);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('a scoped update PR requires a pinned upstream commit and does not write Supabase', () => {
+  const root = mkdtempSync(join(tmpdir(), 'source-monitor-scoped-update-'));
+  const workspace = join(root, 'workspace');
+  const argsFile = join(root, 'args.txt');
+  const expectedCommit = '458df4c41294655f76e551100a9b634114209bb9';
+  try {
+    mkdirSync(join(workspace, 'scripts'), { recursive: true });
+    copyFileSync('scripts/verify-source-monitor-selection.mjs', join(workspace, 'scripts', 'verify-source-monitor-selection.mjs'));
+    const skillDirectory = join(workspace, 'skills', 'owner', 'one');
+    const reportPath = join(skillDirectory, 'skill-report.json');
+    const skillPath = join(skillDirectory, 'SKILL.md');
+    mkdirSync(skillDirectory, { recursive: true });
+    writeFileSync(reportPath, '{"meta":{"slug":"owner-one","upstream_commit_sha":null}}\n');
+    writeFileSync(skillPath, '# old\n');
+    const fakeCli = join(workspace, 'skillstore-cli');
+    writeFileSync(fakeCli, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  echo "2.15.0"
+  exit 0
+fi
+if [ "\${1:-}" = "skill" ] && [ "\${2:-}" = "monitor-upstream" ] && [ "\${3:-}" = "--help" ]; then
+  echo "--writeConcurrency --checkoutCacheDir"
+  exit 0
+fi
+printf '%s\\n' "$*" > "$FAKE_ARGS"
+jsonl=''
+summary=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --jsonlFile) jsonl="$2"; shift 2 ;;
+    --summaryFile) summary="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"slug":"owner-one","scan_status":"updated","upstream_commit_sha":"%s"}\\n' "$FAKE_COMMIT" > "$jsonl"
+printf '{"meta":{"slug":"owner-one","upstream_commit_sha":"%s"}}\\n' "$FAKE_COMMIT" > "$FAKE_REPORT"
+printf '# updated\\n' > "$FAKE_SKILL"
+cat > "$summary" <<'SUMMARY'
+| Observed updated skills | 1 |
+| Selected updated skills for this run | 1 |
+| Applied updated skills | 1 |
+| Failed selected updates | 0 |
+| Deferred updated skills | 0 |
+SUMMARY
+`);
+    chmodSync(fakeCli, 0o755);
+    run('git', ['init', '-q', workspace]);
+    run('git', ['-C', workspace, 'config', 'user.name', 'Fixture']);
+    run('git', ['-C', workspace, 'config', 'user.email', 'fixture@example.com']);
+    run('git', ['-C', workspace, 'add', '.']);
+    run('git', ['-C', workspace, 'commit', '-qm', 'fixture']);
+    writeFileSync(join(workspace, '.git', 'info', 'exclude'), '/source-monitor-results/\n', { flag: 'a' });
+    const baseEnv = {
+      ...process.env,
+      GITHUB_WORKSPACE: workspace,
+      GITHUB_RUN_ID: '1234',
+      GITHUB_OUTPUT: join(root, 'github-output'),
+      GH_TOKEN: 'fixture',
+      SLUGS: 'owner-one',
+      LIMIT: '1',
+      CONCURRENCY: '1',
+      WRITE_CONCURRENCY: '1',
+      MAX_UPDATES_PER_RUN: '1',
+      CHECKOUT_CACHE_DIR: join(root, 'cache'),
+      DRY_RUN: 'false',
+      CREATE_PR: 'true',
+      ARCHIVE_MISSING: 'false',
+      CONFIRM_ARCHIVE: 'false',
+      DELETE_ARCHIVED: 'false',
+      MIN_MISSING_AGE_HOURS: '24',
+      MODEL: '',
+      EXPECTED_UPSTREAM_COMMIT: expectedCommit,
+      FAKE_ARGS: argsFile,
+      FAKE_COMMIT: expectedCommit,
+      FAKE_REPORT: reportPath,
+      FAKE_SKILL: skillPath,
+    };
+    const monitor = extractRunBlock('Run source monitor');
+    const result = run('bash', ['-c', monitor], { cwd: workspace, env: baseEnv });
+    assert.match(result.stdout, /Verified exact source monitor selection: 1\/1/);
+    const invoked = readFileSync(argsFile, 'utf8');
+    assert.match(invoked, /--updateLocal/);
+    assert.doesNotMatch(invoked, /(^|\s)--write(\s|$)/);
+
+    rmSync(argsFile);
+    const rejected = run('bash', ['-c', monitor], {
+      cwd: workspace,
+      env: { ...baseEnv, EXPECTED_UPSTREAM_COMMIT: '' },
+      allowFailure: true,
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stdout + rejected.stderr, /requires expected_upstream_commit/);
+    assert.equal(existsSync(argsFile), false, 'CLI must not execute without the expected commit');
+
+    const helperArgs = [
+      join(workspace, 'scripts', 'verify-source-monitor-selection.mjs'),
+      '--requested', 'owner-one',
+      '--jsonl', join(workspace, 'source-monitor-results', 'skill-source-monitor-1234.jsonl'),
+      '--expected-upstream-commit', expectedCommit,
+      '--require-local-updates',
+      '--summary', join(workspace, 'source-monitor-results', 'skill-source-monitor-1234.md'),
+      '--repository-root', workspace,
+    ];
+    writeFileSync(skillPath, '# old\n');
+    const reportOnly = run('node', helperArgs, { cwd: workspace, allowFailure: true });
+    assert.notEqual(reportOnly.status, 0);
+    assert.match(reportOnly.stderr, /produced no payload file changes/);
+    writeFileSync(skillPath, '# updated\n');
+
+    const unsafeLink = join(skillDirectory, 'unsafe-link');
+    symlinkSync('SKILL.md', unsafeLink);
+    const symlinked = run('node', helperArgs, { cwd: workspace, allowFailure: true });
+    assert.notEqual(symlinked.status, 0);
+    assert.match(symlinked.stderr, /changed a symbolic link/);
+    rmSync(unsafeLink);
+
+    const controlPath = join(skillDirectory, 'control\npath');
+    writeFileSync(controlPath, 'unsafe\n');
+    const controlled = run('node', helperArgs, { cwd: workspace, allowFailure: true });
+    assert.notEqual(controlled.status, 0);
+    assert.match(controlled.stderr, /unsafe changed path/);
+    rmSync(controlPath);
+
+    writeFileSync(join(workspace, 'README.md'), 'unauthorized\n');
+    const unauthorized = run('node', helperArgs, { cwd: workspace, allowFailure: true });
+    assert.notEqual(unauthorized.status, 0);
+    assert.match(unauthorized.stderr, /changed an unauthorized path: README\.md/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/tests/source-monitor-selection.test.mjs
+++ b/scripts/tests/source-monitor-selection.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  parseRequestedSlugs,
+  parseResultSlugs,
+  verifyExactSelection,
+  verifyLocalActionSummary,
+} from '../verify-source-monitor-selection.mjs';
+
+const EXPECTED_COMMIT = '458df4c41294655f76e551100a9b634114209bb9';
+
+function jsonl(...slugs) {
+  return `${slugs.map((slug) => JSON.stringify({
+    slug,
+    scan_status: 'updated',
+    upstream_commit_sha: EXPECTED_COMMIT,
+  })).join('\n')}\n`;
+}
+
+test('accepts an exact explicit source monitor result set independent of order', () => {
+  assert.deepEqual(parseRequestedSlugs('owner-two, owner-one'), ['owner-one', 'owner-two']);
+  assert.deepEqual(parseResultSlugs(jsonl('owner-two', 'owner-one')), ['owner-one', 'owner-two']);
+  assert.deepEqual(verifyExactSelection('owner-two,owner-one', jsonl('owner-one', 'owner-two')), {
+    requested: 2,
+    results: 2,
+    expectedUpstreamCommit: null,
+  });
+  assert.deepEqual(
+    verifyExactSelection('owner-one', jsonl('owner-one'), EXPECTED_COMMIT),
+    { requested: 1, results: 1, expectedUpstreamCommit: EXPECTED_COMMIT },
+  );
+});
+
+test('requires every explicit result to match the expected immutable upstream commit', () => {
+  const drifted = `${JSON.stringify({
+    slug: 'owner-one',
+    scan_status: 'updated',
+    upstream_commit_sha: '1111111111111111111111111111111111111111',
+  })}\n`;
+  assert.throws(
+    () => verifyExactSelection('owner-one', drifted, EXPECTED_COMMIT),
+    /upstream commit mismatch/,
+  );
+  assert.throws(
+    () => verifyExactSelection('owner-one', jsonl('owner-one'), 'main'),
+    /invalid expected upstream commit/,
+  );
+  const wrongStatus = `${JSON.stringify({
+    slug: 'owner-one',
+    scan_status: 'error',
+    upstream_commit_sha: EXPECTED_COMMIT,
+  })}\n`;
+  assert.throws(
+    () => verifyExactSelection('owner-one', wrongStatus, EXPECTED_COMMIT),
+    /update status mismatch/,
+  );
+});
+
+test('requires exact successful local action accounting for every requested update', () => {
+  const valid = [
+    '| Observed updated skills | 2 |',
+    '| Selected updated skills for this run | 2 |',
+    '| Applied updated skills | 2 |',
+    '| Failed selected updates | 0 |',
+    '| Deferred updated skills | 0 |',
+  ].join('\n');
+  assert.deepEqual(verifyLocalActionSummary(valid, 2), {
+    observed: 2,
+    selected: 2,
+    applied: 2,
+    failed: 0,
+    deferred: 0,
+  });
+  assert.throws(
+    () => verifyLocalActionSummary(valid.replace('Applied updated skills | 2', 'Applied updated skills | 1'), 2),
+    /local action mismatch/,
+  );
+});
+
+test('rejects zero matches, partial matches, unexpected results, and duplicates', () => {
+  assert.throws(() => verifyExactSelection('owner-one', ''), /missing=\[owner-one\]/);
+  assert.throws(
+    () => verifyExactSelection('owner-one,owner-two', jsonl('owner-one')),
+    /missing=\[owner-two\]/,
+  );
+  assert.throws(
+    () => verifyExactSelection('owner-one', jsonl('owner-one', 'owner-two')),
+    /unexpected=\[owner-two\]/,
+  );
+  assert.throws(() => parseRequestedSlugs('owner-one owner-one'), /duplicate requested/);
+  assert.throws(() => parseResultSlugs(jsonl('owner-one', 'owner-one')), /duplicate source monitor result/);
+});
+
+test('rejects malformed requested slugs and malformed JSONL records', () => {
+  assert.throws(() => parseRequestedSlugs('owner/one'), /invalid requested/);
+  assert.throws(() => parseResultSlugs('{not-json}\n'), /invalid source monitor JSONL/);
+  assert.throws(() => parseResultSlugs('{"scan_status":"updated"}\n'), /invalid result skill slug/);
+});

--- a/scripts/verify-source-monitor-selection.mjs
+++ b/scripts/verify-source-monitor-selection.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import { dirname, posix, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const COMMIT_RE = /^[a-f0-9]{40}$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+    fail(`missing required option ${name}`);
+  }
+  return args[index + 1];
+}
+
+function optionalOption(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) {
+    fail(`missing value for ${name}`);
+  }
+  return args[index + 1];
+}
+
+export function parseRequestedSlugs(value) {
+  const slugs = value.split(/[\s,]+/u).map((slug) => slug.trim()).filter(Boolean);
+  if (slugs.length === 0) fail('explicit slug request is empty');
+  const seen = new Set();
+  for (const slug of slugs) {
+    if (!SLUG_RE.test(slug)) fail(`invalid requested skill slug: ${slug}`);
+    if (seen.has(slug)) fail(`duplicate requested skill slug: ${slug}`);
+    seen.add(slug);
+  }
+  return slugs.sort((left, right) => left.localeCompare(right, 'en'));
+}
+
+export function parseResults(text) {
+  const results = [];
+  const seen = new Set();
+  for (const [index, line] of text.split('\n').entries()) {
+    if (line.trim() === '') continue;
+    let result;
+    try {
+      result = JSON.parse(line);
+    } catch (error) {
+      fail(`invalid source monitor JSONL at line ${index + 1}: ${error.message}`);
+    }
+    if (typeof result?.slug !== 'string' || !SLUG_RE.test(result.slug)) {
+      fail(`invalid result skill slug at line ${index + 1}`);
+    }
+    if (seen.has(result.slug)) fail(`duplicate source monitor result slug: ${result.slug}`);
+    seen.add(result.slug);
+    results.push(result);
+  }
+  return results.sort((left, right) => left.slug.localeCompare(right.slug, 'en'));
+}
+
+export function parseResultSlugs(text) {
+  return parseResults(text).map(({ slug }) => slug);
+}
+
+export function verifyExactSelection(requestedValue, jsonlText, expectedUpstreamCommit = null) {
+  const requested = parseRequestedSlugs(requestedValue);
+  const records = parseResults(jsonlText);
+  const results = records.map(({ slug }) => slug);
+  const requestedSet = new Set(requested);
+  const resultSet = new Set(results);
+  const missing = requested.filter((slug) => !resultSet.has(slug));
+  const unexpected = results.filter((slug) => !requestedSet.has(slug));
+  if (missing.length > 0 || unexpected.length > 0) {
+    fail(`source monitor selection mismatch: missing=[${missing.join(',')}], unexpected=[${unexpected.join(',')}]`);
+  }
+  if (expectedUpstreamCommit !== null) {
+    if (!COMMIT_RE.test(expectedUpstreamCommit)) {
+      fail(`invalid expected upstream commit: ${expectedUpstreamCommit}`);
+    }
+    const drifted = records
+      .filter(({ upstream_commit_sha: commit }) => commit !== expectedUpstreamCommit)
+      .map(({ slug, upstream_commit_sha: commit }) => `${slug}:${commit ?? 'missing'}`);
+    if (drifted.length > 0) {
+      fail(`source monitor upstream commit mismatch: expected=${expectedUpstreamCommit}, actual=[${drifted.join(',')}]`);
+    }
+    const invalidStatuses = records
+      .filter(({ scan_status: status }) => status !== 'updated')
+      .map(({ slug, scan_status: status }) => `${slug}:${status ?? 'missing'}`);
+    if (invalidStatuses.length > 0) {
+      fail(`source monitor update status mismatch: expected=updated, actual=[${invalidStatuses.join(',')}]`);
+    }
+  }
+  return {
+    requested: requested.length,
+    results: results.length,
+    expectedUpstreamCommit,
+  };
+}
+
+function parseSummaryCount(text, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = [...text.matchAll(new RegExp(`^\\| ${escaped} \\| ([0-9]+) \\|$`, 'gmu'))];
+  if (matches.length !== 1) fail(`missing or duplicate source monitor summary metric: ${label}`);
+  return Number(matches[0][1]);
+}
+
+export function verifyLocalActionSummary(text, expectedCount) {
+  const metrics = {
+    observed: parseSummaryCount(text, 'Observed updated skills'),
+    selected: parseSummaryCount(text, 'Selected updated skills for this run'),
+    applied: parseSummaryCount(text, 'Applied updated skills'),
+    failed: parseSummaryCount(text, 'Failed selected updates'),
+    deferred: parseSummaryCount(text, 'Deferred updated skills'),
+  };
+  if (
+    metrics.observed !== expectedCount
+    || metrics.selected !== expectedCount
+    || metrics.applied !== expectedCount
+    || metrics.failed !== 0
+    || metrics.deferred !== 0
+  ) {
+    fail(`source monitor local action mismatch: expected=${expectedCount}, metrics=${JSON.stringify(metrics)}`);
+  }
+  return metrics;
+}
+
+function walkReports(directory, reports) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) walkReports(path, reports);
+    else if (entry.isFile() && entry.name === 'skill-report.json') reports.push(path);
+  }
+}
+
+function gitPaths(repositoryRoot, args) {
+  const result = spawnSync('git', ['-C', repositoryRoot, ...args], { encoding: 'buffer' });
+  if (result.status !== 0) {
+    fail(`git ${args.join(' ')} failed: ${result.stderr.toString('utf8').trim()}`);
+  }
+  let output;
+  try {
+    output = new TextDecoder('utf-8', { fatal: true }).decode(result.stdout);
+  } catch {
+    fail(`git ${args.join(' ')} returned a non-UTF-8 path`);
+  }
+  return output.split('\0').filter(Boolean);
+}
+
+function validateChangedPath(path) {
+  if (
+    path.startsWith('/')
+    || path.includes('\\')
+    || /[\u0000-\u001f\u007f]/u.test(path)
+    || path.split('/').some((segment) => segment === '..')
+    || posix.normalize(path) !== path
+  ) {
+    fail(`unsafe changed path: ${path}`);
+  }
+  return path;
+}
+
+export function verifyLocalMutations({
+  repositoryRoot,
+  requested,
+  expectedUpstreamCommit,
+  summaryText,
+}) {
+  const root = realpathSync(resolve(repositoryRoot));
+  const requestedSlugs = parseRequestedSlugs(requested);
+  if (!COMMIT_RE.test(expectedUpstreamCommit)) fail(`invalid expected upstream commit: ${expectedUpstreamCommit}`);
+  const metrics = verifyLocalActionSummary(summaryText, requestedSlugs.length);
+
+  const reportPaths = [];
+  walkReports(resolve(root, 'skills'), reportPaths);
+  const reportIndex = new Map();
+  for (const reportPath of reportPaths) {
+    const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+    const slug = report?.meta?.slug;
+    if (!requestedSlugs.includes(slug)) continue;
+    const matches = reportIndex.get(slug) ?? [];
+    matches.push({ reportPath, report });
+    reportIndex.set(slug, matches);
+  }
+
+  const authorized = [];
+  for (const slug of requestedSlugs) {
+    const matches = reportIndex.get(slug) ?? [];
+    if (matches.length !== 1) fail(`expected one marketplace report for ${slug}, found ${matches.length}`);
+    const [{ reportPath, report }] = matches;
+    if (lstatSync(reportPath).isSymbolicLink() || !lstatSync(reportPath).isFile()) {
+      fail(`marketplace report is not a regular file: ${reportPath}`);
+    }
+    if (report.meta.upstream_commit_sha !== expectedUpstreamCommit) {
+      fail(`marketplace report commit mismatch for ${slug}: ${report.meta.upstream_commit_sha ?? 'missing'}`);
+    }
+    const relativeReport = posix.normalize(reportPath.slice(root.length + 1).replaceAll('\\', '/'));
+    authorized.push({ slug, directory: `${dirname(relativeReport).replaceAll('\\', '/')}/`, report: relativeReport });
+  }
+
+  const changed = new Set([
+    ...gitPaths(root, ['diff', '--name-only', '-z', '--no-renames', 'HEAD', '--']),
+    ...gitPaths(root, ['ls-files', '--others', '--exclude-standard', '-z', '--']),
+  ].map(validateChangedPath));
+  if (changed.size === 0) fail('source monitor produced no marketplace file changes');
+
+  for (const path of changed) {
+    if (!authorized.some(({ directory }) => path.startsWith(directory))) {
+      fail(`source monitor changed an unauthorized path: ${path}`);
+    }
+    const absolute = resolve(root, path);
+    if (existsSync(absolute) && lstatSync(absolute).isSymbolicLink()) {
+      fail(`source monitor changed a symbolic link: ${path}`);
+    }
+  }
+  for (const entry of authorized) {
+    if (!changed.has(entry.report)) fail(`source monitor did not update report provenance for ${entry.slug}`);
+    if (![...changed].some((path) => path.startsWith(entry.directory) && path !== entry.report)) {
+      fail(`source monitor produced no payload file changes for ${entry.slug}`);
+    }
+  }
+  return { ...metrics, changedPaths: changed.size, authorizedDirectories: authorized.length };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const requested = option(args, '--requested');
+  const jsonlPath = resolve(option(args, '--jsonl'));
+  const expectedUpstreamCommit = optionalOption(args, '--expected-upstream-commit');
+  const requireLocalUpdates = args.includes('--require-local-updates');
+  const jsonlText = readFileSync(jsonlPath, 'utf8');
+  const summary = verifyExactSelection(
+    requested,
+    jsonlText,
+    expectedUpstreamCommit,
+  );
+  if (requireLocalUpdates) {
+    if (expectedUpstreamCommit === null) fail('--require-local-updates requires --expected-upstream-commit');
+    const summaryPath = resolve(option(args, '--summary'));
+    const repositoryRoot = resolve(option(args, '--repository-root'));
+    const mutations = verifyLocalMutations({
+      repositoryRoot,
+      requested,
+      expectedUpstreamCommit,
+      summaryText: readFileSync(summaryPath, 'utf8'),
+    });
+    process.stdout.write(
+      `Verified source monitor mutations: ${mutations.applied}/${summary.requested}, ${mutations.changedPaths} changed path(s)\n`,
+    );
+  }
+  process.stdout.write(`Verified exact source monitor selection: ${summary.results}/${summary.requested}\n`);
+}
+
+const isMain = process.argv[1]
+  && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- pin Monitor Skill Sources to the audited Skillstore CLI 2.15.0 contract
- require an exact lowercase upstream commit for explicit slug-scoped update PRs
- keep scoped updates local-only with --updateLocal and no --write
- fail closed on slug, status, upstream SHA, action accounting, report provenance, payload mutation, path, and symlink drift
- accept the CLI 2.15 upstream provenance fields in the strict report schema
- report scoped local-only runs as Supabase writes disabled while preserving scheduled full-scan write behavior

## Verification

- 77 focused Node tests passed
- workflow YAML parsed successfully
- git diff --check passed
- 5307 existing Marketplace reports validated with 0 invalid
- 19 reports from canary run 29680887948 validated with 0 invalid
- independent architecture, QA/operations, and security reviews returned SHIP

## Safety boundary

This PR changes infrastructure only. It does not write Supabase data and does not update existing Marketplace skill content. Any later 19-skill content PR is review-only and must not be auto-merged, especially with critical or high audit findings.