### PR TITLE
[codex] Keep submission audits advisory

### DIFF
--- a/scripts/aggregate-submission-shards.mjs
+++ b/scripts/aggregate-submission-shards.mjs
@@ -241,7 +241,6 @@ function aggregate(config) {
       const plan = resolveApprovedSubmission({
         repositoryRoot: root,
         changedFiles,
-        allowBlocked: true,
       });
       shardSkills = plan.skills;
       assertSameStringSet(

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -129,7 +129,7 @@ function rootFromSkillFile(path) {
   return segments.slice(0, -1).join('/');
 }
 
-export function resolveApprovedSubmission({ repositoryRoot, changedFiles, allowBlocked = false }) {
+export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
   const root = realpathSync(repositoryRoot);
   const normalizedFiles = [...new Set(changedFiles.map(normalizeFrozenPath).filter(Boolean))].sort();
   const pendingFiles = normalizedFiles.filter((path) => path === 'pending' || path.startsWith('pending/'));
@@ -188,10 +188,6 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles, allowB
     if (report.meta.slug !== expectedSlug) {
       fail(`${pendingDir} report slug does not match its publication path`);
     }
-    if (report?.security_audit?.is_blocked !== false && !allowBlocked) {
-      fail(`${pendingDir} is blocked or missing an explicit unblocked audit verdict`);
-    }
-
     const expectedContentHash = report?.meta?.content_hash;
     const actualContentHash = sha256(skillPath);
     if (!/^[0-9a-f]{64}$/.test(expectedContentHash ?? '') || expectedContentHash !== actualContentHash) {
@@ -231,9 +227,8 @@ function main() {
   const repositoryRoot = readOption(args, '--repo-root');
   const filesPath = readOption(args, '--files');
   const outputPath = readOption(args, '--output');
-  const allowBlocked = args.includes('--allow-blocked');
   const changedFiles = readFileSync(filesPath, 'utf8').split(/\r?\n/).filter(Boolean);
-  const plan = resolveApprovedSubmission({ repositoryRoot, changedFiles, allowBlocked });
+  const plan = resolveApprovedSubmission({ repositoryRoot, changedFiles });
   writeFileSync(outputPath, `${JSON.stringify(plan, null, 2)}\n`, { mode: 0o600 });
   process.stdout.write(`Resolved ${plan.skills.length} frozen pending skill(s)\n`);
 }

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -98,7 +98,7 @@ test('rejects absolute, traversal, and backslash frozen paths', () => withReposi
   }
 }));
 
-test('rejects stale report hashes and blocked reports', () => withRepository((root) => {
+test('rejects stale report hashes without using audit verdicts as a publication gate', () => withRepository((root) => {
   addSkill(root, 'pending/owner/stale', { hash: '0'.repeat(64), slug: 'owner-stale' });
   assert.throws(
     () => resolveApprovedSubmission({
@@ -109,17 +109,9 @@ test('rejects stale report hashes and blocked reports', () => withRepository((ro
   );
 
   addSkill(root, 'pending/owner/blocked', { blocked: true, slug: 'owner-blocked' });
-  assert.throws(
-    () => resolveApprovedSubmission({
-      repositoryRoot: root,
-      changedFiles: ['pending/owner/blocked/SKILL.md', 'pending/owner/blocked/skill-report.json'],
-    }),
-    /blocked or missing/,
-  );
   assert.equal(resolveApprovedSubmission({
     repositoryRoot: root,
     changedFiles: ['pending/owner/blocked/SKILL.md', 'pending/owner/blocked/skill-report.json'],
-    allowBlocked: true,
   }).skills.length, 1);
 }));
 


### PR DESCRIPTION
## What changed
- remove the audit-verdict publication gate from the shared approval resolver
- remove the obsolete `allowBlocked` escape hatch
- retain path, immutable PR scope, content/tree hash, and overwrite protections

## Root cause
`fix(submissions): isolate publication scope` coupled audit metadata to publication. A merged PR with `security_audit.is_blocked=true` therefore failed after merge even though audits are advisory.

## Impact
Merged Skill PRs publish regardless of audit risk verdict. Audit findings and warnings remain in `skill-report.json`.

## Validation
- `CI=true node --test scripts/tests/resolve-approved-submission.test.mjs scripts/tests/rebind-skill-report-hashes.test.mjs scripts/tests/submission-scope-workflows.test.mjs scripts/tests/submission-runtime-workflow.test.mjs` (55/55)
- `git diff --check`
- `pnpm check` is not defined in this repository