### PR TITLE
fix(governance): authenticate governed artifact pointers

### DIFF
--- a/.github/workflows/bind-legacy-report-origin-audits.yml
+++ b/.github/workflows/bind-legacy-report-origin-audits.yml
@@ -170,15 +170,16 @@ jobs:
           node scripts/fetch-legacy-equivalent-governance-readback.mjs \
             --classification "$work/classification.json" --include-drift true \
             --output "$work/source-evidence.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$ORIGIN_COHORT" --output "$work/inventory.json"
           node scripts/build-legacy-report-origin-audit-binding-plan.mjs \
             --classification "$work/classification.json" \
             --origin-lineage "$work/origin-lineage.json" \
             --source-evidence "$work/source-evidence.json" \
+            --inventory "$work/inventory.json" \
             --repository-root "$GITHUB_WORKSPACE" \
             --expected-selected 11 --expected-v2 54 --expected-governed 5 \
             --output "$work/binding-plan.json"
-          node scripts/fetch-artifact-version-inventory.mjs \
-            --scope-inventory "$ORIGIN_COHORT" --output "$work/inventory.json"
           if [ '${{ inputs.mode }}' = execute ]; then
             cmp "$work/source-evidence.json" "$RUNNER_TEMP/boundary/source-evidence.json"
             cmp "$work/binding-plan.json" "$RUNNER_TEMP/boundary/binding-plan.json"

