### PR TITLE
fix(workflows): reject already-published submissions early

### DIFF
--- a/.github/workflows/approve-submission.yml
+++ b/.github/workflows/approve-submission.yml
@@ -175,6 +175,45 @@ jobs:
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }' || echo "::warning::Failed to notify skillstore"
 
+      - name: Notify skillstore - Rejected because all targets exist
+        if: needs.process-skills.result == 'success' && needs.process-skills.outputs.outcome == 'rejected'
+        env:
+          REASON_CODE: ${{ needs.process-skills.outputs.outcome_reason }}
+          SELECTED_COUNT: ${{ needs.process-skills.outputs.selected_count }}
+          EXISTING_TARGETS: ${{ needs.process-skills.outputs.existing_targets }}
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          SKILLSTORE_CALLBACK_TOKEN: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
+        run: |
+          set -euo pipefail
+          REASON="$REASON_CODE: count=$SELECTED_COUNT; targets=$EXISTING_TARGETS"
+          PAYLOAD=$(jq -n \
+            --arg submission_id "${{ env.SUBMISSION_ID }}" \
+            --arg reason_code "$REASON_CODE" \
+            --arg reason "$REASON" \
+            --arg approved_by "${{ github.actor }}" \
+            --arg workflow_run_id "${{ github.run_id }}" \
+            --arg workflow_run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              submission_id: $submission_id,
+              event: "rejected",
+              outcome: "rejected",
+              reason_code: $reason_code,
+              reason: $reason,
+              processed_count: 0,
+              approved_by: $approved_by,
+              workflow_run_id: ($workflow_run_id | tonumber),
+              workflow_run_url: $workflow_run_url
+            }')
+          curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-delay 2 --retry-max-time 120 --retry-connrefused \
+            --connect-timeout 10 --max-time 30 \
+            -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
+            -H "Authorization: Bearer $SKILLSTORE_CALLBACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+            -H "X-Skillstore-Callback: true" \
+            -d "$PAYLOAD"
+
       - name: Notify skillstore - Failed
         if: needs.process-skills.result == 'failure'
         env:
@@ -211,6 +250,9 @@ jobs:
           PR_URL: ${{ needs.process-skills.outputs.pr_url }}
           PROCESSED_COUNT: ${{ needs.process-skills.outputs.processed_count }}
           HIGHEST_RISK: ${{ needs.process-skills.outputs.highest_risk }}
+          OUTCOME: ${{ needs.process-skills.outputs.outcome }}
+          OUTCOME_REASON: ${{ needs.process-skills.outputs.outcome_reason }}
+          EXISTING_TARGETS: ${{ needs.process-skills.outputs.existing_targets }}
         run: |
           cat << EOF >> $GITHUB_STEP_SUMMARY
           ## Processing Summary (Manual Approval)
@@ -224,8 +266,14 @@ jobs:
           | Workflow Status | ${{ needs.process-skills.result }} |
           | Successfully Processed | ${PROCESSED_COUNT:-N/A} |
           | Highest Risk | ${HIGHEST_RISK:-N/A} |
+          | Business Outcome | ${OUTCOME:-N/A} |
+          | Outcome Reason | ${OUTCOME_REASON:-N/A} |
 
           EOF
+
+          if [ -n "$EXISTING_TARGETS" ]; then
+            echo "Existing targets: \`$EXISTING_TARGETS\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [ -n "$PR_URL" ]; then
             echo "🔗 **PR Created**: $PR_URL" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -128,6 +128,43 @@ jobs:
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }' || echo "::warning::Failed to notify skillstore"
 
+      - name: Notify skillstore - Rejected because all targets exist
+        if: needs.process-skills.result == 'success' && needs.process-skills.outputs.outcome == 'rejected'
+        env:
+          REASON_CODE: ${{ needs.process-skills.outputs.outcome_reason }}
+          SELECTED_COUNT: ${{ needs.process-skills.outputs.selected_count }}
+          EXISTING_TARGETS: ${{ needs.process-skills.outputs.existing_targets }}
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          SKILLSTORE_CALLBACK_TOKEN: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
+        run: |
+          set -euo pipefail
+          REASON="$REASON_CODE: count=$SELECTED_COUNT; targets=$EXISTING_TARGETS"
+          PAYLOAD=$(jq -n \
+            --arg submission_id "${{ env.SUBMISSION_ID }}" \
+            --arg reason_code "$REASON_CODE" \
+            --arg reason "$REASON" \
+            --arg workflow_run_id "${{ github.run_id }}" \
+            --arg workflow_run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              submission_id: $submission_id,
+              event: "rejected",
+              outcome: "rejected",
+              reason_code: $reason_code,
+              reason: $reason,
+              processed_count: 0,
+              workflow_run_id: ($workflow_run_id | tonumber),
+              workflow_run_url: $workflow_run_url
+            }')
+          curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-delay 2 --retry-max-time 120 --retry-connrefused \
+            --connect-timeout 10 --max-time 30 \
+            -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
+            -H "Authorization: Bearer $SKILLSTORE_CALLBACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+            -H "X-Skillstore-Callback: true" \
+            -d "$PAYLOAD"
+
       - name: Notify skillstore - Failed
         if: needs.process-skills.result == 'failure'
         run: |
@@ -150,6 +187,9 @@ jobs:
           PR_URL: ${{ needs.process-skills.outputs.pr_url }}
           PROCESSED_COUNT: ${{ needs.process-skills.outputs.processed_count }}
           HIGHEST_RISK: ${{ needs.process-skills.outputs.highest_risk }}
+          OUTCOME: ${{ needs.process-skills.outputs.outcome }}
+          OUTCOME_REASON: ${{ needs.process-skills.outputs.outcome_reason }}
+          EXISTING_TARGETS: ${{ needs.process-skills.outputs.existing_targets }}
         run: |
           cat << EOF >> $GITHUB_STEP_SUMMARY
           ## Processing Summary
