### PR TITLE
fix(governance): authenticate zero-write RPC recovery

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute, recover, recover-cache, recover-smoke]
+        options: [dry-run, execute, recover-rpc-timeout, recover, recover-cache, recover-smoke]
       cohort_path:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
@@ -498,12 +498,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   execute-boundary:
-    if: inputs.mode == 'execute'
+    if: inputs.mode == 'execute' || inputs.mode == 'recover-rpc-timeout'
     concurrency:
       group: production-skill-score-writes
       cancel-in-progress: false
     runs-on: self-hosted
     timeout-minutes: 180
+    env:
+      ZERO_WRITE_DRY_RUN_ID: '29743150038'
+      ZERO_WRITE_DRY_RUN_SHA: 'd75b0863d962bc58cf69d554f8fa6ea67a5c040a'
+      ZERO_WRITE_DRY_ARTIFACT_ID: '8461534557'
+      ZERO_WRITE_DRY_ARTIFACT_DIGEST: 'sha256:627c18c8d1c127ed6fb4d5020043dae90f35643550b37e6b0150a76233dbfc4b'
+      ZERO_WRITE_FAILED_RUN_ID: '29744338076'
+      ZERO_WRITE_FAILED_RUN_SHA: 'd75b0863d962bc58cf69d554f8fa6ea67a5c040a'
+      ZERO_WRITE_FAILED_ARTIFACT_ID: '8461872394'
+      ZERO_WRITE_FAILED_ARTIFACT_DIGEST: 'sha256:e36360f2dd23fae710d9c6ea3a0f02e40b55b31fe18b57f354a62542b8560b50'
     steps:
       - name: Checkout complete Marketplace history
         uses: actions/checkout@v5
@@ -522,23 +531,34 @@ jobs:
           for path in \
             .github/actions/download-skillstore-cli/action.yml \
             scripts/prepare-fresh-canonical-audit-batch.mjs \
-            scripts/fetch-artifact-version-inventory.mjs; do
+            scripts/fetch-artifact-version-inventory.mjs \
+            scripts/verify-fresh-canonical-zero-write-recovery.mjs; do
             test -f "$path" || { echo "::error file=$path::Missing fresh governance runtime"; exit 1; }
           done
 
       - name: Validate execute inputs
         env:
           CLI_VERSION: ${{ inputs.cli_version }}
+          MODE: ${{ inputs.mode }}
           DRY_RUN_ID: ${{ inputs.dry_run_id }}
           START_AFTER: ${{ inputs.start_after }}
           FAILED_EXECUTE_RUN_ID: ${{ inputs.failed_execute_run_id }}
+          PREVIOUS_BOUNDARY_RUN_ID: ${{ inputs.previous_boundary_run_id }}
+          PREVIOUS_EXECUTE_RUN_ID: ${{ inputs.previous_execute_run_id }}
         run: |
           set -euo pipefail
           test "$GITHUB_REF_NAME" = main || { echo '::error::execute requires main'; exit 1; }
           test "$CLI_VERSION" = "$FRESH_GOVERNANCE_CLI_VERSION" || { echo '::error::workflow CLI pin changed'; exit 1; }
-          [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
           test -z "$START_AFTER" || { echo '::error::execute cannot accept a scan cursor'; exit 1; }
-          test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
+          test -z "$PREVIOUS_BOUNDARY_RUN_ID" && test -z "$PREVIOUS_EXECUTE_RUN_ID"
+          if test "$MODE" = 'recover-rpc-timeout'; then
+            test "$DRY_RUN_ID" = "$ZERO_WRITE_DRY_RUN_ID"
+            test "$FAILED_EXECUTE_RUN_ID" = "$ZERO_WRITE_FAILED_RUN_ID"
+          else
+            [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
+            test "$DRY_RUN_ID" != "$ZERO_WRITE_DRY_RUN_ID" || { echo '::error::sealed zero-write boundary requires recover-rpc-timeout'; exit 1; }
+            test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
+          fi
 
       - name: Download and authenticate the successful frozen boundary
         env:
@@ -558,6 +578,14 @@ jobs:
                 and .digest=="sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b"
               )] | length==1
             ' <<< "$artifacts" >/dev/null
