### PR TITLE
fix(governance): normalize report-origin checkout

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -45,6 +45,20 @@ jobs:
           sparse-checkout: ''
           sparse-checkout-cone-mode: false
 
+      - name: Normalize full checkout and verify report-origin runtime
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          for path in "$ORIGIN_COHORT" \
+            .github/actions/download-skillstore-cli/action.yml \
+            scripts/build-legacy-report-origin-boundary.mjs \
+            scripts/materialize-legacy-report-origin-evidence.mjs \
+            scripts/verify-legacy-report-origin-boundary.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing report-origin runtime after full-checkout normalization"; exit 1; }
+          done
+
       - name: Validate immutable runtime and exact cohort
         env:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
@@ -208,6 +222,20 @@ jobs:
           clean: true
           sparse-checkout: ''
           sparse-checkout-cone-mode: false
+
+      - name: Normalize full checkout and verify report-origin runtime
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          for path in "$ORIGIN_COHORT" \
+            .github/actions/download-skillstore-cli/action.yml \
+            scripts/build-legacy-report-origin-boundary.mjs \
+            scripts/materialize-legacy-report-origin-evidence.mjs \
+            scripts/verify-legacy-report-origin-boundary.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing report-origin runtime after full-checkout normalization"; exit 1; }
+          done
 
       - name: Validate execute gate and production pin
         env:

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -120,6 +120,16 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
   assert.match(workflow, /--expected-count 70/);
+  assert.equal(
+    (workflow.match(/Normalize full checkout and verify report-origin runtime/g) || []).length,
+    2
+  );
+  assert.equal((workflow.match(/git sparse-checkout disable/g) || []).length, 2);
+  assert.equal((workflow.match(/git reset --hard HEAD/g) || []).length, 2);
+  assert.equal(
+    (workflow.match(/Missing report-origin runtime after full-checkout normalization/g) || []).length,
+    2
+  );
   assert.equal((workflow.match(/--legacy-origin-lineage/g) || []).length, 2);
   assert.equal((workflow.match(/--legacy-origin-root/g) || []).length, 2);
   assert.equal((workflow.match(/--legacy-previous-report-root/g) || []).length, 2);


### PR DESCRIPTION
## Summary
- normalize full checkout before both report-origin jobs
- verify all pinned report-origin runtime files after normalization
- add regression coverage for both dry-run and execute paths

## Incident
Dry-run 29717776234 failed before production access because the reused self-hosted runner did not materialize the checked-in cohort after checkout. The run uploaded no artifact and performed no production writes.

## Tests
- CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs
- git diff --check