### PR TITLE
fix(governance): pin CLI 2.15.2 for report origin

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -24,10 +24,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ORIGIN_CLI_VERSION: '2.6.0'
+  ORIGIN_CLI_VERSION: '2.15.2'
   # Production is intentionally impossible until the released linux-x64 binary
   # has been audited and this placeholder is replaced by its exact SHA-256.
-  ORIGIN_CLI_SHA256: 'ae2d7caf57ea7849ad39b0518d640ee2a0c51f1eee3f4eb2b9797c1abb0bd4cc'
+  ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
   ORIGIN_COHORT: scripts/data/legacy-report-origin-cohort-v1.json
   ORIGIN_COHORT_SHA256: d00f9af499ab9da6df52d0de76bac9021ffbf0401bfff85ad4ac26331c2a38af
 
@@ -75,7 +75,7 @@ jobs:
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           jq -e '.schemaVersion == 2 and .selectedCount == 70 and (.rows | length) == 70 and (.sourceBoundaries | length) == 7' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
-            echo '::error::CLI 2.6.0 audit digest is still a non-production placeholder'; exit 1;
+            echo '::error::CLI 2.15.2 audit digest is still a non-production placeholder'; exit 1;
           }
 
       - name: Download and verify seven frozen drift classifications
@@ -145,8 +145,8 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.6.0'
-          minimum-version: '2.6.0'
+          version: '2.15.2'
+          minimum-version: '2.15.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify audited CLI binary identity
@@ -311,8 +311,8 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.6.0'
-          minimum-version: '2.6.0'
+          version: '2.15.2'
+          minimum-version: '2.15.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -114,7 +114,9 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.equal(cohort.selectedCount, 70);
   assert.equal(cohort.rows.length, 70);
   assert.equal(cohort.sourceBoundaries.length, 7);
-  assert.match(workflow, /ORIGIN_CLI_SHA256: 'ae2d7caf57ea7849ad39b0518d640ee2a0c51f1eee3f4eb2b9797c1abb0bd4cc'/);
+  assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.2'/);
+  assert.match(workflow, /ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'/);
+  assert.equal((workflow.match(/version: '2\.15\.2'/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$ORIGIN_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin 70"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);

--- a/scripts/verify-legacy-report-origin-boundary.mjs
+++ b/scripts/verify-legacy-report-origin-boundary.mjs
@@ -91,7 +91,7 @@ export function freezeLegacyReportOriginBoundary(input) {
     !/^\d+$/.test(input.runId || '')
     || input.repository !== 'aiskillstore/marketplace'
     || !COMMIT_RE.test(input.workflowCommit || '')
-    || input.cliVersion !== '2.6.0'
+    || input.cliVersion !== '2.15.2'
     || !SHA256_RE.test(input.cliSha256 || '')
   ) fail('invalid frozen execution identity');
   return {


### PR DESCRIPTION
## Summary
- pin Govern Legacy Report-Origin 70 to released Skillstore CLI 2.15.2
- bind both dry-run and execute to Linux SHA256 fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4
- update the immutable boundary verifier and workflow contract test

## Incident
Dry-run 29718330333 failed closed before writes because CLI 2.6.0 rejected an authenticated score-only timestamp update on a revision-0 Skill. Skillstore PR #310 fixed the CAS projection and released CLI 2.15.2 from merge bc26726600177a4f39b83f3eebd6ea311f838950 (release run 29719899979).

## Verification
- CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs scripts/tests/materialize-legacy-report-origin-evidence.test.mjs (7/7)
- release checksum independently verified
- failed dry-run artifact=0 and production artifact/score delta=0

Generate Pack is out of scope.