--- a/scripts/build-legacy-report-origin-audit-binding-plan.mjs
+++ b/scripts/build-legacy-report-origin-audit-binding-plan.mjs
@@ -30,6 +30,7 @@ export function buildLegacyReportOriginAuditBindingPlan({
   classification,
   originLineage,
   sourceEvidence,
+  inventory,
   repositoryRoot,
   expectedSelected,
   expectedV2Revision0,
@@ -58,8 +59,14 @@ export function buildLegacyReportOriginAuditBindingPlan({
   const audits = uniqueMap(sourceEvidence.audits, 'id', 'source audits');
   const bindings = uniqueMap(sourceEvidence.bindings, 'source_audit_id', 'legacy bindings');
   const lineage = uniqueMap(originLineage.entries, 'slug', 'origin lineage');
+  const inventorySkills = uniqueMap(inventory?.rows, 'id', 'inventory Skills');
+  const artifacts = uniqueMap(inventory?.artifacts, 'id', 'inventory artifacts');
+  const scopedIds = new Set(inventory?.scopedSkillIds || []);
   if (skills.size !== 70 || audits.size !== 70 || lineage.size !== 70) {
     fail('report-origin source evidence does not cover exactly 70 identities');
+  }
+  if (scopedIds.size !== 70 || rows.some((row) => !scopedIds.has(row.id))) {
+    fail('report-origin inventory does not cover exactly the frozen 70 identities');
   }
 
   const entries = [];
@@ -69,16 +76,30 @@ export function buildLegacyReportOriginAuditBindingPlan({
     const skill = skills.get(row.id);
     const audit = audits.get(row.publicEligibilityAuditId);
     const proof = lineage.get(row.slug);
+    const inventorySkill = inventorySkills.get(row.id);
     if (
       !skill || skill.slug !== row.slug
       || !audit || audit.skill_id !== row.id || audit.id !== row.publicEligibilityAuditId
     ) fail(`report-origin immutable identity changed for ${row.slug}`);
 
     if (skill.artifact_revision === 1 && UUID_RE.test(skill.current_artifact_version_id || '')) {
+      const artifact = artifacts.get(skill.current_artifact_version_id);
       if (
-        skill.content_hash !== row.evidence?.artifact?.contentHash
-        || skill.tree_hash !== row.evidence?.artifact?.treeHash
-        || !UUID_RE.test(skill.public_eligibility_audit_id || '')
+        !inventorySkill
+        || inventorySkill.current_artifact_version_id !== skill.current_artifact_version_id
+        || inventorySkill.artifact_revision !== 1
+        || inventorySkill.content_hash !== skill.content_hash
+        || inventorySkill.tree_hash !== skill.tree_hash
+        || inventorySkill.marketplace_commit_sha !== skill.marketplace_commit_sha
+        || inventorySkill.plugin_path !== skill.plugin_path
+        || !artifact
+        || artifact.skill_id !== row.id
+        || artifact.artifact_revision !== 1
+        || artifact.content_hash !== skill.content_hash
+        || artifact.tree_hash !== skill.tree_hash
+        || artifact.marketplace_commit_sha !== skill.marketplace_commit_sha
+        || artifact.source_path !== skill.plugin_path
+        || artifact.snapshot_status !== 'complete'
       ) fail(`report-origin governed projection changed for ${row.slug}`);
       governed += 1;
       continue;
@@ -92,6 +113,14 @@ export function buildLegacyReportOriginAuditBindingPlan({
       || skill.plugin_path !== row.path
       || skill.public_eligible !== true
       || skill.public_eligibility_audit_id !== row.publicEligibilityAuditId
+      || !inventorySkill
+      || inventorySkill.current_artifact_version_id !== null
+      || inventorySkill.artifact_revision !== 0
+      || inventorySkill.content_hash !== skill.content_hash
+      || inventorySkill.tree_hash !== skill.tree_hash
+      || inventorySkill.marketplace_commit_sha !== skill.marketplace_commit_sha
+      || inventorySkill.plugin_path !== skill.plugin_path
+      || inventorySkill.public_eligibility_audit_id !== skill.public_eligibility_audit_id
       || !proof || proof.skillId !== row.id || proof.path !== row.path
       || proof.currentMarketplaceCommit !== row.marketplaceCommit
       || proof.currentReport?.contentHash !== row.contentHash
@@ -183,6 +212,7 @@ if (process.argv[1]?.endsWith('build-legacy-report-origin-audit-binding-plan.mjs
       classification: { type: 'string' },
       'origin-lineage': { type: 'string' },
       'source-evidence': { type: 'string' },
+      inventory: { type: 'string' },
       'repository-root': { type: 'string' },
       'expected-selected': { type: 'string' },
       'expected-v2': { type: 'string' },
@@ -193,6 +223,7 @@ if (process.argv[1]?.endsWith('build-legacy-report-origin-audit-binding-plan.mjs
       classification: JSON.parse(readFileSync(resolve(values.classification), 'utf8')),
       originLineage: JSON.parse(readFileSync(resolve(values['origin-lineage']), 'utf8')),
       sourceEvidence: JSON.parse(readFileSync(resolve(values['source-evidence']), 'utf8')),
+      inventory: JSON.parse(readFileSync(resolve(values.inventory), 'utf8')),
       repositoryRoot: resolve(values['repository-root']),
       expectedSelected: parseCount(values['expected-selected'], '--expected-selected'),
       expectedV2Revision0: parseCount(values['expected-v2'], '--expected-v2'),

--- a/scripts/tests/legacy-report-origin-audit-binding.test.mjs
+++ b/scripts/tests/legacy-report-origin-audit-binding.test.mjs
@@ -117,7 +117,25 @@ function fixture() {
       derivation_kind: null,
     })),
   };
-  return { root, classification, originLineage, sourceEvidence };
+  const inventory = {
+    scopedSkillIds: rows.map((row) => row.id),
+    rows: sourceEvidence.skills,
+    artifacts: rows.slice(65).map((row, offset) => {
+      const index = offset + 65;
+      const skill = sourceEvidence.skills[index];
+      return {
+        id: skill.current_artifact_version_id,
+        skill_id: row.id,
+        artifact_revision: 1,
+        content_hash: skill.content_hash,
+        tree_hash: skill.tree_hash,
+        marketplace_commit_sha: skill.marketplace_commit_sha,
+        source_path: skill.plugin_path,
+        snapshot_status: 'complete',
+      };
+    }),
+  };
+  return { root, classification, originLineage, sourceEvidence, inventory };
 }
 
 test('builds exactly 11 append-only bindings from the authenticated 70-row Report-Origin split', () => {
@@ -145,6 +163,7 @@ test('builds exactly 11 append-only bindings from the authenticated 70-row Repor
       classification: item.classification,
       originLineage: item.originLineage,
       sourceEvidence: tampered,
+      inventory: item.inventory,
       repositoryRoot: item.root,
       expectedSelected: 11,
       expectedV2Revision0: 54,
@@ -157,11 +176,25 @@ test('builds exactly 11 append-only bindings from the authenticated 70-row Repor
       classification: item.classification,
       originLineage: item.originLineage,
       sourceEvidence: alreadyBound,
+      inventory: item.inventory,
       repositoryRoot: item.root,
       expectedSelected: 11,
       expectedV2Revision0: 54,
       expectedGoverned: 5,
     }), /already bound/);
+
+    const brokenPointer = structuredClone(item.inventory);
+    brokenPointer.artifacts[0].tree_hash = '0'.repeat(64);
+    assert.throws(() => buildLegacyReportOriginAuditBindingPlan({
+      classification: item.classification,
+      originLineage: item.originLineage,
+      sourceEvidence: item.sourceEvidence,
+      inventory: brokenPointer,
+      repositoryRoot: item.root,
+      expectedSelected: 11,
+      expectedV2Revision0: 54,
+      expectedGoverned: 5,
+    }), /governed projection changed/);
   } finally {
     rmSync(item.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- freeze the 70-row production artifact inventory before building the Report-Origin binding plan
- authenticate each of the five already-governed rows through its current Skill pointer and exact revision-1 artifact row
- keep frozen legacy identity checks for all 65 revision-0 rows
- reject broken pointer, artifact content/tree/commit/path, or snapshot-status drift

## Incident
Binding dry-run 29721329464 failed before CLI validation and before writes because a second already-governed row had legitimately advanced beyond its old classification canonical hash. artifact=0, binding/artifact/score delta=0.

## Verification
- CI=true node --test scripts/tests/legacy-report-origin-audit-binding.test.mjs scripts/tests/legacy-equivalent-governance.test.mjs (12/12)
- broken governed artifact pointer regression rejects
- YAML parse passed