### PR TITLE
fix(governance): serialize source monitor writers

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.15.4'
+        default: '2.15.5'
 
 permissions:
   actions: read
@@ -64,8 +64,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FRESH_GOVERNANCE_CLI_VERSION: '2.15.4'
-  FRESH_GOVERNANCE_CLI_SHA256: '3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5'
+  FRESH_GOVERNANCE_CLI_VERSION: '2.15.5'
+  FRESH_GOVERNANCE_CLI_SHA256: 'b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189'
   ORIGINAL_FRESH_COHORT: 'governance/fresh-canonical-audit/remaining-lineage.json'
   REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
   REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'
@@ -338,20 +338,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.15.4
+      - name: Download exact fresh-governance CLI 2.15.5
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.4'
-          minimum-version: '2.15.4'
+          version: '2.15.5'
+          minimum-version: '2.15.5'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.4 digest'; exit 1; }
-          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.4 digest mismatch'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.5 digest'; exit 1; }
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.5 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -592,12 +592,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.15.4
+      - name: Download exact audited CLI 2.15.5
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.4'
-          minimum-version: '2.15.4'
+          version: '2.15.5'
+          minimum-version: '2.15.5'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -607,7 +607,7 @@ jobs:
           set -euo pipefail
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.4 digest'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.5 digest'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else

--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -92,6 +92,12 @@ jobs:
     name: Source accuracy scan
     runs-on: self-hosted
     timeout-minutes: 1440
+    concurrency:
+      # Source monitoring writes Skill projections and can invalidate a frozen
+      # governance CAS even when it creates no artifact. Share the exact writer
+      # mutex used by governance and scoring instead of overlapping them.
+      group: production-skill-score-writes
+      cancel-in-progress: false
 
     steps:
       - name: Initialize source monitor diagnostics

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -277,13 +277,14 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
-  assert.match(workflow, /default: '2\.15\.4'/);
+  assert.match(workflow, /default: '2\.15\.5'/);
+  assert.equal((workflow.match(/b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189/g) || []).length, 1);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
   assert.match(workflow, /git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:\$path"/);
   assert.ok((workflow.match(/282cfb6103f580c1758674f6d407493b3039a2ca788c986297684180ae6f0dbb/g) || []).length >= 4);
-  assert.equal((workflow.match(/3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5/g) || []).length, 1);
+  assert.doesNotMatch(workflow, /3fe1650ff585db24a2708ea26819c22bc9f5fa0702fe703885c41537a08c8de5/);
   assert.equal((workflow.match(/296cab05576adec2c6613255b26663fab58e8f3fa585e2c085cd0367d8c7274f/g) || []).length, 2);
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -23,6 +23,11 @@ const runtimeFiles = [
   'scripts/verify-source-monitor-selection.mjs',
 ];
 
+test('source monitor shares the production governance writer mutex', () => {
+  assert.match(workflow, /scan:\n(?:.*\n){0,8}\s+concurrency:\n\s+# Source monitoring[\s\S]{0,260}group: production-skill-score-writes/);
+  assert.match(workflow, /group: production-skill-score-writes\n\s+cancel-in-progress: false/);
+});
+
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: 'utf8', ...options });
   if (result.status !== 0 && !options.allowFailure) {


### PR DESCRIPTION
## Summary
- make Source Monitor share the production governance/score writer mutex
- pin Fresh governance dry-run and execute to released CLI 2.15.5
- bind the pin to Linux SHA256 b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189

## Incident evidence
- execute 29732268977 failed with three 504 responses and zero durable writes
- source monitor 29732452564 overlapped the execute and later changed frozen updated_at state
- old boundary 29730008357 is now correctly rejected and remains sealed
- recovery will use a new dry-run only after all writers close

## Verification
- CI=true node --test scripts/tests/*.test.mjs (476 pass, 0 fail, 2 skip)
- focused workflow/runtime tests (12 pass)
- both YAML workflows parse successfully
- git diff --check