### PR TITLE
fix(submissions): pin CLI 2.15.7

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -25,10 +25,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Reserved compatibility input; this selection-plan rollout is pinned to CLI 2.15.0'
+        description: 'Reserved compatibility input; this selection-plan rollout is pinned to CLI 2.15.7'
         required: false
         type: string
-        default: '2.15.0'
+        default: '2.15.7'
       max_parallel:
         description: 'Maximum parallel shards'
         required: false
@@ -532,11 +532,11 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          # Rollout pin: selection-plan processing requires the exact 2.15.0 contract.
-          version: '2.15.0'
+          # Rollout pin: selection-plan processing requires the exact 2.15.7 contract.
+          version: '2.15.7'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.15.0
+          minimum-version: 2.15.7
           require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -10,7 +10,7 @@ import { pathToFileURL } from 'node:url';
 import { parseSelectionPlan, validateSelectionPlan } from './submission-selection-plan.mjs';
 
 const SOURCE_TYPES = new Set(['community', 'official']);
-// Must stay aligned with the exact CLI 2.15.0 trust allowlist pinned by the workflow.
+// Must stay aligned with the exact CLI 2.15.7 trust allowlist pinned by the workflow.
 const OFFICIAL_REPOSITORIES = new Set([
   'aiskillstore/marketplace',
   'anthropics/skills',

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -202,8 +202,8 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/classify-submission-targets\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
-  assert.match(reusable, /minimum-version: 2\.15\.0/);
-  assert.match(reusable, /Rollout pin: selection-plan processing requires the exact 2\.15\.0 contract/);
+  assert.match(reusable, /minimum-version: 2\.15\.7/);
+  assert.match(reusable, /Rollout pin: selection-plan processing requires the exact 2\.15\.7 contract/);
   assert.match(reusable, /trap cleanup_input_plan EXIT/);
   assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
   assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);


### PR DESCRIPTION
## What changed

- pin submission processing to Skillstore CLI 2.15.7
- raise the writer minimum to 2.15.7
- update the immutable-runtime contract test and trust-allowlist version marker

## Root cause

The source-ref fix was released in CLI 2.15.7, but the Marketplace processing workflow still executed exact CLI 2.15.0. A successful rerun could therefore avoid the race by timing without actually deploying the fix.

## Verification

- `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs` (6/6)
- `git diff --check`