### PR TITLE
fix(workflow): pin Source Monitor CLI 2.15.8

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: 2.15.0
+          version: 2.15.8
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
           minimum-version: 2.14.5

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -517,7 +517,7 @@ test('download action invalidates stale local CLI cache entries', () => {
 
 test('source monitor pins its audited CLI contract and falls back when checkout-cache support is unavailable', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /version: 2\.15\.0/, 'source monitor must download the audited CLI contract version');
+	assert.match(workflow, /version: 2\.15\.8/, 'source monitor must download the audited CLI contract version');
 	assert.doesNotMatch(workflow, /cli_version:/, 'source monitor must not expose a fixed CLI version input');
 	assert.doesNotMatch(workflow, /inputs\.cli_version/, 'source monitor must not consume a fixed CLI version input');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -177,7 +177,7 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
   assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(workflow, /fetch-depth: 1/);
   assert.match(workflow, /persist-credentials: false/);
-  assert.match(workflow, /version: 2\.15\.0/);
+  assert.match(workflow, /version: 2\.15\.8/);
   assert.match(workflow, /minimum-version: 2\.14\.5/);
   assert.match(workflow, /require-checksum: true/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);


### PR DESCRIPTION
## Summary
- pin Source Monitor to skillstore-cli 2.15.8
- include full upstream SKILL.md validation before replacement
- keep invalid candidates as local failures while valid siblings continue
- update the pinned-version workflow contracts

## Verification
- CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs scripts/tests/recalculate-scores.test.mjs (30/30)