### PR TITLE
fix(governance): bound Bun SIGILL audit retry

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -363,16 +363,33 @@ jobs:
             count=$(jq -r .count <<< "$group")
             model_args=()
             test -z "$MODEL" || model_args=(--model "$MODEL")
-            (
-              cd "$RUNNER_TEMP/materialized/$commit"
-              "$GITHUB_WORKSPACE/skillstore-cli" skill audit skills --slugs "$slugs" \
-                --checkpoint-file "$RUNNER_TEMP/audit-$commit.checkpoint.json" \
-                --correlation-id "$GITHUB_RUN_ID-$commit" \
-                --fresh-run-manifest-file "$RUNNER_TEMP/fresh-audit-manifests/$commit.json" \
-                --fresh-run-nonce "$run_nonce" --fresh-run-id "$GITHUB_RUN_ID" \
-                --fresh-run-started-at "$run_started_at" --fresh-selected-count "$count" \
-                "${model_args[@]}"
+            target="$RUNNER_TEMP/materialized/$commit"
+            checkpoint="$RUNNER_TEMP/audit-$commit.checkpoint.json"
+            manifest="$RUNNER_TEMP/fresh-audit-manifests/$commit.json"
+            audit_args=(
+              skill audit skills --slugs "$slugs"
+              --checkpoint-file "$checkpoint"
+              --correlation-id "$GITHUB_RUN_ID-$commit"
+              --fresh-run-manifest-file "$manifest"
+              --fresh-run-nonce "$run_nonce" --fresh-run-id "$GITHUB_RUN_ID"
+              --fresh-run-started-at "$run_started_at" --fresh-selected-count "$count"
+              "${model_args[@]}"
             )
+            set +e
+            (cd "$target" && "$GITHUB_WORKSPACE/skillstore-cli" "${audit_args[@]}")
+            audit_status=$?
+            set -e
+            if [ "$audit_status" -eq 132 ]; then
+              echo '::warning::Bun exited with SIGILL; rematerializing this local-only audit group for one bounded retry'
+              rm -rf "$target"
+              mkdir -p "$target"
+              mapfile -t paths < <(jq -r '.paths[]' <<< "$group")
+              git archive --format=tar "$commit" -- "${paths[@]}" | tar -xf - -C "$target"
+              rm -f "$checkpoint" "$manifest"
+              (cd "$target" && "$GITHUB_WORKSPACE/skillstore-cli" "${audit_args[@]}")
+            elif [ "$audit_status" -ne 0 ]; then
+              exit "$audit_status"
+            fi
           done < <(jq -c '.groups[]' "$RUNNER_TEMP/selected-cohort.json")
           jq -s --arg nonce "$run_nonce" --arg runId "$GITHUB_RUN_ID" --arg startedAt "$run_started_at" '
             if length == 0 or any(.runNonce != $nonce or .runId != $runId or .startedAt != $startedAt or .status != "fresh_audit_run_complete") then error("fresh audit group manifest mismatch") else {

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -307,8 +307,13 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /p_expected_source_ref == \$candidate\.row\.marketplaceCommit/);
   assert.match(workflow, /p_expected_skill_report_url == \("https:\/\/github\.com\/aiskillstore\/marketplace\/blob\/"/);
   assert.match(workflow, /skill audit/);
-  assert.match(workflow, /cd "\$RUNNER_TEMP\/materialized\/\$commit"/);
+  assert.match(workflow, /target="\$RUNNER_TEMP\/materialized\/\$commit"/);
   assert.match(workflow, /skill audit skills --slugs "\$slugs"/);
+  assert.match(workflow, /if \[ "\$audit_status" -eq 132 \]/);
+  assert.match(workflow, /rematerializing this local-only audit group for one bounded retry/);
+  assert.match(workflow, /rm -rf "\$target"/);
+  assert.match(workflow, /rm -f "\$checkpoint" "\$manifest"/);
+  assert.match(workflow, /elif \[ "\$audit_status" -ne 0 \]/);
   assert.doesNotMatch(workflow, /skill audit \\\n\s+"\$RUNNER_TEMP\/materialized\/\$commit\/skills"/);
   assert.match(workflow, /fresh-run-manifest-file/);
   assert.match(workflow, /fresh-audit-run\.json/);


### PR DESCRIPTION
## Summary
- retry a fresh audit group exactly once only when the released Bun executable exits 132/SIGILL
- rematerialize the exact commit-addressed local source tree and delete local checkpoint/manifest before that retry
- propagate every other non-zero exit unchanged

## Incident evidence
No-write dry-run 29790720546 failed on docker-runner-199-4-3 after 119ms with Bun 1.3.14 SIGILL/illegal instruction. The identical CLI 2.15.10 digest completed all 10 fresh audits in sealed run 29787797299 on docker-runner-199-4-5. Both runs created no boundary artifact and production five-class deltas were zero.

## Verification
- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (6/6)
- CI=true focused governance/recovery/runner tests before final formatting (18/18)

This retry only touches RUNNER_TEMP. It cannot write production and does not retry CAS freeze or execute.