+          elif test "$DRY_RUN_ID" = "$ZERO_WRITE_DRY_RUN_ID"; then
+            test "$(jq -r .headSha <<< "$run_json")" = "$ZERO_WRITE_DRY_RUN_SHA"
+            artifacts=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$DRY_RUN_ID/artifacts?per_page=100")
+            jq -e --argjson id "$ZERO_WRITE_DRY_ARTIFACT_ID" \
+              --arg digest "$ZERO_WRITE_DRY_ARTIFACT_DIGEST" \
+              --arg name "fresh-canonical-audit-boundary-$ZERO_WRITE_DRY_RUN_ID" '
+              [.artifacts[] | select(.id==$id and .name==$name and .expired==false and .digest==$digest)] | length==1
+            ' <<< "$artifacts" >/dev/null
           fi
           mkdir -p "$RUNNER_TEMP/boundary"
           gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
@@ -575,6 +603,13 @@ jobs:
               git show "11101c85a06aaec0d8f0deda0a4aac82cf24899b:$path" \
                 | cmp - "$RUNNER_TEMP/boundary/runtime/$path"
             done
+          elif test "$DRY_RUN_ID" = "$ZERO_WRITE_DRY_RUN_ID"; then
+            for path in \
+              .github/workflows/govern-fresh-canonical-audits.yml \
+              .github/actions/download-skillstore-cli/action.yml \
+              scripts/prepare-fresh-canonical-audit-batch.mjs; do
+              git show "$ZERO_WRITE_DRY_RUN_SHA:$path" | cmp - "$RUNNER_TEMP/boundary/runtime/$path"
+            done
           else
             cmp .github/workflows/govern-fresh-canonical-audits.yml \
               "$RUNNER_TEMP/boundary/runtime/.github/workflows/govern-fresh-canonical-audits.yml"
@@ -583,6 +618,49 @@ jobs:
             cmp scripts/prepare-fresh-canonical-audit-batch.mjs \
               "$RUNNER_TEMP/boundary/runtime/scripts/prepare-fresh-canonical-audit-batch.mjs"
           fi
+
+      - name: Authenticate exact zero-write timeout incident
+        if: inputs.mode == 'recover-rpc-timeout'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          incident="$RUNNER_TEMP/zero-write-incident"
+          mkdir -p "$incident/failed-execution"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ZERO_WRITE_DRY_RUN_ID" > "$incident/dry-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ZERO_WRITE_FAILED_RUN_ID" > "$incident/failed-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ZERO_WRITE_DRY_RUN_ID/artifacts?per_page=100" > "$incident/dry-artifacts.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ZERO_WRITE_FAILED_RUN_ID/artifacts?per_page=100" > "$incident/failed-artifacts.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ZERO_WRITE_FAILED_RUN_ID/jobs?filter=latest&per_page=100" > "$incident/failed-jobs.json"
+          gh run download "$ZERO_WRITE_FAILED_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "fresh-canonical-audit-execution-$ZERO_WRITE_FAILED_RUN_ID" \
+            --dir "$incident/failed-execution"
+          mapfile -t top_level < <(find "$incident/failed-execution" -mindepth 1 -maxdepth 1 -printf '%f\n')
+          test "${#top_level[@]}" = 1 && test "${top_level[0]}" = boundary
+          (cd "$incident/failed-execution/boundary" && sha256sum --check SHA256SUMS)
+          diff -qr "$RUNNER_TEMP/boundary" "$incident/failed-execution/boundary"
+
+      - name: Verify all ten rows still match the zero-write boundary
+        if: inputs.mode == 'recover-rpc-timeout'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          incident="$RUNNER_TEMP/zero-write-incident"
+          jq '{schemaVersion:1,scopedSkillIds:[.rows[].skillId],rows:.rows}' \
+            "$RUNNER_TEMP/boundary/selected-cohort.json" > "$incident/scope.json"
+          node scripts/fetch-artifact-version-inventory.mjs \
+            --scope-inventory "$incident/scope.json" --output "$incident/current-inventory.json"
+          node scripts/verify-fresh-canonical-zero-write-recovery.mjs \
+            --boundary "$RUNNER_TEMP/boundary/fresh-boundary.json" \
+            --original-inventory "$RUNNER_TEMP/boundary/pre-inventory.json" \
+            --current-inventory "$incident/current-inventory.json" \
+            --dry-run "$incident/dry-run.json" --failed-run "$incident/failed-run.json" \
+            --dry-artifacts "$incident/dry-artifacts.json" \
+            --failed-artifacts "$incident/failed-artifacts.json" \
+            --failed-jobs "$incident/failed-jobs.json" \
+            > "$incident/verification.json"
 
       - name: Generate GitHub App token
         id: app-token
