### PR TITLE
fix(governance): use commit-addressed raw32 references

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -67,7 +67,7 @@ env:
   FRESH_GOVERNANCE_CLI_VERSION: '2.15.10'
   FRESH_GOVERNANCE_CLI_SHA256: '2ea8ef90fcb890b83b1cf1bd772bd02da3fff98bc8f5162c481287552518bdd8'
   REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
-  REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539'
+  REPORT_ORIGIN_FRESH_COHORT_SHA256: 'c8a2f173067a9064a693669db12db398de1324a044e8ae54176ab368aa3038c3'
 
 jobs:
   freeze-boundary:
@@ -130,10 +130,7 @@ jobs:
                 and all(.rows[];
                   .remainingReason == "same_source_tree_unproven"
                   and .governanceEligibleByLineage == false
-                  and .legacyReference.kind == "frozen_commit_ref"
-                  and .legacyReference.sourceRef == .marketplaceCommit
-                  and .legacyReference.skillReportUrl ==
-                    ("https://github.com/aiskillstore/marketplace/blob/" + .marketplaceCommit + "/" + .path + "/skill-report.json"))
+                  and (has("legacyReference") | not))
               ' "$COHORT_PATH" >/dev/null
               ;;
             *) echo '::error::cohort_path is not an authenticated Fresh campaign'; exit 1 ;;
