### PR TITLE
fix(governance): require exact artifact snapshots

### DIFF
--- a/scripts/build-legacy-report-origin-audit-binding-plan.mjs
+++ b/scripts/build-legacy-report-origin-audit-binding-plan.mjs
@@ -99,7 +99,7 @@ export function buildLegacyReportOriginAuditBindingPlan({
         || artifact.tree_hash !== skill.tree_hash
         || artifact.marketplace_commit_sha !== skill.marketplace_commit_sha
         || artifact.source_path !== skill.plugin_path
-        || artifact.snapshot_status !== 'complete'
+        || artifact.snapshot_status !== 'exact'
       ) fail(`report-origin governed projection changed for ${row.slug}`);
       governed += 1;
       continue;

--- a/scripts/tests/legacy-report-origin-audit-binding.test.mjs
+++ b/scripts/tests/legacy-report-origin-audit-binding.test.mjs
@@ -131,7 +131,7 @@ function fixture() {
         tree_hash: skill.tree_hash,
         marketplace_commit_sha: skill.marketplace_commit_sha,
         source_path: skill.plugin_path,
-        snapshot_status: 'complete',
+        snapshot_status: 'exact',
       };
     }),
   };


### PR DESCRIPTION
## Summary
- require the production artifact snapshot_status value exact for already-governed Report-Origin rows
- update the regression fixture to match the production enum

## Incident
Binding dry-run 29722000019 failed before plan/CLI/write because the verifier expected a nonexistent complete status. Production has 5162 exact snapshots and one legacy_reconstructed snapshot; all five already-governed rows authenticate as exact with zero pointer/content/tree/commit/path mismatches.

## Verification
- focused suites 12/12
- live SQL: governed=5, authenticated=5, mismatch=0
- failed run artifact=0 and production deltas=0