@@ -162,8 +202,14 @@ jobs:
           | Workflow Status | ${{ needs.process-skills.result }} |
           | Successfully Processed | ${PROCESSED_COUNT:-N/A} |
           | Highest Risk | ${HIGHEST_RISK:-N/A} |
+          | Business Outcome | ${OUTCOME:-N/A} |
+          | Outcome Reason | ${OUTCOME_REASON:-N/A} |
 
           EOF
+
+          if [ -n "$EXISTING_TARGETS" ]; then
+            echo "Existing targets: \`$EXISTING_TARGETS\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [ -n "$PR_URL" ]; then
             echo "🔗 **PR Created**: $PR_URL" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -50,16 +50,19 @@ on:
         value: ${{ jobs.merge-and-create-pr.outputs.pr_url }}
       processed_count:
         description: 'Number of skills successfully processed'
-        value: ${{ jobs.merge-and-create-pr.outputs.processed_count }}
+        value: ${{ jobs.discover-and-plan.outputs.target_disposition == 'all_existing' && '0' || jobs.merge-and-create-pr.outputs.processed_count }}
       highest_risk:
         description: 'Highest security risk level found'
-        value: ${{ jobs.merge-and-create-pr.outputs.highest_risk }}
+        value: ${{ jobs.discover-and-plan.outputs.target_disposition == 'all_existing' && 'not_evaluated' || jobs.merge-and-create-pr.outputs.highest_risk }}
       outcome:
-        description: 'Terminal outcome: pr_created or no_op'
-        value: ${{ jobs.merge-and-create-pr.outputs.outcome }}
+        description: 'Terminal outcome: pr_created, no_op, or rejected'
+        value: ${{ jobs.discover-and-plan.outputs.target_disposition == 'all_existing' && 'rejected' || jobs.merge-and-create-pr.outputs.outcome }}
       outcome_reason:
         description: 'Machine-readable terminal outcome reason'
-        value: ${{ jobs.merge-and-create-pr.outputs.outcome_reason }}
+        value: ${{ jobs.discover-and-plan.outputs.target_disposition == 'all_existing' && jobs.discover-and-plan.outputs.target_reason || jobs.merge-and-create-pr.outputs.outcome_reason }}
+      existing_targets:
+        description: 'Comma-separated exact targets for a handled existing-target rejection'
+        value: ${{ jobs.discover-and-plan.outputs.existing_targets }}
       source_sha:
         description: 'Immutable source commit used for discovery'
         value: ${{ jobs.discover-and-plan.outputs.source_sha }}
@@ -127,6 +130,10 @@ jobs:
       ignored_count: ${{ steps.discover.outputs.ignored_count }}
       identical_count: ${{ steps.discover.outputs.identical_count }}
       conflicting_count: ${{ steps.discover.outputs.conflicting_count }}
+      target_disposition: ${{ steps.targets.outputs.disposition }}
+      target_reason: ${{ steps.targets.outputs.reason_code }}
+      existing_count: ${{ steps.targets.outputs.existing_count }}
+      existing_targets: ${{ steps.targets.outputs.existing_targets }}
     steps:
       - name: Clear inherited discovery checkout
         run: |
@@ -165,6 +172,7 @@ jobs:
             ".github/workflows/reusable-process-skills.yml"
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
+            "scripts/classify-submission-targets.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
@@ -188,21 +196,6 @@ jobs:
               exit 1
             }
           done
-
-      - name: Notify skillstore - Processing started
-        if: inputs.is_manual_approval == false
-        run: |
-          curl -sS -X POST "${{ secrets.SKILLSTORE_API_URL }}/api/submit/callback" \
-            -H "Authorization: Bearer ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
-            -H "X-Skillstore-Callback: true" \
-            -d '{
-              "submission_id": "'"${{ inputs.submission_id }}"'",
-              "event": "started",
-              "workflow_run_id": ${{ github.run_id }},
-              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }' || echo "::warning::Failed to notify skillstore"
 
       - name: Clone source repository
         id: clone
@@ -314,8 +307,67 @@ jobs:
             echo "| Conflicting ignored mirror groups | $CONFLICTING_MIRRORS |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Classify submission targets
