### PR TITLE
fix(governance): verify Fresh v3 audit binding

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -421,7 +421,15 @@ jobs:
                 { name: "rpc_expected_audit", ok: ($candidate.rpcPayload.p_expected_latest_audit_id == $candidate.expectedLatestAudit.id and $candidate.rpcPayload.p_expected_latest_audit_version == $candidate.expectedLatestAudit.version and $candidate.rpcPayload.p_expected_latest_audit_content_hash == $candidate.expectedLatestAudit.content_hash) },
                 { name: "rpc_expected_reference", ok: ($candidate.rpcPayload.p_expected_source_ref == $candidate.row.legacyReference.sourceRef and $candidate.rpcPayload.p_expected_skill_report_url == $candidate.row.legacyReference.skillReportUrl) },
                 { name: "fresh_audit_identity", ok: ($candidate.rpcPayload.p_audit_id == $candidate.auditId and $candidate.auditId != $candidate.expectedLatestAudit.id) },
-                { name: "fresh_audit_hash", ok: (($candidate.rpcPayload.p_audit_payload.content_hash | test("^[0-9a-f]{64}$")) and $candidate.rpcPayload.p_audit_payload.content_hash != $candidate.expectedLatestAudit.content_hash) },
+                { name: "fresh_audit_binding_v3", ok: (
+                    ($candidate.rpcPayload.p_audit_payload.content_hash | test("^v3:[0-9a-f]{40}:[0-9a-f]{64}:[0-9a-f]{64}:[0-9a-f]+:[0-9a-f]{32}$"))
+                    and $candidate.rpcPayload.p_audit_payload.content_hash != $candidate.expectedLatestAudit.content_hash
+                    and $candidate.rpcPayload.p_audit_payload.subject_marketplace_commit_sha == $candidate.row.marketplaceCommit
+                    and $candidate.rpcPayload.p_audit_payload.subject_content_hash == $candidate.row.canonicalArtifact.contentHash
+                    and $candidate.rpcPayload.p_audit_payload.subject_tree_hash == $candidate.row.canonicalArtifact.treeHash
+                    and $candidate.rpcPayload.p_audit_payload.subject_plugin_path == $candidate.row.path
+                    and ($candidate.rpcPayload.p_audit_payload.audit_payload_hash | test("^[0-9a-f]{32}$"))
+                  ) },
                 { name: "fresh_report", ok: ($candidate.auditRunEvidence.previousReportSha256 != $candidate.auditRunEvidence.reportSha256) }
               ]
             | map(select(.ok | not) | .name) as $failed

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -293,6 +293,12 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
   assert.match(workflow, /auditReplacementMode == "expected_replaced_pointer_only"/);
   assert.match(workflow, /invalid Report-Origin replacement proof/);
+  assert.match(workflow, /fresh_audit_binding_v3/);
+  assert.match(workflow, /\^v3:\[0-9a-f\]\{40\}:\[0-9a-f\]\{64\}:\[0-9a-f\]\{64\}:\[0-9a-f\]\+:\[0-9a-f\]\{32\}\$/);
+  assert.match(workflow, /subject_marketplace_commit_sha == \$candidate\.row\.marketplaceCommit/);
+  assert.match(workflow, /subject_content_hash == \$candidate\.row\.canonicalArtifact\.contentHash/);
+  assert.match(workflow, /subject_tree_hash == \$candidate\.row\.canonicalArtifact\.treeHash/);
+  assert.match(workflow, /subject_plugin_path == \$candidate\.row\.path/);
   assert.match(workflow, /expected_replaced_pointer_only/);
   assert.match(workflow, /p_expected_latest_audit_content_hash/);
   assert.match(workflow, /p_expected_source_ref == \$candidate\.row\.legacyReference\.sourceRef/);


### PR DESCRIPTION
## Summary
- validate the actual v3 audit content_hash binding instead of treating it as a bare SHA-256
- require exact marketplace commit, content hash, tree hash, plugin path, and payload hash subject fields
- preserve the explicit expected_replaced_pointer_only candidate mode and all old-audit CAS checks

## Incident boundary
Dry-run 29729038334 completed 10/10 fresh audits and froze a no-write boundary, then identified fresh_audit_hash as the only failing proof for all ten candidates. The valid contract is v3:<commit40>:<content64>:<tree64>:<pathHex>:<payload32>. The run produced no artifact and no production artifact/audit/score/binding writes and is sealed.

## Validation
- focused Fresh governance tests: 5/5
- full Marketplace tests: 475 pass, 0 fail, 2 skip
- git diff --check
