### PR TITLE
[codex] Pin Fresh-11 legacy reference boundary

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.15.2'
+        default: '2.15.3'
 
 permissions:
   actions: read
@@ -64,11 +64,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FRESH_GOVERNANCE_CLI_VERSION: '2.15.2'
-  FRESH_GOVERNANCE_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
+  FRESH_GOVERNANCE_CLI_VERSION: '2.15.3'
+  FRESH_GOVERNANCE_CLI_SHA256: '416229f67f2d0d97037ca2255795d65fe5943b7101b52783bc6929b01072be50'
   ORIGINAL_FRESH_COHORT: 'governance/fresh-canonical-audit/remaining-lineage.json'
   REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
-  REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de'
+  REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'
 
 jobs:
   freeze-boundary:
@@ -131,7 +131,11 @@ jobs:
                 and all(.rows[];
                   .marketplaceCommit == "820ccb93d2e2fe828678ed05433bafd1054e5000"
                   and .remainingReason == "same_source_tree_unproven"
-                  and .governanceEligibleByLineage == false)
+                  and .governanceEligibleByLineage == false
+                  and .legacyReference.kind == "frozen_mutable_main"
+                  and .legacyReference.sourceRef == "main"
+                  and .legacyReference.skillReportUrl ==
+                    ("https://github.com/aiskillstore/marketplace/blob/main/" + .path + "/skill-report.json"))
               ' "$COHORT_PATH" >/dev/null
               ;;
             *) echo '::error::cohort_path is not an authenticated Fresh campaign'; exit 1 ;;
@@ -334,20 +338,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.15.2
+      - name: Download exact fresh-governance CLI 2.15.3
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.2'
-          minimum-version: '2.15.2'
+          version: '2.15.3'
+          minimum-version: '2.15.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.2 digest'; exit 1; }
-          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.2 digest mismatch'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.3 digest'; exit 1; }
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.3 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -410,9 +414,13 @@ jobs:
               and .expectedSkill.artifact_revision == 0
               and .expectedSkill.current_artifact_version_id == null
               and .expectedSkill.public_eligibility_audit_id == .expectedLatestAudit.id
+              and .expectedSkill.source_ref == .row.legacyReference.sourceRef
+              and .expectedSkill.skill_report_url == .row.legacyReference.skillReportUrl
               and .rpcPayload.p_expected_latest_audit_id == .expectedLatestAudit.id
               and .rpcPayload.p_expected_latest_audit_version == .expectedLatestAudit.version
               and .rpcPayload.p_expected_latest_audit_content_hash == .expectedLatestAudit.content_hash
+              and .rpcPayload.p_expected_source_ref == .row.legacyReference.sourceRef
+              and .rpcPayload.p_expected_skill_report_url == .row.legacyReference.skillReportUrl
               and (.rpcPayload.p_audit_payload.content_hash | test("^[0-9a-f]{64}$"))
               and .rpcPayload.p_audit_payload.content_hash != .expectedLatestAudit.content_hash
               and .auditRunEvidence.previousReportSha256 != .auditRunEvidence.reportSha256)
@@ -572,12 +580,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.15.2
+      - name: Download exact audited CLI 2.15.3
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.2'
-          minimum-version: '2.15.2'
+          version: '2.15.3'
+          minimum-version: '2.15.3'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -587,7 +595,7 @@ jobs:
           set -euo pipefail
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.2 digest'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.3 digest'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else