@@ -410,14 +407,14 @@ jobs:
           failures=$(jq -r '
             .candidates[] as $candidate
             | [
-                { name: "replacement_mode", ok: ($candidate.auditReplacementMode == "expected_replaced_pointer_only") },
+                { name: "replacement_mode", ok: ($candidate.auditReplacementMode == "commit_addressed") },
                 { name: "legacy_audit_shape", ok: (($candidate.expectedLatestAudit | keys | sort) == ["content_hash", "id", "skill_id", "version"]) },
                 { name: "legacy_audit_raw32", ok: ($candidate.expectedLatestAudit.content_hash | test("^[0-9a-f]{32}$")) },
                 { name: "r0_skill", ok: ($candidate.expectedSkill.artifact_revision == 0 and $candidate.expectedSkill.current_artifact_version_id == null) },
                 { name: "legacy_pointer", ok: ($candidate.expectedSkill.public_eligibility_audit_id == $candidate.expectedLatestAudit.id) },
-                { name: "legacy_source_ref", ok: ($candidate.expectedSkill.source_ref == $candidate.row.legacyReference.sourceRef and $candidate.expectedSkill.skill_report_url == $candidate.row.legacyReference.skillReportUrl) },
+                { name: "commit_source_ref", ok: ($candidate.expectedSkill.source_ref == $candidate.row.marketplaceCommit and $candidate.expectedSkill.skill_report_url == ("https://github.com/aiskillstore/marketplace/blob/" + $candidate.row.marketplaceCommit + "/" + $candidate.row.path + "/skill-report.json")) },
                 { name: "rpc_expected_audit", ok: ($candidate.rpcPayload.p_expected_latest_audit_id == $candidate.expectedLatestAudit.id and $candidate.rpcPayload.p_expected_latest_audit_version == $candidate.expectedLatestAudit.version and $candidate.rpcPayload.p_expected_latest_audit_content_hash == $candidate.expectedLatestAudit.content_hash) },
-                { name: "rpc_expected_reference", ok: ($candidate.rpcPayload.p_expected_source_ref == $candidate.row.legacyReference.sourceRef and $candidate.rpcPayload.p_expected_skill_report_url == $candidate.row.legacyReference.skillReportUrl) },
+                { name: "rpc_expected_reference", ok: ($candidate.rpcPayload.p_expected_source_ref == $candidate.row.marketplaceCommit and $candidate.rpcPayload.p_expected_skill_report_url == ("https://github.com/aiskillstore/marketplace/blob/" + $candidate.row.marketplaceCommit + "/" + $candidate.row.path + "/skill-report.json")) },
                 { name: "fresh_audit_identity", ok: ($candidate.rpcPayload.p_audit_id == $candidate.auditId and $candidate.auditId != $candidate.expectedLatestAudit.id) },
                 { name: "fresh_audit_binding_v3", ok: (
                     ($candidate.rpcPayload.p_audit_payload.content_hash | test("^v3:[0-9a-f]{40}:[0-9a-f]{64}:[0-9a-f]{64}:[0-9a-f]+:[0-9a-f]{32}$"))
@@ -470,7 +467,7 @@ jobs:
             --arg previousExecuteRunId '${{ inputs.previous_execute_run_id }}' \
             --arg cohortSha256 "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" \
             --arg preInventorySha256 "$(sha256sum "$RUNNER_TEMP/pre-inventory.json" | awk '{print $1}')" \
-            --arg auditReplacementMode "$(test "$COHORT_PATH" = "$REPORT_ORIGIN_FRESH_COHORT" && echo expected_replaced_pointer_only || echo standard)" \
+            --arg auditReplacementMode "$(test "$COHORT_PATH" = "$REPORT_ORIGIN_FRESH_COHORT" && echo commit_addressed_raw32_pointer_replacement || echo standard)" \
             '{schemaVersion:1,status:"fresh_canonical_audit_frozen",runId:$runId,repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,cliSha256:$cliSha256,cohortPath:$cohortPath,cohortSha256:$cohortSha256,auditReplacementMode:$auditReplacementMode,startAfter:$startAfter,lastSelected:$lastSelected,previousBoundaryRunId:$previousBoundaryRunId,previousExecuteRunId:$previousExecuteRunId,preInventorySha256:$preInventorySha256}' \
             > "$boundary/metadata.json"
           (cd "$boundary" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)

--- a/governance/fresh-canonical-audit/raw32-exact62-v1.json
+++ b/governance/fresh-canonical-audit/raw32-exact62-v1.json
@@ -15,11 +15,6 @@
       "canonicalArtifact": {
         "treeHash": "71794cbb94a9c412694b098df04950feef8e4beebfb9d56878a5fbc6c420614b",
         "contentHash": "7e83bad4839b2b2b8a603b814399666fa39564184370915e8f5712e78563d6c4"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "14dc8f201a64f8d30fd131d7f036cd5e788be523",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/14dc8f201a64f8d30fd131d7f036cd5e788be523/skills/7sageer/mac-automation/skill-report.json"
       }
     },
     {
@@ -34,11 +29,6 @@
       "canonicalArtifact": {
         "treeHash": "5528283416b9f3787394d2ec77f3ef265f87e0a367d85056890373c5fa0cf607",
         "contentHash": "efb690754a6607d9ff5ca0491f5d91d7fe75203fdd370af95171db87cd826d49"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "d1c4c60b80afc545d96b5e8a51c19b2fdc81df70",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/d1c4c60b80afc545d96b5e8a51c19b2fdc81df70/skills/emilkowalski/apple-design/skill-report.json"
       }
     },
     {
@@ -53,11 +43,6 @@
       "canonicalArtifact": {
         "treeHash": "66aaf5076a663000cbd4460bb63d3754e218dc4e874a9e8373cbb6833ac3f5bd",
         "contentHash": "ef5760601b579a0f5daf14d991934c22d8194d72d01ebe94f4138abe691d4aee"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/a2a-protocol/skill-report.json"
       }
     },
     {
@@ -72,11 +57,6 @@
       "canonicalArtifact": {
         "treeHash": "59caf68e8a1f12cf0c41336319b9ec614187f60f4bb04071ce0f9cff66efa539",
         "contentHash": "dbce03c35b72447f22d245d84f17daa654b7b659a61a2c770c7b9dc8568c97c6"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/agentic-wallet/skill-report.json"
       }
     },
     {
@@ -91,11 +71,6 @@
       "canonicalArtifact": {
         "treeHash": "cf099ebf23337444b11a895138d4753476a56df44712c86b286215cb72555551",
         "contentHash": "13f22c3da3715d8b5668c4dd46a424a56749665a65052173ceebf8297868cdbb"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/agent-wallet/skill-report.json"
       }
     },
     {
@@ -110,11 +85,6 @@
       "canonicalArtifact": {
         "treeHash": "a04cf3bfe6bc16edb673e5cc16e2fd5631d5130b915da543cf06e557f5757fc7",
         "contentHash": "79a0a547ebdd8f087ae2b5032c685e55a2a8b292b192c143c92f5b83d508a2c8"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/alkahest-developer/skill-report.json"
       }
     },
     {
@@ -129,11 +99,6 @@
       "canonicalArtifact": {
         "treeHash": "73bbdff41caba7be7741055c9caaee8e00b272be71f6e509a4e49d313151e38d",
         "contentHash": "434e3a1a3dba5dbd08f485e14ddb3328bbf6b8d9aebedb35a9647a8a97233067"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/alkahest-user/skill-report.json"
       }
     },
     {
@@ -148,11 +113,6 @@
       "canonicalArtifact": {
         "treeHash": "a5b58483614d9febf78c002e8961d1c96ccb32a77b02bb7d308f86838a105184",
         "contentHash": "a00c393aa840c7013f4e3d24a0163c394c0847c9e92c669499a6d538834d23f9"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-api-keys/skill-report.json"
       }
     },
     {
@@ -167,11 +127,6 @@
       "canonicalArtifact": {
         "treeHash": "8c05ae741fccff1b841fcec1451a347c9644cf641823cbb61c005ee24a6904c0",
         "contentHash": "509d15ba24a55530f295913ec9e59d0cb1d2028c1ca67b0bef8adcbd551d2057"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-auth/skill-report.json"
       }
     },
     {
@@ -186,11 +141,6 @@
       "canonicalArtifact": {
         "treeHash": "d0d0fd9e836b150b648018a5bc03573af40cccf2b87ce726242cbd6cbb37f668",
         "contentHash": "f8f6287b174c462eccea238a852c8e45a3165abaec88afa2a4141a37be32b60d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-billing/skill-report.json"
       }
     },
     {
@@ -205,11 +155,6 @@
       "canonicalArtifact": {
         "treeHash": "da275c9ffe4c3957807ec8572f59e5db40722680a74bfd24f1313288ea6e4095",
         "contentHash": "b5f7e70ae812c2f228c643f97da6b28100a3b33710f6b033a90cff6a8cc03133"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-cli/skill-report.json"
       }
     },
     {
@@ -224,11 +169,6 @@
       "canonicalArtifact": {
         "treeHash": "8bb2b9a72178e613012098227a46a23b5c63c8f3bd3c3d2ca88e75e7ab7076be",
         "contentHash": "3b51ed8e6c377a4419a987cafdd0d9715690e872a47f3a74a11b50088a407fed"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/altllm-portal-payments/skill-report.json"
       }
     },
     {
@@ -243,11 +183,6 @@
       "canonicalArtifact": {
         "treeHash": "92b1a2db387af1c90184bad263938025aa507523fdebe2cfb08f28c43c8fe520",
         "contentHash": "7f89a0a34e5921cfa50def009b860f81d39c55d1204a4d40598fe9b611e8475a"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/antseed-connect/skill-report.json"
       }
     },
     {
@@ -262,11 +197,6 @@
       "canonicalArtifact": {
         "treeHash": "4231154c8feb28ff14e2cc301035666ba1ae1df90a66fd8cd7d2be32449a9414",
         "contentHash": "d6c099123677b2fae35d712c9fe0b27e79dbaeba2b6a0c871bc66bc3b608583d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/bnbchain-mcp/skill-report.json"
       }
     },
     {
@@ -281,11 +211,6 @@
       "canonicalArtifact": {
         "treeHash": "c2a4c8516267fccce44451df33ceba4663016c1a481f540a2caee98071c3d93a",
         "contentHash": "3d217568d3c9dbe57a2147a2eae052e0756d1179a5090770857c75431bc07e79"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/chaingpt/skill-report.json"
       }
     },
     {
@@ -300,11 +225,6 @@
       "canonicalArtifact": {
         "treeHash": "8481c85c57e6a89c9b34a4895f7c3f5887887747fe49a78a176d36dd53dd08cd",
         "contentHash": "dfb032390811b7d62203bd3dcd71685999b2db27dacec1f3559add67f3ce5b90"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/cloud-claw/skill-report.json"
       }
     },
     {
@@ -319,11 +239,6 @@
       "canonicalArtifact": {
         "treeHash": "ec8c0da0b04fa5ba393af85242843eafecad9a74f2eb13a5718f2c9b9fab4f8d",
         "contentHash": "9d30ef202851e244f046968ce217f6ada5042aff0361d5e298e31d180c247f82"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/cloud-claw-launch-agent/skill-report.json"
       }
     },
     {
@@ -338,11 +253,6 @@
       "canonicalArtifact": {
         "treeHash": "c480d7fcba53cae07bf0d78631917f5c971c06f77791550fcb407bc84d69184c",
         "contentHash": "5bb5a70b2b857b20e95c3f7ff2992718700ee474bedfcbaf183e8ce7ef26be8d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/direct-tests/skill-report.json"
       }
     },
     {
@@ -357,11 +267,6 @@
       "canonicalArtifact": {
         "treeHash": "452843ccf1e7aa07f174fdedf3e818a1a3b11861a907b157522734636fb119d0",
         "contentHash": "66447673d3ca0d3c7f216e156fb629847096aecf9ae35501cfc47207611d4922"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/fulfill-git-escrow/skill-report.json"
       }
     },
     {
@@ -376,11 +281,6 @@
       "canonicalArtifact": {
         "treeHash": "bd88a6f7c86495bc74240c5bc37b218abb783899ee325e897de736fb218db7a6",
         "contentHash": "ec5540958191c9eae4d90289d97842b8cd1d30cd920327f3e5ba0482f6455396"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-cli/skill-report.json"
       }
     },
     {
@@ -395,11 +295,6 @@
       "canonicalArtifact": {
         "treeHash": "07bffa815102abc28d18407f49f5573e2c1422587f47df3867beb923a383bf33",
         "contentHash": "2cde02c8c1f58fe8d0ae4bede38aa8af503fcf5f3d2e8d2ef25ed19a943dcbab"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-erc7710-connector/skill-report.json"
       }
     },
     {
@@ -414,11 +309,6 @@
       "canonicalArtifact": {
         "treeHash": "4179e994e0ee3ebeb1eb4f6085bb72615112924db5243d018a432d19d33ff91c",
         "contentHash": "f752056aa211201e8525e04def65e40cfd2d77083d7922a88984217a86b96a63"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genlayer-intelligent-contracts/skill-report.json"
       }
     },
     {
@@ -433,11 +323,6 @@
       "canonicalArtifact": {
         "treeHash": "a8b42930ae752472657d80feea8e7ebe2cd559c523c31d749f1bc76063541b8c",
         "contentHash": "06cccf582b76196b8914c3ab57b56e571aeaba2a3f4db735eea8eb8642fa6b1a"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/genvm-lint/skill-report.json"
       }
     },
     {
@@ -452,11 +337,6 @@
       "canonicalArtifact": {
         "treeHash": "f3bdd1e8243703b411fe8df1113ce3d6d9ca0ee0708317b4fea2862dff6138c6",
         "contentHash": "6c53f8999f7fc54a542d0542674c24f10ba8ea2f4cd8840356cdb5eca4d72f6a"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/heurist-mesh-skill/skill-report.json"
       }
     },
     {
@@ -471,11 +351,6 @@
       "canonicalArtifact": {
         "treeHash": "769891ed22559fa4427e0d101a32ed7e1ed84b854bf5b7a897f1b0f794029972",
         "contentHash": "38ac394bb4bae50da905d205170d37066565be2a502b93d0517cbf38e55c0054"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/integration-tests/skill-report.json"
       }
     },
     {
@@ -490,11 +365,6 @@
       "canonicalArtifact": {
         "treeHash": "d42d0cf35d54bea2966e13be20db3a6fdfe02056ed887f520178fcb849ec3dd1",
         "contentHash": "1d46b3392fbae82228659b57ac1258e72ac1ffbfad809b6f995492da461295c4"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/intelligent-oracle/skill-report.json"
       }
     },
     {
@@ -509,11 +379,6 @@
       "canonicalArtifact": {
         "treeHash": "d3e5d4c7cf8c2add78e6304c7d0a06a6f2b5a5e72bcffe7ac28b5f6b0544edb2",
         "contentHash": "031b00fe0944af8db8dce9f2c1983854afc44c5f5220e232ea32efd927ce30e8"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/make-git-escrow/skill-report.json"
       }
     },
     {
@@ -528,11 +393,6 @@
       "canonicalArtifact": {
         "treeHash": "98fd6b5409e4bed75d0affb303e22a2bdd15ec83ff45e1715682a1275963de68",
         "contentHash": "eea81e0a88c1d8bf7ad85a2b35e0eba2e989d53e85ef326861358ef8176677bd"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/mppx/skill-report.json"
       }
     },
     {
@@ -547,11 +407,6 @@
       "canonicalArtifact": {
         "treeHash": "c7c6fb914757efac9fd96556ca34eee0c3ab43b5b8bf7d173759e169628c12a7",
         "contentHash": "3b49ee76e3d6010045092de60ccfa435e640ca4639ec96abb05d94eb24c53bcc"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-general-search/skill-report.json"
       }
     },
     {
@@ -566,11 +421,6 @@
       "canonicalArtifact": {
         "treeHash": "013ab6090ce1a66ca2d8d776dbbc1b66c85b2b383eee1b2282c54d8f4459129a",
         "contentHash": "a4beb0bef2dc66530226d0b9895a3d6e4fd4edd457f69891e84bb0b25537b517"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-holder-analysis/skill-report.json"
       }
     },
     {
@@ -585,11 +435,6 @@
       "canonicalArtifact": {
         "treeHash": "5e8da358d2733e790405fe91c5221585a8bd467647d83fc45223c22c0da00a0c",
         "contentHash": "6aaef9a5b472bafef5ec46b325b17553f095119f043824e36b403b01e53541ba"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-mpp-payment/skill-report.json"
       }
     },
     {
@@ -604,11 +449,6 @@
       "canonicalArtifact": {
         "treeHash": "ea3b664d04ec21d9ef3abb23b945aaa79fc1a868a31a49dc15aac5241d4fbd4f",
         "contentHash": "b42c7905143a57b42f1d7036f9f202e7c2863f04108d509b619b1a3ef7fbc1f3"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-prediction-markets/skill-report.json"
       }
     },
     {
@@ -623,11 +463,6 @@
       "canonicalArtifact": {
         "treeHash": "be895ae78c460ab1a58134216fec545da676ded246bb8a96c94857c3b1912f92",
         "contentHash": "f58b2df19ff3ba974e1dec7f01f954620a236a9e654dfc1c3342907d7a569154"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-smart-money-tracker/skill-report.json"
       }
     },
     {
@@ -642,11 +477,6 @@
       "canonicalArtifact": {
         "treeHash": "614f0fc918ff14e4127a00e25f03881c7e915d45093fb93d5fcebe17363b568f",
         "contentHash": "8b9c5a208d7d70d63afa5f5f19cee1efdf39ed21f7ac65bf75b5d746fbb5711c"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-token-research/skill-report.json"
       }
     },
     {
@@ -661,11 +491,6 @@
       "canonicalArtifact": {
         "treeHash": "61efcbf014d22a3127c4cb411620b4eab4b2bb7d64693ea2b509ffed9a31a835",
         "contentHash": "552545bc0a3ebd9a3fb91fdfd74d5446eb54fed3190c2bd34787722e1dd982fa"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nansen-wallet-profiler/skill-report.json"
       }
     },
     {
@@ -680,11 +505,6 @@
       "canonicalArtifact": {
         "treeHash": "acd7753761197402742273592e77dc4af3a591d11945d9ccc0169a4b84e22c4b",
         "contentHash": "e2bb9aaa795348d44784ab6bdd5c5d7f69db4815d4bfc0c50a78437fd3fd5122"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-ai-cloud/skill-report.json"
       }
     },
     {
@@ -699,11 +519,6 @@
       "canonicalArtifact": {
         "treeHash": "fad11e17f53e62eb817f0375f6464a03caa49fc890c815c3847494b8d4e8bec7",
         "contentHash": "cbd8d12eebb1f40e0b19ec8837e3aab47a744028dc8b176f605f8c58ad33305d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-api-js/skill-report.json"
       }
     },
     {
@@ -718,11 +533,6 @@
       "canonicalArtifact": {
         "treeHash": "122208ce496946ab9cefb610d6729fae89257b4190fe22b0524e0742b7dafc2e",
         "contentHash": "71b7998649b55d7a50113252afae741dc1d5cd91a492034a3b9cb930651ee226"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-dapp/skill-report.json"
       }
     },
     {
@@ -737,11 +547,6 @@
       "canonicalArtifact": {
         "treeHash": "d859f8a8c088964a91abc36e1a1cd90f58173e7b3c4dc513404a654ab728ad09",
         "contentHash": "76062620c39b2e0b9b03ddb77b96ef24b37b08942ba70db1b10464b05afd703d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-intents/skill-report.json"
       }
     },
     {
@@ -756,11 +561,6 @@
       "canonicalArtifact": {
         "treeHash": "e1898ae50bd394efce831dc6ae02e8566d0574186317163885d383bfe026773a",
         "contentHash": "61d6fa8b1bcaf8067cd1d69882fff877f9d6567b3483e60324ff5453d7a1eae3"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-kit/skill-report.json"
       }
     },
     {
@@ -775,11 +575,6 @@
       "canonicalArtifact": {
         "treeHash": "41e61f0681c880ce3b03aa77a1c2df13ee69dbcc44133d23984d148c0c4204e9",
         "contentHash": "c6878b4c3c15442aec04842ad3deb9abff88c6db25c664a21e5a94ea411ab57d"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/near-smart-contracts/skill-report.json"
       }
     },
     {
@@ -794,11 +589,6 @@
       "canonicalArtifact": {
         "treeHash": "4e371012215bf34376af259c66d337a0e068f3575deb86f558ecc8f01a76b2ba",
         "contentHash": "cbbd3ad3eab006e4fbbe51c2cfd5f6fd1c48690f88f8e2745544d0661ff6e1d2"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-arbitrate/skill-report.json"
       }
     },
     {
@@ -813,11 +603,6 @@
       "canonicalArtifact": {
         "treeHash": "4e31b872bfec0a48a1735f29fb5f1bb13de8a089f0ca1750f8a4b95a00f5c098",
         "contentHash": "e5fa9b0b68362b92e6d3faeca300a2d54cbba0e6a87e71425b164df3f423f3f4"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-create/skill-report.json"
       }
     },
     {
@@ -832,11 +617,6 @@
       "canonicalArtifact": {
         "treeHash": "d034e575e1d2d304d3e3b313571086730c61f8deae74649737f44dbbff023e40",
         "contentHash": "6913d7e02cbedb0de6f5aaa2645bcd8c46ba852990cea8c938d38b12e72b7b6a"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/nla-fulfill/skill-report.json"
       }
     },
     {
@@ -851,11 +631,6 @@
       "canonicalArtifact": {
         "treeHash": "743df974375ff10d18951a405b26719498308d89a47f71411856fbf46183c86d",
         "contentHash": "2eee0343fec08049206b408e8ff642d8d32d4a87cc187b01de6c205c07dbe4fc"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-agentic-wallet/skill-report.json"
       }
     },
     {
@@ -870,11 +645,6 @@
       "canonicalArtifact": {
         "treeHash": "831505ec1a131c7bd78b17c27f763ca1c3975e96dab1d99c6af2784c40e9b797",
         "contentHash": "7aadd069238a97ff0887e67d67f9190dc681b7239dbc2490400c60131cbe3a42"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-agent-payments-protocol/skill-report.json"
       }
     },
     {
@@ -889,11 +659,6 @@
       "canonicalArtifact": {
         "treeHash": "d2911137200ac6251ab409e85ace83faa5139d8c3d365d8964951f359f9dbc2c",
         "contentHash": "458fb7f784a48a2b2cc440795ef369ce91c244d4bd32545e37c24dc7a51a06d7"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-ai/skill-report.json"
       }
     },
     {
@@ -908,11 +673,6 @@
       "canonicalArtifact": {
         "treeHash": "184cc14f0f19587cc0f8bc6b90da545b4cf1b4e9959c703717008d822b8fc599",
         "contentHash": "b9a1fc6fb4ad5fe8f43675de7e3bfdb65d15220d6fd653b3be9edb0f8bd95b16"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-dapp-discovery/skill-report.json"
       }
     },
     {
@@ -927,11 +687,6 @@
       "canonicalArtifact": {
         "treeHash": "56f600f4be54d0c7a39bee96b1bf31926cdccd15942e5701b06673c1287e3eaf",
         "contentHash": "583a75c0a303e677af459e7fa72f2816bad501316147d06919696649cede9d6c"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-defi/skill-report.json"
       }
     },
     {
@@ -946,11 +701,6 @@
       "canonicalArtifact": {
         "treeHash": "5435c0425565f9b077d6e8bb879d703de37de5948d7fbcb5c21a96f39804800b",
         "contentHash": "dad0c2199b79e14ced118bb6ad685b98322c269856f350227fec1487f58f0372"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-dex/skill-report.json"
       }
     },
     {
@@ -965,11 +715,6 @@
       "canonicalArtifact": {
         "treeHash": "22d85e4bbd85f7cd474ca6b35efabc685fece6b97596f2a169c61b9892d3f9fa",
         "contentHash": "705263b0a0c9789b0aeeac0058f26948d627eb8d074f6e0f5c7552bfe60123e0"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/okx-growth-competition/skill-report.json"
       }
     },
     {
@@ -984,11 +729,6 @@
       "canonicalArtifact": {
         "treeHash": "ef74d2806489d5dea66f59a36427a0a8ddfbc721ea74d69e6c2e6009d4a310d0",
         "contentHash": "3c61f2a575a32ffca1d1bed09885ace75d1327fe07780a501d0140f4a50a1bb1"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-agent-sdk/skill-report.json"
       }
     },
     {
@@ -1003,11 +743,6 @@
       "canonicalArtifact": {
         "treeHash": "9e1fc1396b32b611eac339a60b84fa83f16bc8bd46e50cfe33c628324180b62a",
         "contentHash": "2a95cbc247b167fb223c0b9b03fb21237b4f8eb378db1051a747be0e1c8abaad"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-client/skill-report.json"
       }
     },
     {
@@ -1022,11 +757,6 @@
       "canonicalArtifact": {
         "treeHash": "5db2e612b8a25df870c4665dcd0679b25f0a37f3f67ef52849fd85bbcafa0ba2",
         "contentHash": "5379b9e64c9c5467240f45bd9f8327a4f040fae31e859d02c30bf440a20c1f87"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-ideaboard-api/skill-report.json"
       }
     },
     {
@@ -1041,11 +771,6 @@
       "canonicalArtifact": {
         "treeHash": "de97d6c61afc42a9cd79e6a849d8a0c0b7d01a5bbff34f36fdf190ebb56ba33c",
         "contentHash": "5b5dddae52d14f06140d9d1a79ec7db3dc0d07abc712c8ddf6e2018ae15bb28a"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-launch/skill-report.json"
       }
     },
     {
@@ -1060,11 +785,6 @@
       "canonicalArtifact": {
         "treeHash": "b7f1847dc17c88f21a5979583b5131ab1073446b0e75a2725d368cca939ba3a2",
         "contentHash": "77ec8993cf9c861f1c0572167b99425a3c34aef3cdf1a880cecce1170ea0bfb1"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/openserv-multi-agent-workflows/skill-report.json"
       }
     },
     {
@@ -1079,11 +799,6 @@
       "canonicalArtifact": {
         "treeHash": "73bbe7cae5c0465ade9e5ecba573c2960c81db3ea3340dc96d2d15aeeaed2133",
         "contentHash": "f484502a0e6be8bccfe95ce187672c6d730adfb83d52a583502850974b583494"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-defi/skill-report.json"
       }
     },
     {
@@ -1098,11 +813,6 @@
       "canonicalArtifact": {
         "treeHash": "0d79ef7b3882c42a82da13e575a3b36cf58151d25c273010182254298debd0c0",
         "contentHash": "42b2a32814d545da53de7669c77bd981d2200eb4d10d63cca69d0136b9a06fef"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-identity/skill-report.json"
       }
     },
     {
@@ -1117,11 +827,6 @@
       "canonicalArtifact": {
         "treeHash": "9a6586f17c4c58ae54baac47244c2d4d76b0e8c20d77554b1268df3397db4e2d",
         "contentHash": "f9abbf0aaa18e58a4363110caae821a73f541ad476cd9bc246f735dfcb95bc96"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-js/skill-report.json"
       }
     },
     {
@@ -1136,11 +841,6 @@
       "canonicalArtifact": {
         "treeHash": "ba59da5f7a27dddcaaf28d716f7cd84ab3b090e3491ad5c09072e4eec03133f3",
         "contentHash": "eb72e1b53847c3e3cb833af8a7294f8fa41bfd9786f87c9c7bcacb19e5c99909"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/starknet-wallet/skill-report.json"
       }
     },
     {
@@ -1155,11 +855,6 @@
       "canonicalArtifact": {
         "treeHash": "6217b3ccbf94bbffcde34299eaab56b7d4c696b93c7d82432da782197efc3dc4",
         "contentHash": "f747fb43a60a889bf92d78c37d2d23e00953d12b02fc2c35cf6c782ba3b88dcf"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/write-contract/skill-report.json"
       }
     },
     {
@@ -1174,11 +869,6 @@
       "canonicalArtifact": {
         "treeHash": "9301c14941c0f4751965e3ea149add46b06cc1ce1e25810d1659028d1a532c58",
         "contentHash": "0f35df473bac38070a237ee9bce648b97706a7ecb6d76e4ea960c2cf8d60b9d3"
-      },
-      "legacyReference": {
-        "kind": "frozen_commit_ref",
-        "sourceRef": "3f6e026a3363e0954ede7bef0cfe88d4475de137",
-        "skillReportUrl": "https://github.com/aiskillstore/marketplace/blob/3f6e026a3363e0954ede7bef0cfe88d4475de137/skills/internet-court/x402-erc7710/skill-report.json"
       }
     }
   ]

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -292,9 +292,9 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.equal((workflow.match(/ecfaa49aa72d24b8ea6322c7dae24d4bbe9df174a5d009cc56d7d2a89e7ae05a/g) || []).length, 4);
   assert.match(workflow, /\[\[ "\$FRESH_GOVERNANCE_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/raw32-exact62-v1\.json'/);
-  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: 'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539'/);
+  assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: 'c8a2f173067a9064a693669db12db398de1324a044e8ae54176ab368aa3038c3'/);
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
-  assert.match(workflow, /auditReplacementMode == "expected_replaced_pointer_only"/);
+  assert.match(workflow, /auditReplacementMode == "commit_addressed"/);
   assert.match(workflow, /invalid Report-Origin replacement proof/);
   assert.match(workflow, /fresh_audit_binding_v3/);
   assert.match(workflow, /\^v3:\[0-9a-f\]\{40\}:\[0-9a-f\]\{64\}:\[0-9a-f\]\{64\}:\[0-9a-f\]\+:\[0-9a-f\]\{32\}\$/);
@@ -302,10 +302,10 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /subject_content_hash == \$candidate\.row\.canonicalArtifact\.contentHash/);
   assert.match(workflow, /subject_tree_hash == \$candidate\.row\.canonicalArtifact\.treeHash/);
   assert.match(workflow, /subject_plugin_path == \$candidate\.row\.path/);
-  assert.match(workflow, /expected_replaced_pointer_only/);
+  assert.match(workflow, /commit_addressed_raw32_pointer_replacement/);
   assert.match(workflow, /p_expected_latest_audit_content_hash/);
-  assert.match(workflow, /p_expected_source_ref == \$candidate\.row\.legacyReference\.sourceRef/);
-  assert.match(workflow, /p_expected_skill_report_url == \$candidate\.row\.legacyReference\.skillReportUrl/);
+  assert.match(workflow, /p_expected_source_ref == \$candidate\.row\.marketplaceCommit/);
+  assert.match(workflow, /p_expected_skill_report_url == \("https:\/\/github\.com\/aiskillstore\/marketplace\/blob\/"/);
   assert.match(workflow, /skill audit/);
   assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
   assert.match(workflow, /skill audit skills --slugs "\$slugs"/);
@@ -419,7 +419,7 @@ test('residual raw32 Fresh cohort is exact, commit-pinned, and replacement-only'
   ));
   const cohort = JSON.parse(bytes.toString('utf8'));
   assert.equal(createHash('sha256').update(bytes).digest('hex'),
-    'ad5938fa521d2c7bd5d3de95304d9e5e5eff74376b0ceab173628058efaf6539');
+    'c8a2f173067a9064a693669db12db398de1324a044e8ae54176ab368aa3038c3');
   assert.equal(cohort.schemaVersion, 1);
   assert.equal(cohort.status, 'lineage_unproven');
   assert.equal(cohort.count, 62);
@@ -439,10 +439,6 @@ test('residual raw32 Fresh cohort is exact, commit-pinned, and replacement-only'
     assert.match(row.reportTreeHash, /^[0-9a-f]{64}$/);
     assert.equal(row.reportContentHash, row.canonicalArtifact.contentHash);
     assert.equal(row.reportTreeHash, row.canonicalArtifact.treeHash);
-    assert.deepEqual(row.legacyReference, {
-      kind: 'frozen_commit_ref',
-      sourceRef: row.marketplaceCommit,
-      skillReportUrl: `https://github.com/aiskillstore/marketplace/blob/${row.marketplaceCommit}/${row.path}/skill-report.json`,
-    });
+    assert.equal(row.legacyReference, undefined);
   }
 });


### PR DESCRIPTION
## Summary
- remove the unsupported mutable-main legacy reference override from the exact62 cohort
- reuse the released CLI's existing commit-addressed reference contract
- continue proving the 32-character audit only as the expected pointer being replaced by a fresh v3 audit

## Incident
No-write dry-run 29787797299 completed all 10 fresh audits, then failed closed before boundary creation with `invalid legacy Skill reference for 7sageer-mac-automation`. It produced no artifact and production artifact/audit/observation/score/binding deltas were all zero. The run is sealed and will not be rerun.

## Verification
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs scripts/tests/fresh-canonical-audit-recovery.test.mjs scripts/tests/cleanup-runners.test.mjs (18/18)
- cohort SHA-256: c8a2f173067a9064a693669db12db398de1324a044e8ae54176ab368aa3038c3

No production write or workflow dispatch is included.