### PR TITLE
fix(governance): freeze residual raw32 Fresh cohort

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -10,10 +10,10 @@ on:
         default: dry-run
         options: [dry-run, execute, recover, recover-cache, recover-smoke]
       cohort_path:
-        description: 'Repository-relative lineage-unproven cohort JSON; dry-run only'
+        description: 'Exact repository-relative raw32 Fresh cohort JSON; dry-run only'
         type: string
         required: false
-        default: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
+        default: 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
       start_after:
         description: 'Exact prior batch end slug; dry-run only'
         type: string
@@ -53,7 +53,7 @@ on:
         description: 'Exact audited CLI version'
         type: string
         required: true
-        default: '2.15.5'
+        default: '2.15.10'
 
 permissions:
   actions: read
@@ -64,11 +64,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FRESH_GOVERNANCE_CLI_VERSION: '2.15.5'
-  FRESH_GOVERNANCE_CLI_SHA256: 'b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189'
-  ORIGINAL_FRESH_COHORT: 'governance/fresh-canonical-audit/remaining-lineage.json'
-  REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
-  REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'
+  FRESH_GOVERNANCE_CLI_VERSION: '2.15.10'
+  FRESH_GOVERNANCE_CLI_SHA256: '2ea8ef90fcb890b83b1cf1bd772bd02da3fff98bc8f5162c481287552518bdd8'
+  REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
+  REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539'
 
 jobs:
   freeze-boundary:
@@ -120,22 +119,21 @@ jobs:
           fi
           test -f "$COHORT_PATH" || { echo '::error::lineage-unproven cohort is missing'; exit 1; }
           case "$COHORT_PATH" in
-            "$ORIGINAL_FRESH_COHORT") ;;
             "$REPORT_ORIGIN_FRESH_COHORT")
               test "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" = "$REPORT_ORIGIN_FRESH_COHORT_SHA256"
               jq -e '
                 .schemaVersion == 1 and .status == "lineage_unproven"
-                and .count == 11 and (.rows | length) == 11
-                and ([.rows[].slug] | unique | length) == 11
-                and ([.rows[].skillId] | unique | length) == 11
+                and .count == 62 and (.rows | length) == 62
+                and ([.rows[].slug] | unique | length) == 62
+                and ([.rows[].skillId] | unique | length) == 62
+                and ([.rows[].path] | unique | length) == 62
                 and all(.rows[];
-                  .marketplaceCommit == "820ccb93d2e2fe828678ed05433bafd1054e5000"
-                  and .remainingReason == "same_source_tree_unproven"
+                  .remainingReason == "same_source_tree_unproven"
                   and .governanceEligibleByLineage == false
-                  and .legacyReference.kind == "frozen_mutable_main"
-                  and .legacyReference.sourceRef == "main"
+                  and .legacyReference.kind == "frozen_commit_ref"
+                  and .legacyReference.sourceRef == .marketplaceCommit
                   and .legacyReference.skillReportUrl ==
-                    ("https://github.com/aiskillstore/marketplace/blob/main/" + .path + "/skill-report.json"))
+                    ("https://github.com/aiskillstore/marketplace/blob/" + .marketplaceCommit + "/" + .path + "/skill-report.json"))
               ' "$COHORT_PATH" >/dev/null
               ;;
             *) echo '::error::cohort_path is not an authenticated Fresh campaign'; exit 1 ;;
@@ -338,20 +336,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact fresh-governance CLI 2.15.5
+      - name: Download exact fresh-governance CLI 2.15.10
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.5'
-          minimum-version: '2.15.5'
+          version: '2.15.10'
+          minimum-version: '2.15.10'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Hard-block until the released Linux binary digest is audited
         run: |
           set -euo pipefail
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.5 digest'; exit 1; }
-          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.5 digest mismatch'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.10 digest'; exit 1; }
+          test "$actual" = "$FRESH_GOVERNANCE_CLI_SHA256" || { echo '::error::CLI 2.15.10 digest mismatch'; exit 1; }
 
       - name: Run genuinely fresh audits against each frozen commit
         env:
@@ -401,7 +399,7 @@ jobs:
             --result-file "$RUNNER_TEMP/fresh-boundary.json"
 
       - name: Prove Report-Origin raw32 audits are replacement pointers only
-        if: inputs.cohort_path == 'governance/fresh-canonical-audit/report-origin-raw32-v1.json'
+        if: inputs.cohort_path == 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
         run: |
           set -euo pipefail
           jq -e --slurpfile selected "$RUNNER_TEMP/selected-cohort.json" '
@@ -670,12 +668,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: marketplace,skillstore
 
-      - name: Download exact audited CLI 2.15.5
+      - name: Download exact audited CLI 2.15.10
         uses: ./.github/actions/download-skillstore-cli
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version: '2.15.5'
-          minimum-version: '2.15.5'
+          version: '2.15.10'
+          minimum-version: '2.15.10'
           cache-dir: /home/runner/_work/_cache/skillstore-cli
 
       - name: Verify frozen CLI identity
@@ -685,7 +683,7 @@ jobs:
           set -euo pipefail
           expected=$(jq -r .cliSha256 "$RUNNER_TEMP/boundary/metadata.json")
           actual=$(sha256sum "$GITHUB_WORKSPACE/skillstore-cli" | awk '{print $1}')
