### PR TITLE
[codex] Re-audit Report-Origin raw32 cohort

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -13,7 +13,7 @@ on:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
         required: false
-        default: 'governance/fresh-canonical-audit/remaining-lineage.json'
+        default: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
       start_after:
         description: 'Exact prior batch end slug; dry-run only'
         type: string
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.15.1'
+        default: '2.15.2'
 
 permissions:
   actions: read
@@ -62,6 +62,13 @@ permissions:
 concurrency:
   group: artifact-version-backfill-production
   cancel-in-progress: false
+
+env:
+  FRESH_GOVERNANCE_CLI_VERSION: '2.15.2'
+  FRESH_GOVERNANCE_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
+  ORIGINAL_FRESH_COHORT: 'governance/fresh-canonical-audit/remaining-lineage.json'
+  REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
+  REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de'
 
 jobs:
   freeze-boundary:
@@ -101,7 +108,7 @@ jobs:
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
         run: |
           set -euo pipefail
-          test "$CLI_VERSION" = '2.15.1' || { echo '::error::workflow is pinned to CLI 2.15.1'; exit 1; }
+          test "$CLI_VERSION" = "$FRESH_GOVERNANCE_CLI_VERSION" || { echo '::error::workflow CLI pin changed'; exit 1; }
           test -z "$DRY_RUN_ID" || { echo '::error::dry-run cannot consume dry_run_id'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::dry-run cannot consume failed_execute_run_id'; exit 1; }
           if test -n "$START_AFTER"; then
@@ -112,6 +119,23 @@ jobs:
             test -z "$PREVIOUS_EXECUTE_RUN_ID" || { echo '::error::initial batch cannot consume previous_execute_run_id'; exit 1; }
           fi
           test -f "$COHORT_PATH" || { echo '::error::lineage-unproven cohort is missing'; exit 1; }
+          case "$COHORT_PATH" in
+            "$ORIGINAL_FRESH_COHORT") ;;
+            "$REPORT_ORIGIN_FRESH_COHORT")
+              test "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" = "$REPORT_ORIGIN_FRESH_COHORT_SHA256"
+              jq -e '
+                .schemaVersion == 1 and .status == "lineage_unproven"
+                and .count == 11 and (.rows | length) == 11
+                and ([.rows[].slug] | unique | length) == 11
+                and ([.rows[].skillId] | unique | length) == 11
+                and all(.rows[];
+                  .marketplaceCommit == "820ccb93d2e2fe828678ed05433bafd1054e5000"
+                  and .remainingReason == "same_source_tree_unproven"
+                  and .governanceEligibleByLineage == false)
+              ' "$COHORT_PATH" >/dev/null
+              ;;
+            *) echo '::error::cohort_path is not an authenticated Fresh campaign'; exit 1 ;;
+          esac
           test -f scripts/prepare-fresh-canonical-audit-batch.mjs
           test -f .github/actions/download-skillstore-cli/action.yml
 
