### PR TITLE
[codex] exclude enumerated snapshot drift

### DIFF
--- a/.github/workflows/govern-legacy-equivalent-artifacts.yml
+++ b/.github/workflows/govern-legacy-equivalent-artifacts.yml
@@ -47,7 +47,7 @@ concurrency:
 
 env:
   DEFERRED_FILE: scripts/data/artifact-governance-deferred-v1.json
-  DEFERRED_SHA256: 1b965077ffcc3feb3daf3d289f19a76971a47e3e49c42a3647fd34cf5031955a
+  DEFERRED_SHA256: e1856405c4a5239539a3301f9c5758b149fdb10d6c34bf1de0f2ae3c30772ede
 
 jobs:
   freeze-boundary:
@@ -118,11 +118,11 @@ jobs:
           jq -e '
             .schemaVersion == 1 and
             .status == "artifact_governance_deferred" and
-            .count == 28 and
-            (.slugs | type == "array" and length == 28) and
+            .count == 32 and
+            (.slugs | type == "array" and length == 32) and
             ([.slugs[] | select(type != "string" or length == 0)] | length == 0) and
             (.slugs == (.slugs | sort)) and
-            ((.slugs | unique | length) == 28)
+            ((.slugs | unique | length) == 32)
           ' "$DEFERRED_FILE" >/dev/null || {
             echo '::error::deferred governance cohort is malformed'; exit 1;
           }

--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -30,9 +30,9 @@ env:
   ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'
   ORIGIN_COHORT: scripts/data/ordinary-v2-report-origin-cohort-v1.json
   # Boundary 29775654869 classified the complete non-deferred residual. This
-  # cohort freezes only its 196 v2 report-origin rows; raw32 and deferred rows
+  # cohort freezes only its 192 v2 report-origin rows; raw32 and deferred rows
   # stay excluded instead of weakening source-audit or install validation.
-  ORIGIN_COHORT_SHA256: 29e248eac74cce31454d167a46d7857fb9d43ac476f8e753b854cab1ce7e84cc
+  ORIGIN_COHORT_SHA256: 3750ca3d83fe28efb5673f384cef74195a44d388f14062ba3cec9f06f78a873c
 
 jobs:
   freeze-boundary:
@@ -76,7 +76,7 @@ jobs:
             test -f "$path" || { echo "::error file=$path::Missing report-origin runtime"; exit 1; }
           done
           test "$(sha256sum "$ORIGIN_COHORT" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
-          jq -e '.schemaVersion == 2 and .selectedCount == 196 and (.rows | length) == 196 and (.sourceBoundaries | length) == 1' "$ORIGIN_COHORT" >/dev/null
+          jq -e '.schemaVersion == 2 and .selectedCount == 192 and (.rows | length) == 192 and (.sourceBoundaries | length) == 1' "$ORIGIN_COHORT" >/dev/null
           [[ "$ORIGIN_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo '::error::CLI 2.15.9 audit digest is still a non-production placeholder'; exit 1;
           }
@@ -107,7 +107,7 @@ jobs:
             }
           done < <(jq -c '.sourceBoundaries[]' "$ORIGIN_COHORT")
 
-      - name: Build exact 196-row v2-only drift classification and plan
+      - name: Build exact 192-row v2-only drift classification and plan
         run: |
           set -euo pipefail
           node scripts/build-legacy-report-origin-boundary.mjs \
@@ -121,7 +121,7 @@ jobs:
           set -euo pipefail
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$ORIGIN_COHORT" \
-            --expected-count 196 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 192 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/origin-lineage.json"
 
@@ -157,7 +157,7 @@ jobs:
           set -euo pipefail
           test "$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')" = "$ORIGIN_CLI_SHA256"
 
-      - name: Run exact 196-row administrator dry-run
+      - name: Run exact 192-row administrator dry-run
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -322,7 +322,7 @@ jobs:
           test "$(sha256sum "$RUNNER_TEMP/boundary/cohort.json" | awk '{print $1}')" = "$ORIGIN_COHORT_SHA256"
           node scripts/materialize-legacy-report-origin-evidence.mjs \
             --repository-root "$GITHUB_WORKSPACE" --cohort "$RUNNER_TEMP/boundary/cohort.json" \
