### PR TITLE
[codex] freeze ordinary v2 residual governance

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -47,7 +47,7 @@ concurrency:
 
 env:
   DEFERRED_FILE: scripts/data/artifact-governance-deferred-v1.json
-  DEFERRED_SHA256: 065d31301818d991a6a525fef083611315ac73a746ee031b86fe5097230e388d
+  DEFERRED_SHA256: f294d245dd228f5f58a2e30a5c52dede96bd8fa4498743b24825ddcbc07aba69
 
 jobs:
   freeze-boundary:
@@ -118,11 +118,11 @@ jobs:
           jq -e '
             .schemaVersion == 1 and
             .status == "artifact_governance_deferred" and
-            .count == 25 and
-            (.slugs | type == "array" and length == 25) and
+            .count == 27 and
+            (.slugs | type == "array" and length == 27) and
             ([.slugs[] | select(type != "string" or length == 0)] | length == 0) and
             (.slugs == (.slugs | sort)) and
-            ((.slugs | unique | length) == 25)
+            ((.slugs | unique | length) == 27)
           ' "$DEFERRED_FILE" >/dev/null || {
             echo '::error::deferred governance cohort is malformed'; exit 1;
           }

--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -28,12 +28,11 @@ env:
   # Production is intentionally impossible until the released linux-x64 binary
   # has been audited and this placeholder is replaced by its exact SHA-256.
   ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'
-  ORIGIN_COHORT: scripts/data/legacy-report-origin-v2-only-cohort-v1.json
-  # Dry-runs 29765964455 and 29767036462 exposed three incomplete stored
-  # file structures: davila7-docx (66/70 nodes), davila7-pptx (62/66), and
-  # dmitrypogrebnoy-generating-rbs (144/365). Keep them deferred instead of
-  # weakening exact install-snapshot validation for the ordinary cohort.
-  ORIGIN_COHORT_SHA256: 164edab51b71a2be141d726cb50f7ae94b1c3f7ae622353d28c3f9ad7ac9b346
+  ORIGIN_COHORT: scripts/data/ordinary-v2-report-origin-cohort-v1.json
+  # Boundary 29775654869 classified the complete non-deferred residual. This
+  # cohort freezes only its 197 v2 report-origin rows; raw32 and deferred rows
+  # stay excluded instead of weakening source-audit or install validation.
+  ORIGIN_COHORT_SHA256: dfb78a0a55e4f534e6706396662de3bdfc116078b89a66c148177f630f0edac0
 
 jobs:
   freeze-boundary:
@@ -77,12 +76,12 @@ jobs:
             test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
           done
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
-          jq -e '.schemaVersion == 2 and .selectedCount == 50 and (.rows | length) == 50 and (.sourceBoundaries | length) == 2' "$ORIGIN_COHORT" >/dev/null
+          jq -e '.schemaVersion == 2 and .selectedCount == 197 and (.rows | length) == 197 and (.sourceBoundaries | length) == 1' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo '::error::CLI 2.15.9 audit digest is still a non-production placeholder'; exit 1;
           }
 
-      - name: Download and verify two frozen drift classifications
+      - name: Download and verify the frozen drift classification
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -108,7 +107,7 @@ jobs:
             }
           done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
 
-      - name: Build exact 50-row v2-only drift classification and plan
+      - name: Build exact 197-row v2-only drift classification and plan
         run: |
           set -euo pipefail
           node scripts/build-legacy-report-origin-boundary.mjs \
@@ -122,7 +121,7 @@ jobs:
           set -euo pipefail
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
-            --expected-count 50 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 197 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/origin-lineage.json"
 
@@ -158,7 +157,7 @@ jobs:
           set -euo pipefail
           test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
 
-      - name: Run exact 50-row administrator dry-run
+      - name: Run exact 197-row administrator dry-run
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -278,7 +277,7 @@ jobs:
           test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
-            --expected-count 50 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 197 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/current-origin-lineage.json"
           cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
@@ -326,7 +325,7 @@ jobs:
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
 
-      - name: Execute only the frozen 50 rows
+      - name: Execute only the frozen 197 rows
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -352,7 +351,7 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
           jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
           jq -e '[.[].result.results[]] as $rows |
-            ($rows | length) == 50 and ($rows | map(.slug) | unique | length) == 50 and
+            ($rows | length) == 197 and ($rows | map(.slug) | unique | length) == 197 and
             ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
             "$RUNNER_TEMP/execution-results.json" >/dev/null
 

--- a/scripts/data/artifact-governance-deferred-v1.json
+++ b/scripts/data/artifact-governance-deferred-v1.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "status": "artifact_governance_deferred",
-  "count": 25,
+  "count": 27,
   "slugs": [
     "davila7-docx",
     "davila7-pptx",
@@ -27,6 +27,8 @@
     "sickn33-docx-official",
     "sickn33-loki-mode",
     "sickn33-pptx",
-    "sickn33-pptx-official"
+    "sickn33-pptx-official",
+    "xlsx",
+    "ytw-debug-mattress-sleep-support-advisor"
   ]
 }