@@ -689,13 +767,15 @@ jobs:
           mkdir -p "$proof"
           jq -n \
             --arg executeRunId "$GITHUB_RUN_ID" --arg dryRunId '${{ inputs.dry_run_id }}' \
+            --arg producerKind '${{ inputs.mode == 'recover-rpc-timeout' && 'fresh_canonical_zero_write_recovery' || 'fresh_canonical_execute' }}' \
+            --arg failedExecuteRunId '${{ inputs.failed_execute_run_id }}' \
             --arg workflowCommit "$GITHUB_SHA" \
             --arg lastSelected "$(jq -r .lastSelected "$RUNNER_TEMP/boundary/selected-cohort.json")" \
             --arg cohortSha256 "$(jq -r .cohortSha256 "$RUNNER_TEMP/boundary/metadata.json")" \
             --arg executionResultsSha256 "$(sha256sum "$RUNNER_TEMP/execution-results.json" | awk '{print $1}')" \
             --arg postInventorySha256 "$(sha256sum "$RUNNER_TEMP/post-inventory.json" | awk '{print $1}')" \
             --argjson executedCount "$expected" \
-            '{schemaVersion:1,status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
+            '{schemaVersion:1,producerKind:$producerKind,status:"fresh_canonical_audit_execution_complete",executeRunId:$executeRunId,dryRunId:$dryRunId,failedExecuteRunId:$failedExecuteRunId,workflowCommit:$workflowCommit,lastSelected:$lastSelected,cohortSha256:$cohortSha256,executedCount:$executedCount,executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,scoreFinalized:true,timestampFinalized:true,cacheClosureCompleted:true,packClosureCompleted:true,productionSmokeCompleted:true}' \
             > "$proof/proof.json"
           (cd "$proof" && sha256sum proof.json > SHA256SUMS)
 
@@ -709,6 +789,7 @@ jobs:
             ${{ runner.temp }}/execution-results.json
             ${{ runner.temp }}/post-inventory.json
             ${{ runner.temp }}/execution-proof/
+            ${{ runner.temp }}/zero-write-incident/
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 30

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -276,7 +276,7 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
+  assert.match(workflow, /options: \[dry-run, execute, recover-rpc-timeout, recover, recover-cache, recover-smoke\]/);
   assert.match(workflow, /default: '2\.15\.5'/);
   assert.equal((workflow.match(/b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189/g) || []).length, 1);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
@@ -327,6 +327,12 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /name: fresh-canonical-audit-execution-\$\{\{ github\.run_id \}\}[\s\S]*?include-hidden-files: true/);
   assert.match(workflow, /productionSmokeCompleted:true/);
   assert.match(workflow, /pre-inventory\.json/);
+  assert.match(workflow, /ZERO_WRITE_DRY_RUN_ID: '29743150038'/);
+  assert.match(workflow, /ZERO_WRITE_FAILED_RUN_ID: '29744338076'/);
+  assert.match(workflow, /ZERO_WRITE_FAILED_ARTIFACT_ID: '8461872394'/);
+  assert.match(workflow, /test "\$DRY_RUN_ID" != "\$ZERO_WRITE_DRY_RUN_ID" \|\| \{ echo '::error::sealed zero-write boundary requires recover-rpc-timeout'; exit 1; \}/);
+  assert.match(workflow, /verify-fresh-canonical-zero-write-recovery\.mjs/);
+  assert.match(workflow, /fresh_canonical_zero_write_recovery/);
   assert.match(workflow, /skill govern-fresh-canonical-audit/);
   assert.match(workflow, /production-skill-score-writes/);
   assert.match(workflow, /CACHE_INVALIDATE_SECRET/);

