### PR TITLE
fix(governance): freeze fully preflighted origin cohort

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -29,10 +29,11 @@ env:
   # has been audited and this placeholder is replaced by its exact SHA-256.
   ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
   ORIGIN_COHORT: scripts/data/legacy-report-origin-v2-only-cohort-v1.json
-  # Dry-run 29765964455 proved davila7-docx has four packaged files missing
-  # from its install-snapshot inputs. Keep it deferred instead of weakening
-  # exact file-structure validation for the ordinary Report-Origin cohort.
-  ORIGIN_COHORT_SHA256: af23709e6068d69460e83c43e026d54b802706ad6d39e2e722a8c2ee5c961c6e
+  # Dry-runs 29765964455 and 29767036462 exposed three incomplete stored
+  # file structures: davila7-docx (66/70 nodes), davila7-pptx (62/66), and
+  # dmitrypogrebnoy-generating-rbs (144/365). Keep them deferred instead of
+  # weakening exact install-snapshot validation for the ordinary cohort.
+  ORIGIN_COHORT_SHA256: 19405cdafddc726fca51dd26b7b7d3f40c1a12816c4b8ebe33fea2ed20e5c616
 
 jobs:
   freeze-boundary:
@@ -76,7 +77,7 @@ jobs:
             test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
           done
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
-          jq -e '.schemaVersion == 2 and .selectedCount == 53 and (.rows | length) == 53 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
+          jq -e '.schemaVersion == 2 and .selectedCount == 51 and (.rows | length) == 51 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo '::error::CLI 2.15.2 audit digest is still a non-production placeholder'; exit 1;
           }
@@ -107,7 +108,7 @@ jobs:
             }
           done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
 
-      - name: Build exact 53-row v2-only drift classification and plan
+      - name: Build exact 51-row v2-only drift classification and plan
         run: |
           set -euo pipefail
           node scripts/build-legacy-report-origin-boundary.mjs \
@@ -121,7 +122,7 @@ jobs:
           set -euo pipefail
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
-            --expected-count 53 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 51 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/origin-lineage.json"
 
@@ -157,7 +158,7 @@ jobs:
           set -euo pipefail
           test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
 
-      - name: Run exact 53-row administrator dry-run
+      - name: Run exact 51-row administrator dry-run
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -277,7 +278,7 @@ jobs:
           test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
-            --expected-count 53 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 51 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/current-origin-lineage.json"
           cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
@@ -325,7 +326,7 @@ jobs:
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
 
-      - name: Execute only the frozen 53 rows
+      - name: Execute only the frozen 51 rows
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -351,7 +352,7 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
           jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
           jq -e '[.[].result.results[]] as $rows |
-            ($rows | length) == 53 and ($rows | map(.slug) | unique | length) == 53 and
+            ($rows | length) == 51 and ($rows | map(.slug) | unique | length) == 51 and
             ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
             "$RUNNER_TEMP/execution-results.json" >/dev/null
 

--- a/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
+++ b/scripts/data/legacy-report-origin-v2-only-cohort-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "status": "frozen_report_origin_cohort",
   "repository": "aiskillstore/marketplace",
