### PR TITLE
fix(governance): authenticate report-origin score recovery

### DIFF
--- a/.github/workflows/recover-report-origin-score-cache.yml
+++ b/.github/workflows/recover-report-origin-score-cache.yml
@@ -1,0 +1,489 @@
+name: Recover Report-Origin Score Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Freeze a no-write recovery boundary, or execute one frozen recovery boundary'
+        type: choice
+        required: true
+        default: dry-run
+        options: [dry-run, execute]
+      recovery_dry_run_id:
+        description: 'Successful recovery dry-run ID; execute only'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: production-skill-score-writes
+  cancel-in-progress: false
+
+env:
+  INCIDENT_DRY_RUN_ID: '29767776933'
+  INCIDENT_DRY_RUN_ARTIFACT_ID: '8471506972'
+  INCIDENT_DRY_RUN_ARTIFACT_DIGEST: 'sha256:54ca9879668e85d536d31ce74422e6df114b3b8252e50dd9e0889a6307f2770b'
+  INCIDENT_EXECUTE_ID: '29768013787'
+  INCIDENT_EXECUTE_ARTIFACT_ID: '8471676204'
+  INCIDENT_EXECUTE_ARTIFACT_DIGEST: 'sha256:8375916d0a9fe27891219f449cc33015522680cf0d8bb8856d52acbe8a19d770'
+  INCIDENT_HEAD_SHA: '2a5337224b4e4ed4b57eb1cd1c0ad07268151a91'
+  RECOVERY_CLI_VERSION: '2.15.9'
+  RECOVERY_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'
+  RECOVERY_SLUG: crossbill-highlights-css-colors
+  RECOVERY_SKILL_ID: '677e8ec5-469c-4f23-b093-600b86d1ec7b'
+  RECOVERY_SOURCE_AUDIT_ID: 'e4c51fcf-ea3a-445c-b272-7efa905b1e7a'
+  RECOVERY_DERIVED_AUDIT_ID: '236bbc4b-a470-4415-8e6e-5bd1a5515c7d'
+  RECOVERY_ARTIFACT_ID: '10a37dd7-df62-4669-a8da-34f0d7117682'
+  RECOVERY_OBSERVATION_ID: 'f8311f04-b75f-4b6a-8147-246b24cae6bb'
+  RECOVERY_CLASSIFIED_UPDATED_AT: '2026-07-14T05:37:43.583904+00:00'
+  RECOVERY_FROZEN_UPDATED_AT: '2026-07-20T10:12:17.326416+00:00'
+
+jobs:
+  freeze-recovery-boundary:
+    if: inputs.mode == 'dry-run'
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout immutable recovery runtime
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Validate no-write recovery request
+        env:
+          RECOVERY_DRY_RUN_ID: ${{ inputs.recovery_dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          test -z "$RECOVERY_DRY_RUN_ID"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -f .github/actions/download-skillstore-cli/action.yml
+          test -f scripts/materialize-legacy-report-origin-evidence.mjs
+
+      - name: Authenticate sealed incident artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/recovery-source"
+          mkdir -p "$source/original-boundary" "$source/failed-execute"
+
+          dry_run=$(gh run view "$INCIDENT_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          failed=$(gh run view "$INCIDENT_EXECUTE_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$INCIDENT_DRY_RUN_ID" --arg sha "$INCIDENT_HEAD_SHA" '
+            .databaseId==$id and .conclusion=="success" and .event=="workflow_dispatch" and
+            .headBranch=="main" and .headSha==$sha and
+            .workflowName=="Govern Legacy Report-Origin V2-Only"
+          ' <<< "$dry_run" >/dev/null
+          jq -e --argjson id "$INCIDENT_EXECUTE_ID" --arg sha "$INCIDENT_HEAD_SHA" '
+            .databaseId==$id and .conclusion=="failure" and .event=="workflow_dispatch" and
+            .headBranch=="main" and .headSha==$sha and
+            .workflowName=="Govern Legacy Report-Origin V2-Only"
+          ' <<< "$failed" >/dev/null
+
+          dry_artifact=$(gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts/$INCIDENT_DRY_RUN_ARTIFACT_ID")
+          failed_artifact=$(gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts/$INCIDENT_EXECUTE_ARTIFACT_ID")
+          jq -e --argjson id "$INCIDENT_DRY_RUN_ARTIFACT_ID" \
+            --arg digest "$INCIDENT_DRY_RUN_ARTIFACT_DIGEST" --arg run "$INCIDENT_DRY_RUN_ID" '
+            .id==$id and .digest==$digest and .expired==false and
+            .name==("legacy-report-origin-v2-only-boundary-"+$run)
+          ' <<< "$dry_artifact" >/dev/null
+          jq -e --argjson id "$INCIDENT_EXECUTE_ARTIFACT_ID" \
+            --arg digest "$INCIDENT_EXECUTE_ARTIFACT_DIGEST" --arg run "$INCIDENT_EXECUTE_ID" '
+            .id==$id and .digest==$digest and .expired==false and
+            .name==("legacy-report-origin-v2-only-execution-"+$run)
+          ' <<< "$failed_artifact" >/dev/null
+
+          gh run download "$INCIDENT_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-report-origin-v2-only-boundary-$INCIDENT_DRY_RUN_ID" \
+            --dir "$source/original-boundary"
+          gh run download "$INCIDENT_EXECUTE_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "legacy-report-origin-v2-only-execution-$INCIDENT_EXECUTE_ID" \
+            --dir "$source/failed-execute"
+          (cd "$source/original-boundary" && sha256sum --check SHA256SUMS)
+          diff -qr "$source/original-boundary" "$source/failed-execute/boundary"
+          test ! -e "$source/failed-execute/execution-results.json"
+          test ! -e "$source/failed-execute/post-inventory.json"
+          test ! -e "$source/failed-execute/execution-proof"
+
+      - name: Build the exact one-row recovery projection
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/recovery-source"
+          jq --arg slug "$RECOVERY_SLUG" \
+            --arg old "$RECOVERY_CLASSIFIED_UPDATED_AT" \
+            --arg live "$RECOVERY_FROZEN_UPDATED_AT" '
+            if (([.cohorts.actual_or_unproven_drift[] | select(.slug==$slug)] | length)==1 and
+              ([.cohorts.actual_or_unproven_drift[] | select(.slug==$slug) |
+                select(.updatedAt==$old and .evidence.artifact.skillUpdatedAt==$old)] | length)==1)
+            then . else error("incident classification timestamp differs") end |
+            .cohorts.actual_or_unproven_drift |= map(
+              if .slug==$slug then
+                .updatedAt=$live | .evidence.artifact.skillUpdatedAt=$live
+              else . end
+            )
+          ' "$source/original-boundary/classification.json" > "$source/recovery-classification.json"
+          jq --arg slug "$RECOVERY_SLUG" --arg live "$RECOVERY_FROZEN_UPDATED_AT" -e '
+            [.cohorts.actual_or_unproven_drift[] | select(.slug==$slug) |
+              select(.updatedAt==$live and .evidence.artifact.skillUpdatedAt==$live)] | length==1
+          ' "$source/recovery-classification.json" >/dev/null
+
+      - name: Re-materialize immutable Git evidence
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/recovery-source"
+          node scripts/materialize-legacy-report-origin-evidence.mjs \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --cohort "$source/original-boundary/cohort.json" --expected-count 51 \
+            --origin-root "$RUNNER_TEMP/origin" --previous-report-root "$RUNNER_TEMP/previous" \
+            --manifest "$RUNNER_TEMP/current-origin-lineage.json"
+          cmp "$source/original-boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            root="$RUNNER_TEMP/current/$commit"
+            mkdir -p "$root"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+          done < <(jq -c '.groups[]' "$source/original-boundary/plan.json")
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact fixed CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.15.9'
+          minimum-version: '2.15.9'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Freeze production state without writes
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          test "$(sha256sum skillstore-cli | awk '{print $1}')" = "$RECOVERY_CLI_SHA256"
+          source="$RUNNER_TEMP/recovery-source"
+          snapshot() {
+            output=$1
+            auth=(-H "apikey: $SUPABASE_SERVICE_ROLE_KEY" -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" -H 'Accept-Profile: skillstore')
+            api="$PUBLIC_SUPABASE_URL/rest/v1"
+            curl -fsS "${auth[@]}" "$api/skills?id=eq.$RECOVERY_SKILL_ID&select=id,slug,artifact_revision,current_artifact_version_id,public_eligibility_audit_id,current_quality_score_snapshot_id,quality_score,updated_at,published_at,content_hash,tree_hash,marketplace_commit_sha,plugin_path" > "$RUNNER_TEMP/skill.json"
+            curl -fsS "${auth[@]}" "$api/skill_artifact_versions?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/artifacts.json"
+            curl -fsS "${auth[@]}" "$api/skill_security_audit?skill_id=eq.$RECOVERY_SKILL_ID&select=id,skill_id,version,content_hash,subject_marketplace_commit_sha,subject_content_hash,subject_tree_hash,subject_plugin_path,derived_from_audit_id,derivation_kind&order=version.asc" > "$RUNNER_TEMP/audits.json"
+            curl -fsS "${auth[@]}" "$api/skill_artifact_observations?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/observations.json"
+            curl -fsS "${auth[@]}" "$api/skill_quality_score_snapshots?skill_id=eq.$RECOVERY_SKILL_ID&select=id,skill_id,composite_score,score_subject,created_at&order=created_at.asc" > "$RUNNER_TEMP/scores.json"
+            curl -fsS "${auth[@]}" "$api/legacy_audit_subject_bindings?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/bindings.json"
+            jq -n -S --slurpfile skill "$RUNNER_TEMP/skill.json" --slurpfile artifacts "$RUNNER_TEMP/artifacts.json" \
+              --slurpfile audits "$RUNNER_TEMP/audits.json" --slurpfile observations "$RUNNER_TEMP/observations.json" \
+              --slurpfile scores "$RUNNER_TEMP/scores.json" --slurpfile bindings "$RUNNER_TEMP/bindings.json" \
+              '{skill:$skill[0],artifacts:$artifacts[0],audits:$audits[0],observations:$observations[0],scores:$scores[0],bindings:$bindings[0]}' > "$output"
+          }
+          snapshot "$source/pre-inventory.json"
+          jq -e --arg artifact "$RECOVERY_ARTIFACT_ID" --arg sourceAudit "$RECOVERY_SOURCE_AUDIT_ID" \
+            --arg derivedAudit "$RECOVERY_DERIVED_AUDIT_ID" --arg observation "$RECOVERY_OBSERVATION_ID" \
+            --arg updated "$RECOVERY_FROZEN_UPDATED_AT" '
+            (.skill|length)==1 and .skill[0].artifact_revision==1 and
+            .skill[0].current_artifact_version_id==$artifact and .skill[0].public_eligibility_audit_id==$derivedAudit and
+            .skill[0].current_quality_score_snapshot_id==null and .skill[0].quality_score==null and
+            .skill[0].updated_at==$updated and
+            ([.artifacts[]|select(.id==$artifact)]|length)==1 and
+            ([.audits[]|select(.id==$sourceAudit)]|length)==1 and
+            ([.audits[]|select(.id==$derivedAudit and .derived_from_audit_id==$sourceAudit)]|length)==1 and
+            ([.observations[]|select(.id==$observation and .artifact_version_id==$artifact)]|length)==1
+          ' "$source/pre-inventory.json" >/dev/null
+
+          mkdir -p "$RUNNER_TEMP/recovery-dry-run-groups"
+          : > "$RUNNER_TEMP/recovery-dry-run-results.jsonl"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            slugs=$(jq -r '.slugs|join(",")' <<< "$group")
+            result="$RUNNER_TEMP/recovery-dry-run-groups/$commit.json"
+            "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+              --classification "$source/recovery-classification.json" \
+              --legacy-origin-lineage "$RUNNER_TEMP/current-origin-lineage.json" \
+              --legacy-origin-root "$RUNNER_TEMP/origin" \
+              --legacy-previous-report-root "$RUNNER_TEMP/previous" \
+              --root "$RUNNER_TEMP/current/$commit" --slugs "$slugs" \
+              --dry-run --concurrency 1 --result-file "$result"
+            jq -n -c --arg commit "$commit" --slurpfile result "$result" \
+              '{marketplaceCommit:$commit,result:$result[0]}' >> "$RUNNER_TEMP/recovery-dry-run-results.jsonl"
+          done < <(jq -c '.groups[]' "$source/original-boundary/plan.json")
+          jq -s . "$RUNNER_TEMP/recovery-dry-run-results.jsonl" > "$source/dry-run-results.json"
+          jq -e --arg slug "$RECOVERY_SLUG" --arg skill "$RECOVERY_SKILL_ID" --arg audit "$RECOVERY_SOURCE_AUDIT_ID" '
+            [.[].result.results[]] as $rows |
+            ($rows|length)==51 and ($rows|map(.slug)|unique|length)==51 and
+            ($rows|all(.mode=="dry-run" and .artifactVersionId==null and .derivedAuditId==null and .scoreSnapshotId==null)) and
+            ([$rows[]|select(.slug==$slug and .skillId==$skill and .sourceAuditId==$audit)]|length)==1
+          ' "$source/dry-run-results.json" >/dev/null
+          snapshot "$source/post-inventory.json"
+          cmp "$source/pre-inventory.json" "$source/post-inventory.json"
+
+      - name: Seal recovery boundary
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/recovery-source"
+          jq -n \
+            --arg workflowCommit "$GITHUB_SHA" --arg runId "$GITHUB_RUN_ID" \
+            --arg incidentDryRunId "$INCIDENT_DRY_RUN_ID" --arg incidentExecuteId "$INCIDENT_EXECUTE_ID" \
+            --arg cliVersion "$RECOVERY_CLI_VERSION" --arg cliSha256 "$RECOVERY_CLI_SHA256" \
+            --arg slug "$RECOVERY_SLUG" --arg skillId "$RECOVERY_SKILL_ID" \
+            --arg artifactId "$RECOVERY_ARTIFACT_ID" --arg sourceAuditId "$RECOVERY_SOURCE_AUDIT_ID" \
+            --arg derivedAuditId "$RECOVERY_DERIVED_AUDIT_ID" --arg frozenUpdatedAt "$RECOVERY_FROZEN_UPDATED_AT" \
+            --arg classificationSha256 "$(sha256sum "$source/recovery-classification.json" | awk '{print $1}')" \
+            --arg preInventorySha256 "$(sha256sum "$source/pre-inventory.json" | awk '{print $1}')" \
+            '{schemaVersion:1,status:"report_origin_score_cache_recovery_frozen",workflowCommit:$workflowCommit,runId:$runId,
+              incidentDryRunId:$incidentDryRunId,incidentExecuteId:$incidentExecuteId,cliVersion:$cliVersion,cliSha256:$cliSha256,
+              slug:$slug,skillId:$skillId,artifactId:$artifactId,sourceAuditId:$sourceAuditId,
+              derivedAuditId:$derivedAuditId,frozenUpdatedAt:$frozenUpdatedAt,
+              classificationSha256:$classificationSha256,preInventorySha256:$preInventorySha256}' \
+            > "$source/recovery-boundary.json"
+          (cd "$source" && sha256sum recovery-boundary.json recovery-classification.json pre-inventory.json post-inventory.json dry-run-results.json > SHA256SUMS)
+
+      - name: Upload immutable recovery boundary
+        uses: actions/upload-artifact@v6
+        with:
+          name: report-origin-score-cache-recovery-boundary-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/recovery-source/original-boundary/
+            ${{ runner.temp }}/recovery-source/failed-execute/
+            ${{ runner.temp }}/recovery-source/recovery-boundary.json
+            ${{ runner.temp }}/recovery-source/recovery-classification.json
+            ${{ runner.temp }}/recovery-source/pre-inventory.json
+            ${{ runner.temp }}/recovery-source/post-inventory.json
+            ${{ runner.temp }}/recovery-source/dry-run-results.json
+            ${{ runner.temp }}/recovery-source/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 30
+
+  execute-recovery-boundary:
+    if: inputs.mode == 'execute'
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout immutable recovery runtime
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          clean: true
+          sparse-checkout: ''
+          sparse-checkout-cone-mode: false
+
+      - name: Download and authenticate recovery boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECOVERY_DRY_RUN_ID: ${{ inputs.recovery_dry_run_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          [[ "$RECOVERY_DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          run=$(gh run view "$RECOVERY_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,conclusion,event,headBranch,headSha,workflowName)
+          jq -e --argjson id "$RECOVERY_DRY_RUN_ID" '
+            .databaseId==$id and .conclusion=="success" and .event=="workflow_dispatch" and
+            .headBranch=="main" and .workflowName=="Recover Report-Origin Score Cache"
+          ' <<< "$run" >/dev/null
+          mkdir -p "$RUNNER_TEMP/recovery"
+          gh run download "$RECOVERY_DRY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "report-origin-score-cache-recovery-boundary-$RECOVERY_DRY_RUN_ID" \
+            --dir "$RUNNER_TEMP/recovery"
+          (cd "$RUNNER_TEMP/recovery" && sha256sum --check SHA256SUMS)
+          (cd "$RUNNER_TEMP/recovery/original-boundary" && sha256sum --check SHA256SUMS)
+          test "$GITHUB_SHA" = "$(jq -r .headSha <<< "$run")"
+          test "$(jq -r .workflowCommit "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$(jq -r .headSha <<< "$run")"
+          test "$(jq -r .cliVersion "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$RECOVERY_CLI_VERSION"
+          test "$(jq -r .cliSha256 "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$RECOVERY_CLI_SHA256"
+          test "$(jq -r .incidentDryRunId "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$INCIDENT_DRY_RUN_ID"
+          test "$(jq -r .incidentExecuteId "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$INCIDENT_EXECUTE_ID"
+          test "$(jq -r .artifactId "$RUNNER_TEMP/recovery/recovery-boundary.json")" = "$RECOVERY_ARTIFACT_ID"
+
+      - name: Re-materialize immutable Git evidence
+        run: |
+          set -euo pipefail
+          recovery="$RUNNER_TEMP/recovery"
+          node scripts/materialize-legacy-report-origin-evidence.mjs \
+            --repository-root "$GITHUB_WORKSPACE" --cohort "$recovery/original-boundary/cohort.json" \
+            --expected-count 51 --origin-root "$RUNNER_TEMP/origin" \
+            --previous-report-root "$RUNNER_TEMP/previous" --manifest "$RUNNER_TEMP/current-origin-lineage.json"
+          cmp "$recovery/original-boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json"
+          while IFS= read -r group; do
+            commit=$(jq -r .marketplaceCommit <<< "$group")
+            root="$RUNNER_TEMP/current/$commit"
+            mkdir -p "$root"
+            mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+            git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$root"
+          done < <(jq -c '.groups[]' "$recovery/original-boundary/plan.json")
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace,skillstore
+
+      - name: Download exact fixed CLI
+        uses: ./.github/actions/download-skillstore-cli
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: '2.15.9'
+          minimum-version: '2.15.9'
+          cache-dir: /home/runner/_work/_cache/skillstore-cli
+
+      - name: Execute score and cache closure only
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          CACHE_INVALIDATE_SECRET: ${{ secrets.CACHE_INVALIDATE_SECRET }}
+          SKILLSTORE_SITE_URL: https://skillstore.io
+        run: |
+          set -euo pipefail
+          test "$(sha256sum skillstore-cli | awk '{print $1}')" = "$RECOVERY_CLI_SHA256"
+          recovery="$RUNNER_TEMP/recovery"
+          snapshot() {
+            output=$1
+            auth=(-H "apikey: $SUPABASE_SERVICE_ROLE_KEY" -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" -H 'Accept-Profile: skillstore')
+            api="$PUBLIC_SUPABASE_URL/rest/v1"
+            curl -fsS "${auth[@]}" "$api/skills?id=eq.$RECOVERY_SKILL_ID&select=id,slug,artifact_revision,current_artifact_version_id,public_eligibility_audit_id,current_quality_score_snapshot_id,quality_score,updated_at,published_at,content_hash,tree_hash,marketplace_commit_sha,plugin_path" > "$RUNNER_TEMP/skill.json"
+            curl -fsS "${auth[@]}" "$api/skill_artifact_versions?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/artifacts.json"
+            curl -fsS "${auth[@]}" "$api/skill_security_audit?skill_id=eq.$RECOVERY_SKILL_ID&select=id,skill_id,version,content_hash,subject_marketplace_commit_sha,subject_content_hash,subject_tree_hash,subject_plugin_path,derived_from_audit_id,derivation_kind&order=version.asc" > "$RUNNER_TEMP/audits.json"
+            curl -fsS "${auth[@]}" "$api/skill_artifact_observations?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/observations.json"
+            curl -fsS "${auth[@]}" "$api/skill_quality_score_snapshots?skill_id=eq.$RECOVERY_SKILL_ID&select=id,skill_id,composite_score,score_subject,created_at&order=created_at.asc" > "$RUNNER_TEMP/scores.json"
+            curl -fsS "${auth[@]}" "$api/legacy_audit_subject_bindings?skill_id=eq.$RECOVERY_SKILL_ID&select=*&order=id.asc" > "$RUNNER_TEMP/bindings.json"
+            jq -n -S --slurpfile skill "$RUNNER_TEMP/skill.json" --slurpfile artifacts "$RUNNER_TEMP/artifacts.json" \
+              --slurpfile audits "$RUNNER_TEMP/audits.json" --slurpfile observations "$RUNNER_TEMP/observations.json" \
+              --slurpfile scores "$RUNNER_TEMP/scores.json" --slurpfile bindings "$RUNNER_TEMP/bindings.json" \
+              '{skill:$skill[0],artifacts:$artifacts[0],audits:$audits[0],observations:$observations[0],scores:$scores[0],bindings:$bindings[0]}' > "$output"
+          }
+          snapshot "$RUNNER_TEMP/live-pre-inventory.json"
+          cmp "$recovery/pre-inventory.json" "$RUNNER_TEMP/live-pre-inventory.json"
+          commit=$(jq -r --arg slug "$RECOVERY_SLUG" '.groups[] | select(.slugs|index($slug)) | .marketplaceCommit' "$recovery/original-boundary/plan.json")
+          "$GITHUB_WORKSPACE/skillstore-cli" skill govern-legacy-equivalent \
+            --classification "$recovery/recovery-classification.json" \
+            --legacy-origin-lineage "$RUNNER_TEMP/current-origin-lineage.json" \
+            --legacy-origin-root "$RUNNER_TEMP/origin" \
+            --legacy-previous-report-root "$RUNNER_TEMP/previous" \
+            --root "$RUNNER_TEMP/current/$commit" --slugs "$RECOVERY_SLUG" \
+            --concurrency 1 --result-file "$RUNNER_TEMP/execution-results.json"
+          jq -e --arg slug "$RECOVERY_SLUG" --arg artifact "$RECOVERY_ARTIFACT_ID" \
+            --arg audit "$RECOVERY_DERIVED_AUDIT_ID" '
+            .mode=="execute" and .governed==1 and .validated==1 and (.results|length)==1 and
+            .results[0].slug==$slug and .results[0].artifactVersionId==$artifact and
+            .results[0].derivedAuditId==$audit and .results[0].artifactCreated==false and
+            (.results[0].scoreSnapshotId|test("^[0-9a-f-]{36}$"))
+          ' "$RUNNER_TEMP/execution-results.json" >/dev/null
+          snapshot "$RUNNER_TEMP/post-inventory.json"
+          jq -e --slurpfile before "$recovery/pre-inventory.json" \
+            --arg artifact "$RECOVERY_ARTIFACT_ID" --arg audit "$RECOVERY_DERIVED_AUDIT_ID" \
+            --arg updated "$RECOVERY_FROZEN_UPDATED_AT" '
+            .artifacts==$before[0].artifacts and .audits==$before[0].audits and
+            .observations==$before[0].observations and .bindings==$before[0].bindings and
+            (.skill|length)==1 and .skill[0].artifact_revision==1 and
+            .skill[0].current_artifact_version_id==$artifact and .skill[0].public_eligibility_audit_id==$audit and
+            (.skill[0].current_quality_score_snapshot_id|test("^[0-9a-f-]{36}$")) and
+            (.skill[0].quality_score|type)=="number" and .skill[0].updated_at==$updated
+          ' "$RUNNER_TEMP/post-inventory.json" >/dev/null
+          before_scores=$(jq '.scores|length' "$recovery/pre-inventory.json")
+          test "$(jq '.scores|length' "$RUNNER_TEMP/post-inventory.json")" -eq "$((before_scores + 1))"
+
+      - name: Verify affected Skill P0/P1 paths without Pack generation
+        env:
+          RECOVERY_RESULT_FILE: ${{ runner.temp }}/recovery-smoke.json
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { writeFile } from 'node:fs/promises';
+          const base = 'https://skillstore.io';
+          const slug = process.env.RECOVERY_SLUG;
+          const get = async (path) => {
+            let last;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              last = await fetch(`${base}${path}`);
+              if (last.ok) return last;
+              await new Promise((resolve) => setTimeout(resolve, 3000));
+            }
+            throw new Error(`${path}: HTTP ${last?.status}`);
+          };
+          let detail;
+          for (let attempt = 1; attempt <= 5; attempt++) {
+            detail = await (await get(`/api/skills/${slug}`)).json();
+            if (detail.data?.slug === slug && typeof detail.data?.qualityScore === 'number' && detail.data?.skillstoreRevision === 1) break;
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+          }
+          if (detail?.data?.slug !== slug || typeof detail.data?.qualityScore !== 'number' || detail.data?.skillstoreRevision !== 1) {
+            throw new Error('detail cache did not expose the recovered score and revision');
+          }
+          const manifestResponse = await get(`/api/skills/${slug}/manifest`);
+          const manifest = await manifestResponse.json();
+          const direct = await get(`/api/skills/${slug}/download`);
+          const zip = Buffer.from(await direct.arrayBuffer());
+          if (zip.length < 100 || !String(direct.headers.get('content-disposition')).includes('attachment;')) {
+            throw new Error('direct Skill ZIP is incomplete');
+          }
+          await get(`/skills/${slug}`);
+          await writeFile(process.env.RECOVERY_RESULT_FILE, `${JSON.stringify({
+            slug,
+            qualityScore: detail.data.qualityScore,
+            skillstoreRevision: detail.data.skillstoreRevision,
+            manifestKind: manifest.kind ?? null,
+            zipBytes: zip.length,
+            zipSha256: createHash('sha256').update(zip).digest('hex'),
+            packGenerationTouched: false,
+          }, null, 2)}\n`);
+          NODE
+
+      - name: Seal and upload recovery proof
+        if: always()
+        run: |
+          set -euo pipefail
+          proof="$RUNNER_TEMP/recovery-proof"
+          mkdir -p "$proof"
+          cp "$RUNNER_TEMP/execution-results.json" "$proof/" 2>/dev/null || true
+          cp "$RUNNER_TEMP/post-inventory.json" "$proof/" 2>/dev/null || true
+          cp "$RUNNER_TEMP/recovery-smoke.json" "$proof/" 2>/dev/null || true
+          if test -f "$proof/execution-results.json" && test -f "$proof/post-inventory.json" && test -f "$proof/recovery-smoke.json"; then
+            jq -n --arg executeRunId "$GITHUB_RUN_ID" --arg dryRunId '${{ inputs.recovery_dry_run_id }}' \
+              --arg workflowCommit "$GITHUB_SHA" --arg slug "$RECOVERY_SLUG" \
+              --arg artifactId "$RECOVERY_ARTIFACT_ID" --arg derivedAuditId "$RECOVERY_DERIVED_AUDIT_ID" \
+              --arg executionResultsSha256 "$(sha256sum "$proof/execution-results.json" | awk '{print $1}')" \
+              --arg postInventorySha256 "$(sha256sum "$proof/post-inventory.json" | awk '{print $1}')" \
+              --arg smokeSha256 "$(sha256sum "$proof/recovery-smoke.json" | awk '{print $1}')" \
+              '{schemaVersion:1,status:"report_origin_score_cache_recovery_complete",executeRunId:$executeRunId,
+                dryRunId:$dryRunId,workflowCommit:$workflowCommit,slug:$slug,artifactId:$artifactId,
+                derivedAuditId:$derivedAuditId,artifactAuditObservationRewritten:false,scoreFinalized:true,
+                cacheClosureCompleted:true,affectedSkillSmokeCompleted:true,packGenerationTouched:false,
+                executionResultsSha256:$executionResultsSha256,postInventorySha256:$postInventorySha256,smokeSha256:$smokeSha256}' \
+              > "$proof/proof.json"
+            (cd "$proof" && sha256sum *.json > SHA256SUMS)
+          fi
+
+      - name: Upload recovery execution evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: report-origin-score-cache-recovery-execution-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/recovery/
+            ${{ runner.temp }}/live-pre-inventory.json
+            ${{ runner.temp }}/execution-results.json
+            ${{ runner.temp }}/post-inventory.json
+            ${{ runner.temp }}/recovery-smoke.json
+            ${{ runner.temp }}/recovery-proof/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -143,3 +143,24 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.equal((workflow.match(/--legacy-origin-root/g) || []).length, 2);
   assert.equal((workflow.match(/--legacy-previous-report-root/g) || []).length, 2);
 });
+
+test('score-cache recovery is one-row, two-stage, and cannot rewrite incident artifacts', () => {
+  const workflow = readFileSync(resolve(
+    import.meta.dirname,
+    '../../.github/workflows/recover-report-origin-score-cache.yml'
+  ), 'utf8');
+  assert.match(workflow, /options: \[dry-run, execute\]/);
+  assert.match(workflow, /group: production-skill-score-writes/);
+  assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29767776933'/);
+  assert.match(workflow, /INCIDENT_EXECUTE_ID: '29768013787'/);
+  assert.match(workflow, /RECOVERY_CLI_VERSION: '2\.15\.9'/);
+  assert.match(workflow, /RECOVERY_SLUG: crossbill-highlights-css-colors/);
+  assert.match(workflow, /\.cohorts\.actual_or_unproven_drift \|= map/);
+  assert.match(workflow, /artifactCreated==false/);
+  assert.match(workflow, /\(\$rows\|length\)==51/);
+  assert.match(workflow, /\.artifacts==\$before\[0\]\.artifacts/);
+  assert.match(workflow, /\.audits==\$before\[0\]\.audits/);
+  assert.match(workflow, /\.observations==\$before\[0\]\.observations/);
+  assert.match(workflow, /packGenerationTouched:false/);
+  assert.doesNotMatch(workflow, /generate-packs|install_pack|\/api\/packs/);
+});


### PR DESCRIPTION
## Summary
- add a one-time two-stage recovery lane for the sealed Report-Origin incident
- authenticate run/artifact/digest identity for 29767776933 and 29768013787
- dry-run all 51 rows after changing only the incident row timestamp to its live frozen value
- execute only crossbill-highlights-css-colors through the existing idempotent CLI path
- require artifact/audit/observation/binding byte-stability, one new score snapshot, cache readback, and affected-Skill smoke
- do not call Generate Pack or Pack APIs

## Runtime
- CLI 2.15.9
- Linux SHA-256: 9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec

## Verification
- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs` (3/3)
- all 11 workflow shell blocks pass `bash -n`
- YAML parses successfully
- exact recovery classification patch reproduced against artifact 8471506972