-            --expected-count 196 --origin-root "$RUNNER_TEMP/origin" \
+            --expected-count 192 --origin-root "$RUNNER_TEMP/origin" \
             --previous-report-root "$RUNNER_TEMP/previous" \
             --manifest "$RUNNER_TEMP/current-origin-lineage.json"
           cmp "$RUNNER_TEMP/boundary/origin-lineage.json" "$RUNNER_TEMP/current-origin-lineage.json" || {
@@ -370,7 +370,7 @@ jobs:
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
           test "$expected" = "$ORIGIN_CLI_SHA256" && test "$actual" = "$ORIGIN_CLI_SHA256"
 
-      - name: Execute only the frozen 196 rows
+      - name: Execute only the frozen 192 rows
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -396,7 +396,7 @@ jobs:
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/boundary/plan.json")
           jq -s . "$RUNNER_TEMP/execution-results.jsonl" > "$RUNNER_TEMP/execution-results.json"
           jq -e '[.[].result.results[]] as $rows |
-            ($rows | length) == 196 and ($rows | map(.slug) | unique | length) == 196 and
+            ($rows | length) == 192 and ($rows | map(.slug) | unique | length) == 192 and
             ($rows | all(.mode == "execute" and .artifactRevision == 1))' \
             "$RUNNER_TEMP/execution-results.json" >/dev/null
 

--- a/scripts/data/artifact-governance-deferred-v1.json
+++ b/scripts/data/artifact-governance-deferred-v1.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "status": "artifact_governance_deferred",
-  "count": 28,
+  "count": 32,
   "slugs": [
     "davila7-docx",
     "davila7-pptx",
@@ -30,6 +30,10 @@
     "sickn33-pptx-official",
     "xlsx",
     "yamadashy-agent-memory",
-    "ytw-debug-mattress-sleep-support-advisor"
+    "yaojingang-yao-meta-skill",
+    "ytw-debug-mattress-sleep-support-advisor",
+    "yuan1z0825-nature-figure",
+    "zach22-1999-zach-seller-skill-creator",
+    "zhanlincui-docx"
   ]
 }

--- a/scripts/data/ordinary-v2-report-origin-cohort-v1.json
+++ b/scripts/data/ordinary-v2-report-origin-cohort-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "status": "frozen_report_origin_cohort",
   "repository": "aiskillstore/marketplace",
-  "selectedCount": 196,
+  "selectedCount": 192,
   "sourceBoundaries": [
     {
       "runId": "29775654869",
@@ -683,13 +683,6 @@
       "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
     },
     {
-      "slug": "yaojingang-yao-meta-skill",
-      "skillId": "0a315bdc-c790-446a-a5fd-b6e7e294b262",
-      "classificationRunId": "29775654869",
-      "path": "skills/yaojingang/yao-meta-skill",
-      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
-    },
-    {
       "slug": "yescan-ai-yescan-scan-universal",
       "skillId": "bb7eb8f9-a3a4-4d4a-8052-2ed280be0a52",
       "classificationRunId": "29775654869",
@@ -750,13 +743,6 @@
       "skillId": "63bf0756-6d92-44f9-8495-285e0e5c6ff3",
       "classificationRunId": "29775654869",
       "path": "skills/yuan1z0825/nature-data",
-      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
-    },
-    {
-      "slug": "yuan1z0825-nature-figure",
-      "skillId": "a526cf41-c983-45ed-bbfb-f3a628f2f216",
-      "classificationRunId": "29775654869",
-      "path": "skills/yuan1z0825/nature-figure",
       "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
     },
     {
@@ -1054,13 +1040,6 @@
       "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
     },
     {
-      "slug": "zach22-1999-zach-seller-skill-creator",
-      "skillId": "cf21d773-e3e4-44c5-88ee-f3d426a7ed43",
-      "classificationRunId": "29775654869",
-      "path": "skills/zach22-1999/zach-seller-skill-creator",
-      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
-    },
-    {
       "slug": "zach22-1999-zach-sif-cvr-threshold-analyzer",
       "skillId": "03200ba7-3646-4158-83f7-2d8657530cbf",
       "classificationRunId": "29775654869",
@@ -1289,13 +1268,6 @@
       "skillId": "3e5ce16f-cc36-41b2-8ef6-7605516650fb",
       "classificationRunId": "29775654869",
       "path": "skills/zhanlincui/doc-sync-tool",
-      "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
-    },
-    {
-      "slug": "zhanlincui-docx",
-      "skillId": "847e98ff-a390-4c87-82b3-9c37db61ef6d",
-      "classificationRunId": "29775654869",
-      "path": "skills/zhanlincui/docx",
       "currentMarketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a"
     },
     {

--- a/scripts/tests/legacy-equivalent-governance.test.mjs
+++ b/scripts/tests/legacy-equivalent-governance.test.mjs
@@ -917,13 +917,13 @@ test('ordinary workflow excludes the exact deferred cohort before planning', () 
   const deferred = JSON.parse(raw);
   assert.equal(deferred.schemaVersion, 1);
   assert.equal(deferred.status, 'artifact_governance_deferred');
-  assert.equal(deferred.count, 28);
-  assert.equal(deferred.slugs.length, 28);
-  assert.equal(new Set(deferred.slugs).size, 28);
+  assert.equal(deferred.count, 32);
+  assert.equal(deferred.slugs.length, 32);
+  assert.equal(new Set(deferred.slugs).size, 32);
   assert.deepEqual(deferred.slugs, [...deferred.slugs].sort());
   assert.equal(
     createHash('sha256').update(raw).digest('hex'),
-    '1b965077ffcc3feb3daf3d289f19a76971a47e3e49c42a3647fd34cf5031955a'
+    'e1856405c4a5239539a3301f9c5758b149fdb10d6c34bf1de0f2ae3c30772ede'
   );
 
   const workflow = readFileSync(
@@ -931,7 +931,7 @@ test('ordinary workflow excludes the exact deferred cohort before planning', () 
     'utf8'
   );
   assert.match(workflow, /DEFERRED_FILE: scripts\/data\/artifact-governance-deferred-v1\.json/);
-  assert.match(workflow, /DEFERRED_SHA256: 1b965077ffcc3feb3daf3d289f19a76971a47e3e49c42a3647fd34cf5031955a/);
+  assert.match(workflow, /DEFERRED_SHA256: e1856405c4a5239539a3301f9c5758b149fdb10d6c34bf1de0f2ae3c30772ede/);
   assert.match(workflow, /\(\$deferred\[0\]\.slugs \| index\(\$slug\) \| not\)/);
   assert.match(workflow, /--inventory "\$RUNNER_TEMP\/ordinary-catalog\.json"/);
 });

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -131,8 +131,8 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
     import.meta.dirname,
     '../data/artifact-governance-deferred-v1.json'
   ), 'utf8'));