-          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.5 digest'; exit 1; }
+          [[ "$FRESH_GOVERNANCE_CLI_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo '::error::invalid CLI 2.15.10 digest'; exit 1; }
           if test "$DRY_RUN_ID" = '29646612265'; then
             test "$expected" = 'ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a'
           else

--- a/governance/fresh-canonical-audit/raw32-exact62-v1.json
+++ b/governance/fresh-canonical-audit/raw32-exact62-v1.json
@@ -1,0 +1,1185 @@
+{
+  "schemaVersion": 1,
+  "status": "lineage_unproven",
+  "count": 62,
+  "rows": [
+    {
+      "slug": "7sageer-mac-automation",
+      "skillId": "433ac2df-5b5f-4b2b-a921-b9dba7ee607e",
+      "path": "skills/7sageer/mac-automation",
+      "marketplaceCommit": "14dc8f201a64f8d30fd131d7f036cd5e788be523",
+      "reportContentHash": "7e83bad4839b2b2b8a603b814399666fa39564184370915e8f5712e78563d6c4",
+      "reportTreeHash": "71794cbb94a9c412694b098df04950feef8e4beebfb9d56878a5fbc6c420614b",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "71794cbb94a9c412694b098df04950feef8e4beebfb9d56878a5fbc6c420614b",
+        "contentHash": "7e83bad4839b2b2b8a603b814399666fa39564184370915e8f5712e78563d6c4"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "14dc8f201a64f8d30fd131d7f036cd5e788be523",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/14dc8f201a64f8d30fd131d7f036cd5e788be523/skills/7sageer/mac-automation/skill-report.json"
+      }
+    },
+    {
+      "slug": "emilkowalski-apple-design",
+      "skillId": "9f4f43d3-0cf2-413c-ba09-df92bcad311e",
+      "path": "skills/emilkowalski/apple-design",
+      "marketplaceCommit": "d1c4c60b80afc545d96b5e8a51c19b2fdc81df70",
+      "reportContentHash": "efb690754a6607d9ff5ca0491f5d91d7fe75203fdd370af95171db87cd826d49",
+      "reportTreeHash": "5528283416b9f3787394d2ec77f3ef265f87e0a367d85056890373c5fa0cf607",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5528283416b9f3787394d2ec77f3ef265f87e0a367d85056890373c5fa0cf607",
+        "contentHash": "efb690754a6607d9ff5ca0491f5d91d7fe75203fdd370af95171db87cd826d49"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "d1c4c60b80afc545d96b5e8a51c19b2fdc81df70",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/d1c4c60b80afc545d96b5e8a51c19b2fdc81df70/skills/emilkowalski/apple-design/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-a2a-protocol",
+      "skillId": "26d2048e-f72f-4a1d-8c88-f147a15f77ca",
+      "path": "skills/internet-court/a2a-protocol",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "ef5760601b579a0f5daf14d991934c22d8194d72d01ebe94f4138abe691d4aee",
+      "reportTreeHash": "66aaf5076a663000cbd4460bb63d3754e218dc4e874a9e8373cbb6833ac3f5bd",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "66aaf5076a663000cbd4460bb63d3754e218dc4e874a9e8373cbb6833ac3f5bd",
+        "contentHash": "ef5760601b579a0f5daf14d991934c22d8194d72d01ebe94f4138abe691d4aee"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/a2a-protocol/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-agentic-wallet",
+      "skillId": "11340222-f79a-48b8-a47b-f0b0428cee3a",
+      "path": "skills/internet-court/agentic-wallet",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "dbce03c35b72447f22d245d84f17daa654b7b659a61a2c770c7b9dc8568c97c6",
+      "reportTreeHash": "59caf68e8a1f12cf0c41336319b9ec614187f60f4bb04071ce0f9cff66efa539",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "59caf68e8a1f12cf0c41336319b9ec614187f60f4bb04071ce0f9cff66efa539",
+        "contentHash": "dbce03c35b72447f22d245d84f17daa654b7b659a61a2c770c7b9dc8568c97c6"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/agentic-wallet/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-agent-wallet",
+      "skillId": "c5e2c797-5a52-48b5-acf4-2b31f61a7c63",
+      "path": "skills/internet-court/agent-wallet",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "13f22c3da3715d8b5668c4dd46a424a56749665a65052173ceebf8297868cdbb",
+      "reportTreeHash": "cf099ebf23337444b11a895138d4753476a56df44712c86b286215cb72555551",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "cf099ebf23337444b11a895138d4753476a56df44712c86b286215cb72555551",
+        "contentHash": "13f22c3da3715d8b5668c4dd46a424a56749665a65052173ceebf8297868cdbb"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/agent-wallet/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-alkahest-developer",
+      "skillId": "46294dfc-5ae5-45f6-914b-84357f23c092",
+      "path": "skills/internet-court/alkahest-developer",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "79a0a547ebdd8f087ae2b5032c685e55a2a8b292b192c143c92f5b83d508a2c8",
+      "reportTreeHash": "a04cf3bfe6bc16edb673e5cc16e2fd5631d5130b915da543cf06e557f5757fc7",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "a04cf3bfe6bc16edb673e5cc16e2fd5631d5130b915da543cf06e557f5757fc7",
+        "contentHash": "79a0a547ebdd8f087ae2b5032c685e55a2a8b292b192c143c92f5b83d508a2c8"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/alkahest-developer/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-alkahest-user",
+      "skillId": "1bb6e606-33af-44d1-86c3-dc310ffd3f8b",
+      "path": "skills/internet-court/alkahest-user",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "434e3a1a3dba5dbd08f485e14ddb3328bbf6b8d9aebedb35a9647a8a97233067",
+      "reportTreeHash": "73bbdff41caba7be7741055c9caaee8e00b272be71f6e509a4e49d313151e38d",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "73bbdff41caba7be7741055c9caaee8e00b272be71f6e509a4e49d313151e38d",
+        "contentHash": "434e3a1a3dba5dbd08f485e14ddb3328bbf6b8d9aebedb35a9647a8a97233067"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/alkahest-user/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-altllm-portal-api-keys",
+      "skillId": "7dd0603e-9b53-4f38-9a94-8257dae06127",
+      "path": "skills/internet-court/altllm-portal-api-keys",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "a00c393aa840c7013f4e3d24a0163c394c0847c9e92c669499a6d538834d23f9",
+      "reportTreeHash": "a5b58483614d9febf78c002e8961d1c96ccb32a77b02bb7d308f86838a105184",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "a5b58483614d9febf78c002e8961d1c96ccb32a77b02bb7d308f86838a105184",
+        "contentHash": "a00c393aa840c7013f4e3d24a0163c394c0847c9e92c669499a6d538834d23f9"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-api-keys/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-altllm-portal-auth",
+      "skillId": "301d8dde-873e-4376-8274-a934abedd128",
+      "path": "skills/internet-court/altllm-portal-auth",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "509d15ba24a55530f295913ec9e59d0cb1d2028c1ca67b0bef8adcbd551d2057",
+      "reportTreeHash": "8c05ae741fccff1b841fcec1451a347c9644cf641823cbb61c005ee24a6904c0",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8c05ae741fccff1b841fcec1451a347c9644cf641823cbb61c005ee24a6904c0",
+        "contentHash": "509d15ba24a55530f295913ec9e59d0cb1d2028c1ca67b0bef8adcbd551d2057"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-auth/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-altllm-portal-billing",
+      "skillId": "05fd3cde-8598-471c-bb46-c1d2b9815ee0",
+      "path": "skills/internet-court/altllm-portal-billing",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f8f6287b174c462eccea238a852c8e45a3165abaec88afa2a4141a37be32b60d",
+      "reportTreeHash": "d0d0fd9e836b150b648018a5bc03573af40cccf2b87ce726242cbd6cbb37f668",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d0d0fd9e836b150b648018a5bc03573af40cccf2b87ce726242cbd6cbb37f668",
+        "contentHash": "f8f6287b174c462eccea238a852c8e45a3165abaec88afa2a4141a37be32b60d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-billing/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-altllm-portal-cli",
+      "skillId": "b96890f8-9adb-410c-b588-cc620b604b76",
+      "path": "skills/internet-court/altllm-portal-cli",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "b5f7e70ae812c2f228c643f97da6b28100a3b33710f6b033a90cff6a8cc03133",
+      "reportTreeHash": "da275c9ffe4c3957807ec8572f59e5db40722680a74bfd24f1313288ea6e4095",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "da275c9ffe4c3957807ec8572f59e5db40722680a74bfd24f1313288ea6e4095",
+        "contentHash": "b5f7e70ae812c2f228c643f97da6b28100a3b33710f6b033a90cff6a8cc03133"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-cli/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-altllm-portal-payments",
+      "skillId": "8eef0ed6-7be4-4023-87ad-b7ca61ebf745",
+      "path": "skills/internet-court/altllm-portal-payments",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "3b51ed8e6c377a4419a987cafdd0d9715690e872a47f3a74a11b50088a407fed",
+      "reportTreeHash": "8bb2b9a72178e613012098227a46a23b5c63c8f3bd3c3d2ca88e75e7ab7076be",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8bb2b9a72178e613012098227a46a23b5c63c8f3bd3c3d2ca88e75e7ab7076be",
+        "contentHash": "3b51ed8e6c377a4419a987cafdd0d9715690e872a47f3a74a11b50088a407fed"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-payments/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-antseed-connect",
+      "skillId": "6d3da872-c593-4d9c-a71a-b6ce70918031",
+      "path": "skills/internet-court/antseed-connect",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "7f89a0a34e5921cfa50def009b860f81d39c55d1204a4d40598fe9b611e8475a",
+      "reportTreeHash": "92b1a2db387af1c90184bad263938025aa507523fdebe2cfb08f28c43c8fe520",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "92b1a2db387af1c90184bad263938025aa507523fdebe2cfb08f28c43c8fe520",
+        "contentHash": "7f89a0a34e5921cfa50def009b860f81d39c55d1204a4d40598fe9b611e8475a"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/antseed-connect/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-bnbchain-mcp",
+      "skillId": "9a939422-b91d-4739-b15a-f4bff1f4fff2",
+      "path": "skills/internet-court/bnbchain-mcp",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "d6c099123677b2fae35d712c9fe0b27e79dbaeba2b6a0c871bc66bc3b608583d",
+      "reportTreeHash": "4231154c8feb28ff14e2cc301035666ba1ae1df90a66fd8cd7d2be32449a9414",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "4231154c8feb28ff14e2cc301035666ba1ae1df90a66fd8cd7d2be32449a9414",
+        "contentHash": "d6c099123677b2fae35d712c9fe0b27e79dbaeba2b6a0c871bc66bc3b608583d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/bnbchain-mcp/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-chaingpt",
+      "skillId": "b7db1378-6aaa-477f-b091-bd3cc5a62f72",
+      "path": "skills/internet-court/chaingpt",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "3d217568d3c9dbe57a2147a2eae052e0756d1179a5090770857c75431bc07e79",
+      "reportTreeHash": "c2a4c8516267fccce44451df33ceba4663016c1a481f540a2caee98071c3d93a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c2a4c8516267fccce44451df33ceba4663016c1a481f540a2caee98071c3d93a",
+        "contentHash": "3d217568d3c9dbe57a2147a2eae052e0756d1179a5090770857c75431bc07e79"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/chaingpt/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-cloud-claw",
+      "skillId": "46da7f53-b323-494b-b0a3-9f17ee8177dc",
+      "path": "skills/internet-court/cloud-claw",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "dfb032390811b7d62203bd3dcd71685999b2db27dacec1f3559add67f3ce5b90",
+      "reportTreeHash": "8481c85c57e6a89c9b34a4895f7c3f5887887747fe49a78a176d36dd53dd08cd",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8481c85c57e6a89c9b34a4895f7c3f5887887747fe49a78a176d36dd53dd08cd",
+        "contentHash": "dfb032390811b7d62203bd3dcd71685999b2db27dacec1f3559add67f3ce5b90"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/cloud-claw/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-cloud-claw-launch-agent",
+      "skillId": "ebac5cc4-1033-42ba-a0f0-48aad5d9094b",
+      "path": "skills/internet-court/cloud-claw-launch-agent",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "9d30ef202851e244f046968ce217f6ada5042aff0361d5e298e31d180c247f82",
+      "reportTreeHash": "ec8c0da0b04fa5ba393af85242843eafecad9a74f2eb13a5718f2c9b9fab4f8d",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "ec8c0da0b04fa5ba393af85242843eafecad9a74f2eb13a5718f2c9b9fab4f8d",
+        "contentHash": "9d30ef202851e244f046968ce217f6ada5042aff0361d5e298e31d180c247f82"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/cloud-claw-launch-agent/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-direct-tests",
+      "skillId": "766ea85f-f1b2-49b2-bf8f-26edd81f5b70",
+      "path": "skills/internet-court/direct-tests",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "5bb5a70b2b857b20e95c3f7ff2992718700ee474bedfcbaf183e8ce7ef26be8d",
+      "reportTreeHash": "c480d7fcba53cae07bf0d78631917f5c971c06f77791550fcb407bc84d69184c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c480d7fcba53cae07bf0d78631917f5c971c06f77791550fcb407bc84d69184c",
+        "contentHash": "5bb5a70b2b857b20e95c3f7ff2992718700ee474bedfcbaf183e8ce7ef26be8d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/direct-tests/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-fulfill-git-escrow",
+      "skillId": "23cc83e9-5fd9-46ae-8d76-4587eab4ccfb",
+      "path": "skills/internet-court/fulfill-git-escrow",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "66447673d3ca0d3c7f216e156fb629847096aecf9ae35501cfc47207611d4922",
+      "reportTreeHash": "452843ccf1e7aa07f174fdedf3e818a1a3b11861a907b157522734636fb119d0",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "452843ccf1e7aa07f174fdedf3e818a1a3b11861a907b157522734636fb119d0",
+        "contentHash": "66447673d3ca0d3c7f216e156fb629847096aecf9ae35501cfc47207611d4922"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/fulfill-git-escrow/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-genlayer-cli",
+      "skillId": "553c1c9a-31cb-4622-9f98-607b7cbf590f",
+      "path": "skills/internet-court/genlayer-cli",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "ec5540958191c9eae4d90289d97842b8cd1d30cd920327f3e5ba0482f6455396",
+      "reportTreeHash": "bd88a6f7c86495bc74240c5bc37b218abb783899ee325e897de736fb218db7a6",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "bd88a6f7c86495bc74240c5bc37b218abb783899ee325e897de736fb218db7a6",
+        "contentHash": "ec5540958191c9eae4d90289d97842b8cd1d30cd920327f3e5ba0482f6455396"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-cli/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-genlayer-erc7710-connector",
+      "skillId": "615d4de7-f1e3-4423-a548-ac163cdd7db5",
+      "path": "skills/internet-court/genlayer-erc7710-connector",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "2cde02c8c1f58fe8d0ae4bede38aa8af503fcf5f3d2e8d2ef25ed19a943dcbab",
+      "reportTreeHash": "07bffa815102abc28d18407f49f5573e2c1422587f47df3867beb923a383bf33",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "07bffa815102abc28d18407f49f5573e2c1422587f47df3867beb923a383bf33",
+        "contentHash": "2cde02c8c1f58fe8d0ae4bede38aa8af503fcf5f3d2e8d2ef25ed19a943dcbab"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-erc7710-connector/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-genlayer-intelligent-contracts",
+      "skillId": "c9105ee6-dedd-4dbe-b05b-24b465213053",
+      "path": "skills/internet-court/genlayer-intelligent-contracts",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f752056aa211201e8525e04def65e40cfd2d77083d7922a88984217a86b96a63",
+      "reportTreeHash": "4179e994e0ee3ebeb1eb4f6085bb72615112924db5243d018a432d19d33ff91c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "4179e994e0ee3ebeb1eb4f6085bb72615112924db5243d018a432d19d33ff91c",
+        "contentHash": "f752056aa211201e8525e04def65e40cfd2d77083d7922a88984217a86b96a63"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-intelligent-contracts/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-genvm-lint",
+      "skillId": "7078c670-feca-496e-bcd7-8a1e60938c19",
+      "path": "skills/internet-court/genvm-lint",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "06cccf582b76196b8914c3ab57b56e571aeaba2a3f4db735eea8eb8642fa6b1a",
+      "reportTreeHash": "a8b42930ae752472657d80feea8e7ebe2cd559c523c31d749f1bc76063541b8c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "a8b42930ae752472657d80feea8e7ebe2cd559c523c31d749f1bc76063541b8c",
+        "contentHash": "06cccf582b76196b8914c3ab57b56e571aeaba2a3f4db735eea8eb8642fa6b1a"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genvm-lint/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-heurist-mesh-skill",
+      "skillId": "c27902b8-d503-41a0-bca5-81c736c86eb9",
+      "path": "skills/internet-court/heurist-mesh-skill",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "6c53f8999f7fc54a542d0542674c24f10ba8ea2f4cd8840356cdb5eca4d72f6a",
+      "reportTreeHash": "f3bdd1e8243703b411fe8df1113ce3d6d9ca0ee0708317b4fea2862dff6138c6",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "f3bdd1e8243703b411fe8df1113ce3d6d9ca0ee0708317b4fea2862dff6138c6",
+        "contentHash": "6c53f8999f7fc54a542d0542674c24f10ba8ea2f4cd8840356cdb5eca4d72f6a"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/heurist-mesh-skill/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-integration-tests",
+      "skillId": "982f7af0-410a-49e2-ae33-0555ec8ef521",
+      "path": "skills/internet-court/integration-tests",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "38ac394bb4bae50da905d205170d37066565be2a502b93d0517cbf38e55c0054",
+      "reportTreeHash": "769891ed22559fa4427e0d101a32ed7e1ed84b854bf5b7a897f1b0f794029972",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "769891ed22559fa4427e0d101a32ed7e1ed84b854bf5b7a897f1b0f794029972",
+        "contentHash": "38ac394bb4bae50da905d205170d37066565be2a502b93d0517cbf38e55c0054"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/integration-tests/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-intelligent-oracle",
+      "skillId": "90db6e4a-7c12-4c5f-b6ad-28d9f6ed63d7",
+      "path": "skills/internet-court/intelligent-oracle",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "1d46b3392fbae82228659b57ac1258e72ac1ffbfad809b6f995492da461295c4",
+      "reportTreeHash": "d42d0cf35d54bea2966e13be20db3a6fdfe02056ed887f520178fcb849ec3dd1",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d42d0cf35d54bea2966e13be20db3a6fdfe02056ed887f520178fcb849ec3dd1",
+        "contentHash": "1d46b3392fbae82228659b57ac1258e72ac1ffbfad809b6f995492da461295c4"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/intelligent-oracle/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-make-git-escrow",
+      "skillId": "2905ba9c-7d1a-42c0-a88c-bf5981783a19",
+      "path": "skills/internet-court/make-git-escrow",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "031b00fe0944af8db8dce9f2c1983854afc44c5f5220e232ea32efd927ce30e8",
+      "reportTreeHash": "d3e5d4c7cf8c2add78e6304c7d0a06a6f2b5a5e72bcffe7ac28b5f6b0544edb2",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d3e5d4c7cf8c2add78e6304c7d0a06a6f2b5a5e72bcffe7ac28b5f6b0544edb2",
+        "contentHash": "031b00fe0944af8db8dce9f2c1983854afc44c5f5220e232ea32efd927ce30e8"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/make-git-escrow/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-mppx",
+      "skillId": "ec896d98-0339-4737-b050-c15ba8ca7d4b",
+      "path": "skills/internet-court/mppx",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "eea81e0a88c1d8bf7ad85a2b35e0eba2e989d53e85ef326861358ef8176677bd",
+      "reportTreeHash": "98fd6b5409e4bed75d0affb303e22a2bdd15ec83ff45e1715682a1275963de68",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "98fd6b5409e4bed75d0affb303e22a2bdd15ec83ff45e1715682a1275963de68",
+        "contentHash": "eea81e0a88c1d8bf7ad85a2b35e0eba2e989d53e85ef326861358ef8176677bd"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/mppx/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-general-search",
+      "skillId": "20aa9c4c-ed04-49a2-a8c9-64bb26259b09",
+      "path": "skills/internet-court/nansen-general-search",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "3b49ee76e3d6010045092de60ccfa435e640ca4639ec96abb05d94eb24c53bcc",
+      "reportTreeHash": "c7c6fb914757efac9fd96556ca34eee0c3ab43b5b8bf7d173759e169628c12a7",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c7c6fb914757efac9fd96556ca34eee0c3ab43b5b8bf7d173759e169628c12a7",
+        "contentHash": "3b49ee76e3d6010045092de60ccfa435e640ca4639ec96abb05d94eb24c53bcc"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-general-search/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-holder-analysis",
+      "skillId": "0ea9b366-7e8e-4aa4-9875-b3c0fdbf0168",
+      "path": "skills/internet-court/nansen-holder-analysis",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "a4beb0bef2dc66530226d0b9895a3d6e4fd4edd457f69891e84bb0b25537b517",
+      "reportTreeHash": "013ab6090ce1a66ca2d8d776dbbc1b66c85b2b383eee1b2282c54d8f4459129a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "013ab6090ce1a66ca2d8d776dbbc1b66c85b2b383eee1b2282c54d8f4459129a",
+        "contentHash": "a4beb0bef2dc66530226d0b9895a3d6e4fd4edd457f69891e84bb0b25537b517"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-holder-analysis/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-mpp-payment",
+      "skillId": "3a2dd274-afdc-4ad0-aa00-e48ecaeeba11",
+      "path": "skills/internet-court/nansen-mpp-payment",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "6aaef9a5b472bafef5ec46b325b17553f095119f043824e36b403b01e53541ba",
+      "reportTreeHash": "5e8da358d2733e790405fe91c5221585a8bd467647d83fc45223c22c0da00a0c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5e8da358d2733e790405fe91c5221585a8bd467647d83fc45223c22c0da00a0c",
+        "contentHash": "6aaef9a5b472bafef5ec46b325b17553f095119f043824e36b403b01e53541ba"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-mpp-payment/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-prediction-markets",
+      "skillId": "e179f5c2-f6f4-40c8-9d90-175e1922d11f",
+      "path": "skills/internet-court/nansen-prediction-markets",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "b42c7905143a57b42f1d7036f9f202e7c2863f04108d509b619b1a3ef7fbc1f3",
+      "reportTreeHash": "ea3b664d04ec21d9ef3abb23b945aaa79fc1a868a31a49dc15aac5241d4fbd4f",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "ea3b664d04ec21d9ef3abb23b945aaa79fc1a868a31a49dc15aac5241d4fbd4f",
+        "contentHash": "b42c7905143a57b42f1d7036f9f202e7c2863f04108d509b619b1a3ef7fbc1f3"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-prediction-markets/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-smart-money-tracker",
+      "skillId": "38a1c621-9bc0-4a7d-b0b4-8e1fe577edad",
+      "path": "skills/internet-court/nansen-smart-money-tracker",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f58b2df19ff3ba974e1dec7f01f954620a236a9e654dfc1c3342907d7a569154",
+      "reportTreeHash": "be895ae78c460ab1a58134216fec545da676ded246bb8a96c94857c3b1912f92",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "be895ae78c460ab1a58134216fec545da676ded246bb8a96c94857c3b1912f92",
+        "contentHash": "f58b2df19ff3ba974e1dec7f01f954620a236a9e654dfc1c3342907d7a569154"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-smart-money-tracker/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-token-research",
+      "skillId": "031a042b-446e-4958-b217-d1594b397daa",
+      "path": "skills/internet-court/nansen-token-research",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "8b9c5a208d7d70d63afa5f5f19cee1efdf39ed21f7ac65bf75b5d746fbb5711c",
+      "reportTreeHash": "614f0fc918ff14e4127a00e25f03881c7e915d45093fb93d5fcebe17363b568f",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "614f0fc918ff14e4127a00e25f03881c7e915d45093fb93d5fcebe17363b568f",
+        "contentHash": "8b9c5a208d7d70d63afa5f5f19cee1efdf39ed21f7ac65bf75b5d746fbb5711c"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-token-research/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nansen-wallet-profiler",
+      "skillId": "9460bb73-5122-450a-a06e-f583d4a6b8a5",
+      "path": "skills/internet-court/nansen-wallet-profiler",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "552545bc0a3ebd9a3fb91fdfd74d5446eb54fed3190c2bd34787722e1dd982fa",
+      "reportTreeHash": "61efcbf014d22a3127c4cb411620b4eab4b2bb7d64693ea2b509ffed9a31a835",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "61efcbf014d22a3127c4cb411620b4eab4b2bb7d64693ea2b509ffed9a31a835",
+        "contentHash": "552545bc0a3ebd9a3fb91fdfd74d5446eb54fed3190c2bd34787722e1dd982fa"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-wallet-profiler/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-ai-cloud",
+      "skillId": "25796503-2a99-45ec-a038-442ad2b9d9e8",
+      "path": "skills/internet-court/near-ai-cloud",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "e2bb9aaa795348d44784ab6bdd5c5d7f69db4815d4bfc0c50a78437fd3fd5122",
+      "reportTreeHash": "acd7753761197402742273592e77dc4af3a591d11945d9ccc0169a4b84e22c4b",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "acd7753761197402742273592e77dc4af3a591d11945d9ccc0169a4b84e22c4b",
+        "contentHash": "e2bb9aaa795348d44784ab6bdd5c5d7f69db4815d4bfc0c50a78437fd3fd5122"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-ai-cloud/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-api-js",
+      "skillId": "3716c019-8a37-4ab2-851a-225962408b09",
+      "path": "skills/internet-court/near-api-js",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "cbd8d12eebb1f40e0b19ec8837e3aab47a744028dc8b176f605f8c58ad33305d",
+      "reportTreeHash": "fad11e17f53e62eb817f0375f6464a03caa49fc890c815c3847494b8d4e8bec7",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "fad11e17f53e62eb817f0375f6464a03caa49fc890c815c3847494b8d4e8bec7",
+        "contentHash": "cbd8d12eebb1f40e0b19ec8837e3aab47a744028dc8b176f605f8c58ad33305d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-api-js/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-dapp",
+      "skillId": "dc2c0c47-a35b-4add-9981-fce1b53c4c09",
+      "path": "skills/internet-court/near-dapp",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "71b7998649b55d7a50113252afae741dc1d5cd91a492034a3b9cb930651ee226",
+      "reportTreeHash": "122208ce496946ab9cefb610d6729fae89257b4190fe22b0524e0742b7dafc2e",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "122208ce496946ab9cefb610d6729fae89257b4190fe22b0524e0742b7dafc2e",
+        "contentHash": "71b7998649b55d7a50113252afae741dc1d5cd91a492034a3b9cb930651ee226"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-dapp/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-intents",
+      "skillId": "880ce0dc-3ce4-4551-aa79-093a641bca04",
+      "path": "skills/internet-court/near-intents",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "76062620c39b2e0b9b03ddb77b96ef24b37b08942ba70db1b10464b05afd703d",
+      "reportTreeHash": "d859f8a8c088964a91abc36e1a1cd90f58173e7b3c4dc513404a654ab728ad09",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d859f8a8c088964a91abc36e1a1cd90f58173e7b3c4dc513404a654ab728ad09",
+        "contentHash": "76062620c39b2e0b9b03ddb77b96ef24b37b08942ba70db1b10464b05afd703d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-intents/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-kit",
+      "skillId": "122452c0-5075-4afc-9480-2727dec8d829",
+      "path": "skills/internet-court/near-kit",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "61d6fa8b1bcaf8067cd1d69882fff877f9d6567b3483e60324ff5453d7a1eae3",
+      "reportTreeHash": "e1898ae50bd394efce831dc6ae02e8566d0574186317163885d383bfe026773a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "e1898ae50bd394efce831dc6ae02e8566d0574186317163885d383bfe026773a",
+        "contentHash": "61d6fa8b1bcaf8067cd1d69882fff877f9d6567b3483e60324ff5453d7a1eae3"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-kit/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-near-smart-contracts",
+      "skillId": "fc1beeaa-3785-452f-a369-9f8ab26d6c78",
+      "path": "skills/internet-court/near-smart-contracts",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "c6878b4c3c15442aec04842ad3deb9abff88c6db25c664a21e5a94ea411ab57d",
+      "reportTreeHash": "41e61f0681c880ce3b03aa77a1c2df13ee69dbcc44133d23984d148c0c4204e9",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "41e61f0681c880ce3b03aa77a1c2df13ee69dbcc44133d23984d148c0c4204e9",
+        "contentHash": "c6878b4c3c15442aec04842ad3deb9abff88c6db25c664a21e5a94ea411ab57d"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-smart-contracts/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nla-arbitrate",
+      "skillId": "6d12f44e-07ad-4b4a-b6ec-c7455c9a8763",
+      "path": "skills/internet-court/nla-arbitrate",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "cbbd3ad3eab006e4fbbe51c2cfd5f6fd1c48690f88f8e2745544d0661ff6e1d2",
+      "reportTreeHash": "4e371012215bf34376af259c66d337a0e068f3575deb86f558ecc8f01a76b2ba",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "4e371012215bf34376af259c66d337a0e068f3575deb86f558ecc8f01a76b2ba",
+        "contentHash": "cbbd3ad3eab006e4fbbe51c2cfd5f6fd1c48690f88f8e2745544d0661ff6e1d2"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-arbitrate/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nla-create",
+      "skillId": "8b891e1e-8976-4401-901f-06c37093ef3a",
+      "path": "skills/internet-court/nla-create",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "e5fa9b0b68362b92e6d3faeca300a2d54cbba0e6a87e71425b164df3f423f3f4",
+      "reportTreeHash": "4e31b872bfec0a48a1735f29fb5f1bb13de8a089f0ca1750f8a4b95a00f5c098",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "4e31b872bfec0a48a1735f29fb5f1bb13de8a089f0ca1750f8a4b95a00f5c098",
+        "contentHash": "e5fa9b0b68362b92e6d3faeca300a2d54cbba0e6a87e71425b164df3f423f3f4"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-create/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-nla-fulfill",
+      "skillId": "1f1132a5-a523-4d3b-8cf1-8d1c5142c177",
+      "path": "skills/internet-court/nla-fulfill",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "6913d7e02cbedb0de6f5aaa2645bcd8c46ba852990cea8c938d38b12e72b7b6a",
+      "reportTreeHash": "d034e575e1d2d304d3e3b313571086730c61f8deae74649737f44dbbff023e40",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d034e575e1d2d304d3e3b313571086730c61f8deae74649737f44dbbff023e40",
+        "contentHash": "6913d7e02cbedb0de6f5aaa2645bcd8c46ba852990cea8c938d38b12e72b7b6a"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-fulfill/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-agentic-wallet",
+      "skillId": "3584f0a2-3712-4672-a56c-f06ab9481333",
+      "path": "skills/internet-court/okx-agentic-wallet",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "2eee0343fec08049206b408e8ff642d8d32d4a87cc187b01de6c205c07dbe4fc",
+      "reportTreeHash": "743df974375ff10d18951a405b26719498308d89a47f71411856fbf46183c86d",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "743df974375ff10d18951a405b26719498308d89a47f71411856fbf46183c86d",
+        "contentHash": "2eee0343fec08049206b408e8ff642d8d32d4a87cc187b01de6c205c07dbe4fc"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-agentic-wallet/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-agent-payments-protocol",
+      "skillId": "bd40046e-5e01-4733-9fc8-4a7d43d69e0e",
+      "path": "skills/internet-court/okx-agent-payments-protocol",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "7aadd069238a97ff0887e67d67f9190dc681b7239dbc2490400c60131cbe3a42",
+      "reportTreeHash": "831505ec1a131c7bd78b17c27f763ca1c3975e96dab1d99c6af2784c40e9b797",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "831505ec1a131c7bd78b17c27f763ca1c3975e96dab1d99c6af2784c40e9b797",
+        "contentHash": "7aadd069238a97ff0887e67d67f9190dc681b7239dbc2490400c60131cbe3a42"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-agent-payments-protocol/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-ai",
+      "skillId": "8438af38-21d5-45ad-a0d2-b0e2020b6ff6",
+      "path": "skills/internet-court/okx-ai",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "458fb7f784a48a2b2cc440795ef369ce91c244d4bd32545e37c24dc7a51a06d7",
+      "reportTreeHash": "d2911137200ac6251ab409e85ace83faa5139d8c3d365d8964951f359f9dbc2c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "d2911137200ac6251ab409e85ace83faa5139d8c3d365d8964951f359f9dbc2c",
+        "contentHash": "458fb7f784a48a2b2cc440795ef369ce91c244d4bd32545e37c24dc7a51a06d7"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-ai/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-dapp-discovery",
+      "skillId": "68f7fb95-cf57-46c6-b363-f02c3ab266aa",
+      "path": "skills/internet-court/okx-dapp-discovery",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "b9a1fc6fb4ad5fe8f43675de7e3bfdb65d15220d6fd653b3be9edb0f8bd95b16",
+      "reportTreeHash": "184cc14f0f19587cc0f8bc6b90da545b4cf1b4e9959c703717008d822b8fc599",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "184cc14f0f19587cc0f8bc6b90da545b4cf1b4e9959c703717008d822b8fc599",
+        "contentHash": "b9a1fc6fb4ad5fe8f43675de7e3bfdb65d15220d6fd653b3be9edb0f8bd95b16"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-dapp-discovery/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-defi",
+      "skillId": "563756f1-67a2-4ca3-95d7-044def15433f",
+      "path": "skills/internet-court/okx-defi",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "583a75c0a303e677af459e7fa72f2816bad501316147d06919696649cede9d6c",
+      "reportTreeHash": "56f600f4be54d0c7a39bee96b1bf31926cdccd15942e5701b06673c1287e3eaf",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "56f600f4be54d0c7a39bee96b1bf31926cdccd15942e5701b06673c1287e3eaf",
+        "contentHash": "583a75c0a303e677af459e7fa72f2816bad501316147d06919696649cede9d6c"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-defi/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-dex",
+      "skillId": "71f61a90-ca0a-4769-af5f-485d7ba1be50",
+      "path": "skills/internet-court/okx-dex",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "dad0c2199b79e14ced118bb6ad685b98322c269856f350227fec1487f58f0372",
+      "reportTreeHash": "5435c0425565f9b077d6e8bb879d703de37de5948d7fbcb5c21a96f39804800b",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5435c0425565f9b077d6e8bb879d703de37de5948d7fbcb5c21a96f39804800b",
+        "contentHash": "dad0c2199b79e14ced118bb6ad685b98322c269856f350227fec1487f58f0372"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-dex/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-okx-growth-competition",
+      "skillId": "5f4188b4-53cc-4db3-bbf6-8d4bc218c76d",
+      "path": "skills/internet-court/okx-growth-competition",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "705263b0a0c9789b0aeeac0058f26948d627eb8d074f6e0f5c7552bfe60123e0",
+      "reportTreeHash": "22d85e4bbd85f7cd474ca6b35efabc685fece6b97596f2a169c61b9892d3f9fa",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "22d85e4bbd85f7cd474ca6b35efabc685fece6b97596f2a169c61b9892d3f9fa",
+        "contentHash": "705263b0a0c9789b0aeeac0058f26948d627eb8d074f6e0f5c7552bfe60123e0"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-growth-competition/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-openserv-agent-sdk",
+      "skillId": "7d45cbcd-53a3-4db8-9bd7-d898d3d7dba0",
+      "path": "skills/internet-court/openserv-agent-sdk",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "3c61f2a575a32ffca1d1bed09885ace75d1327fe07780a501d0140f4a50a1bb1",
+      "reportTreeHash": "ef74d2806489d5dea66f59a36427a0a8ddfbc721ea74d69e6c2e6009d4a310d0",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "ef74d2806489d5dea66f59a36427a0a8ddfbc721ea74d69e6c2e6009d4a310d0",
+        "contentHash": "3c61f2a575a32ffca1d1bed09885ace75d1327fe07780a501d0140f4a50a1bb1"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-agent-sdk/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-openserv-client",
+      "skillId": "59044557-5d11-4422-93c6-fb8c49ba4404",
+      "path": "skills/internet-court/openserv-client",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "2a95cbc247b167fb223c0b9b03fb21237b4f8eb378db1051a747be0e1c8abaad",
+      "reportTreeHash": "9e1fc1396b32b611eac339a60b84fa83f16bc8bd46e50cfe33c628324180b62a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "9e1fc1396b32b611eac339a60b84fa83f16bc8bd46e50cfe33c628324180b62a",
+        "contentHash": "2a95cbc247b167fb223c0b9b03fb21237b4f8eb378db1051a747be0e1c8abaad"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-client/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-openserv-ideaboard-api",
+      "skillId": "36231982-5d50-4d2c-bdc8-1a19616e159c",
+      "path": "skills/internet-court/openserv-ideaboard-api",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "5379b9e64c9c5467240f45bd9f8327a4f040fae31e859d02c30bf440a20c1f87",
+      "reportTreeHash": "5db2e612b8a25df870c4665dcd0679b25f0a37f3f67ef52849fd85bbcafa0ba2",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5db2e612b8a25df870c4665dcd0679b25f0a37f3f67ef52849fd85bbcafa0ba2",
+        "contentHash": "5379b9e64c9c5467240f45bd9f8327a4f040fae31e859d02c30bf440a20c1f87"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-ideaboard-api/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-openserv-launch",
+      "skillId": "68000cbc-d44d-4dd4-a8b3-c32b7ba0d948",
+      "path": "skills/internet-court/openserv-launch",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "5b5dddae52d14f06140d9d1a79ec7db3dc0d07abc712c8ddf6e2018ae15bb28a",
+      "reportTreeHash": "de97d6c61afc42a9cd79e6a849d8a0c0b7d01a5bbff34f36fdf190ebb56ba33c",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "de97d6c61afc42a9cd79e6a849d8a0c0b7d01a5bbff34f36fdf190ebb56ba33c",
+        "contentHash": "5b5dddae52d14f06140d9d1a79ec7db3dc0d07abc712c8ddf6e2018ae15bb28a"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-launch/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-openserv-multi-agent-workflows",
+      "skillId": "259706d1-698f-47c2-9cab-5f87d3a08cfa",
+      "path": "skills/internet-court/openserv-multi-agent-workflows",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "77ec8993cf9c861f1c0572167b99425a3c34aef3cdf1a880cecce1170ea0bfb1",
+      "reportTreeHash": "b7f1847dc17c88f21a5979583b5131ab1073446b0e75a2725d368cca939ba3a2",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "b7f1847dc17c88f21a5979583b5131ab1073446b0e75a2725d368cca939ba3a2",
+        "contentHash": "77ec8993cf9c861f1c0572167b99425a3c34aef3cdf1a880cecce1170ea0bfb1"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-multi-agent-workflows/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-starknet-defi",
+      "skillId": "6daedc66-700b-436f-88e4-25c2f74e9db3",
+      "path": "skills/internet-court/starknet-defi",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f484502a0e6be8bccfe95ce187672c6d730adfb83d52a583502850974b583494",
+      "reportTreeHash": "73bbe7cae5c0465ade9e5ecba573c2960c81db3ea3340dc96d2d15aeeaed2133",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "73bbe7cae5c0465ade9e5ecba573c2960c81db3ea3340dc96d2d15aeeaed2133",
+        "contentHash": "f484502a0e6be8bccfe95ce187672c6d730adfb83d52a583502850974b583494"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-defi/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-starknet-identity",
+      "skillId": "217085b0-051a-4666-8fd7-bbdbe7f51aff",
+      "path": "skills/internet-court/starknet-identity",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "42b2a32814d545da53de7669c77bd981d2200eb4d10d63cca69d0136b9a06fef",
+      "reportTreeHash": "0d79ef7b3882c42a82da13e575a3b36cf58151d25c273010182254298debd0c0",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "0d79ef7b3882c42a82da13e575a3b36cf58151d25c273010182254298debd0c0",
+        "contentHash": "42b2a32814d545da53de7669c77bd981d2200eb4d10d63cca69d0136b9a06fef"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-identity/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-starknet-js",
+      "skillId": "f493621c-b0dc-4061-8864-baaa4622fcf9",
+      "path": "skills/internet-court/starknet-js",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f9abbf0aaa18e58a4363110caae821a73f541ad476cd9bc246f735dfcb95bc96",
+      "reportTreeHash": "9a6586f17c4c58ae54baac47244c2d4d76b0e8c20d77554b1268df3397db4e2d",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "9a6586f17c4c58ae54baac47244c2d4d76b0e8c20d77554b1268df3397db4e2d",
+        "contentHash": "f9abbf0aaa18e58a4363110caae821a73f541ad476cd9bc246f735dfcb95bc96"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-js/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-starknet-wallet",
+      "skillId": "f0985b0c-fcdf-4c9f-bece-633be1e20c1d",
+      "path": "skills/internet-court/starknet-wallet",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "eb72e1b53847c3e3cb833af8a7294f8fa41bfd9786f87c9c7bcacb19e5c99909",
+      "reportTreeHash": "ba59da5f7a27dddcaaf28d716f7cd84ab3b090e3491ad5c09072e4eec03133f3",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "ba59da5f7a27dddcaaf28d716f7cd84ab3b090e3491ad5c09072e4eec03133f3",
+        "contentHash": "eb72e1b53847c3e3cb833af8a7294f8fa41bfd9786f87c9c7bcacb19e5c99909"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-wallet/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-write-contract",
+      "skillId": "9d13611f-71b7-4b4a-ae01-3801db2c6d0c",
+      "path": "skills/internet-court/write-contract",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "f747fb43a60a889bf92d78c37d2d23e00953d12b02fc2c35cf6c782ba3b88dcf",
+      "reportTreeHash": "6217b3ccbf94bbffcde34299eaab56b7d4c696b93c7d82432da782197efc3dc4",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "6217b3ccbf94bbffcde34299eaab56b7d4c696b93c7d82432da782197efc3dc4",
+        "contentHash": "f747fb43a60a889bf92d78c37d2d23e00953d12b02fc2c35cf6c782ba3b88dcf"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/write-contract/skill-report.json"
+      }
+    },
+    {
+      "slug": "internet-court-x402-erc7710",
+      "skillId": "59d39af9-efff-4255-88dd-0d0f76dae134",
+      "path": "skills/internet-court/x402-erc7710",
+      "marketplaceCommit": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+      "reportContentHash": "0f35df473bac38070a237ee9bce648b97706a7ecb6d76e4ea960c2cf8d60b9d3",
+      "reportTreeHash": "9301c14941c0f4751965e3ea149add46b06cc1ce1e25810d1659028d1a532c58",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "9301c14941c0f4751965e3ea149add46b06cc1ce1e25810d1659028d1a532c58",
+        "contentHash": "0f35df473bac38070a237ee9bce648b97706a7ecb6d76e4ea960c2cf8d60b9d3"
+      },
+      "legacyReference": {
+        "kind": "frozen_commit_ref",
+        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
+        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/x402-erc7710/skill-report.json"
+      }
+    }
+  ]
+}

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -279,8 +279,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
   assert.doesNotMatch(workflow, /options: \[[^\]]*recover-rpc-timeout/);
   assert.match(workflow, /execute-boundary:\n    if: inputs\.mode == 'execute'/);