--- a/scripts/tests/fresh-canonical-zero-write-recovery.test.mjs
+++ b/scripts/tests/fresh-canonical-zero-write-recovery.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { INCIDENT, verifyZeroWriteRecovery } from '../verify-fresh-canonical-zero-write-recovery.mjs';
+
+function fixture() {
+  const successfulPrerequisites = [
+    'Checkout complete Marketplace history',
+    'Normalize full checkout and verify governance runtime',
+    'Validate execute inputs',
+    'Download and authenticate the successful frozen boundary',
+    'Generate GitHub App token',
+    'Download exact audited CLI 2.15.5',
+    'Verify frozen CLI identity',
+    'Rematerialize exact source and overlay only frozen fresh reports',
+  ];
+  const candidates = Array.from({ length: 10 }, (_, index) => {
+    const n = String(index + 1).padStart(12, '0');
+    const id = `11111111-1111-4111-8111-${n}`;
+    return {
+      row: { skillId: id, slug: `owner-skill-${index}` },
+      rpcPayload: {
+        p_expected_legacy_content_hash: 'a'.repeat(64),
+        p_expected_legacy_tree_hash: 'b'.repeat(64),
+        p_expected_latest_audit_id: `22222222-2222-4222-8222-${n}`,
+      },
+    };
+  });
+  const rows = candidates.map((candidate) => ({
+    id: candidate.row.skillId, slug: candidate.row.slug, plugin_path: `skills/${candidate.row.slug}`,
+    marketplace_commit_sha: INCIDENT.dryRun.sha, content_hash: 'a'.repeat(64), tree_hash: 'b'.repeat(64),
+    artifact_revision: 0, current_artifact_version_id: null, status: 'approved', public_eligible: true,
+    public_eligibility_audit_id: candidate.rpcPayload.p_expected_latest_audit_id,
+    published_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-20T12:30:00Z',
+    quality_score: 82, quality_tier: 'good', quality_score_calculated_at: '2026-07-20T12:00:00Z',
+    current_quality_score_snapshot_id: `33333333-3333-4333-8333-${candidate.row.skillId.slice(-12)}`,
+  }));
+  const run = (expected, conclusion) => ({ id: expected.id, head_sha: expected.sha,
+    name: 'Govern Fresh Canonical Audits', event: 'workflow_dispatch', head_branch: 'main',
+    run_attempt: 1, actor: { login: 'mylukin' }, triggering_actor: { login: 'mylukin' }, conclusion });
+  const artifact = (expected, name) => ({ artifacts: [{ id: expected.artifactId, name,
+    expired: false, digest: expected.artifactDigest }] });
+  return {
+    boundary: { schemaVersion: 1, status: 'fresh_canonical_audit_frozen', candidates },
+    originalInventory: { rows, artifacts: [], observations: [] },
+    currentInventory: { rows: structuredClone(rows), artifacts: [], observations: [] },
+    dryRun: run(INCIDENT.dryRun, 'success'), failedRun: run(INCIDENT.failedRun, 'failure'),
+    dryArtifacts: artifact(INCIDENT.dryRun, `fresh-canonical-audit-boundary-${INCIDENT.dryRun.id}`),
+    failedArtifacts: artifact(INCIDENT.failedRun, `fresh-canonical-audit-execution-${INCIDENT.failedRun.id}`),
+    failedJobs: { jobs: [{ id: INCIDENT.failedRun.jobId, name: 'execute-boundary',
+      runner_id: INCIDENT.failedRun.runnerId, runner_name: INCIDENT.failedRun.runnerName,
+      conclusion: 'failure', steps: [
+        ...successfulPrerequisites.map((name) => ({ name, conclusion: 'success' })),
+        { name: 'Execute resumable compound governance, score, and cache closure', conclusion: 'failure' },
+        { name: 'Fetch exact post-execution artifact and Pack evidence', conclusion: 'skipped' },
+        { name: 'Verify every P0/P1 download, install, NPX, Pack, and MCP channel', conclusion: 'skipped' },
+        { name: 'Seal successful execute closure for the next cursor', conclusion: 'skipped' },
+      ] }] },
+  };
+}
+
+test('accepts only the exact zero-write incident and unchanged ten-row CAS boundary', () => {
+  assert.deepEqual(verifyZeroWriteRecovery(fixture()), { count: 10 });
+});
+
+test('rejects tampered run, SHA, job, artifact, digest, boundary, and production state', () => {
+  const mutations = [
+    (x) => { x.failedRun.id += 1; },
+    (x) => { x.failedRun.head_sha = 'f'.repeat(40); },
+    (x) => { x.failedRun.actor.login = 'someone-else'; },
+    (x) => { x.failedJobs.jobs[0].id += 1; },
+    (x) => { x.failedArtifacts.artifacts[0].id += 1; },
+    (x) => { x.failedArtifacts.artifacts[0].digest = `sha256:${'f'.repeat(64)}`; },
+    (x) => { x.boundary.candidates.pop(); },
+    (x) => { x.currentInventory.rows[0].content_hash = 'f'.repeat(64); },
+    (x) => { x.currentInventory.rows[0].quality_score = 1; },
+    (x) => { x.currentInventory.artifacts.push({ skill_id: x.currentInventory.rows[0].id }); },
+    (x) => { x.failedJobs.jobs[0].steps = x.failedJobs.jobs[0].steps.filter((step) => step.name !== 'Verify frozen CLI identity'); },
+    (x) => { x.failedJobs.jobs[0].steps.find((step) => step.name === 'Rematerialize exact source and overlay only frozen fresh reports').conclusion = 'failure'; },
+  ];
+  for (const mutate of mutations) {
+    const input = fixture();
+    mutate(input);
+    assert.throws(() => verifyZeroWriteRecovery(input));
+  }
+});

