### PR TITLE
docs(readme): add ~/.agents/skills to scope directories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npx skillstore add aiskillstore/code-review
 
 It downloads the skill and drops it into the right `skills/` directory for your tool. Claude Code auto-discovers it; for Codex, restart the session.
 
-Prefer to do it by hand, or installing via Claude Web? See the full **[Installation Guides](https://skillstore.io/docs/install-guides)** for every method (CLI, manual, and ZIP upload) and the scope directories (`.claude/skills/`, `~/.claude/skills/`, `.codex/skills/`, …).
+Prefer to do it by hand, or installing via Claude Web? See the full **[Installation Guides](https://skillstore.io/docs/install-guides)** for every method (CLI, manual, and ZIP upload) and the scope directories (`~/.agents/skills/`, `.claude/skills/`, `~/.claude/skills/`, `.codex/skills/`, …).
 
 ## Contributing a skill
 


### PR DESCRIPTION
## What

The README's install-guides pointer listed the skill scope directories as `.claude/skills/`, `~/.claude/skills/`, `.codex/skills/` — but omitted `~/.agents/skills/`.

## Why

`~/.agents/skills` is the CLI's **canonical default** global install dir — it's `CANONICAL_SKILLS_DIR` in `packages/skillstore/src/lib/agents.ts:66` and the generic agents entry's `globalPath` (line 114). Leaving it off the list is misleading since it's where `npx skillstore add` drops skills by default.

## Change

One line: prepend `~/.agents/skills/` to the scope-directory list in `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)