-  assert.match(workflow, /default: '2\.15\.5'/);
-  assert.equal((workflow.match(/b47de464e5a2d1469875988c4b815cdf6765731a24aade68b8a904ad87417189/g) || []).length, 1);
+  assert.match(workflow, /default: '2\.15\.10'/);
+  assert.equal((workflow.match(/2ea8ef90fcb890b83b1cf1bd772bd02da3fff98bc8f5162c481287552518bdd8/g) || []).length, 1);
   assert.match(workflow, /DRY_RUN_ID" = '29646612265'/);
   assert.match(workflow, /11101c85a06aaec0d8f0deda0a4aac82cf24899b/);
   assert.match(workflow, /sha256:4d5b40e20e59cd830125e572ed2ba888dcc2ce5309a62001793a87dd8464035b/);
@@ -291,8 +291,8 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/9b885943950c15555e8fbae522adf2cf9514ae74f63050a905c8e97694d52fcb/g) || []).length, 2);
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$FRESH_GOVERNANCE_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
-  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/report-origin-raw32-v1\.json'/);
-  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: '261604847b20ede3b31264c4500433692ba38269b32c48e84c78d4609d4568e6'/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/raw32-exact62-v1\.json'/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539'/);
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
   assert.match(workflow, /auditReplacementMode == "expected_replaced_pointer_only"/);
   assert.match(workflow, /invalid Report-Origin replacement proof/);