@@ -310,21 +334,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.15.1
+      - name: Download exact fresh-governance CLI 2.15.2
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.1'
-          minimum-version: '2.15.1'
+          version: '2.15.2'
+          minimum-version: '2.15.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
-          audited='0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5'
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.15.1 digest TODO before any run'; exit 1; }
-          test "$actual" = "$audited" || { echo '::error::CLI 2.15.1 digest mismatch'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.2 digest'; exit 1; }
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.2 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -373,6 +396,28 @@ jobs:
             --root "$RUNNER_TEMP/materialized" --dry-run \
             --result-file "$RUNNER_TEMP/fresh-boundary.json"
 
+      - name: Prove Report-Origin raw32 audits are replacement pointers only
+        if: inputs.cohort_path == 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
+        run: |
+          set -euo pipefail
+          jq -e --slurpfile selected "$RUNNER_TEMP/selected-cohort.json" '
+            .status == "fresh_canonical_audit_frozen"
+            and (.candidates | length) == $selected[0].count
+            and (([.candidates[].row] | sort_by(.slug)) == ($selected[0].rows | sort_by(.slug)))
+            and all(.candidates[];
+              ((.expectedLatestAudit | keys | sort) == ["content_hash", "id", "skill_id", "version"])
+              and (.expectedLatestAudit.content_hash | test("^[0-9a-f]{32}$"))
+              and .expectedSkill.artifact_revision == 0
+              and .expectedSkill.current_artifact_version_id == null
+              and .expectedSkill.public_eligibility_audit_id == .expectedLatestAudit.id
+              and .rpcPayload.p_expected_latest_audit_id == .expectedLatestAudit.id
+              and .rpcPayload.p_expected_latest_audit_version == .expectedLatestAudit.version
+              and .rpcPayload.p_expected_latest_audit_content_hash == .expectedLatestAudit.content_hash
+              and (.rpcPayload.p_audit_payload.content_hash | test("^[0-9a-f]{64}$"))
+              and .rpcPayload.p_audit_payload.content_hash != .expectedLatestAudit.content_hash
+              and .auditRunEvidence.previousReportSha256 != .auditRunEvidence.reportSha256)
+          ' "$RUNNER_TEMP/fresh-boundary.json" >/dev/null
+
       - name: Freeze exact audited reports and execution boundary
         env:
           COHORT_PATH: ${{ inputs.cohort_path }}
@@ -399,7 +444,7 @@ jobs:
           done < <(jq -r '.rows[] | [.marketplaceCommit,.path] | @tsv' "$boundary/selected-cohort.json")
           jq -n \
             --arg runId "$GITHUB_RUN_ID" --arg repository "$GITHUB_REPOSITORY" \
-            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion '2.15.1' \
+            --arg workflowCommit "$GITHUB_SHA" --arg cliVersion "$FRESH_GOVERNANCE_CLI_VERSION" \
             --arg cliSha256 "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" \
             --arg cohortPath "$COHORT_PATH" --arg startAfter '${{ inputs.start_after }}' \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/selected-cohort.json")" \
@@ -407,7 +452,8 @@ jobs:
             --arg previousExecuteRunId '${{ inputs.previous_execute_run_id }}' \
             --arg cohortSha256 "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" \
             --arg preInventorySha256 "$(sha256sum "$RUNNER_TEMP/pre-inventory.json" | awk '{print $1}')" \
-            '{schemaVersion:1,status:"fresh_canonical_audit_frozen",runId:$runId,repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,cliSha256:$cliSha256,cohortPath:$cohortPath,cohortSha256:$cohortSha256,startAfter:$startAfter,lastSelected:$lastSelected,previousBoundaryRunId:$previousBoundaryRunId,previousExecuteRunId:$previousExecuteRunId,preInventorySha256:$preInventorySha256}' \
+            --arg auditReplacementMode "$(test "$COHORT_PATH" = "$REPORT_ORIGIN_FRESH_COHORT" && echo expected_replaced_pointer_only || echo standard)" \
+            '{schemaVersion:1,status:"fresh_canonical_audit_frozen",runId:$runId,repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,cliSha256:$cliSha256,cohortPath:$cohortPath,cohortSha256:$cohortSha256,auditReplacementMode:$auditReplacementMode,startAfter:$startAfter,lastSelected:$lastSelected,previousBoundaryRunId:$previousBoundaryRunId,previousExecuteRunId:$previousExecuteRunId,preInventorySha256:$preInventorySha256}' \
             > "$boundary/metadata.json"
           (cd "$boundary" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
 
@@ -469,7 +515,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
-          test "$CLI_VERSION" = '2.15.1' || { echo '::error::workflow is pinned to CLI 2.15.1'; exit 1; }
+          test "$CLI_VERSION" = "$FRESH_GOVERNANCE_CLI_VERSION" || { echo '::error::workflow CLI pin changed'; exit 1; }
           [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
           test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
@@ -526,12 +572,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.15.1
+      - name: Download exact audited CLI 2.15.2
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.1'
-          minimum-version: '2.15.1'
+          version: '2.15.2'
+          minimum-version: '2.15.2'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -539,16 +585,15 @@ jobs:
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
         run: |
           set -euo pipefail
-          audited='0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5'
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$audited" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::replace CLI 2.15.1 digest TODO'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.2 digest'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else
-            test "$expected" = "$audited"
+            test "$expected" = "$FRESH_GOVERNANCE_CLI_SHA256"
           fi
-          test "$actual" = "$audited"
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256"
 
       - name: Rematerialize exact source and overlay only frozen fresh reports
         run: |

--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/runner-disk-guard.sh"
       - "scripts/tests/**"
+      - "governance/fresh-canonical-audit/**"
       - "ops/systemd/**"
       - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
@@ -29,6 +30,7 @@ on:
       - ".github/workflows/recover-score-cache-closure.yml"
       - ".github/workflows/cleanup-runners.yml"
       - ".github/workflows/generate-packs.yml"
+      - ".github/workflows/govern-fresh-canonical-audits.yml"
       - ".github/workflows/pack-review.yml"
       - ".github/workflows/publish-pack-production-v4.yml"
       - ".github/actions/invalidate-cache/action.yml"
@@ -49,6 +51,7 @@ on:
       - "scripts/refresh-security-research-stats.sh"
       - "scripts/runner-disk-guard.sh"
       - "scripts/tests/**"
+      - "governance/fresh-canonical-audit/**"
       - "ops/systemd/**"
       - "schemas/skill-report.schema.json"
       - ".github/workflows/refresh-security-research-stats.yml"
@@ -61,6 +64,7 @@ on:
       - ".github/workflows/recover-score-cache-closure.yml"
       - ".github/workflows/cleanup-runners.yml"
       - ".github/workflows/generate-packs.yml"
+      - ".github/workflows/govern-fresh-canonical-audits.yml"
       - ".github/workflows/pack-review.yml"
       - ".github/workflows/publish-pack-production-v4.yml"
       - ".github/actions/invalidate-cache/action.yml"
@@ -82,6 +86,7 @@ jobs:
           # Tests read workflow fixtures as well as the complete scripts tree.
           sparse-checkout: |
             .github
+            governance/fresh-canonical-audit
             ops/systemd
             scripts
             schemas

--- a/governance/fresh-canonical-audit/report-origin-raw32-v1.json
+++ b/governance/fresh-canonical-audit/report-origin-raw32-v1.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "status": "lineage_unproven",
+  "count": 11,
+  "rows": [
+    {
+      "slug": "270aldo-ngx-hybrid-sales",
+      "skillId": "807d2bdd-31e9-41f7-9852-b9837ab60574",
+      "path": "skills/270aldo/ngx-hybrid-sales",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "b6f585b206582d8f333565fef98b0ef066a9be5772c56aecd8869067dec4a3f9",
+      "reportTreeHash": "a5228f3422bf41bde97427eab7230a77ae50481c0f46fc67a1e45d34a841c3ed",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "2e574ed96b5cd9bd14fe65094affd59189525478d84988efd20f3edf617540f6",
+        "treeHash": "e56a828f2e49d676683fac52bb77f17fb8c89cc1cfbadfa568e6384a705b3bff"
+      }
+    },
+    {
+      "slug": "5minfutures-architecture-reference",
+      "skillId": "f3651605-d74c-4aa0-8183-61352eb6bc73",
+      "path": "skills/5minfutures/architecture-reference",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "bebe5beedd202b15f3dd67892a693a0c229ced313b3f43c6eff00e7eff764d70",
+      "reportTreeHash": "aa7d9fa5dbf7ca85655f46b21a6565a6aaf5846f5d912fe6bfc6ce7684747208",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "bebe5beedd202b15f3dd67892a693a0c229ced313b3f43c6eff00e7eff764d70",
+        "treeHash": "560e4031af0fbbfdfef3fd7f3f59ddb50b35c1e4d0c4d162abd200c86f26bd0d"
+      }
+    },
+    {
+      "slug": "5minfutures-coding-standards",
+      "skillId": "4899a218-b0b1-45a6-bea9-6e311303791b",
+      "path": "skills/5minfutures/coding-standards",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "e6ab6d602909e58eac56cd3a718e2b7b8e2241ee77b07bf79505cc184f9cde91",
+      "reportTreeHash": "5802253ef42ed73528a20551d6dfd5f172c04dc40fc9aab9be0e954a30f7be45",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "e6ab6d602909e58eac56cd3a718e2b7b8e2241ee77b07bf79505cc184f9cde91",
+        "treeHash": "ba683c7824a9f60cb878baadd09e55258247fcbe4979599e3c7d0c27fcbfa3e5"
+      }
+    },
+    {
+      "slug": "5minfutures-migration-tracker",
+      "skillId": "10a8ee7b-8a2d-48fb-8e28-fc1b023750c9",
+      "path": "skills/5minfutures/migration-tracker",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "0d8fc2c7248bb4f0afc90c927108b112ba3c8ad3f9c36e00fa5b533c23f99444",
+      "reportTreeHash": "2504bfaf4087aaffe22fc7173767ac4bbbd2f9d07f74f8df96b4b728d3e0174c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "0d8fc2c7248bb4f0afc90c927108b112ba3c8ad3f9c36e00fa5b533c23f99444",
+        "treeHash": "1aa6ee0d453d4fe2e3db3fb642a4ebf9865b345e5613c28d9a3a336b446f27c1"
+      }
+    },
+    {
+      "slug": "5minfutures-portfolio-context",
+      "skillId": "ee1f9cbd-408d-463f-842f-54749b5283ad",
+      "path": "skills/5minfutures/portfolio-context",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "0febc3c521414925c1a81e12bcebd34650f1e664e49aa20b619add2db974b622",
+      "reportTreeHash": "637165bb5bba17f709f7251b37ab7e542ddb404b56fbffff377d4f5c5bed880a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "0febc3c521414925c1a81e12bcebd34650f1e664e49aa20b619add2db974b622",
+        "treeHash": "032bea686d81653ff87eddc77107af84d71430f81e2339dfce513ae94e60f3a5"
+      }
+    },
+    {
+      "slug": "92bilal26-assessment-builder",
+      "skillId": "ec79fd63-6934-4b7a-a872-50b3d1fcf794",
+      "path": "skills/92bilal26/assessment-builder",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "c749dc7b5b64a28cf61557c00f3bb38541ab0ce8ba8c7e0dc8a9e1d957353f86",
+      "reportTreeHash": "8f2e70adb230fb6310028a61ef54f882df816037e97dc1905a845f4f1b1c18f7",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "5b63ceaca5f0f578bc7155563a3cdb4d74b0161da8dc4944cde865deb3fcbabb",
+        "treeHash": "350a72f9a75e387ca1b37ceefa3242226dc38925bae3051ff13060a1265a39c5"
+      }
+    },
+    {
+      "slug": "92bilal26-code-example-generator",
+      "skillId": "8b07a00b-d160-4314-80cb-d596478dff12",
+      "path": "skills/92bilal26/code-example-generator",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "96341a365d42833efcdff39da44925db8018ed4b223b0120a271d2bbdb68ee36",
+      "reportTreeHash": "e6f802cf6b7ab3fd863583f195a5edcd8c4c9c7bd4935d791db5ed14cc91330a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "706fb3154106f15f15fe8667bcfdd86a2ee2daf490bb11209f50da5f16380f7b",
+        "treeHash": "524f6953b19618767413a3e0b8fb258cf2a31769dba169655d48e44b3d7c1cce"
+      }
+    },
+    {
+      "slug": "92bilal26-concept-scaffolding",
+      "skillId": "66d91baf-f4cd-44e8-a54d-416a6ed19d78",
+      "path": "skills/92bilal26/concept-scaffolding",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "cdf9af59bcd79c71f486eed81bb17b521d52259d952023716fc243270fe5fcef",
+      "reportTreeHash": "ff68c82d83e5ce9ca736568be72545adf352ac355f8d7b35d5cb353e0a40fdac",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "754468bff3882f185130fa027d5c9c7edb07ae21a54a7c0c8f4549106811dbc8",
+        "treeHash": "08d5acc024203a05c1db2cf1e1798808a143da6263ebd57a480a49e86092524e"
+      }
+    },
+    {
+      "slug": "92bilal26-exercise-designer",
+      "skillId": "bcbead38-b80e-41db-9a84-c0751a55b980",
+      "path": "skills/92bilal26/exercise-designer",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "8f87bda84a1dece58be8ab696e13640148c8ffa9cf632866dbf4eff81fa0a103",
+      "reportTreeHash": "749e30f7ee9780a343a13a3d39ce5b80caa78ccef90429de37d54e1335386656",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "ccc6da23b61b91ebd5caab1f7c21d5a05baa0ee08a84648a98d245648f28d341",
+        "treeHash": "41151dd5c2441c15fc1193be6a49739cae481f2b8e7e7911e5d2da0f054514a5"
+      }
+    },
+    {
+      "slug": "92bilal26-technical-clarity",
+      "skillId": "f38f488d-2506-4e14-96a3-b55e2581c478",
+      "path": "skills/92bilal26/technical-clarity",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "02bc151b21ae8c51f754fb180aa9008abe13c03a220703672b5d14f1b1debfaa",
+      "reportTreeHash": "66fc6e5cf61f6162c3a91d17dd7fe675e7dd5d22ae3bff0802d0c27b5f0763aa",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "290969bcfd85dbfeb93a990d63b1a9842400f6445cbea5ad75c8ce7b99246eaf",
+        "treeHash": "17551c050ba2970f2b4fbba2b5a8ed82a3a264e5b596de447bd17564a4d26cb5"
+      }
+    },
+    {
+      "slug": "92bilal26-visual-asset-workflow",
+      "skillId": "97728fbf-07a1-4be4-bf7d-9cedced1e2af",
+      "path": "skills/92bilal26/visual-asset-workflow",
+      "marketplaceCommit": "820ccb93d2e2fe828678ed05433bafd1054e5000",
+      "reportContentHash": "82023a4e77aae736a42dec07ad5c26e81b85de1265e18afe4b29c98708425aee",
+      "reportTreeHash": "0422d97320d8238f49b623d2f0d4c50c383ac9106c253737bc72d7240e59330e",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "contentHash": "afedc22d58a01b6755b776ed785cabef5eee1bcf4b9a93c7e496c58f3ca74f5c",
+        "treeHash": "2ca89bb30c40dd19c81f173c7666d3e3cbe7eabc9d091b2b779c2daad05731fb"
+      }
+    }
+  ]
+}