+        id: targets
+        env:
+          FULL_SELECTION_PLAN: ${{ steps.discover.outputs.selection_plan }}
+          SOURCE_REF: ${{ steps.clone.outputs.branch }}
+        run: |
+          set -euo pipefail
+          PLAN_FILE="${RUNNER_TEMP:?}/target-plan-${{ github.run_id }}-${{ github.run_attempt }}.json"
+          cleanup_target_plan() { rm -f "$PLAN_FILE"; }
+          trap cleanup_target_plan EXIT
+          umask 077
+          printf '%s\n' "$FULL_SELECTION_PLAN" > "$PLAN_FILE"
+          CLASSIFICATION=$(node "$GITHUB_WORKSPACE/scripts/classify-submission-targets.mjs" \
+            --marketplace-root "$GITHUB_WORKSPACE" \
+            --selection-plan "$PLAN_FILE" \
+            --source-ref "$SOURCE_REF")
+          DISPOSITION=$(jq -er '.disposition' <<< "$CLASSIFICATION")
+          REASON_CODE=$(jq -er '.reasonCode' <<< "$CLASSIFICATION")
+          SELECTED_COUNT=$(jq -er '.selectedCount' <<< "$CLASSIFICATION")
+          EXISTING_COUNT=$(jq -er '.existingCount' <<< "$CLASSIFICATION")
+          EXISTING_TARGETS=$(jq -er '.existingTargets | join(",")' <<< "$CLASSIFICATION")
+          echo "disposition=$DISPOSITION" >> "$GITHUB_OUTPUT"
+          echo "reason_code=$REASON_CODE" >> "$GITHUB_OUTPUT"
+          echo "existing_count=$EXISTING_COUNT" >> "$GITHUB_OUTPUT"
+          echo "existing_targets=$EXISTING_TARGETS" >> "$GITHUB_OUTPUT"
+          if [ "$DISPOSITION" = "all_existing" ]; then
+            echo "::notice title=SUBMISSION_ALREADY_PUBLISHED::All $EXISTING_COUNT selected targets already exist; skipping CLI, AI, shards, artifacts, branch, and PR"
+          fi
+          {
+            echo "## Submission target preflight"
+            echo
+            echo "| Metric | Value |"
+            echo "|---|---:|"
+            echo "| Disposition | \`$DISPOSITION\` |"
+            echo "| Reason | \`$REASON_CODE\` |"
+            echo "| Selected targets | $SELECTED_COUNT |"
+            echo "| Existing targets | $EXISTING_COUNT |"
+            if [ -n "$EXISTING_TARGETS" ]; then
+              echo
+              echo "Exact existing targets: \`$EXISTING_TARGETS\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify skillstore - Processing started
+        if: inputs.is_manual_approval == false && steps.targets.outputs.disposition == 'processable'
+        run: |
+          curl -sS -X POST "${{ secrets.SKILLSTORE_API_URL }}/api/submit/callback" \
+            -H "Authorization: Bearer ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Actions/SkillstoreBot" \
+            -H "X-Skillstore-Callback: true" \
+            -d '{
+              "submission_id": "'"${{ inputs.submission_id }}"'",
+              "event": "started",
+              "workflow_run_id": ${{ github.run_id }},
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "::warning::Failed to notify skillstore"
+
       - name: Plan processing strategy
         id: plan
+        if: steps.targets.outputs.disposition == 'processable'
         env:
           FULL_SELECTION_PLAN: ${{ steps.discover.outputs.selection_plan }}
           EXPLICIT_PATH: ${{ steps.clone.outputs.explicit_path }}
@@ -381,7 +433,7 @@ jobs:
   # ============================================================
   process:
     needs: discover-and-plan
-    if: needs.discover-and-plan.outputs.shard_count != '0'
+    if: needs.discover-and-plan.outputs.target_disposition == 'processable' && needs.discover-and-plan.outputs.shard_count != '0'
     runs-on: self-hosted
     timeout-minutes: 1440
     strategy:
@@ -453,6 +505,7 @@ jobs:
             ".github/workflows/reusable-process-skills.yml"
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
+            "scripts/classify-submission-targets.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
@@ -584,7 +637,7 @@ jobs:
   # ============================================================
   merge-and-create-pr:
     needs: [discover-and-plan, process]
-    if: always() && needs.discover-and-plan.outputs.shard_count != '0'
+    if: always() && needs.discover-and-plan.outputs.target_disposition == 'processable' && needs.discover-and-plan.outputs.shard_count != '0'
     runs-on: self-hosted
     timeout-minutes: 60
     permissions:
@@ -633,6 +686,7 @@ jobs:
             ".github/workflows/reusable-process-skills.yml"
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
+            "scripts/classify-submission-targets.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -126,6 +126,7 @@ jobs:
         run: |
           node --test \
             scripts/tests/resolve-approved-submission.test.mjs \
+            scripts/tests/submission-existing-targets.test.mjs \
             scripts/tests/submission-source-resolution.test.mjs \
             scripts/tests/submission-runtime-workflow.test.mjs \
             scripts/tests/submission-scope-workflows.test.mjs \

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parseSelectionPlan, validateSelectionPlan } from './submission-selection-plan.mjs';
+
+const SOURCE_TYPES = new Set(['community', 'official']);
+// Must stay aligned with the exact CLI 2.15.0 trust allowlist pinned by the workflow.
+const OFFICIAL_REPOSITORIES = new Set([
+  'aiskillstore/marketplace',
+  'anthropics/skills',
+  'openai/codex',
+]);
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/u;
+const HASH = /^[a-f0-9]{64}$/;
+const RISK_LEVELS = new Set(['safe', 'low', 'medium', 'high', 'critical']);
+
+class SourceIdentityMismatchError extends Error {}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) fail(`missing required option ${name}`);
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function lstatIfPresent(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function assertDirectory(path, label) {
+  const stat = lstatIfPresent(path);
+  if (stat === null) fail(`${label} is missing: ${path}`);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) fail(`${label} must be a non-symlink directory: ${path}`);
+}
+
+function assertRegularFile(path, label) {
+  const stat = lstatIfPresent(path);
+  if (stat === null) fail(`${label} is missing: ${path}`);
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label} must be a non-symlink regular file: ${path}`);
+}
+
+function pathState(root, relativePath, label) {
+  let current = root;
+  const segments = relativePath.split('/');
+  for (const [index, segment] of segments.entries()) {
+    current = join(current, segment);
+    const stat = lstatIfPresent(current);
+    if (stat === null) return null;
+    if (stat.isSymbolicLink()) fail(`${label} contains a symlink path component: ${relativePath}`);
+    if (index < segments.length - 1 && !stat.isDirectory()) {
+      fail(`${label} contains a non-directory ancestor: ${relativePath}`);
+    }
+  }
+  return lstatSync(current);
+}
+
+function assertSafeTree(root, label) {
+  assertDirectory(root, label);
+  const walk = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) fail(`${label} contains symlink: ${path}`);
+      if (stat.isDirectory()) walk(path);
+      else if (!stat.isFile()) fail(`${label} contains a non-regular entry: ${path}`);
+    }
+  };
+  walk(root);
+}
+
+function readReport(path) {
+  assertRegularFile(path, 'published skill report');
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`published skill report is malformed JSON at ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+}
+
+function assertString(value, label) {
+  if (typeof value !== 'string' || value === '') fail(`${label} must be a non-empty string`);
+}
+
+function assertReportContract(report, reportPath) {
+  assertObject(report, `published skill report at ${reportPath}`);
+  if (report.schema_version !== '2.0') fail(`published skill report schema_version must be 2.0 at ${reportPath}`);
+  assertObject(report.meta, `published skill report meta at ${reportPath}`);
+  for (const field of ['generated_at', 'slug', 'source_url', 'source_ref', 'model', 'analysis_version', 'source_type']) {
+    assertString(report.meta[field], `published skill report meta.${field} at ${reportPath}`);
+  }
+  if (!SOURCE_TYPES.has(report.meta.source_type)) fail(`published skill report has an invalid source_type at ${reportPath}`);
+  if (Number.isNaN(Date.parse(report.meta.generated_at))) fail(`published skill report has an invalid generated_at at ${reportPath}`);
+  for (const field of ['content_hash', 'tree_hash']) {
+    if (report.meta[field] !== undefined && (typeof report.meta[field] !== 'string' || !HASH.test(report.meta[field]))) {
+      fail(`published skill report meta.${field} is invalid at ${reportPath}`);
+    }
+  }
+
+  assertObject(report.skill, `published skill report skill at ${reportPath}`);
+  assertString(report.skill.name, `published skill report skill.name at ${reportPath}`);
+  if (typeof report.skill.description !== 'string' || !Array.isArray(report.skill.supported_tools)) {
+    fail(`published skill report skill contract is incomplete at ${reportPath}`);
+  }
+
+  assertObject(report.security_audit, `published skill report security_audit at ${reportPath}`);
+  const audit = report.security_audit;
+  if (!RISK_LEVELS.has(audit.risk_level) || typeof audit.is_blocked !== 'boolean'
+    || typeof audit.safe_to_publish !== 'boolean' || typeof audit.summary !== 'string'
+    || !Number.isInteger(audit.files_scanned) || audit.files_scanned < 0
+    || !Number.isInteger(audit.total_lines) || audit.total_lines < 0
+    || typeof audit.audit_model !== 'string' || typeof audit.audited_at !== 'string'
+    || Number.isNaN(Date.parse(audit.audited_at))) {
+    fail(`published skill report security_audit contract is incomplete at ${reportPath}`);
+  }
+
+  assertObject(report.content, `published skill report content at ${reportPath}`);
+  for (const field of ['user_title', 'value_statement']) {
+    if (typeof report.content[field] !== 'string') fail(`published skill report content.${field} must be a string at ${reportPath}`);
+  }
+  for (const field of [
+    'seo_keywords', 'actual_capabilities', 'limitations', 'use_cases', 'prompt_templates',
+    'output_examples', 'best_practices', 'anti_patterns', 'faq',
+  ]) {
+    if (!Array.isArray(report.content[field])) fail(`published skill report content.${field} must be an array at ${reportPath}`);
+  }
+}
+
+function decodeSourceSegment(segment, url) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    fail(`published skill report source_url contains invalid percent encoding: ${url}`);
+  }
+  if (decoded === '' || decoded !== decoded.normalize('NFC') || CONTROL.test(decoded)
+    || decoded === '.' || decoded === '..' || decoded.startsWith('-') || decoded.includes('\\')) {
+    fail(`published skill report source_url contains an unsafe segment: ${url}`);
+  }
+  return decoded;
+}
+
+function decodedSegments(url) {
+  const authorityStart = url.indexOf('//');
+  const pathStart = url.indexOf('/', authorityStart === -1 ? 0 : authorityStart + 2);
+  const rawPath = pathStart === -1 ? '' : url.slice(pathStart).split(/[?#]/, 1)[0];
+  for (const rawSegment of rawPath.split('/').filter(Boolean)) decodeSourceSegment(rawSegment, url);
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    fail(`published skill report has an invalid source_url: ${JSON.stringify(url)}`);
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com'
+    || parsed.username !== '' || parsed.password !== '' || parsed.port !== ''
+    || parsed.search !== '' || parsed.hash !== '') {
+    fail(`published skill report source_url must be a canonical HTTPS GitHub URL: ${url}`);
+  }
+  return parsed.pathname.split('/').filter(Boolean).map((segment) => decodeSourceSegment(segment, url));
+}
+
+function sourceMismatch(message) {
+  throw new SourceIdentityMismatchError(message);
+}
+
+function assertSourceIdentity(report, { repository, sourceRef, skillPath }, reportPath) {
+  const sourceUrl = report?.meta?.source_url;
+  const reportRef = report?.meta?.source_ref;
+  if (typeof sourceUrl !== 'string' || typeof reportRef !== 'string' || reportRef === '') {
+    fail(`published skill report is missing source_url or source_ref: ${reportPath}`);
+  }
+  if (reportRef !== sourceRef) {
+    sourceMismatch(`published target source ref mismatch at ${reportPath}: expected ${sourceRef}, got ${reportRef}`);
+  }
+
+  const segments = decodedSegments(sourceUrl);
+  const canonicalPath = `/${repository}/tree/${encodeURIComponent(sourceRef)}${skillPath === '.'
+    ? ''
+    : `/${skillPath.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`}`;
+  const parsedPath = new URL(sourceUrl).pathname;
+  if (parsedPath !== canonicalPath && parsedPath !== `${canonicalPath}/`) {
+    sourceMismatch(`published target source_url is not canonical at ${reportPath}: expected ${canonicalPath}`);
+  }
+  const [owner, repo, kind, ...remainder] = segments;
+  if (`${owner ?? ''}/${repo ?? ''}` !== repository || kind !== 'tree') {
+    sourceMismatch(`published target source repository mismatch at ${reportPath}: expected ${repository}`);
+  }
+
+  const pathSegments = skillPath === '.' ? [] : skillPath.split('/');
+  if (remainder.length <= pathSegments.length) {
+    fail(`published target source_url has no source ref at ${reportPath}`);
+  }
+  const actualPathSegments = pathSegments.length === 0 ? [] : remainder.slice(-pathSegments.length);
+  if (actualPathSegments.some((segment) => segment.includes('/'))) {
+    fail(`published target source_url encodes a path separator inside a path segment at ${reportPath}`);
+  }
+  const actualPath = actualPathSegments.join('/');
+  const actualRef = remainder.slice(0, remainder.length - pathSegments.length).join('/');
+  if (actualRef !== sourceRef || actualPath !== (skillPath === '.' ? '' : skillPath)) {
+    sourceMismatch(`published target source path mismatch at ${reportPath}: expected ${skillPath}`);
+  }
+}
+
+function validateCandidate(candidate, identity) {
+  assertSafeTree(candidate.directory, 'published skill target');
+  assertRegularFile(join(candidate.directory, 'SKILL.md'), 'published SKILL.md');
+  const reportPath = join(candidate.directory, 'skill-report.json');
+  const report = readReport(reportPath);
+  assertReportContract(report, reportPath);
+
+  const expectedReportSlug = candidate.layout === 'community'
+    ? `${identity.owner}-${identity.slug}`
+    : identity.slug;
+  if (report?.meta?.slug !== expectedReportSlug) {
+    fail(`published target report slug mismatch at ${reportPath}: expected ${expectedReportSlug}`);
+  }
+  if (report?.skill?.name !== identity.slug) {
+    fail(`published target skill name mismatch at ${reportPath}: expected ${identity.slug}`);
+  }
+  if (candidate.layout === 'community') {
+    if (report.meta.source_type !== 'community') {
+      fail(`namespaced published target must be community at ${reportPath}`);
+    }
+    if (typeof report?.skill?.author !== 'string'
+      || report.skill.author.toLowerCase() !== identity.owner.toLowerCase()) {
+      fail(`published target author mismatch at ${reportPath}: expected ${identity.owner}`);
+    }
+  } else if (report.meta.source_type !== 'official') {
+    fail(`flat published target must be official at ${reportPath}`);
+  }
+
+  assertSourceIdentity(report, identity, reportPath);
+  return candidate.relativePath;
+}
+
+function assertNoPendingCollision(root, owner, slug) {
+  for (const relativePath of [`pending/${owner}/${slug}`, `pending/${slug}`]) {
+    if (pathState(root, relativePath, 'pending target') !== null) {
+      fail(`pending target collision: ${relativePath}`);
+    }
+  }
+}
+
+export function classifySubmissionTargets({ marketplaceRoot, selectionPlan, sourceRef }) {
+  const plan = typeof selectionPlan === 'string'
+    ? parseSelectionPlan(selectionPlan)
+    : validateSelectionPlan(selectionPlan);
+  assertDirectory(marketplaceRoot, 'marketplace root');
+  const root = resolve(marketplaceRoot);
+  if (typeof sourceRef !== 'string' || sourceRef === '') fail('source ref must be a non-empty string');
+
+  const [owner] = plan.repository.split('/');
+  const expectedLayout = OFFICIAL_REPOSITORIES.has(plan.repository) ? 'official' : 'community';
+  const existingTargets = [];
+  const newTargets = [];
+
+  for (const skill of plan.skills) {
+    assertNoPendingCollision(root, owner, skill.slug);
+    const identity = {
+      repository: plan.repository,
+      sourceRef,
+      skillPath: skill.path,
+      owner,
+      slug: skill.slug,
+    };
+    const candidates = [
+      {
+        layout: 'community',
+        relativePath: `skills/${owner}/${skill.slug}`,
+        directory: join(root, 'skills', owner, skill.slug),
+      },
+      {
+        layout: 'official',
+        relativePath: `skills/${skill.slug}`,
+        directory: join(root, 'skills', skill.slug),
+      },
+    ];
+    const expectedCandidate = candidates.find(({ layout }) => layout === expectedLayout);
+    const present = candidates.filter(({ layout, relativePath }) => {
+      const state = pathState(root, relativePath, 'published target');
+      if (state === null) return false;
+      if (layout === expectedLayout || !state.isDirectory()) return true;
+      return pathState(root, `${relativePath}/SKILL.md`, 'alternate published target') !== null
+        || pathState(root, `${relativePath}/skill-report.json`, 'alternate published target') !== null;
+    });
+    const presentExpected = present.find(({ layout }) => layout === expectedLayout);
+    let expectedTarget = null;
+    if (presentExpected !== undefined) {
+      expectedTarget = validateCandidate(presentExpected, identity);
+    }
+
+    const alternate = present.find(({ layout }) => layout !== expectedLayout);
+    let alternateExact = null;
+    if (alternate !== undefined) {
+      try {
+        alternateExact = validateCandidate(alternate, identity);
+      } catch (error) {
+        if (!(error instanceof SourceIdentityMismatchError)) throw error;
+        // A structurally valid target from another source is valid in the alternate namespace.
+      }
+    }
+
+    if (expectedTarget !== null && alternateExact !== null) {
+      fail(`ambiguous published target identity for ${skill.slug}: ${expectedTarget}, ${alternateExact}`);
+    }
+    if (expectedTarget === null && alternateExact !== null) {
+      fail(`published target identity for ${skill.slug} exists at unexpected path: ${alternateExact}`);
+    }
+    if (expectedTarget !== null) {
+      existingTargets.push(expectedTarget);
+      continue;
+    }
+    newTargets.push(expectedCandidate.relativePath);
+  }
+
+  if (existingTargets.length > 0 && newTargets.length > 0) {
+    fail(`partial published-target collision: ${existingTargets.length} existing, ${newTargets.length} new`);
+  }
+
+  const disposition = existingTargets.length === plan.skills.length && plan.skills.length > 0
+    ? 'all_existing'
+    : 'processable';
+  return {
+    schemaVersion: 1,
+    disposition,
+    reasonCode: disposition === 'all_existing'
+      ? 'all_selected_targets_already_published'
+      : 'no_selected_targets_already_published',
+    selectedCount: plan.skills.length,
+    existingCount: existingTargets.length,
+    existingTargets: existingTargets.sort((left, right) => left.localeCompare(right, 'en')),
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const selectionPlanPath = option(args, '--selection-plan');
+  const result = classifySubmissionTargets({
+    marketplaceRoot: option(args, '--marketplace-root'),
+    selectionPlan: readFileSync(selectionPlanPath, 'utf8'),
+    sourceRef: option(args, '--source-ref'),
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Submission target classification failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -1,0 +1,304 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+import { classifySubmissionTargets } from '../classify-submission-targets.mjs';
+
+const SOURCE_COMMIT = '1'.repeat(40);
+
+function withMarketplace(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'submission-targets-'));
+  mkdirSync(join(root, 'skills'), { recursive: true });
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function selectionPlan(
+  skills = [
+    { slug: 'alpha', path: 'skills/alpha' },
+    { slug: 'beta', path: 'skills/beta' },
+  ],
+  repository = 'example/source',
+) {
+  return {
+    schemaVersion: 1,
+    repository,
+    sourceCommit: SOURCE_COMMIT,
+    scope: { reason: 'conventional_skills', path: 'skills' },
+    skills,
+  };
+}
+
+function writeTarget(root, slug, {
+  layout = 'community',
+  repository = 'example/source',
+  sourceRef = 'main',
+  skillPath = `skills/${slug}`,
+  malformed = false,
+  targetOwner = 'example',
+  sourceUrl = null,
+  schemaValid = true,
+} = {}) {
+  const relative = layout === 'community' ? `skills/${targetOwner}/${slug}` : `skills/${slug}`;
+  const directory = join(root, ...relative.split('/'));
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'SKILL.md'), `---\nname: ${slug}\n---\n`);
+  if (malformed) {
+    writeFileSync(join(directory, 'skill-report.json'), '{not-json\n');
+  } else {
+    const [owner, repo] = repository.split('/');
+    const report = {
+      schema_version: '2.0',
+      meta: {
+        generated_at: '2026-07-19T00:00:00.000Z',
+        slug: layout === 'community' ? `${targetOwner}-${slug}` : slug,
+        source_url: sourceUrl ?? `https://github.com/${owner}/${repo}/tree/${sourceRef}/${skillPath}/`,
+        source_ref: sourceRef,
+        model: 'fixture',
+        analysis_version: '3.0.0',
+        source_type: layout === 'community' ? 'community' : 'official',
+      },
+      skill: {
+        name: slug,
+        author: layout === 'community' ? targetOwner : owner,
+        description: 'fixture',
+        supported_tools: ['codex'],
+      },
+      security_audit: {
+        risk_level: 'safe',
+        is_blocked: false,
+        safe_to_publish: true,
+        summary: 'fixture',
+        files_scanned: 1,
+        total_lines: 1,
+        audit_model: 'fixture',
+        audited_at: '2026-07-19T00:00:00.000Z',
+      },
+      content: {
+        user_title: 'Fixture',
+        value_statement: 'Fixture',
+        seo_keywords: [],
+        actual_capabilities: [],
+        limitations: [],
+        use_cases: [],
+        prompt_templates: [],
+        output_examples: [],
+        best_practices: [],
+        anti_patterns: [],
+        faq: [],
+      },
+    };
+    if (!schemaValid) delete report.security_audit;
+    writeFileSync(join(directory, 'skill-report.json'), `${JSON.stringify(report)}\n`);
+  }
+  return directory;
+}
+
+function classify(root, plan = selectionPlan(), sourceRef = 'main') {
+  return classifySubmissionTargets({ marketplaceRoot: root, selectionPlan: plan, sourceRef });
+}
+
+test('zero existing targets preserves the complete processable selection', () => withMarketplace((root) => {
+  assert.deepEqual(classify(root), {
+    schemaVersion: 1,
+    disposition: 'processable',
+    reasonCode: 'no_selected_targets_already_published',
+    selectedCount: 2,
+    existingCount: 0,
+    existingTargets: [],
+  });
+}));
+
+test('all exact community targets become a handled rejection', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha');
+  writeTarget(root, 'beta');
+  assert.deepEqual(classify(root), {
+    schemaVersion: 1,
+    disposition: 'all_existing',
+    reasonCode: 'all_selected_targets_already_published',
+    selectedCount: 2,
+    existingCount: 2,
+    existingTargets: ['skills/example/alpha', 'skills/example/beta'],
+  });
+}));
+
+test('an exact official flat target is recognized without weakening community identity', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { layout: 'official', repository: 'anthropics/skills' });
+  const result = classify(
+    root,
+    selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }], 'anthropics/skills'),
+  );
+  assert.equal(result.disposition, 'all_existing');
+  assert.deepEqual(result.existingTargets, ['skills/alpha']);
+}));
+
+test('mixed existing and new targets fail closed instead of processing a subset', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha');
+  assert.throws(() => classify(root), /partial published-target collision: 1 existing, 1 new/);
+}));
+
+for (const mismatch of [
+  { name: 'repository', options: { repository: 'other/source' }, pattern: /source (?:repository mismatch|URL is not canonical)|source_url is not canonical/ },
+  { name: 'ref', options: { sourceRef: 'release' }, pattern: /source ref mismatch/ },
+  { name: 'path', options: { skillPath: 'skills/other' }, pattern: /source (?:path mismatch|URL is not canonical)|source_url is not canonical/ },
+]) {
+  test(`a published target with a ${mismatch.name} mismatch fails closed`, () => withMarketplace((root) => {
+    writeTarget(root, 'alpha', mismatch.options);
+    assert.throws(
+      () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+      mismatch.pattern,
+    );
+  }));
+}
+
+test('malformed report and ambiguous exact identities fail closed', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { malformed: true });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /malformed JSON/,
+  );
+
+  rmSync(join(root, 'skills', 'example', 'alpha'), { recursive: true, force: true });
+  writeTarget(root, 'alpha');
+  writeTarget(root, 'alpha', { layout: 'official' });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /ambiguous published target identity/,
+  );
+}));
+
+test('an identity-looking report that omits required schema fields fails closed', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { schemaValid: false });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /security_audit.*must be an object/,
+  );
+}));
+
+test('malformed alternate target layouts fail closed instead of being ignored', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { layout: 'official', malformed: true });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /malformed JSON/,
+  );
+
+  rmSync(join(root, 'skills', 'alpha'), { recursive: true, force: true });
+  writeTarget(root, 'alpha', { layout: 'community', targetOwner: 'anthropics', malformed: true });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }], 'anthropics/skills')),
+    /malformed JSON/,
+  );
+}));
+
+test('pending paths, including dangling symlinks, fail before target classification', () => withMarketplace((root) => {
+  mkdirSync(join(root, 'pending', 'example'), { recursive: true });
+  symlinkSync(join(root, 'missing'), join(root, 'pending', 'example', 'alpha'));
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /pending target (?:collision|contains a symlink)/,
+  );
+}));
+
+test('official flat pending and source mismatches fail closed', () => withMarketplace((root) => {
+  mkdirSync(join(root, 'pending', 'alpha'), { recursive: true });
+  const officialPlan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }], 'anthropics/skills');
+  assert.throws(() => classify(root, officialPlan), /pending target collision: pending\/alpha/);
+
+  rmSync(join(root, 'pending'), { recursive: true, force: true });
+  writeTarget(root, 'alpha', { layout: 'official', repository: 'other/source' });
+  assert.throws(() => classify(root, officialPlan), /source (?:repository mismatch|URL is not canonical)|source_url is not canonical/);
+}));
+
+test('alternate pending layouts also fail closed for community and official sources', () => withMarketplace((root) => {
+  mkdirSync(join(root, 'pending', 'alpha'), { recursive: true });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /pending target collision: pending\/alpha/,
+  );
+
+  rmSync(join(root, 'pending'), { recursive: true, force: true });
+  mkdirSync(join(root, 'pending', 'anthropics', 'alpha'), { recursive: true });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }], 'anthropics/skills')),
+    /pending target collision: pending\/anthropics\/alpha/,
+  );
+}));
+
+for (const sourceUrl of [
+  'https://github.com:444/example/source/tree/main/skills/alpha/',
+  'https://github.com/example/source/tree/main/skills%2Falpha',
+  'https://github.com/example/source/tree/main/skills/%2e/alpha',
+  'https://github.com/example/source/tree/main/skills/%0Aalpha',
+  'https://github.com/Example/source/tree/main/skills/alpha/',
+]) {
+  test(`noncanonical published source URL fails closed: ${sourceUrl}`, () => withMarketplace((root) => {
+    writeTarget(root, 'alpha', { sourceUrl });
+    assert.throws(
+      () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+      /source_(?:url|repository)|source (?:URL|repository)|source_url|no source ref/,
+    );
+  }));
+}
+
+test('a symlink anywhere inside an existing target fails closed', () => withMarketplace((root) => {
+  const target = writeTarget(root, 'alpha');
+  mkdirSync(join(target, 'references'));
+  symlinkSync('/etc/hosts', join(target, 'references', 'linked.md'));
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /contains symlink/,
+  );
+}));
+
+test('an alternate flat owner namespace without direct identity files is not a skill target', () => withMarketplace((root) => {
+  mkdirSync(join(root, 'skills', 'alpha', 'nested-skill'), { recursive: true });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.disposition, 'processable');
+}));
+
+test('slash refs require the canonical percent-encoded source URL', () => withMarketplace((root) => {
+  const plan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]);
+  writeTarget(root, 'alpha', {
+    sourceRef: 'feature/ready',
+    sourceUrl: 'https://github.com/example/source/tree/feature%2Fready/skills/alpha/',
+  });
+  assert.equal(classify(root, plan, 'feature/ready').disposition, 'all_existing');
+
+  rmSync(join(root, 'skills', 'example', 'alpha'), { recursive: true, force: true });
+  writeTarget(root, 'alpha', {
+    sourceRef: 'feature/ready',
+    sourceUrl: 'https://github.com/example/source/tree/feature/ready/skills/alpha/',
+  });
+  assert.throws(() => classify(root, plan, 'feature/ready'), /source_url is not canonical/);
+}));
+
+test('a symlinked target ancestor fails closed even when the final path is missing', () => withMarketplace((root) => {
+  const outside = join(root, 'outside');
+  mkdirSync(outside);
+  symlinkSync(outside, join(root, 'skills', 'example'));
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /symlink path component/,
+  );
+}));
+
+test('an unrelated flat official slug does not hide an exact namespaced target', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha');
+  writeTarget(root, 'alpha', {
+    layout: 'official',
+    repository: 'other/source',
+  });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.disposition, 'all_existing');
+  assert.deepEqual(result.existingTargets, ['skills/example/alpha']);
+}));

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -23,6 +23,7 @@ const runtimeFiles = [
   '.github/workflows/reusable-process-skills.yml',
   'scripts/resolve-submission-source.mjs',
   'scripts/discover-submission-skills.mjs',
+  'scripts/classify-submission-targets.mjs',
   'scripts/process-submission-shard.mjs',
   'scripts/submission-selection-plan.mjs',
   'scripts/submission-shard-contract.mjs',
@@ -93,6 +94,7 @@ function createFixture() {
     '.github/workflows/reusable-process-skills.yml': 'name: fixture workflow\n',
     'scripts/resolve-submission-source.mjs': 'export const source = true;\n',
     'scripts/discover-submission-skills.mjs': 'export const discover = true;\n',
+    'scripts/classify-submission-targets.mjs': 'export const classify = true;\n',
     'scripts/process-submission-shard.mjs': 'export const process = true;\n',
     'scripts/submission-selection-plan.mjs': 'export const selectionPlan = true;\n',
     'scripts/submission-shard-contract.mjs': 'export const contract = true;\n',
@@ -198,6 +200,7 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/process-submission-shard\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/submission-shard-contract\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
+  assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/classify-submission-targets\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
   assert.match(reusable, /minimum-version: 2\.15\.0/);
   assert.match(reusable, /Rollout pin: selection-plan processing requires the exact 2\.15\.0 contract/);
@@ -208,6 +211,8 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(readFileSync('scripts/process-submission-shard.mjs', 'utf8'), /'--selection-plan', join\(config\.resultDir, 'selection-plan\.json'\)/);
   assert.equal((reusable.match(/"scripts\/submission-selection-plan\.mjs"/g) ?? []).length, 3,
     'discovery, processing, and aggregation immutable runtime lists must all include the plan validator');
+  assert.equal((reusable.match(/"scripts\/classify-submission-targets\.mjs"/g) ?? []).length, 3,
+    'discovery, processing, and aggregation immutable runtime lists must all include the target classifier');
   assert.match(
     readFileSync('scripts/aggregate-submission-shards.mjs', 'utf8'),
     /from '\.\/resolve-approved-submission\.mjs'/,
@@ -246,5 +251,43 @@ test('repository dispatch caller preserves reusable failure and callback status 
   assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);
   assert.match(caller, /name: Notify skillstore - Failed\n\s+if: needs\.process-skills\.result == 'failure'/);
   assert.match(caller, /"event": "failed"/);
+  assert.match(caller, /needs\.process-skills\.outputs\.outcome == 'rejected'/);
+  assert.match(caller, /event: "rejected"/);
+  assert.match(caller, /outcome: "rejected"/);
+  assert.match(caller, /reason_code: \$reason_code/);
+  assert.match(caller, /reason: \$reason/);
+  assert.match(caller, /processed_count: 0/);
+  assert.match(caller, /curl --fail-with-body/);
+  assert.match(caller, /--retry 3/);
+  assert.doesNotMatch(
+    extractRunBlock(caller, 'Notify skillstore - Rejected because all targets exist'),
+    /\|\|\s+echo/,
+  );
   assert.doesNotMatch(caller, /continue-on-error:\s*true/);
+});
+
+test('existing-target classification is a pre-CLI gate with a handled rejection output', () => {
+  const classifyIndex = reusable.indexOf('- name: Classify submission targets');
+  const planIndex = reusable.indexOf('- name: Plan processing strategy');
+  const processIndex = reusable.indexOf('\n  process:');
+  assert.ok(classifyIndex > reusable.indexOf('- name: Discover skills (fast - no AI)'));
+  assert.ok(classifyIndex < planIndex);
+  assert.ok(planIndex < processIndex);
+  const startedIndex = reusable.indexOf('- name: Notify skillstore - Processing started');
+  assert.ok(startedIndex > classifyIndex);
+  assert.match(reusable, /inputs\.is_manual_approval == false && steps\.targets\.outputs\.disposition == 'processable'/);
+  assert.match(reusable, /if: steps\.targets\.outputs\.disposition == 'processable'/);
+  assert.match(reusable, /target_disposition == 'processable' && needs\.discover-and-plan\.outputs\.shard_count != '0'/);
+  assert.match(reusable, /target_disposition == 'all_existing' && 'rejected'/);
+  assert.match(
+    readFileSync('scripts/classify-submission-targets.mjs', 'utf8'),
+    /all_selected_targets_already_published/,
+  );
+  assert.match(reusable, /existing_targets:/);
+  const latePendingGuard = reusable.indexOf('Pending path already exists on main');
+  const latePublishedGuard = reusable.indexOf('Published target already exists; use the explicit update workflow');
+  const lateCopy = reusable.indexOf('cp -R "$MERGED_RESULTS/$pending_dir"');
+  assert.ok(latePendingGuard > 0 && latePendingGuard < lateCopy);
+  assert.ok(latePublishedGuard > latePendingGuard && latePublishedGuard < lateCopy);
+  assert.match(reusable, /Published target already exists; use the explicit update workflow/);
 });

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -626,12 +626,20 @@ for (const fixture of rejectedFixtures) {
   }));
 }
 