--- a/scripts/data/ordinary-v2-report-origin-cohort-v1.json
+++ b/scripts/data/ordinary-v2-report-origin-cohort-v1.json
@@ -1,0 +1,1393 @@
+{
+  "schemaVersion": 2,
+  "status": "frozen_report_origin_cohort",
+  "repository": "aiskillstore/marketplace",
+  "selectedCount": 197,
+  "sourceBoundaries": [
+    {
+      "runId": "29775654869",
+      "classificationSha256": "b3627fab08453788d08e4ddfa89726ad8260d28cb1bd55420b2b032691d4b07e"
+    }
+  ],
+  "rows": [
+    {
+      "slug": "wshobson-mobile-android-design",
+      "skillId": "e466c1e0-b96c-4b27-8796-3ced50e5d97e",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/mobile-android-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-mobile-ios-design",
+      "skillId": "ad594f54-5a10-413a-b3e6-34b1c31b4c80",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/mobile-ios-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-modern-javascript-patterns",
+      "skillId": "50267225-1b20-45dc-adcc-c665d2fa8b1a",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/modern-javascript-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-monorepo-management",
+      "skillId": "51196c45-5dac-44e2-bf3e-24d74ab23bba",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/monorepo-management",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-mtls-configuration",
+      "skillId": "8977ddde-8687-42bc-b2df-9e4670e74dbd",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/mtls-configuration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-multi-cloud-architecture",
+      "skillId": "bc7cac27-c61b-4a1c-81d7-c01ceb8b80ef",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/multi-cloud-architecture",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-nextjs-app-router-patterns",
+      "skillId": "a00998bb-1919-4305-88d4-9e95186c91a9",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/nextjs-app-router-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-nft-standards",
+      "skillId": "37031206-7f97-458e-afab-d478d7315dc8",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/nft-standards",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-nodejs-backend-patterns",
+      "skillId": "a0964d22-d2c4-4f32-853a-ddc870a183f1",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/nodejs-backend-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-nx-workspace-patterns",
+      "skillId": "65326195-91b4-4d35-985e-27bf5b5c98e2",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/nx-workspace-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-on-call-handoff-patterns",
+      "skillId": "bcb4aad5-2f8b-4be4-b9c3-f7493eb5ab28",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/on-call-handoff-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-openapi-spec-generation",
+      "skillId": "700a0fbd-7acd-412b-b35c-8d0b167e6404",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/openapi-spec-generation",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-paypal-integration",
+      "skillId": "2f37eb35-3312-4848-908b-6c8419f25881",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/paypal-integration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-pci-compliance",
+      "skillId": "2e63ec16-d337-42b1-9126-8bb5f7f75326",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/pci-compliance",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-postgresql-table-design",
+      "skillId": "85808db5-c3a9-4b37-8466-907f05af712a",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/postgresql-table-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-postmortem-writing",
+      "skillId": "f5c948e5-8ca1-448b-b223-0709de35f3ca",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/postmortem-writing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-projection-patterns",
+      "skillId": "a934281f-cc18-4af9-ae0f-aef8291984f7",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/projection-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-prometheus-configuration",
+      "skillId": "b832332b-fb2f-4635-bfd1-40af0b90ab8b",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/prometheus-configuration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-prompt-engineering-patterns",
+      "skillId": "5e1a5903-8737-4a7b-a43f-620ea88d47ec",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/prompt-engineering-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-python-design-patterns",
+      "skillId": "3cbfb99a-4953-4bd5-81e8-910b80eb006f",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/python-design-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-python-packaging",
+      "skillId": "65113aab-2ba1-414c-8eea-c855fce2652e",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/python-packaging",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-python-performance-optimization",
+      "skillId": "85ef3fbd-bab4-4686-9e9d-aeda9c9eb8ce",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/python-performance-optimization",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-python-testing-patterns",
+      "skillId": "021c24c1-6e2f-4d99-892f-54f523fa6b91",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/python-testing-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-rag-implementation",
+      "skillId": "2a4579d9-faa6-4311-a230-57c20b4c6364",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/rag-implementation",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-react-modernization",
+      "skillId": "236aa35f-ed55-47a6-90b3-7e9f4164bc24",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/react-modernization",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-react-native-architecture",
+      "skillId": "138e8611-98aa-47d9-a580-ef65e2959ee1",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/react-native-architecture",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-react-native-design",
+      "skillId": "02957352-61c0-437c-98e3-dc03b89c7f0c",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/react-native-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-react-state-management",
+      "skillId": "804c032f-e5c6-4560-9ab3-3f99d77e7d99",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/react-state-management",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-responsive-design",
+      "skillId": "d90142b3-2f6b-492b-9e35-798fc45cacfc",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/responsive-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-risk-metrics-calculation",
+      "skillId": "55747550-8a75-471a-b5cc-49d05eef0ebe",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/risk-metrics-calculation",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-rust-async-patterns",
+      "skillId": "5e91a271-8c1c-4647-a0e3-d1b60541f5b0",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/rust-async-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-saga-orchestration",
+      "skillId": "1ef58bd1-d59e-40ee-a7c5-aa2953345f24",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/saga-orchestration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-sast-configuration",
+      "skillId": "6804fb5c-dc4d-4931-bcca-e0e2187606f7",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/sast-configuration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-screen-reader-testing",
+      "skillId": "dbc7a0db-10cf-4d20-a2b3-cc99744f2292",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/screen-reader-testing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-secrets-management",
+      "skillId": "f2969b03-4195-4ab3-b319-88aaca0c23c2",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/secrets-management",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-security-requirement-extraction",
+      "skillId": "71778d4c-fa5f-4fa6-8039-aa587982b4d8",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/security-requirement-extraction",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-service-mesh-observability",
+      "skillId": "7b356fd4-c24c-4175-ab52-2a99a346ade8",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/service-mesh-observability",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-shellcheck-configuration",
+      "skillId": "c6591312-2cfb-4ea5-811b-4786e45f0ed1",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/shellcheck-configuration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-similarity-search-patterns",
+      "skillId": "60d814b3-0b92-49e9-9f25-8d04edf6135b",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/similarity-search-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-slo-implementation",
+      "skillId": "c53b9606-4b62-4800-816d-90ce03509ba2",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/slo-implementation",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-solidity-security",
+      "skillId": "fdd8653d-90b7-4d10-bfcd-e12f5699222a",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/solidity-security",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-spark-optimization",
+      "skillId": "fd2e9a22-ae94-4efe-b0ab-2830619ed0ac",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/spark-optimization",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-sql-optimization-patterns",
+      "skillId": "a5e89834-cbcf-43fc-bd3d-40ad1add4ee0",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/sql-optimization-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-startup-financial-modeling",
+      "skillId": "c699573e-7fbd-42b6-a291-7f3a88ef2ece",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/startup-financial-modeling",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-startup-metrics-framework",
+      "skillId": "479828de-6d6f-4da7-9db6-56480561d022",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/startup-metrics-framework",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-stride-analysis-patterns",
+      "skillId": "59158568-4105-40f8-9a17-159488588487",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/stride-analysis-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-stripe-integration",
+      "skillId": "27a6ca41-fd6c-4d33-a37f-e6f40774be8d",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/stripe-integration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-tailwind-design-system",
+      "skillId": "4cbde284-d349-4248-abf8-1148e900a47f",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/tailwind-design-system",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-temporal-python-testing",
+      "skillId": "c7290b8e-22ea-41f5-a33c-1d5b58478fe9",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/temporal-python-testing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-terraform-module-library",
+      "skillId": "2ac40c5c-9980-4082-a566-ab180433cf98",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/terraform-module-library",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-threat-mitigation-mapping",
+      "skillId": "d118b60c-2b3a-4867-a032-eb5c64396883",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/threat-mitigation-mapping",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-turborepo-caching",
+      "skillId": "a521169e-0a37-48f9-ba7f-f28597242d72",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/turborepo-caching",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-typescript-advanced-types",
+      "skillId": "454dbb55-2f43-45aa-b513-75e828683edd",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/typescript-advanced-types",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-unity-ecs-patterns",
+      "skillId": "4f666adc-5e20-4392-86b7-27d77afbb30c",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/unity-ecs-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-uv-package-manager",
+      "skillId": "d39aa7c5-d7bb-4c1e-a2b6-0b11eb577832",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/uv-package-manager",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-vector-index-tuning",
+      "skillId": "5e696cfd-5316-46ab-9abe-f26bd8db947b",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/vector-index-tuning",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-visual-design-foundations",
+      "skillId": "044c9855-56b5-4fe4-9b13-5aea53f6bb5d",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/visual-design-foundations",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-wcag-audit-patterns",
+      "skillId": "3c80f65b-e93a-41c3-a332-2659d6aad15a",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/wcag-audit-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-web-component-design",
+      "skillId": "60bac801-41fd-4324-8b4e-7b524ce79dd0",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/web-component-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-web3-testing",
+      "skillId": "f3233406-0f3d-4222-9bc4-516270b82ca5",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/web3-testing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-workflow-orchestration-patterns",
+      "skillId": "15e69f00-eee8-407c-a800-20c0b3245fdb",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/workflow-orchestration-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshobson-workflow-patterns",
+      "skillId": "1d508052-369d-42df-a8db-81d85d73c17f",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshobson/workflow-patterns",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "wshuyi-x-article-publisher",
+      "skillId": "903d8606-f6ec-4395-a52b-546d09edd7e9",
+      "classificationRunId": "29775654869",
+      "path": "skills/wshuyi/x-article-publisher",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiangyusu611-obsidian-theme-designer",
+      "skillId": "6f281cf9-7878-471e-b1c0-724396abad7b",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiangyusu611/obsidian-theme-designer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiaomengbi520-pptx-prep",
+      "skillId": "c8569678-a46a-4439-8d95-a903f71e7ae1",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiaomengbi520/pptx-prep",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-hybrid",
+      "skillId": "38d54ab9-fe35-4774-a757-cd4963c041c8",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-hybrid",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-lemon8",
+      "skillId": "72c9a60f-0456-4651-b3a8-fb5b80d7142e",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-lemon8",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-skills",
+      "skillId": "4d612efa-c253-4a7f-bb33-5061254a2f70",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-skills",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-tiktok",
+      "skillId": "d97803e0-bb5d-4776-8b54-c0cfba81d85e",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-tiktok",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-toutiao",
+      "skillId": "5c9fddb3-bc9f-4284-a30f-3050f28c453a",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-toutiao",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xiewxx-maxhub-wechat",
+      "skillId": "d87f030e-10df-4a12-ba7e-2f59ef7fea10",
+      "classificationRunId": "29775654869",
+      "path": "skills/xiewxx/maxhub-wechat",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-develop-userscripts",
+      "skillId": "b19f8ef6-bf1d-4245-9e23-a50c49eeeed2",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/develop-userscripts",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-github-actions-docs",
+      "skillId": "470bac76-be35-409f-90b8-5415a791d28e",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/github-actions-docs",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-openclaw-secure-linux-cloud",
+      "skillId": "a54e3441-b683-43a2-8fba-02ce669cd92c",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/openclaw-secure-linux-cloud",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-opensource-guide-coach",
+      "skillId": "7b724066-ccb0-4afb-a3b1-7114eedbdfb4",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/opensource-guide-coach",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-readme-i18n",
+      "skillId": "a106280e-631f-4d33-91dc-d169ca4b9846",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/readme-i18n",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-running-claude-code-via-litellm-copilot",
+      "skillId": "801d74c4-8abb-456e-bf77-67e5fcfc3d25",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/running-claude-code-via-litellm-copilot",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-secure-linux-web-hosting",
+      "skillId": "a7ab7ddd-08e5-429c-86dc-e57abb4a16c4",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/secure-linux-web-hosting",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-skills-cli",
+      "skillId": "def4c26a-faf9-4bbd-943c-9d5e8bc64ef0",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/skills-cli",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-tzst",
+      "skillId": "ae0e9f8c-edf2-405d-972b-87dfd6ac8e56",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/tzst",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-use-my-browser",
+      "skillId": "950b593f-75fa-4c94-a4cb-a00019f1ae44",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/use-my-browser",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-xdrop",
+      "skillId": "e9752b17-7d38-40c1-8fae-389f0e1876c4",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/xdrop",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xixu-me-xget",
+      "skillId": "a3cfbae0-54e8-47a5-a944-c4e6f6b422b1",
+      "classificationRunId": "29775654869",
+      "path": "skills/xixu-me/xget",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xllinbupt-liepin-cli",
+      "skillId": "c0551c0e-31b0-4057-942f-a08848baf99b",
+      "classificationRunId": "29775654869",
+      "path": "skills/xllinbupt/liepin-cli",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "xquik-dev-x-twitter-scraper",
+      "skillId": "69218f99-637b-4b6b-a3ef-846907b2c368",
+      "classificationRunId": "29775654869",
+      "path": "skills/xquik-dev/x-twitter-scraper",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yamadashy-agent-memory",
+      "skillId": "d4df10de-5f96-4f70-a64a-51ead25119a2",
+      "classificationRunId": "29775654869",
+      "path": "skills/yamadashy/agent-memory",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yamadashy-browser-extension-developer",
+      "skillId": "67209348-ecb9-4f57-8c58-5eedb349ef12",
+      "classificationRunId": "29775654869",
+      "path": "skills/yamadashy/browser-extension-developer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yamadashy-lint-fixer",
+      "skillId": "a31e16fb-4cab-4c54-90e1-d4d5d724b4dc",
+      "classificationRunId": "29775654869",
+      "path": "skills/yamadashy/lint-fixer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yamadashy-website-maintainer",
+      "skillId": "42b6cd25-b2a4-4f6b-8671-21364dc535f0",
+      "classificationRunId": "29775654869",
+      "path": "skills/yamadashy/website-maintainer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-broken-skill",
+      "skillId": "6f39940b-e874-4ca2-a1ff-ba154d9039ce",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/broken-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-broken-yaml-skill",
+      "skillId": "9153392f-81f6-4fc7-a0af-85cb57b463e8",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/broken-yaml-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-frontend-review",
+      "skillId": "423ae30b-2a7b-4c3e-8aea-784b965d6aa0",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/frontend-review",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-geo-content-brief-skill",
+      "skillId": "581d393f-1e7a-423f-ad8a-ee5fbd5772d5",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/geo-content-brief-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-incident-command-governor",
+      "skillId": "8b068845-4482-498b-8bb1-2f0e082118f9",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/incident-command-governor",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-invalid-governance-skill",
+      "skillId": "d395305e-8bc5-4377-b888-5e282728ca21",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/invalid-governance-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-note-cleanup",
+      "skillId": "6f079acc-18c8-4328-9f2d-117e5d4e75dc",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/note-cleanup",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-release-orchestrator",
+      "skillId": "b4b374d8-bc36-4943-8c60-b4bad230396c",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/release-orchestrator",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yaojingang-yao-meta-skill",
+      "skillId": "0a315bdc-c790-446a-a5fd-b6e7e294b262",
+      "classificationRunId": "29775654869",
+      "path": "skills/yaojingang/yao-meta-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yescan-ai-yescan-scan-universal",
+      "skillId": "bb7eb8f9-a3a4-4d4a-8052-2ed280be0a52",
+      "classificationRunId": "29775654869",
+      "path": "skills/yescan-ai/yescan-scan-universal",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yescan-ai-yescan-transoffice-universal",
+      "skillId": "d74bf6bb-6156-48b3-be47-a5958d692f76",
+      "classificationRunId": "29775654869",
+      "path": "skills/yescan-ai/yescan-transoffice-universal",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yescan-ai-yescan-universal",
+      "skillId": "74ffd163-c072-49ef-800a-c7139d0d83e6",
+      "classificationRunId": "29775654869",
+      "path": "skills/yescan-ai/yescan-universal",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yetone-native-feel-cross-platform-desktop",
+      "skillId": "33aa9c96-6b55-4448-842b-e7b6ad91b48b",
+      "classificationRunId": "29775654869",
+      "path": "skills/yetone/native-feel-cross-platform-desktop",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yizhiyanhua-ai-media-downloader",
+      "skillId": "7326b5c5-c1b3-4d60-89a9-7ed1fb45539b",
+      "classificationRunId": "29775654869",
+      "path": "skills/yizhiyanhua-ai/media-downloader",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yizhiyanhua-ai-zimage-skill",
+      "skillId": "9bf0a4fe-fdec-421e-ad96-b1116d9d7aac",
+      "classificationRunId": "29775654869",
+      "path": "skills/yizhiyanhua-ai/zimage-skill",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-academic-search",
+      "skillId": "7e7b7fd1-5023-45c3-8a0a-4681d6724c48",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-academic-search",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-citation",
+      "skillId": "a1163be1-2bc3-403e-98d5-323937a8ffda",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-citation",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-data",
+      "skillId": "63bf0756-6d92-44f9-8495-285e0e5c6ff3",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-data",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-figure",
+      "skillId": "a526cf41-c983-45ed-bbfb-f3a628f2f216",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-figure",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-paper-to-patent",
+      "skillId": "f5d008a9-88b4-4939-90ae-073d10fe08dc",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-paper-to-patent",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-paper2ppt",
+      "skillId": "404f9c5d-7199-46e2-9fb5-d154b7568a3f",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-paper2ppt",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-polishing",
+      "skillId": "1362c493-4c4e-4058-a7aa-b1c071147dae",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-polishing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-reader",
+      "skillId": "c7b77a54-3ae1-4bb0-96de-297380a2b37e",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-reader",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-response",
+      "skillId": "b5ebebb9-f6b9-4f1b-8974-a5ba15e6a79c",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-response",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-reviewer",
+      "skillId": "5c9a8757-4c89-43c8-8819-451b3d2f93da",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-reviewer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-nature-writing",
+      "skillId": "499707e9-c1dc-4aae-b73a-86ccbdc597f9",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/nature-writing",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuan1z0825-openclaw-medical-skills",
+      "skillId": "85227712-325a-4a7e-8a94-d1742ac1953e",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuan1z0825/openclaw-medical-skills",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuanjian068yuan-ppxc-find-customers",
+      "skillId": "fe6b468d-c12c-4954-afa8-189fa163db4b",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuanjian068yuan/ppxc-find-customers",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuki001-animation-shader",
+      "skillId": "c1b979f6-819e-4edb-be5c-c65c2f9f2169",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuki001/animation-shader",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-backlog-manager",
+      "skillId": "94bae3e3-3847-43d7-944d-d90293e51904",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/backlog-manager",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-design-exploration",
+      "skillId": "12539555-929d-402c-933b-d0cc7f5edf7a",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/design-exploration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-git-push",
+      "skillId": "e1c6fee9-a32f-4b85-a70e-d87985b3f057",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/git-push",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-github-repo-search",
+      "skillId": "aee4f0b9-ce82-4aa1-807a-5ff2ca6a0576",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/github-repo-search",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-image-assistant",
+      "skillId": "396e8706-7250-4eda-96b9-c1ec60ebe24f",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/image-assistant",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-issue-triage",
+      "skillId": "4dcdd7d3-9bcb-429f-a82b-a8e752fe3da8",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/issue-triage",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-lesson-builder",
+      "skillId": "2412a389-c40a-4d4e-b0d5-35d483dc83e6",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/lesson-builder",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-memory-init",
+      "skillId": "b62299cb-4ffd-46c2-8748-1d3f1c5e4b89",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/memory-init",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-prd-doc-writer",
+      "skillId": "ac0de308-5774-4af0-b417-c43327933c6d",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/prd-doc-writer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-priority-judge",
+      "skillId": "68b74918-7369-4419-83aa-6c665f3d3af7",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/priority-judge",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-product-naming",
+      "skillId": "28119a19-43fa-4ab3-97d3-76a865e9db51",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/product-naming",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-project-map-builder",
+      "skillId": "0cf1d3c3-ed47-4134-8284-0297260756c9",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/project-map-builder",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-req-change-workflow",
+      "skillId": "8a702533-f97d-4f9a-9095-d09b2df1ff27",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/req-change-workflow",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-thinking-partner",
+      "skillId": "91b76fc8-632d-4c6c-8c72-d151525b1da9",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/thinking-partner",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-thought-mining",
+      "skillId": "24510712-49f3-4fa8-9608-97cc3ef39a8e",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/thought-mining",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-ui-design",
+      "skillId": "dce691f2-4c9a-4e83-ab57-08a333b4cbeb",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/ui-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-version-planner",
+      "skillId": "b88022bb-31e3-4521-8c47-df823af2556f",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/version-planner",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-vision-exploration",
+      "skillId": "2efbca08-903a-4835-b1ca-332878523878",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/vision-exploration",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-weekly-report",
+      "skillId": "8306f552-6211-413a-aaf1-0ecd3c693936",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/weekly-report",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yunshu0909-writing-assistant",
+      "skillId": "13902d6f-0068-49c3-97bc-31becbaea5a4",
+      "classificationRunId": "29775654869",
+      "path": "skills/yunshu0909/writing-assistant",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yuzu-octopus-vanilla-webpage",
+      "skillId": "70d8d6d7-4984-427e-a71a-976ecd1dc623",
+      "classificationRunId": "29775654869",
+      "path": "skills/yuzu-octopus/vanilla-webpage",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-create-skill-file",
+      "skillId": "591a8954-7fb8-4106-8185-bef0cb55ab04",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/create-skill-file",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-daily-ai-news",
+      "skillId": "337e0562-40af-4bf0-8bef-da766e59d467",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/daily-ai-news",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-deep-reading-analyst",
+      "skillId": "8f8ab9e0-314d-4431-abc0-bbbab80e7527",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/deep-reading-analyst",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-dry-refactoring",
+      "skillId": "a4aed8b2-bf8b-41eb-8cfa-3b4d730fa0a5",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/dry-refactoring",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-frontend-design",
+      "skillId": "ed76a65b-26b0-4142-a245-761c224e3fc6",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/frontend-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-mcp-builder",
+      "skillId": "f60bf4c8-73ce-4684-bb42-aade986cd866",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/mcp-builder",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "yyh211-prompt-optimize",
+      "skillId": "1a069ffd-bed5-4fe4-9152-7b214718df06",
+      "classificationRunId": "29775654869",
+      "path": "skills/yyh211/prompt-optimize",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-feature-demand-validator",
+      "skillId": "86678e63-6cb1-466c-9487-d6a90935dcbc",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-feature-demand-validator",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-listing-health-checker",
+      "skillId": "00c76745-8a63-400c-8b67-6a18fe22cf72",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-listing-health-checker",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-product-research",
+      "skillId": "fd5f467a-6868-4ec4-a8a4-b73d7a50c141",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-product-research",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-search-term-report-analyzer",
+      "skillId": "2e3892f5-0c3a-40c3-bef0-ffab2a4abb99",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-search-term-report-analyzer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-seller-skill-creator",
+      "skillId": "cf21d773-e3e4-44c5-88ee-f3d426a7ed43",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-seller-skill-creator",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zach22-1999-zach-sif-cvr-threshold-analyzer",
+      "skillId": "03200ba7-3646-4158-83f7-2d8657530cbf",
+      "classificationRunId": "29775654869",
+      "path": "skills/zach22-1999/zach-sif-cvr-threshold-analyzer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zaddy6-agent-email-cli",
+      "skillId": "74c63692-06b0-4ed4-9eed-3ee6f1ac167c",
+      "classificationRunId": "29775654869",
+      "path": "skills/zaddy6/agent-email-cli",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zaker-coder-zaker-category-news",
+      "skillId": "b1c48be0-99ee-491f-ad39-10ae0b2eefb0",
+      "classificationRunId": "29775654869",
+      "path": "skills/zaker-coder/zaker-category-news",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zaker-coder-zaker-hot-news",
+      "skillId": "9c592630-9431-4a1a-b7ed-456042379d23",
+      "classificationRunId": "29775654869",
+      "path": "skills/zaker-coder/zaker-hot-news",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zaker-coder-zaker-news-search",
+      "skillId": "6ff06868-5584-48a7-8609-c24e54238142",
+      "classificationRunId": "29775654869",
+      "path": "skills/zaker-coder/zaker-news-search",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zengliangyi-chatcrystal-debug-recall",
+      "skillId": "1ae2285b-b24d-4bc0-ba72-26f01bcc36b3",
+      "classificationRunId": "29775654869",
+      "path": "skills/zengliangyi/chatcrystal-debug-recall",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zengliangyi-chatcrystal-task-recall",
+      "skillId": "85e7dbce-a467-42aa-862c-6ec22928d50c",
+      "classificationRunId": "29775654869",
+      "path": "skills/zengliangyi/chatcrystal-task-recall",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zengliangyi-chatcrystal-task-writeback",
+      "skillId": "c6ae2af4-e6b6-4c80-b391-ea5ce003e6fe",
+      "classificationRunId": "29775654869",
+      "path": "skills/zengliangyi/chatcrystal-task-writeback",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-api-doc-generator",
+      "skillId": "db57c52d-ed05-4eb4-b114-daca558db1e7",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/api-doc-generator",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-code-review-assistant",
+      "skillId": "b3e8cd22-4307-4302-84a7-affd583da664",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/code-review-assistant",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-competitor-analysis-bot",
+      "skillId": "ade134c9-1599-43eb-984a-6d9eb2898a33",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/competitor-analysis-bot",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-data-cleaning-pipeline",
+      "skillId": "a39e1c2a-f5b5-4154-ab1f-4cb1ea5a1ca3",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/data-cleaning-pipeline",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-email-campaign-writer",
+      "skillId": "1fe72df3-1664-4395-929f-1c607544cdb3",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/email-campaign-writer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-excel-formula-wizard",
+      "skillId": "893d2f74-1cce-4e87-b460-2f71d0a7cdc7",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/excel-formula-wizard",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-invoice-ocr-sorter",
+      "skillId": "109833bb-2f67-4d6a-a8a4-a3f995d1c97f",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/invoice-ocr-sorter",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-lead-scraper",
+      "skillId": "23ae5e4b-d443-44bc-add4-dde8c588b58d",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/lead-scraper",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-meeting-minutes-assistant",
+      "skillId": "1168897c-3c16-4b10-b925-70a3ebc67f11",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/meeting-minutes-assistant",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-resume-optimizer",
+      "skillId": "ef56be6c-b851-486d-b108-872844daabcb",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/resume-optimizer",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-social-media-calendar",
+      "skillId": "861f61e6-f57f-4333-b67f-96a7e32bc575",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/social-media-calendar",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-sql-query-builder",
+      "skillId": "3a866881-fd24-49ac-8dcd-026a26629ad0",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/sql-query-builder",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-weekly-report-generator",
+      "skillId": "9bddf061-4e0d-4c65-ba73-8bd4cb6d7629",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/weekly-report-generator",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangchenlai-dev-xiaohongshu-copywriter",
+      "skillId": "fda4429f-f157-4e07-96e9-bca7ccac6bef",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangchenlai-dev/xiaohongshu-copywriter",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanghandong-makepad-evolution",
+      "skillId": "393be20a-0924-4155-9b7b-a0e23eaccc26",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanghandong/makepad-evolution",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhangzeyu99-web-ariadne-loop",
+      "skillId": "00ae1d82-fab3-47da-8035-f1b2cf8f035b",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhangzeyu99-web/ariadne-loop",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-algorithmic-art",
+      "skillId": "53389573-e85b-4db0-a29c-418a996a7116",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/algorithmic-art",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-brainstorming",
+      "skillId": "07c89c80-96ca-4c0c-99cb-64cd6d02e9db",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/brainstorming",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-brand-guidelines",
+      "skillId": "623c8c7b-8869-4fe2-b79f-361600d7f447",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/brand-guidelines",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-canvas-design",
+      "skillId": "e185a2f1-5178-407e-aa55-2fdaa3abb470",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/canvas-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-chat-compactor",
+      "skillId": "370c974a-f355-48c4-86b2-920e9c61f979",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/chat-compactor",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-deploying-to-production",
+      "skillId": "e9506227-b331-41f1-88c0-135c61f707c2",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/deploying-to-production",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-dispatching-parallel-agents",
+      "skillId": "07176d0b-61a5-4944-b6ee-7af4ba241e33",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/dispatching-parallel-agents",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-doc-coauthoring",
+      "skillId": "88607a17-b1e4-42f7-8066-6a00f91e62be",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/doc-coauthoring",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-doc-sync-tool",
+      "skillId": "3e5ce16f-cc36-41b2-8ef6-7605516650fb",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/doc-sync-tool",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-docx",
+      "skillId": "847e98ff-a390-4c87-82b3-9c37db61ef6d",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/docx",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-executing-plans",
+      "skillId": "8feedad5-5dc6-434c-ba3a-bc4f6885a6ab",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/executing-plans",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-finishing-a-development-branch",
+      "skillId": "d48f0fa1-bb5c-4824-ba39-ce4de14da676",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/finishing-a-development-branch",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-frontend-design",
+      "skillId": "16540055-07f3-4bd4-8f10-7ec494b13176",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/frontend-design",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-github-release-assistant",
+      "skillId": "9716461a-f4d3-4493-935e-4a7165a92681",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/github-release-assistant",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-google-official-seo-guide",
+      "skillId": "05c81a5c-cf85-4096-984e-6bba0f7242ed",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/google-official-seo-guide",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-internal-comms",
+      "skillId": "189a3222-1b47-483a-bef9-e19c65efe422",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/internal-comms",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-internationalizing-websites",
+      "skillId": "f16fd4ee-bb0a-4e24-b45f-20bb473600cf",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/internationalizing-websites",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-json-canvas",
+      "skillId": "01d79bc3-05a4-4dc3-bacb-e80dea29573f",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/json-canvas",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-mcp-builder",
+      "skillId": "3f89c9f1-7828-47d4-a846-438599d30c2e",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/mcp-builder",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-notebooklm",
+      "skillId": "bf3bc32d-a9fa-4d5a-b31a-fc070720c6fd",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/notebooklm",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-obsidian-bases",
+      "skillId": "79a8e583-2040-435e-80ba-942d6bd0e2d3",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/obsidian-bases",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    },
+    {
+      "slug": "zhanlincui-obsidian-helper",
+      "skillId": "329e66cc-c909-406a-87ea-5fc276b7bc04",
+      "classificationRunId": "29775654869",
+      "path": "skills/zhanlincui/obsidian-helper",
+      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
+    }
+  ]
+}

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -917,13 +917,13 @@ test('ordinary workflow excludes the exact deferred cohort before planning', () 
   const deferred = JSON.parse(raw);
   assert.equal(deferred.schemaVersion, 1);
   assert.equal(deferred.status, 'artifact_governance_deferred');
-  assert.equal(deferred.count, 25);
-  assert.equal(deferred.slugs.length, 25);
-  assert.equal(new Set(deferred.slugs).size, 25);
+  assert.equal(deferred.count, 27);
+  assert.equal(deferred.slugs.length, 27);
+  assert.equal(new Set(deferred.slugs).size, 27);
   assert.deepEqual(deferred.slugs, [...deferred.slugs].sort());
   assert.equal(
     createHash('sha256').update(raw).digest('hex'),
-    '065d31301818d991a6a525fef083611315ac73a746ee031b86fe5097230e388d'
+    'f294d245dd228f5f58a2e30a5c52dede96bd8fa4498743b24825ddcbc07aba69'
   );
 
   const workflow = readFileSync(
@@ -931,7 +931,7 @@ test('ordinary workflow excludes the exact deferred cohort before planning', () 
     'utf8'
   );
   assert.match(workflow, /DEFERRED_FILE: scripts\/data\/artifact-governance-deferred-v1\.json/);
-  assert.match(workflow, /DEFERRED_SHA256: 065d31301818d991a6a525fef083611315ac73a746ee031b86fe5097230e388d/);
+  assert.match(workflow, /DEFERRED_SHA256: f294d245dd228f5f58a2e30a5c52dede96bd8fa4498743b24825ddcbc07aba69/);
   assert.match(workflow, /\(\$deferred\[0\]\.slugs \| index\(\$slug\) \| not\)/);
   assert.match(workflow, /--inventory "\$RUNNER_TEMP\/ordinary-catalog\.json"/);
 });

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -125,18 +125,26 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   ), 'utf8');
   const cohort = JSON.parse(readFileSync(resolve(
     import.meta.dirname,
-    '../data/legacy-report-origin-v2-only-cohort-v1.json'
+    '../data/ordinary-v2-report-origin-cohort-v1.json'
   ), 'utf8'));
