### PR TITLE
fix(governance): freeze exact report-origin v2 cohort

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -1,4 +1,4 @@
-name: Govern Legacy Report-Origin 70
+name: Govern Legacy Report-Origin V2-Only
 
 on:
   workflow_dispatch:
@@ -28,8 +28,8 @@ env:
   # Production is intentionally impossible until the released linux-x64 binary
   # has been audited and this placeholder is replaced by its exact SHA-256.
   ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
-  ORIGIN_COHORT: scripts/data/legacy-report-origin-cohort-v1.json
-  ORIGIN_COHORT_SHA256: d00f9af499ab9da6df52d0de76bac9021ffbf0401bfff85ad4ac26331c2a38af
+  ORIGIN_COHORT: scripts/data/legacy-report-origin-v2-only-cohort-v1.json
+  ORIGIN_COHORT_SHA256: 7b9409e3eb748c9974e7e0c14a10b8507832ae0c22d2cc8b2171bf56d2292938
 
 jobs:
   freeze-boundary:
@@ -73,12 +73,12 @@ jobs:
             test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
           done
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
-          jq -e '.schemaVersion == 2 and .selectedCount == 70 and (.rows | length) == 70 and (.sourceBoundaries | length) == 7' "$ORIGIN_COHORT" >/dev/null
+          jq -e '.schemaVersion == 2 and .selectedCount == 54 and (.rows | length) == 54 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo '::error::CLI 2.15.2 audit digest is still a non-production placeholder'; exit 1;
           }
 
-      - name: Download and verify seven frozen drift classifications
+      - name: Download and verify two frozen drift classifications
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -104,7 +104,7 @@ jobs:
             }
           done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
 
-      - name: Build exact 70-row drift classification and plan
+      - name: Build exact 54-row v2-only drift classification and plan
         run: |
           set -euo pipefail
           node scripts/build-legacy-report-origin-boundary.mjs \
@@ -118,7 +118,7 @@ jobs:
           set -euo pipefail
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
-            --expected-count 70 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 54 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/origin-lineage.json"
 
@@ -154,7 +154,7 @@ jobs:
           set -euo pipefail
           test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
 
-      - name: Run exact 70-row administrator dry-run
+      - name: Run exact 54-row administrator dry-run
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -202,7 +202,7 @@ jobs:
       - name: Upload immutable report-origin boundary
         uses: actions/upload-artifact@v6
         with:
-          name: legacy-report-origin-70-boundary-${{ github.run_id }}
+          name: legacy-report-origin-v2-only-boundary-${{ github.run_id }}
           path: ${{ runner.temp }}/origin-boundary/
           if-no-files-found: error
           retention-days: 30
@@ -259,11 +259,11 @@ jobs:
           jq -e --argjson id "$DRY_RUN_ID" '
             .databaseId == $id and .conclusion == "success" and
             .event == "workflow_dispatch" and .headBranch == "main" and
-            .workflowName == "Govern Legacy Report-Origin 70"
+            .workflowName == "Govern Legacy Report-Origin V2-Only"
           ' <<< "$run_json" >/dev/null || { echo '::error::dry_run_id is not a successful origin dry-run'; exit 1; }
           mkdir -p "$RUNNER_TEMP/boundary"
           gh run download "$DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
-            --name "legacy-report-origin-70-boundary-$DRY_RUN_ID" --dir "$RUNNER_TEMP/boundary"
+            --name "legacy-report-origin-v2-only-boundary-$DRY_RUN_ID" --dir "$RUNNER_TEMP/boundary"
           (cd "$RUNNER_TEMP/boundary" && sha256sum --check SHA256SUMS)
           test "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" = "$(jq -r .headSha <<< "$run_json")"
           git merge-base --is-ancestor "$(jq -r .workflowCommit "$RUNNER_TEMP/boundary/boundary.json")" "$GITHUB_SHA"
@@ -274,7 +274,7 @@ jobs:
           test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
-            --expected-count 70 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 54 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/current-origin-lineage.json"
           cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
@@ -322,7 +322,7 @@ jobs:
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
 
-      - name: Execute only the frozen 70 rows
+      - name: Execute only the frozen 54 rows
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -348,7 +348,7 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
           jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
           jq -e '[.[].result.results[]] as $rows |