-test('submission callers emit a terminal callback for explicit legal no-op and failure', () => {
+test('submission callers emit distinct terminal callbacks for legal no-op, rejection, and failure', () => {
   for (const workflow of [processSubmission, approveSubmission]) {
     assert.match(workflow, /needs\.process-skills\.result == 'failure'/);
     assert.match(workflow, /needs\.process-skills\.outputs\.outcome == 'no_op'/);
     assert.match(workflow, /"event": "completed"/);
     assert.match(workflow, /"reason_code":/);
+    assert.match(workflow, /needs\.process-skills\.outputs\.outcome == 'rejected'/);
+    assert.match(workflow, /event: "rejected"/);
+    assert.match(workflow, /outcome: "rejected"/);
+    assert.match(workflow, /reason_code: \$reason_code/);
+    assert.match(workflow, /reason: \$reason/);
+    assert.match(workflow, /processed_count: 0/);
+    assert.match(workflow, /curl --fail-with-body/);
+    assert.match(workflow, /--retry 3/);
   }
 });
 


### PR DESCRIPTION
## Summary

- classify published/pending targets immediately after immutable discovery
- return `outcome=rejected`, `outcome_reason=all_selected_targets_already_published`, and `processed_count=0` when every selected target already exists
- skip CLI, AI, shards, artifacts, branch, and PR for that handled rejection
- fail closed before AI on partial collisions, source/ref/path drift, ambiguous identities, malformed reports, noncanonical URLs, pending collisions, and symlinks
- send a bounded, fail-closed `event=rejected` callback with exact reason code/count/target diagnostics
- preserve the aggregation-stage pending/published guards as TOCTOU backstops

## Incident

Run 29678253203 processed all 19 Hyperframes Skills successfully, then failed only during aggregation on `skills/heygen-com/embedded-captions`. The same 19-target submission now classifies as `all_existing` before processing.

## Verification

- submission contract suite: 130 passed
- real Hyperframes snapshot: 19/19 exact existing targets
- YAML parse, Node syntax, and `git diff --check` passed
- callback behavior: transient 503/503/200 retried to success; permanent 400 failed once
- three independent architecture, callback-state, and supply-chain reviews; no P0 remains

## Paired state-machine fix

- https://github.com/aiskillstore/skillstore/pull/303