-  assert.equal(cohort.selectedCount, 50);
-  assert.equal(cohort.rows.length, 50);
-  assert.equal(cohort.sourceBoundaries.length, 2);
+  const deferred = JSON.parse(readFileSync(resolve(
+    import.meta.dirname,
+    '../data/artifact-governance-deferred-v1.json'
+  ), 'utf8'));
+  assert.equal(cohort.selectedCount, 197);
+  assert.equal(cohort.rows.length, 197);
+  assert.deepEqual(cohort.sourceBoundaries, [{
+    runId: '29775654869',
+    classificationSha256: 'b3627fab08453788d08e4ddfa89726ad8260d28cb1bd55420b2b032691d4b07e',
+  }]);
+  assert.ok(cohort.rows.every((row) => row.classificationRunId === '29775654869'));
   assert.deepEqual(
-    ['crossbill-highlights-css-colors', 'davila7-docx', 'davila7-pptx', 'dmitrypogrebnoy-generating-rbs']
+    deferred.slugs
       .filter((slug) => cohort.rows.some((row) => row.slug === slug)),
     []
   );
-  assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/legacy-report-origin-v2-only-cohort-v1\.json/);
-  assert.match(workflow, /ORIGIN_COHORT_SHA256: 164edab51b71a2be141d726cb50f7ae94b1c3f7ae622353d28c3f9ad7ac9b346/);
+  assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/ordinary-v2-report-origin-cohort-v1\.json/);
+  assert.match(workflow, /ORIGIN_COHORT_SHA256: dfb78a0a55e4f534e6706396662de3bdfc116078b89a66c148177f630f0edac0/);
   assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.9'/);
   assert.match(workflow, /ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'/);
   assert.equal((workflow.match(/version: '2\.15\.9'/g) || []).length, 4);
@@ -144,7 +152,7 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
-  assert.match(workflow, /--expected-count 50/);
+  assert.match(workflow, /--expected-count 197/);
   assert.equal(
     (workflow.match(/Normalize full checkout and verify report-origin runtime/g) || []).length,
     2


### PR DESCRIPTION
## What changed

- freeze the exact 197 non-deferred v2 report-origin rows from immutable dry-run 29775654869
- reuse the existing Report-Origin dry-run and execute contract with the new cohort hash and count
- add xlsx and ytw-debug-mattress-sleep-support-advisor to the deferred contract after strict local validation rejected their path or first-parent lineage
- update focused cohort and deferred contract tests

## Why

The ordinary legacy-equivalent dry-run correctly classified zero executable rows: 62 raw32 rows lack source-audit proof, while 199 v2 rows are actual or unproven artifact drift. The existing Report-Origin v2-only path is the smallest safe path for the 197 rows that pass all immutable lineage and install checks.

## Validation

- CI=true node --test focused governance suites: 13/13
- full local Git-lineage and install-snapshot validation: 197/197
- exact cohort identity equals classification drift minus deferred
- YAML parse and bash -n: 46 workflow run blocks
- exact cohort and deferred SHA-256 contracts
- git diff --check