### PR TITLE
feat(governance): bind report-origin legacy audits

### DIFF
--- a/.github/workflows/bind-legacy-report-origin-audits.yml
+++ b/.github/workflows/bind-legacy-report-origin-audits.yml
@@ -1,0 +1,286 @@
+name: Bind Legacy Report-Origin Audits 11
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Freeze a no-write binding boundary, or execute one successful boundary
+        type: choice
+        required: true
+        default: dry-run
+        options: [dry-run, execute]
+      dry_run_id:
+        description: Successful binding dry-run ID; execute only
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: artifact-version-backfill-production
+  cancel-in-progress: false
+
+env:
+  BINDING_CLI_VERSION: '2.15.2'
+  BINDING_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
+  ORIGIN_COHORT: scripts/data/legacy-report-origin-cohort-v1.json
+  ORIGIN_COHORT_SHA256: d00f9af499ab9da6df52d0de76bac9021ffbf0401bfff85ad4ac26331c2a38af
+
+jobs:
+  bind:
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout complete Marketplace history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Normalize full checkout and validate immutable runtime
+        env:
+          MODE: ${{ inputs.mode }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git sparse-checkout disable
+          git reset --hard HEAD
+          test "$GITHUB_REF_NAME" = main
+          if [ "$MODE" = execute ]; then
+            [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::execute requires dry_run_id'; exit 1; }
+          else
+            test -z "$DRY_RUN_ID" || { echo '::error::dry-run does not accept dry_run_id'; exit 1; }
+          fi
+          test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
+          jq -e '.schemaVersion == 2 and .selectedCount == 70 and (.rows | length) == 70 and (.sourceBoundaries | length) == 7' "$ORIGIN_COHORT" >/dev/null
+          for path in .github/actions/download-skillstore-cli/action.yml \
+            scripts/build-legacy-report-origin-boundary.mjs \
+            scripts/materialize-legacy-report-origin-evidence.mjs \
+            scripts/build-legacy-report-origin-audit-binding-plan.mjs \
+            scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            scripts/fetch-artifact-version-inventory.mjs; do
+            test -f "$path" || { echo "::error file=$path::Missing binding runtime"; exit 1; }
+          done
+
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact audited CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.token.outputs.token }}
+          version: '2.15.2'
+          minimum-version: '2.15.2'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Verify audited CLI binary identity
+        run: |
+          set -euo pipefail
+          test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$BINDING_CLI_SHA256"
+
+      - name: Authenticate exact successful binding dry-run
+        if: inputs.mode == 'execute'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          DRY_RUN_ID: ${{ inputs.dry_run_id }}
+        run: |
+          set -euo pipefail
+          run_json=$(gh run view "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --arg id "$DRY_RUN_ID" '
+            (.databaseId | tostring) == $id and .conclusion == "success"
+            and .event == "workflow_dispatch" and .headBranch == "main"
+            and .workflowName == "Bind Legacy Report-Origin Audits 11"
+          ' <<< "$run_json" >/dev/null
+          mkdir -p "$RUNNER_TEMP/boundary"
+          gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-report-origin-audit-binding-boundary-$DRY_RUN_ID" \
+            --dir "$RUNNER_TEMP/boundary"
+          (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
+          jq -e --arg runId "$DRY_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
+            --arg headSha "$(jq -r .headSha <<< "$run_json")" \
+            --arg cliSha "$BINDING_CLI_SHA256" '
+            .schemaVersion == 1 and .status == "report_origin_audit_binding_frozen"
+            and .runId == $runId and .repository == $repository
+            and .workflowCommit == $headSha and .cliVersion == "2.15.2"
+            and .cliSha256 == $cliSha and .selectedCount == 11
+          ' "$RUNNER_TEMP/boundary/boundary.json" >/dev/null
+          git merge-base --is-ancestor "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" "$GITHUB_SHA"
+
+      - name: Download and verify seven frozen source boundaries
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/current/source-boundaries"; mkdir -p "$root"
+          while IFS= read -r boundary; do
+            run_id=$(jq -r .runId <<< "$boundary")
+            expected=$(jq -r .classificationSha256 <<< "$boundary")
+            target="$root/$run_id"; mkdir -p "$target"
+            run_json=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId,conclusion,event,headBranch,workflowName)
+            jq -e --argjson id "$run_id" '
+              .databaseId == $id and .conclusion == "success"
+              and .event == "workflow_dispatch" and .headBranch == "main"
+              and .workflowName == "Govern Legacy-Equivalent Artifacts"
+            ' <<< "$run_json" >/dev/null
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+              --name "legacy-equivalent-boundary-$run_id" --dir "$target"
+            (cd "$target" && sha256sum --check SHA256SUMS)
+            test "$(sha256sum "$target/classification.json" | awk '{print $1}')" = "$expected"
+          done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
+
+      - name: Rebuild exact classification and Report-Origin Git proof
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/current"
+          node scripts/build-legacy-report-origin-boundary.mjs \
+            --cohort "$ORIGIN_COHORT" --boundaries-root "$work/source-boundaries" \
+            --classification-output "$work/classification.json" \
+            --plan-output "$work/report-origin-plan.json"
+          node scripts/materialize-legacy-report-origin-evidence.mjs \
+            --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
+            --expected-count 70 --origin-root "$work/origin" \
+            --previous-report-root "$work/previous" \
+            --manifest "$work/origin-lineage.json"
+          if [ '${{ inputs.mode }}' = execute ]; then
+            cmp "$work/classification.json" "$RUNNER_TEMP/boundary/classification.json"
+            cmp "$work/report-origin-plan.json" "$RUNNER_TEMP/boundary/report-origin-plan.json"
+            cmp "$work/origin-lineage.json" "$RUNNER_TEMP/boundary/origin-lineage.json"
+          fi
+
+      - name: Freeze exact source, binding plan, and no-write inventory
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/current"
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$work/classification.json" --include-drift true \
+            --output "$work/source-evidence.json"
+          node scripts/build-legacy-report-origin-audit-binding-plan.mjs \
+            --classification "$work/classification.json" \
+            --origin-lineage "$work/origin-lineage.json" \
+            --source-evidence "$work/source-evidence.json" \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --expected-selected 11 --expected-v2 54 --expected-governed 5 \
+            --output "$work/binding-plan.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$ORIGIN_COHORT" --output "$work/inventory.json"
+          if [ '${{ inputs.mode }}' = execute ]; then
+            cmp "$work/source-evidence.json" "$RUNNER_TEMP/boundary/source-evidence.json"
+            cmp "$work/binding-plan.json" "$RUNNER_TEMP/boundary/binding-plan.json"
+            cmp "$work/inventory.json" "$RUNNER_TEMP/boundary/inventory.json"
+          fi
+
+      - name: Materialize and validate exactly 11 pinned reports
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/current"; reports="$RUNNER_TEMP/reports"
+          jq -c '.entries[]' "$work/binding-plan.json" | while read -r row; do
+            commit=$(jq -r .marketplaceCommit <<< "$row"); path=$(jq -r .pluginPath <<< "$row")
+            mkdir -p "$reports/$path"
+            git show "$commit:$path/skill-report.json" > "$reports/$path/skill-report.json"
+          done
+          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit \
+            --plan "$work/binding-plan.json" --root "$reports" --dry-run \
+            --concurrency 1 --result-file "$work/binding-dry-run.json"
+          jq -e '.success == true and .mode == "dry-run" and (.results | length) == 11 and all(.results[]; .status == "validated")' \
+            "$work/binding-dry-run.json" >/dev/null
+          if [ '${{ inputs.mode }}' = execute ]; then
+            cmp "$work/binding-dry-run.json" "$RUNNER_TEMP/boundary/binding-dry-run.json"
+          fi
+
+      - name: Freeze immutable 11-row binding boundary
+        if: inputs.mode == 'dry-run'
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/boundary"; work="$RUNNER_TEMP/current"; mkdir -p "$out"
+          cp "$ORIGIN_COHORT" "$out/cohort.json"
+          cp "$work/classification.json" "$work/report-origin-plan.json" \
+            "$work/origin-lineage.json" "$work/source-evidence.json" \
+            "$work/binding-plan.json" "$work/inventory.json" \
+            "$work/binding-dry-run.json" "$out/"
+          jq -n --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion "$BINDING_CLI_VERSION" \
+            --arg cliSha256 "$BINDING_CLI_SHA256" \
+            '{schemaVersion:1,status:"report_origin_audit_binding_frozen",runId:$runId,
+              repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,
+              cliSha256:$cliSha256,selectedCount:11}' > "$out/boundary.json"
+          (cd "$out" && sha256sum cohort.json classification.json report-origin-plan.json \
+            origin-lineage.json source-evidence.json binding-plan.json inventory.json \
+            binding-dry-run.json boundary.json > SHA256SUMS)
+
+      - name: Upload immutable binding boundary
+        if: success() && inputs.mode == 'dry-run'
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-report-origin-audit-binding-boundary-${{ github.run_id }}
+          path: ${{ runner.temp }}/boundary/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Record exactly 11 append-only audit bindings
+        if: inputs.mode == 'execute'
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/skillstore-cli" skill bind-legacy-audit \
+            --plan "$RUNNER_TEMP/current/binding-plan.json" --root "$RUNNER_TEMP/reports" \
+            --concurrency 1 --result-file "$RUNNER_TEMP/binding-execute.json"
+          jq -e '.success == true and .mode == "execute" and (.results | length) == 11 and all(.results[]; .status == "created")' \
+            "$RUNNER_TEMP/binding-execute.json" >/dev/null
+
+      - name: Prove only 11 append-only bindings changed
+        if: inputs.mode == 'execute'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/fetch-legacy-equivalent-governance-readback.mjs \
+            --classification "$RUNNER_TEMP/current/classification.json" --include-drift true \
+            --output "$RUNNER_TEMP/post-source-evidence.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$ORIGIN_COHORT" --output "$RUNNER_TEMP/post-inventory.json"
+          jq -S 'del(.bindings)' "$RUNNER_TEMP/current/source-evidence.json" > "$RUNNER_TEMP/pre-without-bindings.json"
+          jq -S 'del(.bindings)' "$RUNNER_TEMP/post-source-evidence.json" > "$RUNNER_TEMP/post-without-bindings.json"
+          cmp "$RUNNER_TEMP/pre-without-bindings.json" "$RUNNER_TEMP/post-without-bindings.json"
+          cmp "$RUNNER_TEMP/current/inventory.json" "$RUNNER_TEMP/post-inventory.json"
+          test "$(jq '.bindings | length' "$RUNNER_TEMP/post-source-evidence.json")" = 11
+          jq -e --slurpfile plan "$RUNNER_TEMP/current/binding-plan.json" '
+            [.bindings[].source_audit_id] | sort == ([$plan[0].entries[].sourceAuditId] | sort)
+          ' "$RUNNER_TEMP/post-source-evidence.json" >/dev/null
+
+      - name: Upload binding execution evidence
+        if: always() && inputs.mode == 'execute'
+        uses: actions/upload-artifact@v6
+        with:
+          name: legacy-report-origin-audit-binding-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/boundary/
+            ${{ runner.temp }}/current/source-evidence.json
+            ${{ runner.temp }}/current/binding-plan.json
+            ${{ runner.temp }}/current/inventory.json
+            ${{ runner.temp }}/binding-execute.json
+            ${{ runner.temp }}/post-source-evidence.json
+            ${{ runner.temp }}/post-inventory.json
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/build-legacy-report-origin-audit-binding-plan.mjs
+++ b/scripts/build-legacy-report-origin-audit-binding-plan.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const RAW32_RE = /^[0-9a-f]{32}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function fail(message) { throw new Error(message); }
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`;
+  return JSON.stringify(value);
+}
+function uniqueMap(rows, key, label) {
+  const result = new Map();
+  for (const row of rows || []) {
+    if (!row?.[key] || result.has(row[key])) fail(`${label} identity is invalid`);
+    result.set(row[key], row);
+  }
+  return result;
+}
+function sha256(bytes) { return createHash('sha256').update(bytes).digest('hex'); }
+
+export function buildLegacyReportOriginAuditBindingPlan({
+  classification,
+  originLineage,
+  sourceEvidence,
+  repositoryRoot,
+  expectedSelected,
+  expectedV2Revision0,
+  expectedGoverned,
+}) {
+  const rows = classification?.cohorts?.actual_or_unproven_drift;
+  if (
+    classification?.schemaVersion !== 1
+    || classification?.status !== 'classified'
+    || classification?.classifiedCount !== 70
+    || classification?.counts?.actual_or_unproven_drift !== 70
+    || !Array.isArray(rows)
+    || rows.length !== 70
+  ) fail('report-origin classification is not the exact frozen 70-row drift cohort');
+  if (
+    originLineage?.status !== 'legacy_report_origin_evidence_materialized'
+    || originLineage?.selectedCount !== 70
+    || !Array.isArray(originLineage?.entries)
+    || originLineage.entries.length !== 70
+  ) fail('report-origin lineage is not the exact materialized 70-row proof');
+  if (sourceEvidence?.schemaVersion !== 1 || sourceEvidence?.status !== 'source_evidence_fetched') {
+    fail('report-origin source evidence is incomplete');
+  }
+
+  const skills = uniqueMap(sourceEvidence.skills, 'id', 'source Skills');
+  const audits = uniqueMap(sourceEvidence.audits, 'id', 'source audits');
+  const bindings = uniqueMap(sourceEvidence.bindings, 'source_audit_id', 'legacy bindings');
+  const lineage = uniqueMap(originLineage.entries, 'slug', 'origin lineage');
+  if (skills.size !== 70 || audits.size !== 70 || lineage.size !== 70) {
+    fail('report-origin source evidence does not cover exactly 70 identities');
+  }
+
+  const entries = [];
+  let v2Revision0 = 0;
+  let governed = 0;
+  for (const row of rows) {
+    const skill = skills.get(row.id);
+    const audit = audits.get(row.publicEligibilityAuditId);
+    const proof = lineage.get(row.slug);
+    if (
+      !skill || skill.slug !== row.slug
+      || skill.marketplace_commit_sha !== row.marketplaceCommit
+      || skill.plugin_path !== row.path
+      || skill.public_eligible !== true
+      || !audit || audit.skill_id !== row.id || audit.id !== row.publicEligibilityAuditId
+      || !proof || proof.skillId !== row.id || proof.path !== row.path
+      || proof.currentMarketplaceCommit !== row.marketplaceCommit
+      || proof.currentReport?.contentHash !== row.contentHash
+      || proof.currentReport?.treeHash !== row.treeHash
+    ) fail(`report-origin immutable identity changed for ${row.slug}`);
+
+    if (skill.artifact_revision === 1 && UUID_RE.test(skill.current_artifact_version_id || '')) {
+      if (
+        skill.content_hash !== row.evidence?.artifact?.contentHash
+        || skill.tree_hash !== row.evidence?.artifact?.treeHash
+        || !UUID_RE.test(skill.public_eligibility_audit_id || '')
+      ) fail(`report-origin governed projection changed for ${row.slug}`);
+      governed += 1;
+      continue;
+    }
+    if (
+      skill.artifact_revision !== 0
+      || skill.current_artifact_version_id !== null
+      || skill.content_hash !== row.contentHash
+      || skill.tree_hash !== row.treeHash
+      || skill.public_eligibility_audit_id !== row.publicEligibilityAuditId
+    ) {
+      fail(`report-origin artifact projection is inconsistent for ${row.slug}`);
+    }
+    if (!RAW32_RE.test(audit.content_hash || '')) {
+      const v2Prefix = `v2:${row.marketplaceCommit}:${row.contentHash}:${row.treeHash}:`;
+      if (
+        !audit.content_hash.startsWith(v2Prefix)
+        || !RAW32_RE.test(audit.content_hash.slice(v2Prefix.length))
+        || audit.audit_payload_hash !== null
+        || audit.subject_marketplace_commit_sha !== null
+        || audit.subject_content_hash !== null
+        || audit.subject_tree_hash !== null
+        || audit.subject_plugin_path !== null
+        || audit.derived_from_audit_id !== null
+        || audit.derivation_kind !== null
+      ) fail(`report-origin v2 source audit changed for ${row.slug}`);
+      v2Revision0 += 1;
+      continue;
+    }
+    if (bindings.has(audit.id)) fail(`report-origin raw32 audit is already bound for ${row.slug}`);
+    if (
+      audit.audit_payload_hash !== null
+      || audit.subject_marketplace_commit_sha !== null
+      || audit.subject_content_hash !== null
+      || audit.subject_tree_hash !== null
+      || audit.subject_plugin_path !== null
+      || audit.derived_from_audit_id !== null
+      || audit.derivation_kind !== null
+    ) fail(`report-origin raw32 audit columns changed for ${row.slug}`);
+
+    const objectSpec = `${row.marketplaceCommit}:${row.path}/skill-report.json`;
+    const reportBytes = execFileSync('git', ['-C', repositoryRoot, 'show', objectSpec]);
+    const reportBlob = execFileSync(
+      'git', ['-C', repositoryRoot, 'rev-parse', `${row.marketplaceCommit}:${row.path}/skill-report.json`],
+      { encoding: 'utf8' }
+    ).trim();
+    if (sha256(reportBytes) !== proof.currentReport.sha256 || reportBlob !== proof.currentReport.gitBlob) {
+      fail(`report-origin report bytes changed for ${row.slug}`);
+    }
+    const report = JSON.parse(reportBytes.toString('utf8'));
+    if (
+      report?.meta?.slug !== row.slug
+      || report?.meta?.content_hash !== row.contentHash
+      || report?.meta?.tree_hash !== row.treeHash
+      || !report?.security_audit
+    ) fail(`report-origin pinned report identity mismatch for ${row.slug}`);
+    entries.push({
+      skillId: row.id,
+      slug: row.slug,
+      pluginPath: row.path,
+      marketplaceCommit: row.marketplaceCommit,
+      skillContentHash: row.contentHash,
+      treeHash: row.treeHash,
+      sourceAuditId: audit.id,
+      sourceAuditVersion: audit.version,
+      sourceAuditPayloadHash: audit.content_hash,
+      reportBlobSha256: sha256(reportBytes),
+    });
+  }
+  entries.sort((left, right) => left.slug.localeCompare(right.slug, 'en-US'));
+  if (
+    entries.length !== expectedSelected
+    || v2Revision0 !== expectedV2Revision0
+    || governed !== expectedGoverned
+    || bindings.size !== 0
+  ) fail(`report-origin binding split changed: selected=${entries.length} v2=${v2Revision0} governed=${governed} bound=${bindings.size}`);
+
+  const identity = { schemaVersion: 1, entries };
+  return {
+    ...identity,
+    planSha256: sha256(canonical(identity)),
+    status: 'legacy_report_origin_audit_binding_plan',
+    counts: { selected: entries.length, v2Revision0, governed, existingBindings: bindings.size },
+  };
+}
+
+function parseCount(value, name) {
+  if (!/^(0|[1-9][0-9]*)$/.test(value || '')) fail(`${name} must be a non-negative integer`);
+  return Number(value);
+}
+
+if (process.argv[1]?.endsWith('build-legacy-report-origin-audit-binding-plan.mjs')) {
+  try {
+    const { values } = parseArgs({ options: {
+      classification: { type: 'string' },
+      'origin-lineage': { type: 'string' },
+      'source-evidence': { type: 'string' },
+      'repository-root': { type: 'string' },
+      'expected-selected': { type: 'string' },
+      'expected-v2': { type: 'string' },
+      'expected-governed': { type: 'string' },
+      output: { type: 'string' },
+    } });
+    const plan = buildLegacyReportOriginAuditBindingPlan({
+      classification: JSON.parse(readFileSync(resolve(values.classification), 'utf8')),
+      originLineage: JSON.parse(readFileSync(resolve(values['origin-lineage']), 'utf8')),
+      sourceEvidence: JSON.parse(readFileSync(resolve(values['source-evidence']), 'utf8')),
+      repositoryRoot: resolve(values['repository-root']),
+      expectedSelected: parseCount(values['expected-selected'], '--expected-selected'),
+      expectedV2Revision0: parseCount(values['expected-v2'], '--expected-v2'),
+      expectedGoverned: parseCount(values['expected-governed'], '--expected-governed'),
+    });
+    writeFileSync(resolve(values.output), `${JSON.stringify(plan, null, 2)}\n`, { flag: 'wx' });
+    process.stdout.write(`${JSON.stringify(plan.counts)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/fetch-legacy-equivalent-governance-readback.mjs
+++ b/scripts/fetch-legacy-equivalent-governance-readback.mjs
@@ -116,13 +116,17 @@ export async function fetchLegacyGovernanceSourceEvidence({
   supabaseUrl,
   serviceKey,
   classification,
+  includeDrift = false,
   fetchImpl = fetch,
 }) {
   const legacy = classification?.cohorts?.legacy_algorithm_equivalent;
   if (!Array.isArray(legacy)) fail('classification lacks the legacy-equivalent cohort');
-  const skillIds = unique(legacy.map((row) => row.id));
-  const auditIds = unique(legacy.map((row) => row.publicEligibilityAuditId));
-  if (skillIds.length !== legacy.length || auditIds.length !== legacy.length) {
+  const drift = classification?.cohorts?.actual_or_unproven_drift;
+  if (includeDrift && !Array.isArray(drift)) fail('classification lacks the drift cohort');
+  const selected = includeDrift ? [...legacy, ...drift] : legacy;
+  const skillIds = unique(selected.map((row) => row.id));
+  const auditIds = unique(selected.map((row) => row.publicEligibilityAuditId));
+  if (skillIds.length !== selected.length || auditIds.length !== selected.length) {
     fail('classification contains duplicate or missing Skill/audit ids');
   }
   const request = (table, select, filter, values) => fetchRows({
@@ -137,14 +141,14 @@ export async function fetchLegacyGovernanceSourceEvidence({
   const [skills, audits, bindings] = await Promise.all([
     request(
       'skills',
-      'id,slug,name,description,author_name,supported_tools,file_structure,public_eligibility_audit_id',
+      'id,slug,name,description,author_name,supported_tools,file_structure,current_artifact_version_id,artifact_revision,content_hash,tree_hash,marketplace_commit_sha,plugin_path,public_eligible,public_eligibility_audit_id,published_at,updated_at,repository,source_ref,current_quality_score_snapshot_id,quality_score',
       'id',
       skillIds
     ),
     request('skill_security_audit', '*', 'id', auditIds),
     request('legacy_audit_subject_bindings', '*', 'source_audit_id', auditIds),
   ]);
-  if (skills.length !== legacy.length || audits.length !== legacy.length) {
+  if (skills.length !== selected.length || audits.length !== selected.length) {
     fail('source evidence readback is incomplete');
   }
   return {
@@ -170,6 +174,9 @@ function parseArgs(argv) {
 
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
+  if (args['include-drift'] !== undefined && !['true', 'false'].includes(args['include-drift'])) {
+    fail('--include-drift must be true or false');
+  }
   const supabaseUrl = process.env.SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_KEY;
   if (!supabaseUrl || !serviceKey) fail('SUPABASE_URL and SUPABASE_SERVICE_KEY are required');
@@ -178,6 +185,7 @@ export async function main(argv = process.argv.slice(2)) {
         supabaseUrl,
         serviceKey,
         classification: JSON.parse(readFileSync(resolve(args.classification), 'utf8')),
+        includeDrift: args['include-drift'] === 'true',
       })
     : await fetchLegacyGovernanceReadback({
         supabaseUrl,

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -870,6 +870,42 @@ test('freezes the complete source audit row and unhashed Skill install metadata'
   assert.deepEqual(output.audits.map((row) => row.id), [SOURCE_AUDIT_ID, secondAuditId]);
 });
 
+test('includes the drift cohort only when an exact caller requests it', async () => {
+  const classification = structuredClone(fixtures().hashClassification);
+  const drift = {
+    ...classification.cohorts.legacy_algorithm_equivalent[0],
+    id: '00000000-0000-4000-8000-000000000002',
+    slug: 'owner-drift',
+    publicEligibilityAuditId: '10000000-0000-4000-8000-000000000002',
+  };
+  classification.cohorts.actual_or_unproven_drift.push(drift);
+  classification.counts.actual_or_unproven_drift = 1;
+  const requested = [];
+  const fetchImpl = async (url) => {
+    const table = url.pathname.split('/').at(-1);
+    requested.push({ table, select: url.searchParams.get('select') });
+    if (table === 'legacy_audit_subject_bindings') return { ok: true, json: async () => [] };
+    if (table === 'skills') return { ok: true, json: async () => [
+      { id: SKILL_ID, slug: 'owner-image' },
+      { id: drift.id, slug: drift.slug },
+    ] };
+    return { ok: true, json: async () => [
+      { id: SOURCE_AUDIT_ID, skill_id: SKILL_ID },
+      { id: drift.publicEligibilityAuditId, skill_id: drift.id },
+    ] };
+  };
+  const output = await fetchLegacyGovernanceSourceEvidence({
+    supabaseUrl: 'https://db.example.test',
+    serviceKey: 'service-key',
+    classification,
+    includeDrift: true,
+    fetchImpl,
+  });
+  assert.equal(output.skills.length, 2);
+  assert.equal(output.audits.length, 2);
+  assert.ok(requested.find((row) => row.table === 'skills').select.includes('artifact_revision'));
+});
+
 test('workflow is two-phase, exactly pinned, bounded, and never executes ordinary sync', () => {
   const workflow = readFileSync(
     resolve(import.meta.dirname, '../../.github/workflows/govern-legacy-equivalent-artifacts.yml'),

--- a/scripts/tests/legacy-report-origin-audit-binding.test.mjs
+++ b/scripts/tests/legacy-report-origin-audit-binding.test.mjs
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { buildLegacyReportOriginAuditBindingPlan } from '../build-legacy-report-origin-audit-binding-plan.mjs';
+
+function sha256(bytes) { return createHash('sha256').update(bytes).digest('hex'); }
+function uuid(prefix, index) {
+  return `${prefix}0000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`;
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'report-origin-binding-'));
+  execFileSync('git', ['init', '-q', root]);
+  execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+  const baseRows = Array.from({ length: 70 }, (_, index) => {
+    const slug = `owner-skill-${String(index).padStart(2, '0')}`;
+    const path = `skills/owner/skill-${String(index).padStart(2, '0')}`;
+    const contentHash = index.toString(16).padStart(64, '0');
+    const treeHash = (index + 100).toString(16).padStart(64, '0');
+    const canonicalContent = (index + 200).toString(16).padStart(64, '0');
+    const canonicalTree = (index + 300).toString(16).padStart(64, '0');
+    if (index < 11) {
+      const reportPath = join(root, path, 'skill-report.json');
+      mkdirSync(dirname(reportPath), { recursive: true });
+      writeFileSync(reportPath, `${JSON.stringify({
+        meta: { slug, content_hash: contentHash, tree_hash: treeHash },
+        security_audit: { summary: `audit-${index}` },
+      }, null, 2)}\n`);
+    }
+    return { index, slug, path, contentHash, treeHash, canonicalContent, canonicalTree };
+  });
+  execFileSync('git', ['-C', root, 'add', '.']);
+  execFileSync('git', ['-C', root, 'commit', '-qm', 'fixture']);
+  const commit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const rows = baseRows.map((row) => ({
+    id: uuid('0', row.index),
+    slug: row.slug,
+    path: row.path,
+    marketplaceCommit: commit,
+    contentHash: row.contentHash,
+    treeHash: row.treeHash,
+    artifactRevision: 0,
+    currentArtifactVersionId: null,
+    status: 'approved',
+    publicEligible: true,
+    publicEligibilityAuditId: uuid('1', row.index),
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    evidence: { artifact: { contentHash: row.canonicalContent, treeHash: row.canonicalTree } },
+  }));
+  const classification = {
+    schemaVersion: 1,
+    status: 'classified',
+    classifiedCount: 70,
+    counts: { exact: 0, legacy_algorithm_equivalent: 0, actual_or_unproven_drift: 70 },
+    cohorts: { exact: [], legacy_algorithm_equivalent: [], actual_or_unproven_drift: rows },
+  };
+  const originLineage = {
+    status: 'legacy_report_origin_evidence_materialized',
+    selectedCount: 70,
+    entries: rows.map((row, index) => {
+      const reportPath = `${row.path}/skill-report.json`;
+      const bytes = index < 11 ? execFileSync('git', ['-C', root, 'show', `${commit}:${reportPath}`]) : Buffer.from('');
+      const gitBlob = index < 11
+        ? execFileSync('git', ['-C', root, 'rev-parse', `${commit}:${reportPath}`], { encoding: 'utf8' }).trim()
+        : '0'.repeat(40);
+      return {
+        slug: row.slug,
+        skillId: row.id,
+        path: row.path,
+        currentMarketplaceCommit: commit,
+        currentReport: {
+          contentHash: row.contentHash,
+          treeHash: row.treeHash,
+          sha256: sha256(bytes),
+          gitBlob,
+        },
+      };
+    }),
+  };
+  const sourceEvidence = {
+    schemaVersion: 1,
+    status: 'source_evidence_fetched',
+    bindings: [],
+    skills: rows.map((row, index) => ({
+      id: row.id,
+      slug: row.slug,
+      content_hash: index >= 65 ? row.evidence.artifact.contentHash : row.contentHash,
+      tree_hash: index >= 65 ? row.evidence.artifact.treeHash : row.treeHash,
+      marketplace_commit_sha: commit,
+      plugin_path: row.path,
+      public_eligible: true,
+      public_eligibility_audit_id: index >= 65 ? uuid('2', index) : row.publicEligibilityAuditId,
+      artifact_revision: index >= 65 ? 1 : 0,
+      current_artifact_version_id: index >= 65 ? uuid('3', index) : null,
+      repository: 'https://github.com/owner/repo',
+      source_ref: 'main',
+    })),
+    audits: rows.map((row, index) => ({
+      id: row.publicEligibilityAuditId,
+      skill_id: row.id,
+      version: 1,
+      content_hash: index < 11
+        ? (index + 1).toString(16).padStart(32, '0')
+        : `v2:${commit}:${row.contentHash}:${row.treeHash}:${'f'.repeat(32)}`,
+      audit_payload_hash: null,
+      subject_marketplace_commit_sha: null,
+      subject_content_hash: null,
+      subject_tree_hash: null,
+      subject_plugin_path: null,
+      derived_from_audit_id: null,
+      derivation_kind: null,
+    })),
+  };
+  return { root, classification, originLineage, sourceEvidence };
+}
+
+test('builds exactly 11 append-only bindings from the authenticated 70-row Report-Origin split', () => {
+  const item = fixture();
+  try {
+    const plan = buildLegacyReportOriginAuditBindingPlan({
+      ...item,
+      repositoryRoot: item.root,
+      expectedSelected: 11,
+      expectedV2Revision0: 54,
+      expectedGoverned: 5,
+    });
+    assert.deepEqual(plan.counts, {
+      selected: 11,
+      v2Revision0: 54,
+      governed: 5,
+      existingBindings: 0,
+    });
+    assert.equal(plan.entries.length, 11);
+    assert.match(plan.planSha256, /^[0-9a-f]{64}$/);
+
+    const tampered = structuredClone(item.sourceEvidence);
+    tampered.audits[0].subject_tree_hash = '0'.repeat(64);
+    assert.throws(() => buildLegacyReportOriginAuditBindingPlan({
+      classification: item.classification,
+      originLineage: item.originLineage,
+      sourceEvidence: tampered,
+      repositoryRoot: item.root,
+      expectedSelected: 11,
+      expectedV2Revision0: 54,
+      expectedGoverned: 5,
+    }), /raw32 audit columns changed/);
+
+    const alreadyBound = structuredClone(item.sourceEvidence);
+    alreadyBound.bindings.push({ source_audit_id: alreadyBound.audits[0].id });
+    assert.throws(() => buildLegacyReportOriginAuditBindingPlan({
+      classification: item.classification,
+      originLineage: item.originLineage,
+      sourceEvidence: alreadyBound,
+      repositoryRoot: item.root,
+      expectedSelected: 11,
+      expectedV2Revision0: 54,
+      expectedGoverned: 5,
+    }), /already bound/);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test('workflow freezes one dry-run before binding and forbids governance side effects', () => {
+  const workflow = readFileSync(resolve(
+    import.meta.dirname,
+    '../../.github/workflows/bind-legacy-report-origin-audits.yml'
+  ), 'utf8');
+  assert.match(workflow, /name: Bind Legacy Report-Origin Audits 11/);
+  assert.match(workflow, /BINDING_CLI_VERSION: '2\.15\.2'/);
+  assert.match(workflow, /fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4/);
+  assert.match(workflow, /--expected-selected 11 --expected-v2 54 --expected-governed 5/);
+  assert.match(workflow, /skill bind-legacy-audit/);
+  assert.match(workflow, /Prove only 11 append-only bindings changed/);
+  assert.match(workflow, /cmp "\$RUNNER_TEMP\/current\/inventory\.json" "\$RUNNER_TEMP\/post-inventory\.json"/);
+  assert.doesNotMatch(workflow, /govern-legacy-equivalent|skill score|CACHE_INVALIDATE/);
+});


### PR DESCRIPTION
## Summary
- add a two-phase, immutable workflow for the exact 11 raw32 audits blocking Report-Origin governance
- bind each report to the seven frozen classifications plus independently rematerialized Report-Origin Git history
- re-read and byte-compare source evidence, the 70-row inventory, plan, and CLI dry-run before the first write
- prove post-execute that only 11 append-only subject bindings changed

## Live incident evidence
- Report-Origin dry-run 29720179975 used CLI 2.15.2 and passed the score-only CAS gate
- it then failed closed on missing binding for 270aldo-ngx-hybrid-sales
- artifact=0, governance/score delta=0
- exact 70-row split: 11 raw32 missing bindings, 54 v2 revision0, 5 already governed

## Verification
- CI=true node --test on Report-Origin, audit-binding, materialization, and governance suites: 25/25
- YAML parse passed
- no govern-legacy-equivalent, score, cache invalidation, or Generate Pack call exists in the new workflow

The execute phase writes only skillstore.legacy_audit_subject_bindings through the existing fail-closed RPC.