@@ -409,6 +409,40 @@ test('Report-Origin Fresh-11 cohort is exact, immutable, and source-addressed', 
       kind: 'frozen_mutable_main',
       sourceRef: 'main',
       skillReportUrl: `https://github.com/aiskillstore/marketplace/blob/main/${row.path}/skill-report.json`,
+    });
+  }
+});
+
+test('residual raw32 Fresh cohort is exact, commit-pinned, and replacement-only', () => {
+  const bytes = readFileSync(new URL(
+    '../../governance/fresh-canonical-audit/raw32-exact62-v1.json', import.meta.url
+  ));
+  const cohort = JSON.parse(bytes.toString('utf8'));
+  assert.equal(createHash('sha256').update(bytes).digest('hex'),
+    'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539');
+  assert.equal(cohort.schemaVersion, 1);
+  assert.equal(cohort.status, 'lineage_unproven');
+  assert.equal(cohort.count, 62);
+  assert.equal(cohort.rows.length, 62);
+  assert.equal(new Set(cohort.rows.map((row) => row.slug)).size, 62);
+  assert.equal(new Set(cohort.rows.map((row) => row.skillId)).size, 62);
+  assert.equal(new Set(cohort.rows.map((row) => row.path)).size, 62);
+  assert.deepEqual([...new Set(cohort.rows.map((row) => row.marketplaceCommit))].sort(), [
+    '14dc8f201a64f8d30fd131d7f036cd5e788be523',
+    '3f6e026a3363e0954ede7bef0cfe88d4475de137',
+    'd1c4c60b80afc545d96b5e8a51c19b2fdc81df70',
+  ]);
+  for (const row of cohort.rows) {
+    assert.equal(row.remainingReason, 'same_source_tree_unproven');
+    assert.equal(row.governanceEligibleByLineage, false);
+    assert.match(row.reportContentHash, /^[0-9a-f]{64}$/);
+    assert.match(row.reportTreeHash, /^[0-9a-f]{64}$/);
+    assert.equal(row.reportContentHash, row.canonicalArtifact.contentHash);
+    assert.equal(row.reportTreeHash, row.canonicalArtifact.treeHash);
+    assert.deepEqual(row.legacyReference, {
+      kind: 'frozen_commit_ref',
+      sourceRef: row.marketplaceCommit,
+      skillReportUrl: `https://github.com/aiskillstore/marketplace/blob/${row.marketplaceCommit}/${row.path}/skill-report.json`,
     });
   }
 });


### PR DESCRIPTION
## Summary
- freeze the exact live residual raw32 cohort at 62 unique Skills across three commit-addressed source trees
- pin Fresh canonical governance to released CLI 2.15.10 and its audited Linux digest
- keep legacy raw32 audits strictly as replaced pointers while requiring genuinely fresh v3 audit evidence

## Verification
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/cleanup-runners.test.mjs (18/18)
- exact cohort SHA-256: ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539
- 62/62 Git commit/path reports verified as analysis_version 3.0.0 and byte identities matched to production content/tree hashes

No production write or workflow dispatch is included in this PR.