### PR TITLE
fix(workflow): accept isolated Source Monitor failures

### DIFF
--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -284,6 +284,10 @@ cat > "$summary" <<'SUMMARY'
 | Applied updated skills | 1 |
 | Failed selected updates | 0 |
 | Deferred updated skills | 0 |
+
+### Local Actions
+
+- updated: owner-one (skills/owner/one)
 SUMMARY
 `);
     chmodSync(fakeCli, 0o755);

--- a/scripts/tests/source-monitor-selection.test.mjs
+++ b/scripts/tests/source-monitor-selection.test.mjs
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -6,6 +10,7 @@ import {
   parseResultSlugs,
   verifyExactSelection,
   verifyLocalActionSummary,
+  verifyLocalMutations,
 } from '../verify-source-monitor-selection.mjs';
 
 const EXPECTED_COMMIT = '458df4c41294655f76e551100a9b634114209bb9';
@@ -57,7 +62,7 @@ test('requires every explicit result to match the expected immutable upstream co
   );
 });
 
-test('requires exact successful local action accounting for every requested update', () => {
+test('requires exact applied-or-failed local action accounting for every requested update', () => {
   const valid = [
     '| Observed updated skills | 2 |',
     '| Selected updated skills for this run | 2 |',
@@ -76,6 +81,64 @@ test('requires exact successful local action accounting for every requested upda
     () => verifyLocalActionSummary(valid.replace('Applied updated skills | 2', 'Applied updated skills | 1'), 2),
     /local action mismatch/,
   );
+  assert.deepEqual(verifyLocalActionSummary([
+    '| Observed updated skills | 2 |',
+    '| Selected updated skills for this run | 2 |',
+    '| Applied updated skills | 1 |',
+    '| Failed selected updates | 1 |',
+    '| Deferred updated skills | 0 |',
+  ].join('\n'), 2), {
+    observed: 2,
+    selected: 2,
+    applied: 1,
+    failed: 1,
+    deferred: 0,
+  });
+});
+
+test('accepts a fully accounted invalid candidate with no marketplace mutations', () => {
+  const root = mkdtempSync(join(tmpdir(), 'source-monitor-selection-'));
+  try {
+    const directory = join(root, 'skills', 'owner', 'broken');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, 'SKILL.md'), '---\nname: broken\ndescription: old\n---\n');
+    writeFileSync(join(directory, 'skill-report.json'), JSON.stringify({
+      meta: { slug: 'broken', upstream_commit_sha: null },
+    }));
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Fixture'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'fixture@example.com'], { cwd: root });
+    execFileSync('git', ['add', '.'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'fixture'], { cwd: root });
+
+    const summary = [
+      '| Observed updated skills | 1 |',
+      '| Selected updated skills for this run | 1 |',
+      '| Applied updated skills | 0 |',
+      '| Failed selected updates | 1 |',
+      '| Deferred updated skills | 0 |',
+      '',
+      '### Local Action Failures',
+      '',
+      '- broken: invalid upstream SKILL.md',
+    ].join('\n');
+    assert.deepEqual(verifyLocalMutations({
+      repositoryRoot: root,
+      requested: 'broken',
+      expectedUpstreamCommit: EXPECTED_COMMIT,
+      summaryText: summary,
+    }), {
+      observed: 1,
+      selected: 1,
+      applied: 0,
+      failed: 1,
+      deferred: 0,
+      changedPaths: 0,
+      authorizedDirectories: 0,
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('rejects zero matches, partial matches, unexpected results, and duplicates', () => {

--- a/scripts/verify-source-monitor-selection.mjs
+++ b/scripts/verify-source-monitor-selection.mjs
@@ -125,13 +125,34 @@ export function verifyLocalActionSummary(text, expectedCount) {
   if (
     metrics.observed !== expectedCount
     || metrics.selected !== expectedCount
-    || metrics.applied !== expectedCount
-    || metrics.failed !== 0
+    || metrics.applied + metrics.failed !== expectedCount
     || metrics.deferred !== 0
   ) {
     fail(`source monitor local action mismatch: expected=${expectedCount}, metrics=${JSON.stringify(metrics)}`);
   }
   return metrics;
+}
+
+function parseLocalActionSlugs(text, metrics) {
+  const section = (heading) => {
+    const marker = `### ${heading}`;
+    const start = text.indexOf(marker);
+    if (start === -1) return '';
+    const following = text.slice(start + marker.length);
+    const end = following.search(/^### /mu);
+    return end === -1 ? following : following.slice(0, end);
+  };
+  const applied = [...section('Local Actions').matchAll(/^- updated: ([a-z0-9](?:[a-z0-9-]*[a-z0-9])?) \([^\n]+\)$/gmu)]
+    .map((match) => match[1]);
+  const failed = [...section('Local Action Failures').matchAll(/^- ([a-z0-9](?:[a-z0-9-]*[a-z0-9])?): .+$/gmu)]
+    .map((match) => match[1]);
+  if (new Set(applied).size !== applied.length || new Set(failed).size !== failed.length) {
+    fail('source monitor summary contains duplicate local action slugs');
+  }
+  if (applied.length !== metrics.applied || failed.length !== metrics.failed) {
+    fail(`source monitor local action detail mismatch: metrics=${JSON.stringify(metrics)}, applied=[${applied.join(',')}], failed=[${failed.join(',')}]`);
+  }
+  return { applied, failed };
 }
 
 function walkReports(directory, reports) {
@@ -180,6 +201,12 @@ export function verifyLocalMutations({
   const requestedSlugs = parseRequestedSlugs(requested);
   if (!COMMIT_RE.test(expectedUpstreamCommit)) fail(`invalid expected upstream commit: ${expectedUpstreamCommit}`);
   const metrics = verifyLocalActionSummary(summaryText, requestedSlugs.length);
+  const actionSlugs = parseLocalActionSlugs(summaryText, metrics);
+  const accountedSlugs = [...actionSlugs.applied, ...actionSlugs.failed]
+    .sort((left, right) => left.localeCompare(right, 'en'));
+  if (accountedSlugs.join('\0') !== requestedSlugs.join('\0')) {
+    fail(`source monitor local action slug mismatch: requested=[${requestedSlugs.join(',')}], applied=[${actionSlugs.applied.join(',')}], failed=[${actionSlugs.failed.join(',')}]`);
+  }
 
   const reportPaths = [];
   walkReports(resolve(root, 'skills'), reportPaths);
@@ -201,6 +228,7 @@ export function verifyLocalMutations({
     if (lstatSync(reportPath).isSymbolicLink() || !lstatSync(reportPath).isFile()) {
       fail(`marketplace report is not a regular file: ${reportPath}`);
     }
+    if (!actionSlugs.applied.includes(slug)) continue;
     if (report.meta.upstream_commit_sha !== expectedUpstreamCommit) {
       fail(`marketplace report commit mismatch for ${slug}: ${report.meta.upstream_commit_sha ?? 'missing'}`);
     }
@@ -212,7 +240,7 @@ export function verifyLocalMutations({
     ...gitPaths(root, ['diff', '--name-only', '-z', '--no-renames', 'HEAD', '--']),
     ...gitPaths(root, ['ls-files', '--others', '--exclude-standard', '-z', '--']),
   ].map(validateChangedPath));
-  if (changed.size === 0) fail('source monitor produced no marketplace file changes');
+  if (metrics.applied > 0 && changed.size === 0) fail('source monitor produced no marketplace file changes');
 
   for (const path of changed) {
     if (!authorized.some(({ directory }) => path.startsWith(directory))) {


### PR DESCRIPTION
## Summary
- accept fully accounted Source Monitor candidates as either applied or locally failed
- require exact, unique applied/failed slug detail and reject deferred or unaccounted candidates
- allow a zero-mutation run when every requested candidate was safely isolated
- keep mutation provenance checks for every applied candidate

## Runtime evidence
Run 29760475755 showed CLI 2.15.8 correctly isolated agent-development, then the old verifier failed because applied=0 and failed=1. This patch fixes that remaining workflow boundary.

## Verification
- CI=true node --test scripts/tests/source-monitor-selection.test.mjs scripts/tests/source-monitor-runtime-workflow.test.mjs scripts/tests/recalculate-scores.test.mjs (36/36)