-  "selectedCount": 53,
+  "selectedCount": 51,
   "sourceBoundaries": [
     {
       "runId": "29391998167",
@@ -260,13 +260,6 @@
       "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
     },
     {
-      "slug": "davila7-pptx",
-      "skillId": "e70ad74d-85cc-410d-b502-30b100b9702a",
-      "classificationRunId": "29392177791",
-      "path": "skills/davila7/pptx",
-      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
-    },
-    {
       "slug": "davila7-reactome-database",
       "skillId": "42c1c9a6-c444-437a-bf2d-a4e325b2ba52",
       "classificationRunId": "29392177791",
@@ -376,13 +369,6 @@
       "skillId": "002db7ad-7f2d-4750-a9e3-07a86f72a8c8",
       "classificationRunId": "29392177791",
       "path": "skills/davila7/shap",
-      "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
-    },
-    {
-      "slug": "dmitrypogrebnoy-generating-rbs",
-      "skillId": "6e6dc5b9-7093-421e-b9ff-d10d0e89b622",
-      "classificationRunId": "29392177791",
-      "path": "skills/dmitrypogrebnoy/generating-rbs",
       "currentMarketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5"
     }
   ]

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -13,7 +13,7 @@ function sha256(bytes) {
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'origin-boundary-'));
-  const rows = Array.from({ length: 53 }, (_, index) => ({
+  const rows = Array.from({ length: 51 }, (_, index) => ({
     slug: `owner-skill-${String(index).padStart(2, '0')}`,
     skillId: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
     classificationRunId: String(1000 + (index % 2)),
@@ -46,20 +46,20 @@ function fixture() {
       schemaVersion: 2,
       status: 'frozen_report_origin_cohort',
       repository: 'aiskillstore/marketplace',
-      selectedCount: 53,
+      selectedCount: 51,
       sourceBoundaries,
       rows,
     },
   };
 }
 
-test('builds and verifies only the exact 53 identities from two hash-bound classifications', () => {
+test('builds and verifies only the exact 51 identities from two hash-bound classifications', () => {
   const item = fixture();
   try {
     const built = buildLegacyReportOriginBoundary({ cohort: item.cohort, boundariesRoot: item.root });
     const manifest = {
       status: 'legacy_report_origin_evidence_materialized',
-      selectedCount: 53,
+      selectedCount: 51,
       entries: item.cohort.rows,
     };
     const dryRunResults = [{
@@ -82,7 +82,7 @@ test('builds and verifies only the exact 53 identities from two hash-bound class
     }));
 
     const outside = structuredClone(manifest);
-    outside.selectedCount = 54;
+    outside.selectedCount = 52;
     outside.entries.push({ ...outside.entries[0], slug: 'outside-row' });
     assert.throws(() => verifyLegacyReportOriginDocuments({
       cohort: item.cohort,
@@ -111,12 +111,16 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
     import.meta.dirname,
     '../data/legacy-report-origin-v2-only-cohort-v1.json'
   ), 'utf8'));
-  assert.equal(cohort.selectedCount, 53);
-  assert.equal(cohort.rows.length, 53);
+  assert.equal(cohort.selectedCount, 51);
+  assert.equal(cohort.rows.length, 51);
   assert.equal(cohort.sourceBoundaries.length, 2);
-  assert.equal(cohort.rows.some((row) => row.slug === 'davila7-docx'), false);
+  assert.deepEqual(
+    ['davila7-docx', 'davila7-pptx', 'dmitrypogrebnoy-generating-rbs']
+      .filter((slug) => cohort.rows.some((row) => row.slug === slug)),
+    []
+  );
   assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/legacy-report-origin-v2-only-cohort-v1\.json/);
-  assert.match(workflow, /ORIGIN_COHORT_SHA256: af23709e6068d69460e83c43e026d54b802706ad6d39e2e722a8c2ee5c961c6e/);
+  assert.match(workflow, /ORIGIN_COHORT_SHA256: 19405cdafddc726fca51dd26b7b7d3f40c1a12816c4b8ebe33fea2ed20e5c616/);
   assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.2'/);
   assert.match(workflow, /ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'/);
   assert.equal((workflow.match(/version: '2\.15\.2'/g) || []).length, 4);
@@ -124,7 +128,7 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
-  assert.match(workflow, /--expected-count 53/);
+  assert.match(workflow, /--expected-count 51/);
   assert.equal(
     (workflow.match(/Normalize full checkout and verify report-origin runtime/g) || []).length,
     2


### PR DESCRIPTION
## Summary
- seal failed no-write run `29767036462`
- preflight every remaining Report-Origin row with the exact CLI install-snapshot validator
- defer `davila7-pptx` (62/66 nodes) and `dmitrypogrebnoy-generating-rbs` (144/365 nodes), alongside previously deferred `davila7-docx`
- freeze the fully preflighted ordinary v2-only cohort at exact 51

## Safety evidence
- run `29767036462` artifact count 0; execute skipped; production totals unchanged
- full local exact validator: 51 checked, 0 failures
- effective deferred: 25

## Tests
- focused Report-Origin tests 7/7
- 51/51 classification replay
- 51/51 Git lineage materialization
- 51/51 live DB install-snapshot input validation
- syntax and diff checks