### PR TITLE
fix(governance): verify explicit Fresh audit replacement mode

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.15.3'
+        default: '2.15.4'
 
 permissions:
   actions: read
@@ -64,8 +64,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FRESH_GOVERNANCE_CLI_VERSION: '2.15.3'
-  FRESH_GOVERNANCE_CLI_SHA256: '416229f67f2d0d97037ca2255795d65fe5943b7101b52783bc6929b01072be50'
+  FRESH_GOVERNANCE_CLI_VERSION: '2.15.4'
+  FRESH_GOVERNANCE_CLI_SHA256: '3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5'
   ORIGINAL_FRESH_COHORT: 'governance/fresh-canonical-audit/remaining-lineage.json'
   REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
   REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'
@@ -338,20 +338,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.15.3
+      - name: Download exact fresh-governance CLI 2.15.4
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.3'
-          minimum-version: '2.15.3'
+          version: '2.15.4'
+          minimum-version: '2.15.4'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.3 digest'; exit 1; }
-          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.3 digest mismatch'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.4 digest'; exit 1; }
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.4 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -407,24 +407,28 @@ jobs:
           jq -e --slurpfile selected "$RUNNER_TEMP/selected-cohort.json" '
             .status == "fresh_canonical_audit_frozen"
             and (.candidates | length) == $selected[0].count
-            and (([.candidates[].row] | sort_by(.slug)) == ($selected[0].rows | sort_by(.slug)))
-            and all(.candidates[];
-              ((.expectedLatestAudit | keys | sort) == ["content_hash", "id", "skill_id", "version"])
-              and (.expectedLatestAudit.content_hash | test("^[0-9a-f]{32}$"))
-              and .expectedSkill.artifact_revision == 0
-              and .expectedSkill.current_artifact_version_id == null
-              and .expectedSkill.public_eligibility_audit_id == .expectedLatestAudit.id
-              and .expectedSkill.source_ref == .row.legacyReference.sourceRef
-              and .expectedSkill.skill_report_url == .row.legacyReference.skillReportUrl
-              and .rpcPayload.p_expected_latest_audit_id == .expectedLatestAudit.id
-              and .rpcPayload.p_expected_latest_audit_version == .expectedLatestAudit.version
-              and .rpcPayload.p_expected_latest_audit_content_hash == .expectedLatestAudit.content_hash
-              and .rpcPayload.p_expected_source_ref == .row.legacyReference.sourceRef
-              and .rpcPayload.p_expected_skill_report_url == .row.legacyReference.skillReportUrl
-              and (.rpcPayload.p_audit_payload.content_hash | test("^[0-9a-f]{64}$"))
-              and .rpcPayload.p_audit_payload.content_hash != .expectedLatestAudit.content_hash
-              and .auditRunEvidence.previousReportSha256 != .auditRunEvidence.reportSha256)
+            and (([.candidates[].row.slug] | sort) == ([$selected[0].rows[].slug] | sort))
           ' "$RUNNER_TEMP/fresh-boundary.json" >/dev/null