-  assert.equal(cohort.selectedCount, 196);
-  assert.equal(cohort.rows.length, 196);
+  assert.equal(cohort.selectedCount, 192);
+  assert.equal(cohort.rows.length, 192);
   assert.deepEqual(cohort.sourceBoundaries, [{
     runId: '29775654869',
     classificationSha256: 'b3627fab08453788d08e4ddfa89726ad8260d28cb1bd55420b2b032691d4b07e',
@@ -144,7 +144,7 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
     []
   );
   assert.match(workflow, /ORIGIN_COHORT: scripts\/data\/ordinary-v2-report-origin-cohort-v1\.json/);
-  assert.match(workflow, /ORIGIN_COHORT_SHA256: 29e248eac74cce31454d167a46d7857fb9d43ac476f8e753b854cab1ce7e84cc/);
+  assert.match(workflow, /ORIGIN_COHORT_SHA256: 3750ca3d83fe28efb5673f384cef74195a44d388f14062ba3cec9f06f78a873c/);
   assert.match(workflow, /ORIGIN_CLI_VERSION: '2\.15\.9'/);
   assert.match(workflow, /ORIGIN_CLI_SHA256: '9a980bbb9574dd3da976803264796dd3ba57d15bafde5645afe6fe5783e5e9ec'/);
   assert.equal((workflow.match(/version: '2\.15\.9'/g) || []).length, 4);
@@ -152,7 +152,7 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /\.workflowName == "Govern Legacy Report-Origin V2-Only"/);
   assert.match(workflow, /sha256sum --check SHA256SUMS/);
   assert.match(workflow, /cmp "\$RUNNER_TEMP\/boundary\/origin-lineage\.json" "\$RUNNER_TEMP\/current-origin-lineage\.json"/);
-  assert.match(workflow, /--expected-count 196/);
+  assert.match(workflow, /--expected-count 192/);
   assert.match(workflow, /done < <\(jq -r '\.slugs\[\]' <<< "\$group"\)/);
   assert.match(workflow, /--root "\$RUNNER_TEMP\/current\/\$commit" --slugs "\$slug"/);
   assert.match(workflow, /dry-run-failures\.jsonl/);


### PR DESCRIPTION
## What changed

- add the four complete no-write enumeration failures from run 29779618666 to the deferred contract
- freeze the remaining exact 192-row v2 report-origin cohort
- update workflow count and SHA pins plus focused tests

## Evidence

- failure artifact 8476144198, digest sha256:6279bb2da66f1448d26fb3e4b8bcd5ca9837bb06e98ac28d962dce14a1bb7f58
- exact failures: yaojingang-yao-meta-skill, yuan1z0825-nature-figure, zach22-1999-zach-seller-skill-creator, zhanlincui-docx
- production deltas after the run: artifact/audit/observation/score/binding 0/0/0/0/0

## Validation

- CI=true node --test focused governance suites: 13/13
- all enumerated failures are deferred and absent from the cohort
- exact cohort identity equals immutable classification drift minus deferred
- YAML parse and bash -n: 46 workflow run blocks
- exact SHA-256 contracts and git diff --check