### PR TITLE
fix(governance): pin report-origin boundary verifier

### DIFF
--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -5,7 +5,10 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
 import { buildLegacyReportOriginBoundary } from '../build-legacy-report-origin-boundary.mjs';
-import { verifyLegacyReportOriginDocuments } from '../verify-legacy-report-origin-boundary.mjs';
+import {
+  freezeLegacyReportOriginBoundary,
+  verifyLegacyReportOriginDocuments,
+} from '../verify-legacy-report-origin-boundary.mjs';
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -80,6 +83,19 @@ test('builds and verifies only the exact 50 identities from two hash-bound class
       manifest,
       dryRunResults,
     }));
+    const frozen = freezeLegacyReportOriginBoundary({
+      cohort: item.cohort,
+      plan: built.plan,
+      classification: built.classification,
+      manifest,
+      dryRunResults,
+      runId: '29773180840',
+      repository: 'aiskillstore/marketplace',
+      workflowCommit: 'a'.repeat(40),
+      cliVersion: '2.15.9',
+      cliSha256: 'b'.repeat(64),
+    });
+    assert.equal(frozen.cliVersion, '2.15.9');
 
     const outside = structuredClone(manifest);
     outside.selectedCount = 51;

--- a/scripts/verify-legacy-report-origin-boundary.mjs
+++ b/scripts/verify-legacy-report-origin-boundary.mjs
@@ -93,7 +93,7 @@ export function freezeLegacyReportOriginBoundary(input) {
     !/^\d+$/.test(input.runId || '')
     || input.repository !== 'aiskillstore/marketplace'
     || !COMMIT_RE.test(input.workflowCommit || '')
-    || input.cliVersion !== '2.15.2'
+    || input.cliVersion !== '2.15.9'
     || !SHA256_RE.test(input.cliSha256 || '')
   ) fail('invalid frozen execution identity');
   return {


### PR DESCRIPTION
## Summary
- align the immutable Report-Origin boundary verifier with the already-pinned CLI 2.15.9
- add a focused freeze-boundary regression using the exact current CLI version

## Failure classification
- dry-run 29773180840 completed all 50 CLI no-write validations
- boundary sealing then failed before artifact upload because the verifier still hard-coded CLI 2.15.2
- production artifact/audit/observation/score/binding writes remained zero
- run 29773180840 is sealed and will not be rerun

## Verification
- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs` (2/2)