### PR TITLE
fix(governance): pin CLI 2.15.9 for report origin

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -24,10 +24,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ORIGIN_CLI_VERSION: '2.15.2'
+  ORIGIN_CLI_VERSION: '2.15.9'
   # Production is intentionally impossible until the released linux-x64 binary
   # has been audited and this placeholder is replaced by its exact SHA-256.
-  ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'
+  ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'
   ORIGIN_COHORT: scripts/data/legacy-report-origin-v2-only-cohort-v1.json
   # Dry-runs 29765964455 and 29767036462 exposed three incomplete stored
   # file structures: davila7-docx (66/70 nodes), davila7-pptx (62/66), and
@@ -79,7 +79,7 @@ jobs:
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           jq -e '.schemaVersion == 2 and .selectedCount == 51 and (.rows | length) == 51 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
-            echo '::error::CLI 2.15.2 audit digest is still a non-production placeholder'; exit 1;
+            echo '::error::CLI 2.15.9 audit digest is still a non-production placeholder'; exit 1;
           }
 
       - name: Download and verify two frozen drift classifications
@@ -149,8 +149,8 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.2'
-          minimum-version: '2.15.2'
+          version: '2.15.9'
+          minimum-version: '2.15.9'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify audited CLI binary identity
@@ -315,8 +315,8 @@ jobs:
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.2'
-          minimum-version: '2.15.2'
+          version: '2.15.9'
+          minimum-version: '2.15.9'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI binary identity

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -121,9 +121,9 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   );
   assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/legacy-report-origin-v2-only-cohort-v1\.json/);
   assert.match(workflow, /ORIGIN_COHORT_SHA256: 19405cdafddc726fca51dd26b7b7d3f40c1a12816c4b8ebe33fea2ed20e5c616/);
-  assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.2'/);
-  assert.match(workflow, /ORIGIN_CLI_SHA256: 'fceaa46ab5e8cb2b68398a49f1e6c041bfa4cc83abc00221ba7d1e2bf83a73e4'/);
-  assert.equal((workflow.match(/version: '2\.15\.2'/g) || []).length, 4);
+  assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.9'/);
+  assert.match(workflow, /ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'/);
+  assert.equal((workflow.match(/version: '2\.15\.9'/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$ORIGIN_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);


### PR DESCRIPTION
## Summary
- pin Report-Origin governance to Skillstore CLI 2.15.9
- bind the released Linux binary SHA-256 `9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec`
- update the workflow contract test

## Incident boundary
- sealed dry-run: 29767776933
- sealed failed execute: 29768013787
- this PR does not add or dispatch a recovery mode

## Verification
- release run 29770019939 succeeded
- release checksum verified locally with `sha256sum -c`
- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs` (2/2)