--- a/scripts/tests/cleanup-runners.test.mjs
+++ b/scripts/tests/cleanup-runners.test.mjs
@@ -42,5 +42,5 @@ test('host guard can reclaim shared Docker build cache before Actions setup', ()
   assert.match(timer, /Persistent=true/);
   assert.match(testWorkflow, /- "scripts\/runner-disk-guard\.sh"/);
   assert.match(testWorkflow, /- "ops\/systemd\/\*\*"/);
-  assert.match(testWorkflow, /sparse-checkout: \|\n\s+\.github\n\s+ops\/systemd\n\s+scripts/);
+  assert.match(testWorkflow, /sparse-checkout: \|\n\s+\.github\n\s+governance\/fresh-canonical-audit\n\s+ops\/systemd\n\s+scripts/);
 });

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -276,17 +277,22 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.15\.1'/);
+  assert.match(workflow, /default: '2\.15\.2'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
   assert.ok((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length >= 4);
-  assert.equal((workflow.match(/0d9b845310aed9f7213c6e384e86aa1a3eb8676894f3bfdec1309a840b413ad5/g) || []).length, 2);
+  assert.equal((workflow.match(/fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4/g) || []).length, 1);
   assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
-  assert.match(workflow, /\[\[ "\$audited" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
+  assert.match(workflow, /\[\[ "\$FRESH_GOVERNANCE_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/report-origin-raw32-v1\.json'/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de'/);
+  assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
+  assert.match(workflow, /expected_replaced_pointer_only/);
+  assert.match(workflow, /p_expected_latest_audit_content_hash/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
   assert.match(workflow, /skill audit skills --slugs "\$slugs"/);
@@ -343,4 +349,42 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /elif type=="array" and all\(\.\[\]; type=="object" and \(\.jobs\|type\)=="array"\)/);
   const recovery = workflow.slice(workflow.indexOf('  recover-boundary:'));
   assert.doesNotMatch(recovery, /skill govern-fresh-canonical-audit|recalculate-scores|record_fresh_canonical_audit/);
+});
+
+test('Report-Origin Fresh-11 cohort is exact, immutable, and source-addressed', () => {
+  const bytes = readFileSync(new URL(
+    '../../governance/fresh-canonical-audit/report-origin-raw32-v1.json', import.meta.url
+  ));
+  const cohort = JSON.parse(bytes.toString('utf8'));
+  const expectedSlugs = [
+    '270aldo-ngx-hybrid-sales',
+    '5minfutures-architecture-reference',
+    '5minfutures-coding-standards',
+    '5minfutures-migration-tracker',
+    '5minfutures-portfolio-context',
+    '92bilal26-assessment-builder',
+    '92bilal26-code-example-generator',
+    '92bilal26-concept-scaffolding',
+    '92bilal26-exercise-designer',
+    '92bilal26-technical-clarity',
+    '92bilal26-visual-asset-workflow',
+  ];
+  assert.equal(createHash('sha256').update(bytes).digest('hex'),
+    'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de');
+  assert.equal(cohort.schemaVersion, 1);
+  assert.equal(cohort.status, 'lineage_unproven');
+  assert.equal(cohort.count, 11);
+  assert.deepEqual(cohort.rows.map((row) => row.slug), expectedSlugs);
+  assert.equal(new Set(cohort.rows.map((row) => row.skillId)).size, 11);
+  assert.equal(new Set(cohort.rows.map((row) => row.path)).size, 11);
+  for (const row of cohort.rows) {
+    assert.equal(row.marketplaceCommit, '820ccb93d2e2fe828678ed05433bafd1054e5000');
+    assert.equal(row.remainingReason, 'same_source_tree_unproven');
+    assert.equal(row.governanceEligibleByLineage, false);
+    assert.match(row.reportContentHash, /^[0-9a-f]{64}$/);
+    assert.match(row.reportTreeHash, /^[0-9a-f]{64}$/);
+    assert.match(row.canonicalArtifact.contentHash, /^[0-9a-f]{64}$/);
+    assert.match(row.canonicalArtifact.treeHash, /^[0-9a-f]{64}$/);
+    assert.notEqual(row.reportTreeHash, row.canonicalArtifact.treeHash);
+  }
 });


### PR DESCRIPTION
## What changed

- add an immutable exact 11-row Report-Origin raw32 Fresh cohort
- pin the Fresh governance workflow to released CLI 2.15.2 and its audited Linux SHA-256
- prove legacy raw32 audits are used only as expected replacement pointers; every new audit payload comes from the genuinely fresh run
- keep the existing no-write dry-run, immutable boundary, unique execute, score/cache closure, and production smoke chain

## Why

The legacy binding path cannot independently prove these 11 audit payloads. Re-auditing the exact commit-addressed source trees is the safe path that avoids deriving production evidence from unverified raw32 hashes.

## Validation

- `CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/legacy-report-origin-workflow.test.mjs` (17/17)
- exact 11 live production revision0/CAS/raw32 identities matched
- canonical content/tree hashes recomputed with the CLI 2.15.2 source algorithm
- workflow YAML parse and `git diff --check` passed