-            ($rows | length) == 70 and ($rows | map(.slug) | unique | length) == 70 and
+            ($rows | length) == 54 and ($rows | map(.slug) | unique | length) == 54 and
             ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
             "$RUNNER_TEMP/execution-results.json" >/dev/null
 
@@ -356,7 +356,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: legacy-report-origin-70-execution-${{ github.run_id }}
+          name: legacy-report-origin-v2-only-execution-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/boundary/
             ${{ runner.temp }}/current-origin-lineage.json

--- a/scripts/build-legacy-report-origin-boundary.mjs
+++ b/scripts/build-legacy-report-origin-boundary.mjs
@@ -33,12 +33,13 @@ function validateCohort(cohort) {
     || cohort.schemaVersion !== 2
     || cohort.status !== 'frozen_report_origin_cohort'
     || cohort.repository !== 'aiskillstore/marketplace'
-    || cohort.selectedCount !== 70
+    || !Number.isSafeInteger(cohort.selectedCount)
+    || cohort.selectedCount < 1
     || !Array.isArray(cohort.rows)
-    || cohort.rows.length !== 70
+    || cohort.rows.length !== cohort.selectedCount
     || !Array.isArray(cohort.sourceBoundaries)
-    || cohort.sourceBoundaries.length !== 7
-  ) fail('report-origin cohort must freeze exactly 70 rows and seven source boundaries');
+    || cohort.sourceBoundaries.length < 1
+  ) fail('report-origin cohort must freeze a positive exact row set and its source boundaries');
   const boundaries = new Map();
   for (const boundary of cohort.sourceBoundaries) {
     if (
@@ -77,6 +78,7 @@ function validateCohort(cohort) {
 
 export function buildLegacyReportOriginBoundary({ cohort, boundariesRoot }) {
   const expectedBoundaries = validateCohort(cohort);
+  const selectedCount = cohort.selectedCount;
   const classifications = new Map();
   for (const [runId, expectedSha256] of expectedBoundaries) {
     const path = join(resolve(boundariesRoot), runId, 'classification.json');
@@ -136,14 +138,14 @@ export function buildLegacyReportOriginBoundary({ cohort, boundariesRoot }) {
     classification: {
       schemaVersion: 1,
       status: 'classified',
-      classifiedCount: 70,
-      counts: { exact: 0, legacy_algorithm_equivalent: 0, actual_or_unproven_drift: 70 },
+      classifiedCount: selectedCount,
+      counts: { exact: 0, legacy_algorithm_equivalent: 0, actual_or_unproven_drift: selectedCount },
       cohorts: { exact: [], legacy_algorithm_equivalent: [], actual_or_unproven_drift: selected },
     },
     plan: {
       schemaVersion: 1,
       status: 'frozen_report_origin_plan',
-      selectedCount: 70,
+      selectedCount,
       identitySha256,
       sourceBoundaries: cohort.sourceBoundaries,
       identities,
@@ -176,7 +178,7 @@ export function main(argv = process.argv.slice(2)) {
   });
   writeFileSync(resolve(args['classification-output']), `${JSON.stringify(output.classification, null, 2)}\n`, { flag: 'wx' });
   writeFileSync(resolve(args['plan-output']), `${JSON.stringify(output.plan, null, 2)}\n`, { flag: 'wx' });
-  process.stdout.write(`${JSON.stringify({ status: output.plan.status, selectedCount: 70 })}\n`);
+  process.stdout.write(`${JSON.stringify({ status: output.plan.status, selectedCount: output.plan.selectedCount })}\n`);
 }
 
 if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {

--- a/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
+++ b/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
@@ -1,0 +1,396 @@
+{
+  "schemaVersion": 2,
+  "status": "frozen_report_origin_cohort",
+  "repository": "aiskillstore/marketplace",
+  "selectedCount": 54,
+  "sourceBoundaries": [
+    {
+      "runId": "29391998167",
+      "classificationSha256": "f26842b5596caf8214cec91cedbdd70a4eaeff535ecf48f776dee20c3c6a64ad"
+    },
+    {
+      "runId": "29392177791",
+      "classificationSha256": "a8c4235a607396bde82af2bf31bbd54fd659d330b07ea8ae0d027452e276a41b"
+    }
+  ],
+  "rows": [
+    {
+      "slug": "crossbill-highlights-css-colors",
+      "skillId": "677e8ec5-469c-4f23-b093-600b86d1ec7b",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/css-colors",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-database-operations",
+      "skillId": "8e8184ea-25fb-4062-89b2-14085a9e52e9",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/database-operations",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-frontend-aesthetics",
+      "skillId": "621008dd-db95-47bc-8c16-deb5428ba543",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/frontend-aesthetics",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-making-commits",
+      "skillId": "18c9dbe9-545b-427f-8101-a2b92afc6356",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/making-commits",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-typography",
+      "skillId": "bad3b1a0-73c2-4ecd-905c-90d4a31ab142",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/typography",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "crossbill-highlights-writing-tests",
+      "skillId": "15030479-23b9-47c4-9e42-3d0b311b5119",
+      "classificationRunId": "29391998167",
+      "path": "skills/crossbill-highlights/writing-tests",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "daviddworetzky-code-review",
+      "skillId": "b932f86b-ccf4-44c8-9ae1-b2a38a5bb341",
+      "classificationRunId": "29392177791",
+      "path": "skills/daviddworetzky/code-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "daviddworetzky-skill-creator",
+      "skillId": "f0a9bbdc-08ca-4579-bbdb-26bdb313b515",
+      "classificationRunId": "29392177791",
+      "path": "skills/daviddworetzky/skill-creator",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-adaptyv",
+      "skillId": "494a8b34-df29-44fd-9c40-053394f1e2f3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/adaptyv",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-algorithmic-art",
+      "skillId": "fafe9202-69ae-4d4f-b5e1-fbd7b86bc3d2",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/algorithmic-art",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-citation-management",
+      "skillId": "92c0226e-d148-48c5-8eca-016b394dd500",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/citation-management",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-clinpgx-database",
+      "skillId": "b1886565-59a7-4019-aa5d-dfaf02ba7099",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/clinpgx-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-clinvar-database",
+      "skillId": "4b8f9e73-51cd-455e-8f15-dc19a62ec0ad",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/clinvar-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-code-reviewer",
+      "skillId": "1638b454-a9ef-4712-b4a8-d87b580b9415",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/code-reviewer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-create-pr",
+      "skillId": "4e1664eb-2528-4f2a-8baa-69657c66df6c",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/create-pr",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-diffdock",
+      "skillId": "2b7f6468-de3a-4490-beaa-a18f7d98a869",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/diffdock",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-docx",
+      "skillId": "bbdb6fc6-804c-4482-8efb-babd259b67c6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/docx",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-drugbank-database",
+      "skillId": "49f58e40-cd8a-4bac-be05-45ed6360ad84",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/drugbank-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-ena-database",
+      "skillId": "f5c2420a-0973-4ea4-ab70-0cdb183e49d7",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/ena-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-ensembl-database",
+      "skillId": "66b91cb0-7489-44c7-8023-990ae6ac0b0a",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/ensembl-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-etetoolkit",
+      "skillId": "1c3f40ff-1e8d-4288-af73-73f6f332cff1",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/etetoolkit",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-executing-marketing-campaigns",
+      "skillId": "c1561bb0-13a4-4aa3-a9d8-5a3098a2f267",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/executing-marketing-campaigns",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-exploratory-data-analysis",
+      "skillId": "21992c59-481f-48e2-b430-81fd0f2f9504",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/exploratory-data-analysis",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gene-database",
+      "skillId": "ea8f8f42-0492-412c-8019-6b99a4239568",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gene-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-geniml",
+      "skillId": "b7c8f272-a123-4dfb-b42d-2937e933f403",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/geniml",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-geo-database",
+      "skillId": "d2b4cb06-a64b-48fd-9c14-9973a0530c7e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/geo-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gget",
+      "skillId": "44020571-226e-4584-8e91-c9b3a7c8d1e9",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gget",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-gwas-database",
+      "skillId": "20c5e440-99ef-4042-a397-3bc6ebc68d06",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/gwas-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-hypothesis-generation",
+      "skillId": "88a9aae4-a673-4209-a1b6-a473392b739e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/hypothesis-generation",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-literature-review",
+      "skillId": "2f6ad830-9495-4452-a646-0f28326e53b3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/literature-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-matplotlib",
+      "skillId": "a4eb9717-8509-4e7c-b47b-a74512e52d13",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/matplotlib",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-neurokit2",
+      "skillId": "2ab5248f-719a-46d3-8fde-54678dcbcfbf",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/neurokit2",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-opentargets-database",
+      "skillId": "d4bde71d-82d1-41a2-92ee-f6122ef3c814",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/opentargets-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-paper-2-web",
+      "skillId": "9acb87b9-258e-4e39-8e6f-81fc33552779",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/paper-2-web",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-pdf-processing-pro",
+      "skillId": "d3a0e807-8da9-4827-8963-e0d62d6806f7",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/pdf-processing-pro",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-peer-review",
+      "skillId": "5a01a7b5-c8e8-4fca-908e-f8633ac9edd6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/peer-review",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-pptx",
+      "skillId": "e70ad74d-85cc-410d-b502-30b100b9702a",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/pptx",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-reactome-database",
+      "skillId": "42c1c9a6-c444-437a-bf2d-a4e325b2ba52",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/reactome-database",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-regulatory-affairs-head",
+      "skillId": "b7a53147-9571-4855-ba28-169cd4922f97",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/regulatory-affairs-head",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-scholar-evaluation",
+      "skillId": "19df73c4-9ded-4a80-bb06-47f1a854e9a5",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/scholar-evaluation",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-scientific-visualization",
+      "skillId": "c7a5e0fc-7724-49a4-8736-2d224174f55e",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/scientific-visualization",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-architect",
+      "skillId": "c82884aa-73fb-47ae-91b9-e1e0a415b07f",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-architect",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-backend",
+      "skillId": "7b7e2c70-e800-42b1-bdf8-2c6ea5836ce4",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-backend",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-devops",
+      "skillId": "c64122a1-6fca-4b27-93f0-d9f46324c5a3",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-devops",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-frontend",
+      "skillId": "8ed9c078-d4da-4bb3-9af7-7c191b8f2acc",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-frontend",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-fullstack",
+      "skillId": "3f9a3c25-09da-4ac1-93d0-0c55c18164f6",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-fullstack",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-ml-engineer",
+      "skillId": "c106af2d-1fd8-4aa7-b400-a45be2fd3831",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-ml-engineer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-prompt-engineer",
+      "skillId": "6a1756c7-13b3-4415-bf78-2d8d05b67cd2",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-prompt-engineer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-qa",
+      "skillId": "721cc65f-0480-405e-b9f0-441f6536b754",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-qa",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-secops",
+      "skillId": "4ee19016-fb4e-4b9a-a09b-4c6f86f10de4",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-secops",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-senior-security",
+      "skillId": "07fb3555-b493-4902-b40e-162ab52f6c26",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/senior-security",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-seo-optimizer",
+      "skillId": "d7599570-7ae5-4996-b989-3a10fda02e3c",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/seo-optimizer",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "davila7-shap",
+      "skillId": "002db7ad-7f2d-4750-a9e3-07a86f72a8c8",
+      "classificationRunId": "29392177791",
+      "path": "skills/davila7/shap",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    },
+    {
+      "slug": "dmitrypogrebnoy-generating-rbs",
+      "skillId": "6e6dc5b9-7093-421e-b9ff-d10d0e89b622",
+      "classificationRunId": "29392177791",
+      "path": "skills/dmitrypogrebnoy/generating-rbs",
+      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
+    }
+  ]
+}

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -13,15 +13,15 @@ function sha256(bytes) {
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'origin-boundary-'));
-  const rows = Array.from({ length: 70 }, (_, index) => ({
+  const rows = Array.from({ length: 54 }, (_, index) => ({
     slug: `owner-skill-${String(index).padStart(2, '0')}`,
     skillId: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
-    classificationRunId: String(1000 + (index % 7)),
+    classificationRunId: String(1000 + (index % 2)),
     path: `skills/owner/skill-${String(index).padStart(2, '0')}`,
     currentMarketplaceCommit: 'a'.repeat(40),
   }));
   const sourceBoundaries = [];
-  for (let index = 0; index < 7; index++) {
+  for (let index = 0; index < 2; index++) {
     const runId = String(1000 + index);
     const selected = rows.filter((row) => row.classificationRunId === runId).map((row) => ({
       id: row.skillId,
@@ -46,20 +46,20 @@ function fixture() {
       schemaVersion: 2,
       status: 'frozen_report_origin_cohort',
       repository: 'aiskillstore/marketplace',
-      selectedCount: 70,
+      selectedCount: 54,
       sourceBoundaries,
       rows,
     },
   };
 }
 
-test('builds and verifies only the exact 70 identities from seven hash-bound classifications', () => {
+test('builds and verifies only the exact 54 identities from two hash-bound classifications', () => {
   const item = fixture();
   try {
     const built = buildLegacyReportOriginBoundary({ cohort: item.cohort, boundariesRoot: item.root });
     const manifest = {
       status: 'legacy_report_origin_evidence_materialized',
-      selectedCount: 70,
+      selectedCount: 54,
       entries: item.cohort.rows,
     };
     const dryRunResults = [{
@@ -82,7 +82,7 @@ test('builds and verifies only the exact 70 identities from seven hash-bound cla
     }));
 
     const outside = structuredClone(manifest);
-    outside.selectedCount = 71;
+    outside.selectedCount = 55;
     outside.entries.push({ ...outside.entries[0], slug: 'outside-row' });
     assert.throws(() => verifyLegacyReportOriginDocuments({
       cohort: item.cohort,
@@ -90,7 +90,7 @@ test('builds and verifies only the exact 70 identities from seven hash-bound cla
       classification: built.classification,
       manifest: outside,
       dryRunResults,
-    }), /exactly the frozen 70-row cohort/);
+    }), /exactly the frozen cohort/);
 
     writeFileSync(join(item.root, '1000', 'classification.json'), '{"drift":true}\n');
     assert.throws(() => buildLegacyReportOriginBoundary({
@@ -109,19 +109,21 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   ), 'utf8');
   const cohort = JSON.parse(readFileSync(resolve(
     import.meta.dirname,
-    '../data/legacy-report-origin-cohort-v1.json'
+    '../data/legacy-report-origin-v2-only-cohort-v1.json'
   ), 'utf8'));
-  assert.equal(cohort.selectedCount, 70);
-  assert.equal(cohort.rows.length, 70);
-  assert.equal(cohort.sourceBoundaries.length, 7);
+  assert.equal(cohort.selectedCount, 54);
+  assert.equal(cohort.rows.length, 54);
+  assert.equal(cohort.sourceBoundaries.length, 2);
+  assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/legacy-report-origin-v2-only-cohort-v1\.json/);
+  assert.match(workflow, /ORIGIN_COHORT_SHA256: 7b9409e3eb748c9974e7e0c14a10b8507832ae0c22d2cc8b2171bf56d2292938/);
   assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.2'/);
   assert.match(workflow, /ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'/);
   assert.equal((workflow.match(/version: '2\.15\.2'/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$ORIGIN_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
-  assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin 70"/);
+  assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
-  assert.match(workflow, /--expected-count 70/);
+  assert.match(workflow, /--expected-count 54/);
   assert.equal(
     (workflow.match(/Normalize full checkout and verify report-origin runtime/g) || []).length,
     2

--- a/scripts/verify-legacy-report-origin-boundary.mjs
+++ b/scripts/verify-legacy-report-origin-boundary.mjs
@@ -29,23 +29,25 @@ function canonicalIdentities(rows) {
 }
 
 export function verifyLegacyReportOriginDocuments({ cohort, plan, classification, manifest, dryRunResults }) {
+  const selectedCount = cohort?.selectedCount;
   if (
     cohort?.schemaVersion !== 2
     || cohort?.status !== 'frozen_report_origin_cohort'
-    || cohort?.selectedCount !== 70
-    || cohort?.rows?.length !== 70
+    || !Number.isSafeInteger(selectedCount)
+    || selectedCount < 1
+    || cohort?.rows?.length !== selectedCount
     || plan?.status !== 'frozen_report_origin_plan'
-    || plan?.selectedCount !== 70
+    || plan?.selectedCount !== selectedCount
     || manifest?.status !== 'legacy_report_origin_evidence_materialized'
-    || manifest?.selectedCount !== 70
+    || manifest?.selectedCount !== selectedCount
     || classification?.status !== 'classified'
-    || classification?.classifiedCount !== 70
+    || classification?.classifiedCount !== selectedCount
     || classification?.counts?.exact !== 0
     || classification?.counts?.legacy_algorithm_equivalent !== 0
-    || classification?.counts?.actual_or_unproven_drift !== 70
-    || classification?.cohorts?.actual_or_unproven_drift?.length !== 70
+    || classification?.counts?.actual_or_unproven_drift !== selectedCount
+    || classification?.cohorts?.actual_or_unproven_drift?.length !== selectedCount
     || !Array.isArray(dryRunResults)
-  ) fail('report-origin boundary must cover exactly the frozen 70-row cohort');
+  ) fail('report-origin boundary must cover exactly the frozen cohort');
 
   const expected = canonicalIdentities(cohort.rows);
   const fromPlan = canonicalIdentities(plan.identities || []);
@@ -73,7 +75,7 @@ export function verifyLegacyReportOriginDocuments({ cohort, plan, classification
   const drySlugs = dryRows.map((row) => row?.slug).sort();
   const expectedSlugs = expected.map((row) => row.slug).sort();
   if (
-    dryRows.length !== 70
+    dryRows.length !== selectedCount
     || JSON.stringify(drySlugs) !== JSON.stringify(expectedSlugs)
     || dryRows.some((row) => (
       row?.mode !== 'dry-run'
@@ -81,8 +83,8 @@ export function verifyLegacyReportOriginDocuments({ cohort, plan, classification
       || row?.artifactRevision !== null
       || row?.derivedAuditId !== null
     ))
-  ) fail('administrator dry-run does not cover exactly 70 no-write results');
-  return { identitySha256: plan.identitySha256 };
+  ) fail('administrator dry-run does not cover exactly the frozen no-write cohort');
+  return { identitySha256: plan.identitySha256, selectedCount };
 }
 
 export function freezeLegacyReportOriginBoundary(input) {
@@ -97,13 +99,13 @@ export function freezeLegacyReportOriginBoundary(input) {
   return {
     schemaVersion: 1,
     status: 'frozen',
-    workflow: 'govern-legacy-report-origin-70',
+    workflow: 'govern-legacy-report-origin-v2-only',
     runId: input.runId,
     repository: input.repository,
     workflowCommit: input.workflowCommit,
     cliVersion: input.cliVersion,
     cliSha256: input.cliSha256,
-    selectedCount: 70,
+    selectedCount: verified.selectedCount,
     identitySha256: verified.identitySha256,
     cohortSha256: input.cohortSha256,
     planSha256: input.planSha256,
@@ -175,13 +177,13 @@ export function main(argv = process.argv.slice(2)) {
     };
     if (
       boundary?.status !== 'frozen'
-      || boundary?.workflow !== 'govern-legacy-report-origin-70'
+      || boundary?.workflow !== 'govern-legacy-report-origin-v2-only'
       || boundary?.runId !== args['expected-run-id']
-      || boundary?.selectedCount !== 70
+      || boundary?.selectedCount !== verified.selectedCount
       || boundary?.identitySha256 !== verified.identitySha256
       || Object.entries(digests).some(([key, value]) => boundary[key] !== value)
     ) fail('execute inputs differ from the successful frozen boundary');
-    return { status: 'verified', selectedCount: 70 };
+    return { status: 'verified', selectedCount: verified.selectedCount };
   }
   fail(`unsupported phase: ${args.phase}`);
 }


### PR DESCRIPTION
## Summary
- replace the stale 70-row Report-Origin workflow input with the live-rebuilt exact 54-row v2-only cohort
- pin the two immutable source classifications and exact cohort SHA-256
- make boundary construction and verification derive the frozen count while the workflow hard-gates 54 rows

## Production evidence
- current frozen source set: 70
- already governed: 16
- exact revision-0 v2 source-audit rows: 54/54
- raw32 overlap: 0
- deferred overlap: 0
- unqualified revision-0 rows: 0

## Tests
- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs scripts/tests/materialize-legacy-report-origin-evidence.test.mjs` (7/7)
- exact source-boundary replay and 54/54 Git lineage materialization
- `CI=true node --check` for both boundary scripts
- `git diff --check`