+          failures=$(jq -r '
+            .candidates[] as $candidate
+            | [
+                { name: "replacement_mode", ok: ($candidate.auditReplacementMode == "expected_replaced_pointer_only") },
+                { name: "legacy_audit_shape", ok: (($candidate.expectedLatestAudit | keys | sort) == ["content_hash", "id", "skill_id", "version"]) },
+                { name: "legacy_audit_raw32", ok: ($candidate.expectedLatestAudit.content_hash | test("^[0-9a-f]{32}$")) },
+                { name: "r0_skill", ok: ($candidate.expectedSkill.artifact_revision == 0 and $candidate.expectedSkill.current_artifact_version_id == null) },
+                { name: "legacy_pointer", ok: ($candidate.expectedSkill.public_eligibility_audit_id == $candidate.expectedLatestAudit.id) },
+                { name: "legacy_source_ref", ok: ($candidate.expectedSkill.source_ref == $candidate.row.legacyReference.sourceRef and $candidate.expectedSkill.skill_report_url == $candidate.row.legacyReference.skillReportUrl) },
+                { name: "rpc_expected_audit", ok: ($candidate.rpcPayload.p_expected_latest_audit_id == $candidate.expectedLatestAudit.id and $candidate.rpcPayload.p_expected_latest_audit_version == $candidate.expectedLatestAudit.version and $candidate.rpcPayload.p_expected_latest_audit_content_hash == $candidate.expectedLatestAudit.content_hash) },
+                { name: "rpc_expected_reference", ok: ($candidate.rpcPayload.p_expected_source_ref == $candidate.row.legacyReference.sourceRef and $candidate.rpcPayload.p_expected_skill_report_url == $candidate.row.legacyReference.skillReportUrl) },
+                { name: "fresh_audit_identity", ok: ($candidate.rpcPayload.p_audit_id == $candidate.auditId and $candidate.auditId != $candidate.expectedLatestAudit.id) },
+                { name: "fresh_audit_hash", ok: (($candidate.rpcPayload.p_audit_payload.content_hash | test("^[0-9a-f]{64}$")) and $candidate.rpcPayload.p_audit_payload.content_hash != $candidate.expectedLatestAudit.content_hash) },
+                { name: "fresh_report", ok: ($candidate.auditRunEvidence.previousReportSha256 != $candidate.auditRunEvidence.reportSha256) }
+              ]
+            | map(select(.ok | not) | .name) as $failed
+            | select($failed | length > 0)
+            | "\($candidate.row.slug):\($failed | join(","))"
+          ' "$RUNNER_TEMP/fresh-boundary.json")
+          test -z "$failures" || { echo "::error::invalid Report-Origin replacement proof: $failures"; exit 1; }
 
       - name: Freeze exact audited reports and execution boundary
         env:
@@ -580,12 +584,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.15.3
+      - name: Download exact audited CLI 2.15.4
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.3'
-          minimum-version: '2.15.3'
+          version: '2.15.4'
+          minimum-version: '2.15.4'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -595,7 +599,7 @@ jobs:
           set -euo pipefail
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.3 digest'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.4 digest'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -277,13 +277,13 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.15\.3'/);
+  assert.match(workflow, /default: '2\.15\.4'/);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
   assert.ok((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length >= 4);
-  assert.equal((workflow.match(/416229f67f2d0d97037ca2255795d65fe5943b7101b52783bc6929b01072be50/g) || []).length, 1);
+  assert.equal((workflow.match(/3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5/g) || []).length, 1);
   assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
@@ -291,10 +291,12 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/report-origin-raw32-v1\.json'/);
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'/);
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
+  assert.match(workflow, /auditReplacementMode == "expected_replaced_pointer_only"/);
+  assert.match(workflow, /invalid Report-Origin replacement proof/);
   assert.match(workflow, /expected_replaced_pointer_only/);
   assert.match(workflow, /p_expected_latest_audit_content_hash/);
-  assert.match(workflow, /p_expected_source_ref == \.row\.legacyReference\.sourceRef/);
-  assert.match(workflow, /p_expected_skill_report_url == \.row\.legacyReference\.skillReportUrl/);
+  assert.match(workflow, /p_expected_source_ref == \$candidate\.row\.legacyReference\.sourceRef/);
+  assert.match(workflow, /p_expected_skill_report_url == \$candidate\.row\.legacyReference\.skillReportUrl/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
   assert.match(workflow, /skill audit skills --slugs "\$slugs"/);


### PR DESCRIPTION
## Summary
- pin Fresh governance to released CLI 2.15.4 and Linux SHA256 3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5
- require each Report-Origin candidate to authenticate auditReplacementMode=expected_replaced_pointer_only
- compare selected/candidate slug sets while the CLI owns exact row parsing
- report per-slug failed replacement predicates instead of an opaque aggregate jq exit

## Incident boundary
Replacement dry-run 29727073906 completed 10/10 fresh audits and froze a no-write boundary, then failed the old aggregate jq proof. It has zero artifacts and zero production artifact/audit/score/binding writes and must not be rerun.

## Validation
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (5/5)
- CI=true node --test scripts/tests/*.test.mjs (475 pass, 0 fail, 2 skip)
- git diff --check
