### PR TITLE
fix(governance): retire sealed RPC recovery

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute, recover-rpc-timeout, recover, recover-cache, recover-smoke]
+        options: [dry-run, execute, recover, recover-cache, recover-smoke]
       cohort_path:
         description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
         type: string
@@ -498,7 +498,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   execute-boundary:
-    if: inputs.mode == 'execute' || inputs.mode == 'recover-rpc-timeout'
+    if: inputs.mode == 'execute'
     concurrency:
       group: production-skill-score-writes
       cancel-in-progress: false
@@ -556,7 +556,7 @@ jobs:
             test "$FAILED_EXECUTE_RUN_ID" = "$ZERO_WRITE_FAILED_RUN_ID"
           else
             [[ "$DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo '::error::numeric dry_run_id required'; exit 1; }
-            test "$DRY_RUN_ID" != "$ZERO_WRITE_DRY_RUN_ID" || { echo '::error::sealed zero-write boundary requires recover-rpc-timeout'; exit 1; }
+            test "$DRY_RUN_ID" != "$ZERO_WRITE_DRY_RUN_ID" || { echo '::error::sealed zero-write boundary cannot be executed'; exit 1; }
             test -z "$FAILED_EXECUTE_RUN_ID" || { echo '::error::execute cannot consume failed_execute_run_id'; exit 1; }
           fi
 

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -276,7 +276,9 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute, recover-rpc-timeout, recover, recover-cache, recover-smoke\]/);
+  assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
+  assert.doesNotMatch(workflow, /options: \[[^\]]*recover-rpc-timeout/);
+  assert.match(workflow, /execute-boundary:\n    if: inputs\.mode == 'execute'/);
   assert.match(workflow, /default: '2\.15\.5'/);
   assert.equal((workflow.match(/b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189/g) || []).length, 1);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
@@ -330,7 +332,7 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /ZERO_WRITE_DRY_RUN_ID: '29743150038'/);
   assert.match(workflow, /ZERO_WRITE_FAILED_RUN_ID: '29744338076'/);
   assert.match(workflow, /ZERO_WRITE_FAILED_ARTIFACT_ID: '8461872394'/);
-  assert.match(workflow, /test "\$DRY_RUN_ID" != "\$ZERO_WRITE_DRY_RUN_ID" \|\| \{ echo '::error::sealed zero-write boundary requires recover-rpc-timeout'; exit 1; \}/);
+  assert.match(workflow, /test "\$DRY_RUN_ID" != "\$ZERO_WRITE_DRY_RUN_ID" \|\| \{ echo '::error::sealed zero-write boundary cannot be executed'; exit 1; \}/);
   assert.match(workflow, /verify-fresh-canonical-zero-write-recovery\.mjs/);
   assert.match(workflow, /fresh_canonical_zero_write_recovery/);
   assert.match(workflow, /skill govern-fresh-canonical-audit/);


### PR DESCRIPTION
## Summary
- remove `recover-rpc-timeout` from dispatch choices
- restrict the shared execute job to ordinary `mode=execute` only
- keep the zero-write verifier and incident evidence code for auditability
- keep dry-run 29743150038 sealed from ordinary execute

Even if an API submits the retired string directly, no production write job is eligible.

## Validation
- focused governance tests: 7/7
- workflow YAML parse
- `git diff --check`