### PR TITLE
fix(governance): defer incomplete docx snapshot

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -29,7 +29,10 @@ env:
   # has been audited and this placeholder is replaced by its exact SHA-256.
   ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
   ORIGIN_COHORT: scripts/data/legacy-report-origin-v2-only-cohort-v1.json
-  ORIGIN_COHORT_SHA256: 7b9409e3eb748c9974e7e0c14a10b8507832ae0c22d2cc8b2171bf56d2292938
+  # Dry-run 29765964455 proved davila7-docx has four packaged files missing
+  # from its install-snapshot inputs. Keep it deferred instead of weakening
+  # exact file-structure validation for the ordinary Report-Origin cohort.
+  ORIGIN_COHORT_SHA256: af23709e6068d69460e83c43e026d54b802706ad6d39e2e722a8c2ee5c961c6e
 
 jobs:
   freeze-boundary:
@@ -73,7 +76,7 @@ jobs:
             test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
           done
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
-          jq -e '.schemaVersion == 2 and .selectedCount == 54 and (.rows | length) == 54 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
+          jq -e '.schemaVersion == 2 and .selectedCount == 53 and (.rows | length) == 53 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo '::error::CLI 2.15.2 audit digest is still a non-production placeholder'; exit 1;
           }
@@ -104,7 +107,7 @@ jobs:
             }
           done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
 
-      - name: Build exact 54-row v2-only drift classification and plan
+      - name: Build exact 53-row v2-only drift classification and plan
         run: |
           set -euo pipefail
           node scripts/build-legacy-report-origin-boundary.mjs \
@@ -118,7 +121,7 @@ jobs:
           set -euo pipefail
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
-            --expected-count 54 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 53 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/origin-lineage.json"
 
@@ -154,7 +157,7 @@ jobs:
           set -euo pipefail
           test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
 
-      - name: Run exact 54-row administrator dry-run
+      - name: Run exact 53-row administrator dry-run
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -274,7 +277,7 @@ jobs:
           test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
-            --expected-count 54 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 53 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/current-origin-lineage.json"
           cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
@@ -322,7 +325,7 @@ jobs:
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
 
-      - name: Execute only the frozen 54 rows
+      - name: Execute only the frozen 53 rows
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -348,7 +351,7 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
           jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
           jq -e '[.[].result.results[]] as $rows |
-            ($rows | length) == 54 and ($rows | map(.slug) | unique | length) == 54 and
+            ($rows | length) == 53 and ($rows | map(.slug) | unique | length) == 53 and
             ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
             "$RUNNER_TEMP/execution-results.json" >/dev/null
 

--- a/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
+++ b/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "status": "frozen_report_origin_cohort",
   "repository": "aiskillstore/marketplace",
-  "selectedCount": 54,
+  "selectedCount": 53,
   "sourceBoundaries": [
     {
       "runId": "29391998167",
@@ -124,13 +124,6 @@
       "skillId": "2b7f6468-de3a-4490-beaa-a18f7d98a869",
       "classificationRunId": "29392177791",
       "path": "skills/davila7/diffdock",
-      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
-    },
-    {
-      "slug": "davila7-docx",
-      "skillId": "bbdb6fc6-804c-4482-8efb-babd259b67c6",
-      "classificationRunId": "29392177791",
-      "path": "skills/davila7/docx",
       "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
     },
     {

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -13,7 +13,7 @@ function sha256(bytes) {
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'origin-boundary-'));
-  const rows = Array.from({ length: 54 }, (_, index) => ({
+  const rows = Array.from({ length: 53 }, (_, index) => ({
     slug: `owner-skill-${String(index).padStart(2, '0')}`,
     skillId: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
     classificationRunId: String(1000 + (index % 2)),
@@ -46,20 +46,20 @@ function fixture() {
       schemaVersion: 2,
       status: 'frozen_report_origin_cohort',
       repository: 'aiskillstore/marketplace',
-      selectedCount: 54,
+      selectedCount: 53,
       sourceBoundaries,
       rows,
     },
   };
 }
 
-test('builds and verifies only the exact 54 identities from two hash-bound classifications', () => {
+test('builds and verifies only the exact 53 identities from two hash-bound classifications', () => {
   const item = fixture();
   try {
     const built = buildLegacyReportOriginBoundary({ cohort: item.cohort, boundariesRoot: item.root });
     const manifest = {
       status: 'legacy_report_origin_evidence_materialized',
-      selectedCount: 54,
+      selectedCount: 53,
       entries: item.cohort.rows,
     };
     const dryRunResults = [{
@@ -82,7 +82,7 @@ test('builds and verifies only the exact 54 identities from two hash-bound class
     }));
 
     const outside = structuredClone(manifest);
-    outside.selectedCount = 55;
+    outside.selectedCount = 54;
     outside.entries.push({ ...outside.entries[0], slug: 'outside-row' });
     assert.throws(() => verifyLegacyReportOriginDocuments({
       cohort: item.cohort,
@@ -111,11 +111,12 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
     import.meta.dirname,
     '../data/legacy-report-origin-v2-only-cohort-v1.json'
   ), 'utf8'));
-  assert.equal(cohort.selectedCount, 54);
-  assert.equal(cohort.rows.length, 54);
+  assert.equal(cohort.selectedCount, 53);
+  assert.equal(cohort.rows.length, 53);
   assert.equal(cohort.sourceBoundaries.length, 2);
+  assert.equal(cohort.rows.some((row) => row.slug === 'davila7-docx'), false);
   assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/legacy-report-origin-v2-only-cohort-v1\.json/);
-  assert.match(workflow, /ORIGIN_COHORT_SHA256: 7b9409e3eb748c9974e7e0c14a10b8507832ae0c22d2cc8b2171bf56d2292938/);
+  assert.match(workflow, /ORIGIN_COHORT_SHA256: af23709e6068d69460e83c43e026d54b802706ad6d39e2e722a8c2ee5c961c6e/);
   assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.2'/);
   assert.match(workflow, /ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'/);
   assert.equal((workflow.match(/version: '2\.15\.2'/g) || []).length, 4);
@@ -123,7 +124,7 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
-  assert.match(workflow, /--expected-count 54/);
+  assert.match(workflow, /--expected-count 53/);
   assert.equal(
     (workflow.match(/Normalize full checkout and verify report-origin runtime/g) || []).length,
     2


### PR DESCRIPTION
## Summary
- seal failed no-write Report-Origin run `29765964455`
- defer only `davila7-docx` because its stored/report file structure omits four packaged OPC schema files (66 vs 70 nodes)
- freeze the ordinary v2-only cohort at exact 53 rows and keep strict install-snapshot validation unchanged

## Safety evidence
- failed run had artifact count 0 and execute job skipped
- production artifact/audit/observation/score/binding totals unchanged
- governed 5012/5349, revision0 337, broken pointers 0
- new deferred total: 23

## Tests
- focused Report-Origin tests 7/7
- exact 53/53 classification replay
- exact 53/53 Git lineage materialization
- node syntax checks and git diff check