--- a/scripts/verify-fresh-canonical-zero-write-recovery.mjs
+++ b/scripts/verify-fresh-canonical-zero-write-recovery.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const INCIDENT = Object.freeze({
+  dryRun: {
+    id: 29743150038,
+    sha: 'd75b0863d962bc58cf69d554f8fa6ea67a5c040a',
+    artifactId: 8461534557,
+    artifactDigest: 'sha256:627c18c8d1c127ed6fb4d5020043dae90f35643550b37e6b0150a76233dbfc4b',
+  },
+  failedRun: {
+    id: 29744338076,
+    sha: 'd75b0863d962bc58cf69d554f8fa6ea67a5c040a',
+    artifactId: 8461872394,
+    artifactDigest: 'sha256:e36360f2dd23fae710d9c6ea3a0f02e40b55b31fe18b57f354a62542b8560b50',
+    jobId: 88358488559,
+    runnerId: 174,
+    runnerName: 'docker-runner-199-4-2',
+  },
+});
+
+const STABLE_SKILL_FIELDS = [
+  'id', 'slug', 'plugin_path', 'marketplace_commit_sha', 'content_hash', 'tree_hash',
+  'artifact_revision', 'current_artifact_version_id', 'status', 'public_eligible',
+  'public_eligibility_audit_id', 'published_at', 'updated_at', 'quality_score',
+  'quality_tier', 'quality_score_calculated_at', 'current_quality_score_snapshot_id',
+];
+
+function exactRun(run, expected, conclusion) {
+  assert.equal(run.id, expected.id);
+  assert.equal(run.head_sha, expected.sha);
+  assert.equal(run.name, 'Govern Fresh Canonical Audits');
+  assert.equal(run.event, 'workflow_dispatch');
+  assert.equal(run.head_branch, 'main');
+  assert.equal(run.run_attempt, 1);
+  assert.equal(run.actor?.login, 'mylukin');
+  assert.equal(run.triggering_actor?.login, 'mylukin');
+  assert.equal(run.conclusion, conclusion);
+}
+
+function exactArtifact(response, name, expected) {
+  const matches = response.artifacts.filter((artifact) => artifact.id === expected.artifactId
+    && artifact.name === name && artifact.expired === false
+    && artifact.digest === expected.artifactDigest);
+  assert.equal(matches.length, 1);
+}
+
+function rowMap(rows, ids) {
+  return new Map(rows.filter((row) => ids.has(row.id)).map((row) => [row.id, row]));
+}
+
+function stableSkill(row) {
+  return Object.fromEntries(STABLE_SKILL_FIELDS.map((field) => [field, row[field]]));
+}
+
+export function verifyZeroWriteRecovery(input) {
+  const { boundary, originalInventory, currentInventory, dryRun, failedRun,
+    dryArtifacts, failedArtifacts, failedJobs } = input;
+  assert.equal(boundary.schemaVersion, 1);
+  assert.equal(boundary.status, 'fresh_canonical_audit_frozen');
+  assert.equal(boundary.candidates.length, 10);
+  exactRun(dryRun, INCIDENT.dryRun, 'success');
+  exactRun(failedRun, INCIDENT.failedRun, 'failure');
+  exactArtifact(dryArtifacts, `fresh-canonical-audit-boundary-${INCIDENT.dryRun.id}`, INCIDENT.dryRun);
+  exactArtifact(failedArtifacts, `fresh-canonical-audit-execution-${INCIDENT.failedRun.id}`, INCIDENT.failedRun);
+
+  const job = failedJobs.jobs.find((candidate) => candidate.id === INCIDENT.failedRun.jobId);
+  assert(job);
+  assert.equal(job.name, 'execute-boundary');
+  assert.equal(job.runner_id, INCIDENT.failedRun.runnerId);
+  assert.equal(job.runner_name, INCIDENT.failedRun.runnerName);
+  assert.equal(job.conclusion, 'failure');
+  const steps = new Map(job.steps.map((step) => [step.name, step.conclusion]));
+  for (const name of [
+    'Checkout complete Marketplace history',
+    'Normalize full checkout and verify governance runtime',
+    'Validate execute inputs',
+    'Download and authenticate the successful frozen boundary',
+    'Generate GitHub App token',
+    'Download exact audited CLI 2.15.5',
+    'Verify frozen CLI identity',
+    'Rematerialize exact source and overlay only frozen fresh reports',
+  ]) assert.equal(steps.get(name), 'success');
+  assert.equal(steps.get('Execute resumable compound governance, score, and cache closure'), 'failure');
+  for (const name of [
+    'Fetch exact post-execution artifact and Pack evidence',
+    'Verify every P0/P1 download, install, NPX, Pack, and MCP channel',
+    'Seal successful execute closure for the next cursor',
+  ]) assert.equal(steps.get(name), 'skipped');
+
+  const ids = new Set(boundary.candidates.map((candidate) => candidate.row.skillId));
+  assert.equal(ids.size, 10);
+  const original = rowMap(originalInventory.rows, ids);
+  const current = rowMap(currentInventory.rows, ids);
+  assert.equal(original.size, 10);
+  assert.equal(current.size, 10);
+  for (const candidate of boundary.candidates) {
+    const before = original.get(candidate.row.skillId);
+    const now = current.get(candidate.row.skillId);
+    assert.deepEqual(stableSkill(now), stableSkill(before));
+    assert.equal(now.artifact_revision, 0);
+    assert.equal(now.current_artifact_version_id, null);
+    assert.equal(now.content_hash, candidate.rpcPayload.p_expected_legacy_content_hash);
+    assert.equal(now.tree_hash, candidate.rpcPayload.p_expected_legacy_tree_hash);
+    assert.equal(now.public_eligibility_audit_id, candidate.rpcPayload.p_expected_latest_audit_id);
+  }
+  for (const inventory of [originalInventory, currentInventory]) {
+    assert.equal(inventory.artifacts.filter((row) => ids.has(row.skill_id)).length, 0);
+    assert.equal(inventory.observations.filter((row) => ids.has(row.skill_id)).length, 0);
+  }
+  return { count: ids.size };
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  assert(index >= 0 && args[index + 1], `missing ${name}`);
+  return args[index + 1];
+}
+
+export function main(args = process.argv.slice(2)) {
+  const read = (name) => JSON.parse(readFileSync(option(args, name), 'utf8'));
+  const result = verifyZeroWriteRecovery({
+    boundary: read('--boundary'),
+    originalInventory: read('--original-inventory'),
+    currentInventory: read('--current-inventory'),
+    dryRun: read('--dry-run'),
+    failedRun: read('--failed-run'),
+    dryArtifacts: read('--dry-artifacts'),
+    failedArtifacts: read('--failed-artifacts'),
+    failedJobs: read('--failed-jobs'),
+  });
+  process.stdout.write(`${JSON.stringify({ status: 'zero_write_recovery_verified', ...result })}\n`);
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1] || '')).href) {
+  try { main(); } catch (error) {
+    process.stderr.write(`zero-write recovery verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a one-incident `recover-rpc-timeout` lane for the sealed Fresh-11 boundary
- authenticate the exact dry-run, failed execute, runner/job/steps, artifacts, checksums, actor, and unchanged ten-row production CAS state
- reuse the existing atomic execute, score/cache closure, and P0/P1 smoke path
- prevent ordinary execute from consuming the sealed boundary

## Safety
- never reruns dry-run 29743150038 or failed execute 29744338076
- fails closed on identity, boundary, prerequisite-step, artifact, or production-state drift
- preserves TLS, atomic artifact+audit writes, CAS, idempotency, score/cache closure, and production smoke

## Validation
- `node --check scripts/verify-fresh-canonical-zero-write-recovery.mjs`
- `CI=true node --test scripts/tests/fresh-canonical-zero-write-recovery.test.mjs scripts/tests/fresh-canonical-audit-governance.test.mjs` (7/7)
- workflow YAML parse
- `git diff --check`