--- a/governance/fresh-canonical-audit/report-origin-raw32-v1.json
+++ b/governance/fresh-canonical-audit/report-origin-raw32-v1.json
@@ -15,6 +15,11 @@
       "canonicalArtifact": {
         "contentHash": "2e574ed96b5cd9bd14fe65094affd59189525478d84988efd20f3edf617540f6",
         "treeHash": "e56a828f2e49d676683fac52bb77f17fb8c89cc1cfbadfa568e6384a705b3bff"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/270aldo/ngx-hybrid-sales/skill-report.json"
       }
     },
     {
@@ -29,6 +34,11 @@
       "canonicalArtifact": {
         "contentHash": "bebe5beedd202b15f3dd67892a693a0c229ced313b3f43c6eff00e7eff764d70",
         "treeHash": "560e4031af0fbbfdfef3fd7f3f59ddb50b35c1e4d0c4d162abd200c86f26bd0d"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/5minfutures/architecture-reference/skill-report.json"
       }
     },
     {
@@ -43,6 +53,11 @@
       "canonicalArtifact": {
         "contentHash": "e6ab6d602909e58eac56cd3a718e2b7b8e2241ee77b07bf79505cc184f9cde91",
         "treeHash": "ba683c7824a9f60cb878baadd09e55258247fcbe4979599e3c7d0c27fcbfa3e5"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/5minfutures/coding-standards/skill-report.json"
       }
     },
     {
@@ -57,6 +72,11 @@
       "canonicalArtifact": {
         "contentHash": "0d8fc2c7248bb4f0afc90c927108b112ba3c8ad3f9c36e00fa5b533c23f99444",
         "treeHash": "1aa6ee0d453d4fe2e3db3fb642a4ebf9865b345e5613c28d9a3a336b446f27c1"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/5minfutures/migration-tracker/skill-report.json"
       }
     },
     {
@@ -71,6 +91,11 @@
       "canonicalArtifact": {
         "contentHash": "0febc3c521414925c1a81e12bcebd34650f1e664e49aa20b619add2db974b622",
         "treeHash": "032bea686d81653ff87eddc77107af84d71430f81e2339dfce513ae94e60f3a5"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/5minfutures/portfolio-context/skill-report.json"
       }
     },
     {
@@ -85,6 +110,11 @@
       "canonicalArtifact": {
         "contentHash": "5b63ceaca5f0f578bc7155563a3cdb4d74b0161da8dc4944cde865deb3fcbabb",
         "treeHash": "350a72f9a75e387ca1b37ceefa3242226dc38925bae3051ff13060a1265a39c5"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/assessment-builder/skill-report.json"
       }
     },
     {
@@ -99,6 +129,11 @@
       "canonicalArtifact": {
         "contentHash": "706fb3154106f15f15fe8667bcfdd86a2ee2daf490bb11209f50da5f16380f7b",
         "treeHash": "524f6953b19618767413a3e0b8fb258cf2a31769dba169655d48e44b3d7c1cce"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/code-example-generator/skill-report.json"
       }
     },
     {
@@ -113,6 +148,11 @@
       "canonicalArtifact": {
         "contentHash": "754468bff3882f185130fa027d5c9c7edb07ae21a54a7c0c8f4549106811dbc8",
         "treeHash": "08d5acc024203a05c1db2cf1e1798808a143da6263ebd57a480a49e86092524e"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/concept-scaffolding/skill-report.json"
       }
     },
     {
@@ -127,6 +167,11 @@
       "canonicalArtifact": {
         "contentHash": "ccc6da23b61b91ebd5caab1f7c21d5a05baa0ee08a84648a98d245648f28d341",
         "treeHash": "41151dd5c2441c15fc1193be6a49739cae481f2b8e7e7911e5d2da0f054514a5"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/exercise-designer/skill-report.json"
       }
     },
     {
@@ -141,6 +186,11 @@
       "canonicalArtifact": {
         "contentHash": "290969bcfd85dbfeb93a990d63b1a9842400f6445cbea5ad75c8ce7b99246eaf",
         "treeHash": "17551c050ba2970f2b4fbba2b5a8ed82a3a264e5b596de447bd17564a4d26cb5"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/technical-clarity/skill-report.json"
       }
     },
     {
@@ -155,6 +205,11 @@
       "canonicalArtifact": {
         "contentHash": "afedc22d58a01b6755b776ed785cabef5eee1bcf4b9a93c7e496c58f3ca74f5c",
         "treeHash": "2ca89bb30c40dd19c81f173c7666d3e3cbe7eabc9d091b2b779c2daad05731fb"
+      },
+      "legacyReference": {
+        "kind": "frozen_mutable_main",
+        "sourceRef": "main",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/main/skills/92bilal26/visual-asset-workflow/skill-report.json"
       }
     }
   ]

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -277,22 +277,24 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.15\.2'/);
+  assert.match(workflow, /default: '2\.15\.3'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
   assert.ok((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length >= 4);
-  assert.equal((workflow.match(/fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4/g) || []).length, 1);
+  assert.equal((workflow.match(/416229f67f2d0d97037ca2255795d65fe5943b7101b52783bc6929b01072be50/g) || []).length, 1);
   assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$FRESH_GOVERNANCE_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/report-origin-raw32-v1\.json'/);
-  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de'/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'/);
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
   assert.match(workflow, /expected_replaced_pointer_only/);
   assert.match(workflow, /p_expected_latest_audit_content_hash/);
+  assert.match(workflow, /p_expected_source_ref == \.row\.legacyReference\.sourceRef/);
+  assert.match(workflow, /p_expected_skill_report_url == \.row\.legacyReference\.skillReportUrl/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
   assert.match(workflow, /skill audit skills --slugs "\$slugs"/);
@@ -370,7 +372,7 @@ test('Report-Origin Fresh-11 cohort is exact, immutable, and source-addressed', 
     '92bilal26-visual-asset-workflow',
   ];
   assert.equal(createHash('sha256').update(bytes).digest('hex'),
-    'ac43e014ee21aa3038c82b341586e3b9aeb3fd47d7080fc683c2b90671bb80de');
+    '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6');
   assert.equal(cohort.schemaVersion, 1);
   assert.equal(cohort.status, 'lineage_unproven');
   assert.equal(cohort.count, 11);
@@ -386,5 +388,10 @@ test('Report-Origin Fresh-11 cohort is exact, immutable, and source-addressed', 
     assert.match(row.canonicalArtifact.contentHash, /^[0-9a-f]{64}$/);
     assert.match(row.canonicalArtifact.treeHash, /^[0-9a-f]{64}$/);
     assert.notEqual(row.reportTreeHash, row.canonicalArtifact.treeHash);
+    assert.deepEqual(row.legacyReference, {
+      kind: 'frozen_mutable_main',
+      sourceRef: 'main',
+      skillReportUrl: `https://github.com/aiskillstore/marketplace/blob/main/${row.path}/skill-report.json`,
+    });
   }
 });


### PR DESCRIPTION
## What changed

- pin the Fresh governance workflow to released CLI 2.15.3 and Linux SHA-256 `416229f...`
- bind each exact Report-Origin raw32 row to its frozen `source_ref=main` and path-derived `blob/main` report URL
- verify the frozen Skill reference is carried only as expected CAS state while the new audit payload remains genuinely fresh
- update the immutable cohort checksum and focused workflow tests

## Why

No-write run 29724051790 completed all 10 genuine audits but failed before artifact creation because CLI 2.15.2 assumed those two historical reference fields were commit-addressed. Skillstore PR #311/CLI 2.15.3 adds a narrow opt-in contract without relaxing the default Fresh identity path.

The failed run remains sealed and will not be rerun. A new dry-run may start only after this PR merges and production CPU, pointer, and writer gates pass.

## Validation

- focused Fresh/Report-Origin tests: 17/17
- complete Marketplace script suite: 475 pass, 0 fail, 2 skip
- workflow YAML and cohort JSON parse
- CLI 2.15.3 release run 29726560146 succeeded