### PR TITLE
[codex] recover remaining Marketplace action failures

### DIFF
--- a/.github/workflows/cleanup-runners.yml
+++ b/.github/workflows/cleanup-runners.yml
@@ -20,6 +20,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 concurrency:
   group: cleanup-runners
   cancel-in-progress: false
@@ -29,6 +31,32 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
+      - name: Reclaim bounded Docker build cache under disk pressure
+        env:
+          AGE_DAYS: ${{ inputs.age_days || 7 }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          [[ "$AGE_DAYS" =~ ^[1-9][0-9]*$ ]] || { echo '::error::age_days must be a positive integer'; exit 1; }
+          usage=$(df -P / | awk 'NR==2 {gsub(/%/, "", $5); print $5}')
+          [[ "$usage" =~ ^[0-9]+$ ]] || { echo '::error::Unable to read root disk usage'; exit 1; }
+          echo "Root disk usage before bounded cleanup: ${usage}%"
+          docker system df || true
+
+          if [ "$DRY_RUN" = true ]; then
+            echo "[DRY RUN] Would prune only unused Docker build cache older than $AGE_DAYS days when disk usage is at least 90%."
+          elif [ "$usage" -lt 90 ]; then
+            echo 'Disk pressure is below 90%; Docker build cache is unchanged.'
+          else
+            command -v docker >/dev/null 2>&1 || { echo '::error::Docker CLI is required under disk pressure'; exit 1; }
+            docker info >/dev/null 2>&1 || { echo '::error::Docker daemon is unavailable under disk pressure'; exit 1; }
+            age_hours=$((AGE_DAYS * 24))
+            docker builder prune --all --force --filter "until=${age_hours}h"
+            echo 'Only unused build cache was pruned; images, containers, and volumes were preserved.'
+          fi
+
+          df -h /
+
       - name: Cleanup orphaned temp directories
         env:
           AGE_DAYS: ${{ inputs.age_days || 7 }}
@@ -108,6 +136,7 @@ jobs:
           **Dry Run:** ${{ inputs.dry_run || false }}
 
           ### Cleanup Patterns
+          - Unused Docker build cache older than the age threshold, only when root disk usage is at least 90%
           - \`/tmp/marketplace-*\` - Main workflow temp directories
           - \`/tmp/marketplace-audit-*\` - Audit workflow temp directories
           - \`/tmp/marketplace-approve-*\` - Approval workflow temp directories
@@ -117,6 +146,7 @@ jobs:
 
           ### Next Steps
           - Monitor disk usage trends
+          - Images, containers, and volumes are never pruned by this workflow
           - Adjust age threshold if needed
           - Run manual cleanup with workflow_dispatch if disk space is critical
 

--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute, recover, recover-smoke]
+        options: [dry-run, execute, recover, recover-cache, recover-smoke]
       cohort_path:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.8.4'
+        default: '2.15.1'
 
 permissions:
   actions: read
@@ -101,7 +101,7 @@ jobs:
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.8.4' || { echo '::error::workflow is pinned to CLI 2.8.4'; exit 1; }
+          test "$CLI_VERSION" = '2.15.1' || { echo '::error::workflow is pinned to CLI 2.15.1'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
@@ -170,10 +170,49 @@ jobs:
               '.status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
               "$proof" >/dev/null
           elif [ "$proof_schema" = 2 ] && [ "$(jq -r .producerKind "$proof")" = fresh_canonical_audit_recovery ]; then
+            case "$(jq -r .failedExecuteRunId "$proof")" in
+              29666546406)
+                expected_failed_sha='3e7baf520a4d078047b53b95352156e3a3f74260'
+                expected_original_cli='2.8.0'
+                expected_original_cli_sha='ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
+                expected_failed_cli='2.8.2'
+                expected_failed_cli_sha='9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
+                expected_smoke_commit='e368da730951aceca17a7e5d9d5a9adc0e3efc2a'
+                ;;
+              29684825610)
+                expected_failed_sha='2bfe0fd5cf25a967c5481dd83207b0de24997273'
+                expected_original_cli='2.8.4'
+                expected_original_cli_sha='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
+                expected_failed_cli='2.8.4'
+                expected_failed_cli_sha='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
+                expected_smoke_commit='0f78b2d983b0e233f6b7071e38ddf6b4f29c9168'
+                ;;
+              *) echo '::error::unsupported cache-recovery incident'; exit 1 ;;
+            esac
             jq -e --arg executeRunId "$PREVIOUS_EXECUTE_RUN_ID" \
               --arg dryRunId "$PREVIOUS_BOUNDARY_RUN_ID" --arg lastSelected "$START_AFTER" \
               --arg executeHeadSha "$execute_head_sha" \
-              '.producerKind=="fresh_canonical_audit_recovery" and .status=="fresh_canonical_audit_execution_complete" and .executeRunId==$executeRunId and .dryRunId==$dryRunId and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha and .failedExecuteRunId=="29666546406" and .failedExecuteHeadSha=="3e7baf520a4d078047b53b95352156e3a3f74260" and .originalCli.version=="2.8.0" and .originalCli.sha256=="ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a" and .failedExecutionCli.version=="2.8.2" and .failedExecutionCli.sha256=="9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb" and .scoreFinalized==true and .timestampFinalized==true and .cacheClosureCompleted==true and .packClosureCompleted==true and .productionSmokeCompleted==true' \
+              --arg failedExecuteRunId "$(jq -r .failedExecuteRunId "$proof")" \
+              --arg failedExecuteHeadSha "$expected_failed_sha" \
+              --arg originalCliVersion "$expected_original_cli" \
+              --arg originalCliSha "$expected_original_cli_sha" \
+              --arg failedCliVersion "$expected_failed_cli" \
+              --arg failedCliSha "$expected_failed_cli_sha" \
+              --arg smokeCommit "$expected_smoke_commit" '
+              .producerKind=="fresh_canonical_audit_recovery"
+              and .status=="fresh_canonical_audit_execution_complete"
+              and .executeRunId==$executeRunId and .dryRunId==$dryRunId
+              and .lastSelected==$lastSelected and .workflowCommit==$executeHeadSha
+              and .failedExecuteRunId==$failedExecuteRunId
+              and .failedExecuteHeadSha==$failedExecuteHeadSha
+              and .originalCli.version==$originalCliVersion and .originalCli.sha256==$originalCliSha
+              and .failedExecutionCli.version==$failedCliVersion and .failedExecutionCli.sha256==$failedCliSha
+              and .recoveryRuntime.cacheVersion=="v7" and .recoveryRuntime.smokeCommit==$smokeCommit
+              and .recoveryRuntime.publicCliVersion=="0.1.10"
+              and .recoveryRuntime.publicCliIntegrity=="sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=="
+              and .scoreFinalized==true and .timestampFinalized==true
+              and .cacheClosureCompleted==true and .packClosureCompleted==true
+              and .productionSmokeCompleted==true' \
               "$proof" >/dev/null
             recovery="$RUNNER_TEMP/previous-execution/recovery-evidence"
             (cd "$recovery" && sha256sum --check SHA256SUMS)
@@ -271,21 +310,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.8.4
+      - name: Download exact fresh-governance CLI 2.15.1
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.4'
-          minimum-version: '2.8.4'
+          version: '2.15.1'
+          minimum-version: '2.15.1'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
+          audited='0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.4 digest TODO before any run'; exit 1; }
-          test "$actual" = "$audited" || { echo '::error::CLI 2.8.4 digest mismatch'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.15.1 digest TODO before any run'; exit 1; }
+          test "$actual" = "$audited" || { echo '::error::CLI 2.15.1 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -360,7 +399,7 @@ jobs:
           done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
           jq -n \
             --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
-            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.8.4' \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.15.1' \
             --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
@@ -430,7 +469,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
-          test "$CLI_VERSION" = '2.8.4' || { echo '::error::workflow is pinned to CLI 2.8.4'; exit 1; }
+          test "$CLI_VERSION" = '2.15.1' || { echo '::error::workflow is pinned to CLI 2.15.1'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
@@ -487,12 +526,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.8.4
+      - name: Download exact audited CLI 2.15.1
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.8.4'
-          minimum-version: '2.8.4'
+          version: '2.15.1'
+          minimum-version: '2.15.1'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -500,10 +539,10 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          audited='282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb'
+          audited='0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.8.4 digest TODO'; exit 1; }
+          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.15.1 digest TODO'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else
@@ -619,25 +658,26 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   recover-boundary:
-    if: inputs.mode == 'recover'
+    if: inputs.mode == 'recover' || inputs.mode == 'recover-cache'
     concurrency:
       group: production-skill-score-writes
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
-      INCIDENT_DRY_RUN_ID: '29646612265'
-      INCIDENT_DRY_RUN_SHA: '11101c85a06aaec0d8f0deda0a4aac82cf24899b'
-      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: 'sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b'
-      INCIDENT_FAILED_EXECUTE_RUN_ID: '29666546406'
-      INCIDENT_FAILED_EXECUTE_SHA: '3e7baf520a4d078047b53b95352156e3a3f74260'
-      INCIDENT_FAILED_ARTIFACT_DIGEST: 'sha256:d35558237279c275c3dd0d7169f8f0ae718719c050e7d2055dd8ac32d344b526'
-      INCIDENT_BOUNDARY_CLI_VERSION: '2.8.0'
-      INCIDENT_BOUNDARY_CLI_SHA256: 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
-      INCIDENT_EXECUTE_CLI_VERSION: '2.8.2'
-      INCIDENT_EXECUTE_CLI_SHA256: '9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb'
+      INCIDENT_DRY_RUN_ID: ${{ inputs.mode == 'recover-cache' && '29682699325' || '29646612265' }}
+      INCIDENT_DRY_RUN_SHA: ${{ inputs.mode == 'recover-cache' && 'e8ce3fcb20197aefea54f9fb43ccce4716e3209c' || '11101c85a06aaec0d8f0deda0a4aac82cf24899b' }}
+      INCIDENT_BOUNDARY_ARTIFACT_DIGEST: ${{ inputs.mode == 'recover-cache' && 'sha256:4fd86f8b01d8fdea25d94dc843cf7a26a3e46bca09605e41ddca8d28fff4d4cd' || 'sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b' }}
+      INCIDENT_FAILED_EXECUTE_RUN_ID: ${{ inputs.mode == 'recover-cache' && '29684825610' || '29666546406' }}
+      INCIDENT_FAILED_EXECUTE_SHA: ${{ inputs.mode == 'recover-cache' && '2bfe0fd5cf25a967c5481dd83207b0de24997273' || '3e7baf520a4d078047b53b95352156e3a3f74260' }}
+      INCIDENT_FAILED_ARTIFACT_DIGEST: ${{ inputs.mode == 'recover-cache' && 'sha256:95583b3df74c1f5af7f351a6f44d05490df46aa84531bc44f439947decf8daf6' || 'sha256:d35558237279c275c3dd0d7169f8f0ae718719c050e7d2055dd8ac32d344b526' }}
+      INCIDENT_BOUNDARY_CLI_VERSION: ${{ inputs.mode == 'recover-cache' && '2.8.4' || '2.8.0' }}
+      INCIDENT_BOUNDARY_CLI_SHA256: ${{ inputs.mode == 'recover-cache' && '282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb' || 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a' }}
+      INCIDENT_EXECUTE_CLI_VERSION: ${{ inputs.mode == 'recover-cache' && '2.8.4' || '2.8.2' }}
+      INCIDENT_EXECUTE_CLI_SHA256: ${{ inputs.mode == 'recover-cache' && '282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb' || '9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb' }}
+      RECOVERY_INPUT_CLI_VERSION: ${{ inputs.mode == 'recover-cache' && '2.8.4' || '2.8.3' }}
       RECOVERY_EXPECTED_CACHE_VERSION: 'v7'
-      RECOVERY_SMOKE_SHA: 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a'
+      RECOVERY_SMOKE_SHA: ${{ inputs.mode == 'recover-cache' && '0f78b2d983b0e233f6b7071e38ddf6b4f29c9168' || 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a' }}
       RECOVERY_PUBLIC_CLI_VERSION: '0.1.10'
       RECOVERY_PUBLIC_CLI_INTEGRITY: 'sha512-HKxQJadsobOSJFrf43w9kPHjwlzel0KC9G0R2tIfHVwIbypj2r0eQE2mZkj07wZKQOtYLbQRBcLi2eZpLftzJw=='
     steps:
@@ -660,7 +700,7 @@ jobs:
           test "$GITHUB_REF_NAME" = main
           test "$DRY_RUN_ID" = "$INCIDENT_DRY_RUN_ID"
           test "$FAILED_EXECUTE_RUN_ID" = "$INCIDENT_FAILED_EXECUTE_RUN_ID"
-          test "$CLI_VERSION" = '2.8.3'
+          test "$CLI_VERSION" = "$RECOVERY_INPUT_CLI_VERSION"
           test -z "$START_AFTER" && test -z "$PREVIOUS_BOUNDARY_RUN_ID" && test -z "$PREVIOUS_EXECUTE_RUN_ID"
           [[ "$RECOVERY_EXPECTED_CACHE_VERSION" =~ ^v[1-9][0-9]*$ ]] || {
             echo '::error::pin the deployed Skill score-detail cache version before recovery'; exit 1;
@@ -726,7 +766,7 @@ jobs:
 
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INCIDENT_FAILED_EXECUTE_RUN_ID/jobs?filter=latest&per_page=100" \
             > "$evidence/failed-jobs.json"
-          jq -e '
+          jq -e --arg cliStep "Download exact audited CLI $INCIDENT_EXECUTE_CLI_VERSION" '
             def job_rows:
               if type=="object" and (.jobs|type)=="array" then .jobs
               elif type=="array" and all(.[]; type=="object" and (.jobs|type)=="array") then [.[].jobs[]]
@@ -739,7 +779,7 @@ jobs:
             and ([$jobs[].steps[] | select(.name=="Validate execute inputs" and .conclusion=="success")] | length==1)
             and ([$jobs[].steps[] | select(.name=="Download and authenticate the successful frozen boundary" and .conclusion=="success")] | length==1)
             and ([$jobs[].steps[] | select(.name=="Generate GitHub App token" and .conclusion=="success")] | length==1)
-            and ([$jobs[].steps[] | select(.name=="Download exact audited CLI 2.8.2" and .conclusion=="success")] | length==1)
+            and ([$jobs[].steps[] | select(.name==$cliStep and .conclusion=="success")] | length==1)
             and ([$jobs[].steps[] | select(.name=="Verify frozen CLI identity" and .conclusion=="success")] | length==1)
             and ([$jobs[].steps[] | select(.name=="Rematerialize exact source and overlay only frozen fresh reports" and .conclusion=="success")] | length==1)
             and ([$jobs[].steps[] | select(.name=="Execute resumable compound governance, score, and cache closure" and .conclusion=="failure")] | length==1)
@@ -772,6 +812,8 @@ jobs:
             --boundary "$RUNNER_TEMP/recovery-source/original-boundary/fresh-boundary.json" \
             --post-inventory "$RUNNER_TEMP/fresh-recovery/post-inventory.json" \
             --failed-run "$RUNNER_TEMP/recovery-source/failed-run.json" \
+            --expected-failed-run-id "$INCIDENT_FAILED_EXECUTE_RUN_ID" \
+            --expected-failed-run-sha "$INCIDENT_FAILED_EXECUTE_SHA" \
             --output-dir "$RUNNER_TEMP/fresh-recovery/recovery-evidence"
           cp "$RUNNER_TEMP/fresh-recovery/recovery-evidence/execution-results.json" \
             "$RUNNER_TEMP/fresh-recovery/execution-results.json"
@@ -889,11 +931,15 @@ jobs:
 
       - name: Publish verified recovery summary
         run: |
+          recovered=$(jq length "$RUNNER_TEMP/fresh-recovery/execution-results.json")
+          expected=$(jq -r .count "$RUNNER_TEMP/fresh-recovery/boundary/selected-cohort.json")
+          next_cursor=$(jq -r .lastSelected "$RUNNER_TEMP/fresh-recovery/boundary/selected-cohort.json")
           {
             echo '## Fresh canonical audit execution recovered'
             echo "- Frozen boundary: \`$INCIDENT_DRY_RUN_ID\`"
             echo "- Failed execute: \`$INCIDENT_FAILED_EXECUTE_RUN_ID\`"
-            echo '- Reconstructed durable writes: `10/10`; next campaign cursor: `40/106`.'
+            echo "- Reconstructed durable writes: \`$recovered/$expected\`."
+            echo "- Next campaign cursor: \`$next_cursor\`."
             echo '- No governance RPC or score recalculation ran in recovery.'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -15,7 +15,9 @@ on:
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
+      - "scripts/runner-disk-guard.sh"
       - "scripts/tests/**"
+      - "ops/systemd/**"
       - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
@@ -25,6 +27,7 @@ on:
       - ".github/workflows/warm-cache.yml"
       - ".github/workflows/recalculate-scores.yml"
       - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/workflows/cleanup-runners.yml"
       - ".github/workflows/generate-packs.yml"
       - ".github/workflows/pack-review.yml"
       - ".github/workflows/publish-pack-production-v4.yml"
@@ -44,7 +47,9 @@ on:
       - "scripts/recalculate-scores.sh"
       - "scripts/score-cache-closure.mjs"
       - "scripts/refresh-security-research-stats.sh"
+      - "scripts/runner-disk-guard.sh"
       - "scripts/tests/**"
+      - "ops/systemd/**"
       - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
       - ".github/workflows/reconcile-security-events.yml"
@@ -54,6 +59,7 @@ on:
       - ".github/workflows/warm-cache.yml"
       - ".github/workflows/recalculate-scores.yml"
       - ".github/workflows/recover-score-cache-closure.yml"
+      - ".github/workflows/cleanup-runners.yml"
       - ".github/workflows/generate-packs.yml"
       - ".github/workflows/pack-review.yml"
       - ".github/workflows/publish-pack-production-v4.yml"
@@ -76,6 +82,7 @@ jobs:
           # Tests read workflow fixtures as well as the complete scripts tree.
           sparse-checkout: |
             .github
+            ops/systemd
             scripts
             schemas
 

--- a/ops/systemd/marketplace-runner-disk-guard.service
+++ b/ops/systemd/marketplace-runner-disk-guard.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Marketplace runner bounded Docker build-cache guard
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+Environment=USAGE_THRESHOLD=90
+Environment=AGE_HOURS=168
+ExecStart=/usr/local/sbin/marketplace-runner-disk-guard
+Nice=19
+IOSchedulingClass=idle
+IOSchedulingPriority=7

--- a/ops/systemd/marketplace-runner-disk-guard.timer
+++ b/ops/systemd/marketplace-runner-disk-guard.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check Marketplace runner disk pressure every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+Unit=marketplace-runner-disk-guard.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/runner-disk-guard.sh
+++ b/scripts/runner-disk-guard.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage_threshold="${USAGE_THRESHOLD:-90}"
+age_hours="${AGE_HOURS:-168}"
+
+[[ "$usage_threshold" =~ ^[1-9][0-9]?$ ]] || {
+  echo 'USAGE_THRESHOLD must be an integer from 1 through 99' >&2
+  exit 2
+}
+[[ "$age_hours" =~ ^[1-9][0-9]*$ ]] || {
+  echo 'AGE_HOURS must be a positive integer' >&2
+  exit 2
+}
+
+# /run is tmpfs, so locking still works when the root filesystem is under pressure.
+exec 9>/run/lock/marketplace-runner-disk-guard.lock
+flock -n 9 || exit 0
+
+usage=$(df -P / | awk 'NR==2 {gsub(/%/, "", $5); print $5}')
+[[ "$usage" =~ ^[0-9]+$ ]] || {
+  echo 'Unable to read root disk usage' >&2
+  exit 1
+}
+
+if (( usage < usage_threshold )); then
+  echo "Root disk usage is ${usage}%; threshold is ${usage_threshold}%. No cleanup needed."
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || {
+  echo 'Docker CLI is unavailable under disk pressure' >&2
+  exit 1
+}
+docker info >/dev/null 2>&1 || {
+  echo 'Docker daemon is unavailable under disk pressure' >&2
+  exit 1
+}
+
+echo "Root disk usage is ${usage}%; pruning only unused Docker build cache older than ${age_hours}h."
+docker builder prune --all --force --filter "until=${age_hours}h"
+df -h /

--- a/scripts/tests/cleanup-runners.test.mjs
+++ b/scripts/tests/cleanup-runners.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  new URL('../../.github/workflows/cleanup-runners.yml', import.meta.url),
+  'utf8'
+);
+const guard = readFileSync(
+  new URL('../runner-disk-guard.sh', import.meta.url),
+  'utf8'
+);
+const service = readFileSync(
+  new URL('../../ops/systemd/marketplace-runner-disk-guard.service', import.meta.url),
+  'utf8'
+);
+const timer = readFileSync(
+  new URL('../../ops/systemd/marketplace-runner-disk-guard.timer', import.meta.url),
+  'utf8'
+);
+
+test('runner cleanup bounds Docker maintenance to old build cache under pressure', () => {
+  assert.match(workflow, /usage" -lt 90/);
+  assert.match(workflow, /docker builder prune --all --force --filter "until=\$\{age_hours\}h"/);
+  assert.doesNotMatch(workflow, /docker (system|image|volume|container) prune/);
+  assert.match(workflow, /images, containers, and volumes were preserved/);
+  assert.match(workflow, /permissions: \{\}/);
+  assert.match(workflow, /age_days must be a positive integer/);
+});
+
+test('host guard can reclaim shared Docker build cache before Actions setup', () => {
+  assert.match(guard, /flock -n 9/);
+  assert.match(guard, /docker builder prune --all --force --filter "until=\$\{age_hours\}h"/);
+  assert.doesNotMatch(guard, /docker (system|image|volume|container) prune/);
+  assert.match(service, /ExecStart=\/usr\/local\/sbin\/marketplace-runner-disk-guard/);
+  assert.match(service, /Nice=19/);
+  assert.match(timer, /OnUnitActiveSec=15min/);
+  assert.match(timer, /Persistent=true/);
+});

--- a/scripts/tests/cleanup-runners.test.mjs
+++ b/scripts/tests/cleanup-runners.test.mjs
@@ -18,6 +18,10 @@ const timer = readFileSync(
   new URL('../../ops/systemd/marketplace-runner-disk-guard.timer', import.meta.url),
   'utf8'
 );
+const testWorkflow = readFileSync(
+  new URL('../../.github/workflows/test-recalculate-scores.yml', import.meta.url),
+  'utf8'
+);
 
 test('runner cleanup bounds Docker maintenance to old build cache under pressure', () => {
   assert.match(workflow, /usage" -lt 90/);
@@ -36,4 +40,7 @@ test('host guard can reclaim shared Docker build cache before Actions setup', ()
   assert.match(service, /Nice=19/);
   assert.match(timer, /OnUnitActiveSec=15min/);
   assert.match(timer, /Persistent=true/);
+  assert.match(testWorkflow, /- "scripts\/runner-disk-guard\.sh"/);
+  assert.match(testWorkflow, /- "ops\/systemd\/\*\*"/);
+  assert.match(testWorkflow, /sparse-checkout: \|\n\s+\.github\n\s+ops\/systemd\n\s+scripts/);
 });

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -231,13 +231,14 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute, recover, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.8\.4'/);
+  assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
+  assert.match(workflow, /default: '2\.15\.1'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
-  assert.equal((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length, 2);
+  assert.ok((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length >= 4);
+  assert.equal((workflow.match(/0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5/g) || []).length, 2);
   assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
@@ -274,10 +275,16 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /production-smoke\.mjs/);
   assert.match(workflow, /MCP channel/);
   assert.match(workflow, /recover-boundary:/);
-  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29646612265'/);
-  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: '29666546406'/);
-  assert.match(workflow, /INCIDENT_BOUNDARY_CLI_VERSION: '2\.8\.0'/);
-  assert.match(workflow, /INCIDENT_EXECUTE_CLI_VERSION: '2\.8\.2'/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_ID: \$\{\{ inputs\.mode == 'recover-cache' && '29682699325' \|\| '29646612265' \}\}/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_SHA: \$\{\{ inputs\.mode == 'recover-cache' && 'e8ce3fcb20197aefea54f9fb43ccce4716e3209c' \|\| '11101c85a06aaec0d8f0deda0a4aac82cf24899b' \}\}/);
+  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_RUN_ID: \$\{\{ inputs\.mode == 'recover-cache' && '29684825610' \|\| '29666546406' \}\}/);
+  assert.match(workflow, /INCIDENT_FAILED_EXECUTE_SHA: \$\{\{ inputs\.mode == 'recover-cache' && '2bfe0fd5cf25a967c5481dd83207b0de24997273' \|\| '3e7baf520a4d078047b53b95352156e3a3f74260' \}\}/);
+  assert.match(workflow, /RECOVERY_INPUT_CLI_VERSION: \$\{\{ inputs\.mode == 'recover-cache' && '2\.8\.4' \|\| '2\.8\.3' \}\}/);
+  assert.match(workflow, /RECOVERY_SMOKE_SHA: \$\{\{ inputs\.mode == 'recover-cache' && '0f78b2d983b0e233f6b7071e38ddf6b4f29c9168' \|\| 'e368da730951aceca17a7e5d9d5a9adc0e3efc2a' \}\}/);
+  assert.match(workflow, /2\.8\.0/);
+  assert.match(workflow, /2\.8\.2/);
+  assert.match(workflow, /--expected-failed-run-id/);
+  assert.match(workflow, /--expected-failed-run-sha/);
   assert.match(workflow, /failedExecutionCli:\{version:\$failedExecutionCliVersion,sha256:\$failedExecutionCliSha256\}/);
   assert.match(workflow, /RECOVERY_EXPECTED_CACHE_VERSION: 'v7'/);
   assert.match(workflow, /producerKind:"fresh_canonical_audit_recovery"/);

--- a/scripts/tests/fresh-canonical-audit-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-recovery.test.mjs
@@ -79,7 +79,9 @@ function fixture() {
       skill_id: ids.skill, score_snapshot_id: ids.snapshot, stale_at: null, stale_reason: null,
       calculated_at: '2026-07-19T00:12:55Z', scorer_version: '1.9.1', composite_score: 88,
     }],
-    failedRun,
+    failedRun: { ...failedRun },
+    expectedFailedRunId: failedRun.id,
+    expectedFailedRunSha: failedRun.head_sha,
   };
 }
 
@@ -94,7 +96,7 @@ test('reconstructs deterministic execution results only from exact incident-boun
   assert.equal(result.expectedScoreEvidence.scores[0].qualityScore, 88);
 });
 
-test('rejects later mutation, wrong snapshot binding, or a different failed run', () => {
+test('rejects later mutation, wrong snapshot binding, or a non-first failed attempt', () => {
   const later = fixture();
   later.inventory.artifacts[0].created_at = '2026-07-19T00:17:00Z';
   assert.throws(() => verifyRecoveryState(later), /artifact evidence mismatch/);
@@ -104,6 +106,26 @@ test('rejects later mutation, wrong snapshot binding, or a different failed run'
   const run = fixture();
   run.failedRun.run_attempt = 2;
   assert.throws(() => verifyRecoveryState(run), /failed run identity/);
+});
+
+test('rejects a failed run whose ID or SHA does not match the explicit incident boundary', () => {
+  const wrongId = fixture();
+  wrongId.expectedFailedRunId += 1;
+  assert.throws(() => verifyRecoveryState(wrongId), /failed run identity/);
+
+  const wrongSha = fixture();
+  wrongSha.expectedFailedRunSha = 'f'.repeat(40);
+  assert.throws(() => verifyRecoveryState(wrongSha), /failed run identity/);
+});
+
+test('binds recovery to an explicitly supplied incident instead of one hard-coded run', () => {
+  const nextIncident = fixture();
+  nextIncident.failedRun.id = 29684825610;
+  nextIncident.failedRun.head_sha = '2bfe0fd5cf25a967c5481dd83207b0de24997273';
+  nextIncident.expectedFailedRunId = nextIncident.failedRun.id;
+  nextIncident.expectedFailedRunSha = nextIncident.failedRun.head_sha;
+
+  assert.equal(verifyRecoveryState(nextIncident).recoveryEvidence.verifiedCount, 1);
 });
 
 function preflight(slug, packs = []) {

--- a/scripts/verify-fresh-canonical-audit-recovery.mjs
+++ b/scripts/verify-fresh-canonical-audit-recovery.mjs
@@ -52,12 +52,25 @@ function latestAuditsBySkill(rows, skillIds) {
   return result;
 }
 
-export function verifyRecoveryState({ boundary, inventory, audits, snapshots, breakdowns, failedRun }) {
+export function verifyRecoveryState({
+  boundary,
+  inventory,
+  audits,
+  snapshots,
+  breakdowns,
+  failedRun,
+  expectedFailedRunId,
+  expectedFailedRunSha,
+}) {
   if (boundary?.schemaVersion !== 1 || boundary?.status !== 'fresh_canonical_audit_frozen'
     || !Array.isArray(boundary.candidates) || boundary.candidates.length === 0) {
     fail('unsupported frozen boundary');
   }
-  if (failedRun?.id !== 29666546406 || failedRun?.head_sha !== '3e7baf520a4d078047b53b95352156e3a3f74260'
+  if (!Number.isSafeInteger(expectedFailedRunId) || expectedFailedRunId <= 0
+    || !/^[0-9a-f]{40}$/.test(expectedFailedRunSha || '')) {
+    fail('expected failed run identity is invalid');
+  }
+  if (failedRun?.id !== expectedFailedRunId || failedRun?.head_sha !== expectedFailedRunSha
     || failedRun?.conclusion !== 'failure' || failedRun?.event !== 'workflow_dispatch'
     || failedRun?.head_branch !== 'main' || failedRun?.run_attempt !== 1) {
     fail('failed run identity does not match the incident boundary');
@@ -242,6 +255,8 @@ export async function main(args = process.argv.slice(2)) {
   const boundary = JSON.parse(readFileSync(option(args, '--boundary'), 'utf8'));
   const inventory = JSON.parse(readFileSync(option(args, '--post-inventory'), 'utf8'));
   const failedRun = JSON.parse(readFileSync(option(args, '--failed-run'), 'utf8'));
+  const expectedFailedRunId = Number(option(args, '--expected-failed-run-id'));
+  const expectedFailedRunSha = option(args, '--expected-failed-run-sha');
   const outputDir = resolve(option(args, '--output-dir'));
   const ids = boundary.candidates.map((candidate) => candidate.row.skillId);
   const common = {
@@ -265,6 +280,8 @@ export async function main(args = process.argv.slice(2)) {
     snapshots,
     breakdowns,
     failedRun,
+    expectedFailedRunId,
+    expectedFailedRunSha,
   });
   mkdirSync(outputDir, { recursive: true });
   writeFileSync(resolve(outputDir, 'execution-results.json'), `${JSON.stringify(result.executionResults, null, 2)}\n`);


### PR DESCRIPTION
## What changed

- add an incident-bound `recover-cache` path for failed governance run `29684825610` without repeating governance or score writes
- authenticate the frozen boundary, failed run, artifacts, CLI identities, and durable `10/10` database state before closing cache and production smoke
- pin future governance runs to released CLI `2.15.1` and its audited Linux SHA256
- add bounded Docker build-cache cleanup under disk pressure
- add a host-level systemd disk guard that runs before GitHub Actions setup can fail from ENOSPC
- reduce cleanup workflow permissions to none and strengthen incident identity tests

## Root cause

The governance run finished its durable writes but failed during cache closure, so a full rerun would duplicate production work. Separately, the runner cleanup job could not start after the host filesystem filled because Actions failed while creating its pipeline mapping.

## Safety

- recovery is restricted to exact historical run IDs, SHAs, artifact digests, and CLI digests
- recovery performs readback first and does not invoke the governance RPC or score recalculation
- Docker maintenance removes only unused build cache older than seven days when root usage is at least 90%; it never prunes images, containers, or volumes
- the host timer uses a `/run` lock and low I/O priority

## Verification

- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/cleanup-runners.test.mjs` — 16/16 passed
- workflow YAML parsing and `git diff --check` passed
- Bash syntax check passed
- `cli-v2.15.1` release run `29689418750` passed; Linux SHA256 `0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5`
- host timer is installed, enabled, and active; Docker root, runner `_work`, and `/` resolve to the same root filesystem; current disk usage is 56%
