### PR TITLE
[codex] retire consumed Report-Origin recovery lane

### DIFF
--- a/.github/workflows/govern-legacy-report-origin-70.yml
+++ b/.github/workflows/govern-legacy-report-origin-70.yml
@@ -4,19 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Recover the exact sealed post-score incident'
+        description: 'Retired after successful recovery run 29785426241'
         type: choice
         required: true
-        default: recover-post-score
-        options: [recover-post-score]
+        default: retired
+        options: [retired]
       dry_run_id:
         description: 'Exact successful dry-run run ID'
         type: string
-        required: true
+        required: false
+        default: ''
       failed_execute_run_id:
         description: 'Exact cancelled execute run ID'
         type: string
-        required: true
+        required: false
+        default: ''
 
 permissions:
   actions: read

--- a/scripts/tests/legacy-report-origin-workflow.test.mjs
+++ b/scripts/tests/legacy-report-origin-workflow.test.mjs
@@ -151,7 +151,8 @@ test('workflow freezes and replays Git evidence with the audited CLI digest', ()
   assert.match(workflow, /RECOVERY_CLI_SHA256: '2ea8ef90fcb890b83b1cf1bd772bd02da3fff98bc8f5162c481287552518bdd8'/);
   assert.equal((workflow.match(/version: '2\.15\.9'/g) || []).length, 2);
   assert.equal((workflow.match(/version: '2\.15\.10'/g) || []).length, 2);
-  assert.match(workflow, /options: \[recover-post-score\]/);
+  assert.match(workflow, /options: \[retired\]/);
+  assert.match(workflow, /if: inputs\.mode == 'recover-post-score'/);
   assert.match(workflow, /INCIDENT_DRY_RUN_ID: '29781656344'/);
   assert.match(workflow, /INCIDENT_EXECUTE_RUN_ID: '29782034145'/);
   assert.match(workflow, /INCIDENT_EXECUTION_ARTIFACT_ID: '8477301225'/);


### PR DESCRIPTION
## Summary
- retire the one-time Report-Origin post-score recovery input after successful run 29785426241
- keep the historical workflow and incident constants readable, but leave no write job eligible for a new dispatch

## Verification
- `CI=true node --test scripts/tests/legacy-report-origin-workflow.test.mjs` (2/2)
- workflow YAML parsed and all 18 shell blocks passed `bash -n`
