### PR TITLE
[codex] Fix Remotion interactivity video editing link

### DIFF
--- a/skills/remotion-dev/remotion-interactivity/SKILL.md
+++ b/skills/remotion-dev/remotion-interactivity/SKILL.md
@@ -15,4 +15,4 @@ To make an element or custom component interactive, use:
 
 ## Video editing
 
-If a Remotion component mainly consists of video and audio clips, see [Video editing](../remotion-markup/video-editing.md) for best practices on how to structure Remotion markup so the clips are interactively editable in the timeline.
+If a Remotion component mainly consists of video and audio clips, see [Video editing](https://github.com/remotion-dev/skills/blob/e44d7f765ed42412d8e91ef87f217c5a158abf57/skills/remotion-markup/video-editing.md) for best practices on how to structure Remotion markup so the clips are interactively editable in the timeline.

--- a/skills/remotion-dev/remotion-interactivity/skill-report.json
+++ b/skills/remotion-dev/remotion-interactivity/skill-report.json
@@ -8,8 +8,8 @@
     "model": "claude",
     "analysis_version": "3.0.0",
     "source_type": "community",
-    "content_hash": "f48586fcd9d343cf756d4e1c9d3a6bd1fbbac3b14e00668526fbdddf5887e2e3",
-    "tree_hash": "acda37afa6d83fe0ad2e483c10847501a144e79399c07975f967ba94c91771ba",
+    "content_hash": "28fa1367795cec5c0f5c931e0530342ad6ae667a44107bac4d760d07f314bd36",
+    "tree_hash": "7769df6c6c9f83b8bfd341c4727ea1e9cf3a5a15d9fbbc0837f8fab1ed6ddf54",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [


### PR DESCRIPTION
## What changed

- Replace the broken Marketplace-relative `remotion-markup` link with the exact upstream commit URL.
- Rebind `content_hash` and `tree_hash` for the published Skill report.

## Why

PR #2667 published `remotion-interactivity`, but Marketplace does not currently contain the sibling `remotion-markup/video-editing.md`. The primary official Remotion links work; this narrow follow-up repairs the one broken optional reference without rolling back the Skill.

## Validation

- `CI=true node --test scripts/tests/rebind-skill-report-hashes.test.mjs` (3/3)
- Exact content/tree hash readback matched the rebound report
- `git diff --check`