### PR TITLE
fix(governance): skip authenticated governed rows

### DIFF
--- a/scripts/build-legacy-report-origin-audit-binding-plan.mjs
+++ b/scripts/build-legacy-report-origin-audit-binding-plan.mjs
@@ -71,14 +71,7 @@ export function buildLegacyReportOriginAuditBindingPlan({
     const proof = lineage.get(row.slug);
     if (
       !skill || skill.slug !== row.slug
-      || skill.marketplace_commit_sha !== row.marketplaceCommit
-      || skill.plugin_path !== row.path
-      || skill.public_eligible !== true
       || !audit || audit.skill_id !== row.id || audit.id !== row.publicEligibilityAuditId
-      || !proof || proof.skillId !== row.id || proof.path !== row.path
-      || proof.currentMarketplaceCommit !== row.marketplaceCommit
-      || proof.currentReport?.contentHash !== row.contentHash
-      || proof.currentReport?.treeHash !== row.treeHash
     ) fail(`report-origin immutable identity changed for ${row.slug}`);
 
     if (skill.artifact_revision === 1 && UUID_RE.test(skill.current_artifact_version_id || '')) {
@@ -95,7 +88,14 @@ export function buildLegacyReportOriginAuditBindingPlan({
       || skill.current_artifact_version_id !== null
       || skill.content_hash !== row.contentHash
       || skill.tree_hash !== row.treeHash
+      || skill.marketplace_commit_sha !== row.marketplaceCommit
+      || skill.plugin_path !== row.path
+      || skill.public_eligible !== true
       || skill.public_eligibility_audit_id !== row.publicEligibilityAuditId
+      || !proof || proof.skillId !== row.id || proof.path !== row.path
+      || proof.currentMarketplaceCommit !== row.marketplaceCommit
+      || proof.currentReport?.contentHash !== row.contentHash
+      || proof.currentReport?.treeHash !== row.treeHash
     ) {
       fail(`report-origin artifact projection is inconsistent for ${row.slug}`);
     }

--- a/scripts/tests/legacy-report-origin-audit-binding.test.mjs
+++ b/scripts/tests/legacy-report-origin-audit-binding.test.mjs
@@ -92,7 +92,7 @@ function fixture() {
       slug: row.slug,
       content_hash: index >= 65 ? row.evidence.artifact.contentHash : row.contentHash,
       tree_hash: index >= 65 ? row.evidence.artifact.treeHash : row.treeHash,
-      marketplace_commit_sha: commit,
+      marketplace_commit_sha: index >= 65 ? 'b'.repeat(40) : commit,
       plugin_path: row.path,
       public_eligible: true,
       public_eligibility_audit_id: index >= 65 ? uuid('2', index) : row.publicEligibilityAuditId,


### PR DESCRIPTION
## Summary
- count already-governed Report-Origin rows before applying frozen legacy commit/path checks
- keep full frozen identity checks for all revision-0 rows and the exact 11 binding targets
- add a regression where an already-governed row has advanced to a newer normal Marketplace commit

## Incident
Binding dry-run 29720983516 failed before CLI validation and before any write because browser-act-google-image-api-skill is already governed at revision 1 and later advanced to a normal newer Marketplace commit. artifact=0, binding delta=0, artifact/score delta=0.

## Verification
- CI=true node --test scripts/tests/legacy-report-origin-audit-binding.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs (12/12)
- revision-0 identity checks remain unchanged