### PR TITLE
[codex] authenticate deferred fresh cohort

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -10,7 +10,7 @@ on:
         default: dry-run
         options: [dry-run, execute, recover, recover-cache, recover-smoke]
       cohort_path:
-        description: 'Exact repository-relative raw32 Fresh cohort JSON; dry-run only'
+        description: 'Exact authenticated repository-relative Fresh cohort JSON; dry-run only'
         type: string
         required: false
         default: 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
@@ -68,6 +68,9 @@ env:
   FRESH_GOVERNANCE_CLI_SHA256: '2ea8ef90fcb890b83b1cf1bd772bd02da3fff98bc8f5162c481287552518bdd8'
   REPORT_ORIGIN_FRESH_COHORT: 'governance/fresh-canonical-audit/raw32-exact62-v1.json'
   REPORT_ORIGIN_FRESH_COHORT_SHA256: '5c0f8f7eafd327b25ce059839143dfad453d0b008431777e213b2e8387f6f6f5'
+  DEFERRED_V2_FRESH_COHORT: 'governance/fresh-canonical-audit/deferred-v2-exact32-v1.json'
+  DEFERRED_V2_FRESH_COHORT_SHA256: '77a0b4ee301ef7d7d1513bb874b228bd18fc037db3b6550a2c34961b15cf6ffe'
+  DEFERRED_V2_SOURCE_SHA256: 'e1856405c4a5239539a3301f9c5758b149fdb10d6c34bf1de0f2ae3c30772ede'
 
 jobs:
   freeze-boundary:
@@ -132,6 +135,24 @@ jobs:
                   and .governanceEligibleByLineage == false
                   and (has("legacyReference") | not))
               ' "$COHORT_PATH" >/dev/null
+              ;;
+            "$DEFERRED_V2_FRESH_COHORT")
+              test "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" = "$DEFERRED_V2_FRESH_COHORT_SHA256"
+              test "$(sha256sum scripts/data/artifact-governance-deferred-v1.json | awk '{print $1}')" = "$DEFERRED_V2_SOURCE_SHA256"
+              jq -e '
+                .schemaVersion == 1 and .status == "lineage_unproven"
+                and .count == 32 and (.rows | length) == 32
+                and ([.rows[].slug] | unique | length) == 32
+                and ([.rows[].skillId] | unique | length) == 32
+                and ([.rows[].path] | unique | length) == 32
+                and all(.rows[];
+                  .remainingReason == "same_source_tree_unproven"
+                  and .governanceEligibleByLineage == false
+                  and (has("legacyReference") | not))
+              ' "$COHORT_PATH" >/dev/null
+              diff -u \
+                <(jq -S '.slugs' scripts/data/artifact-governance-deferred-v1.json) \
+                <(jq -S '[.rows[].slug] | sort' "$COHORT_PATH")
               ;;
             *) echo '::error::cohort_path is not an authenticated Fresh campaign'; exit 1 ;;
           esac
@@ -450,6 +471,51 @@ jobs:
           ' "$RUNNER_TEMP/fresh-boundary.json")
           test -z "$failures" || { echo "::error::invalid Report-Origin replacement proof: $failures"; exit 1; }
 
+      - name: Prove deferred v2 audits are replacement pointers only
+        if: inputs.cohort_path == 'governance/fresh-canonical-audit/deferred-v2-exact32-v1.json'
+        run: |
+          set -euo pipefail
+          jq -e --slurpfile selected "$RUNNER_TEMP/selected-cohort.json" '
+            .status == "fresh_canonical_audit_frozen"
+            and (.candidates | length) == $selected[0].count
+            and (([.candidates[].row.slug] | sort) == ([$selected[0].rows[].slug] | sort))
+          ' "$RUNNER_TEMP/fresh-boundary.json" >/dev/null
+          failures=$(jq -r '
+            .candidates[] as $candidate
+            | ("v2:" + $candidate.row.marketplaceCommit + ":" + $candidate.row.reportContentHash + ":" + $candidate.row.reportTreeHash + ":") as $v2prefix
+            | [
+                { name: "replacement_mode", ok: ($candidate.auditReplacementMode == "commit_addressed") },
+                { name: "legacy_audit_shape", ok: (($candidate.expectedLatestAudit | keys | sort) == ["content_hash", "id", "skill_id", "version"]) },
+                { name: "legacy_audit_v2", ok: (
+                    ($candidate.expectedLatestAudit.content_hash | startswith($v2prefix))
+                    and (($candidate.expectedLatestAudit.content_hash | ltrimstr($v2prefix)) | test("^[0-9a-f]{32}$"))
+                  ) },
+                { name: "r0_skill", ok: ($candidate.expectedSkill.artifact_revision == 0 and $candidate.expectedSkill.current_artifact_version_id == null) },
+                { name: "legacy_pointer", ok: ($candidate.expectedSkill.public_eligibility_audit_id == $candidate.expectedLatestAudit.id) },
+                { name: "commit_source_ref", ok: ($candidate.expectedSkill.source_ref == $candidate.row.marketplaceCommit and $candidate.expectedSkill.skill_report_url == ("https://github.com/aiskillstore/marketplace/blob/" + $candidate.row.marketplaceCommit + "/" + $candidate.row.path + "/skill-report.json")) },
+                { name: "rpc_expected_audit", ok: ($candidate.rpcPayload.p_expected_latest_audit_id == $candidate.expectedLatestAudit.id and $candidate.rpcPayload.p_expected_latest_audit_version == $candidate.expectedLatestAudit.version and $candidate.rpcPayload.p_expected_latest_audit_content_hash == $candidate.expectedLatestAudit.content_hash) },
+                { name: "rpc_expected_reference", ok: ($candidate.rpcPayload.p_expected_source_ref == $candidate.row.marketplaceCommit and $candidate.rpcPayload.p_expected_skill_report_url == ("https://github.com/aiskillstore/marketplace/blob/" + $candidate.row.marketplaceCommit + "/" + $candidate.row.path + "/skill-report.json")) },
+                { name: "strict_legacy_hash_cas", ok: ($candidate.rpcPayload.p_expected_legacy_content_hash == $candidate.row.reportContentHash and $candidate.rpcPayload.p_expected_legacy_tree_hash == $candidate.row.reportTreeHash) },
+                { name: "canonical_artifact_identity", ok: ($candidate.rpcPayload.p_content_hash == $candidate.row.canonicalArtifact.contentHash and $candidate.rpcPayload.p_tree_hash == $candidate.row.canonicalArtifact.treeHash) },
+                { name: "snapshot_cas_separation", ok: (($candidate.rpcPayload.p_expected_file_structure | type) == "array" and ($candidate.rpcPayload.p_artifact_file_structure | type) == "array" and $candidate.rpcPayload.p_expected_file_structure == $candidate.expectedSkill.file_structure) },
+                { name: "fresh_audit_identity", ok: ($candidate.rpcPayload.p_audit_id == $candidate.auditId and $candidate.auditId != $candidate.expectedLatestAudit.id) },
+                { name: "fresh_audit_binding_v3", ok: (
+                    ($candidate.rpcPayload.p_audit_payload.content_hash | test("^v3:[0-9a-f]{40}:[0-9a-f]{64}:[0-9a-f]{64}:[0-9a-f]+:[0-9a-f]{32}$"))
+                    and $candidate.rpcPayload.p_audit_payload.content_hash != $candidate.expectedLatestAudit.content_hash
+                    and $candidate.rpcPayload.p_audit_payload.subject_marketplace_commit_sha == $candidate.row.marketplaceCommit
+                    and $candidate.rpcPayload.p_audit_payload.subject_content_hash == $candidate.row.canonicalArtifact.contentHash
+                    and $candidate.rpcPayload.p_audit_payload.subject_tree_hash == $candidate.row.canonicalArtifact.treeHash
+                    and $candidate.rpcPayload.p_audit_payload.subject_plugin_path == $candidate.row.path
+                    and ($candidate.rpcPayload.p_audit_payload.audit_payload_hash | test("^[0-9a-f]{32}$"))
+                  ) },
+                { name: "fresh_report", ok: ($candidate.auditRunEvidence.previousReportSha256 != $candidate.auditRunEvidence.reportSha256) }
+              ]
+            | map(select(.ok | not) | .name) as $failed
+            | select($failed | length > 0)
+            | "\($candidate.row.slug):\($failed | join(","))"
+          ' "$RUNNER_TEMP/fresh-boundary.json")
+          test -z "$failures" || { echo "::error::invalid deferred v2 replacement proof: $failures"; exit 1; }
+
       - name: Freeze exact audited reports and execution boundary
         env:
           COHORT_PATH: ${{ inputs.cohort_path }}
@@ -484,7 +550,7 @@ jobs:
             --arg previousExecuteRunId '${{ inputs.previous_execute_run_id }}' \
             --arg cohortSha256 "$(sha256sum "$COHORT_PATH" | awk '{print $1}')" \
             --arg preInventorySha256 "$(sha256sum "$RUNNER_TEMP/pre-inventory.json" | awk '{print $1}')" \
-            --arg auditReplacementMode "$(test "$COHORT_PATH" = "$REPORT_ORIGIN_FRESH_COHORT" && echo commit_addressed_raw32_pointer_replacement || echo standard)" \
+            --arg auditReplacementMode "$(if test "$COHORT_PATH" = "$REPORT_ORIGIN_FRESH_COHORT"; then echo commit_addressed_raw32_pointer_replacement; elif test "$COHORT_PATH" = "$DEFERRED_V2_FRESH_COHORT"; then echo commit_addressed_v2_pointer_replacement; else echo standard; fi)" \
             '{schemaVersion:1,status:"fresh_canonical_audit_frozen",runId:$runId,repository:$repository,workflowCommit:$workflowCommit,cliVersion:$cliVersion,cliSha256:$cliSha256,cohortPath:$cohortPath,cohortSha256:$cohortSha256,auditReplacementMode:$auditReplacementMode,startAfter:$startAfter,lastSelected:$lastSelected,previousBoundaryRunId:$previousBoundaryRunId,previousExecuteRunId:$previousExecuteRunId,preInventorySha256:$preInventorySha256}' \
             > "$boundary/metadata.json"
           (cd "$boundary" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)

--- a/governance/fresh-canonical-audit/deferred-v2-exact32-v1.json
+++ b/governance/fresh-canonical-audit/deferred-v2-exact32-v1.json
@@ -1,0 +1,455 @@
+{
+  "schemaVersion": 1,
+  "status": "lineage_unproven",
+  "count": 32,
+  "rows": [
+    {
+      "slug": "davila7-docx",
+      "skillId": "bbdb6fc6-804c-4482-8efb-babd259b67c6",
+      "path": "skills/davila7/docx",
+      "marketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5",
+      "reportContentHash": "d2e7652f8c5e710ed6583c8fd8c4d8dd314f43dab2a15309613c0a784c34fed2",
+      "reportTreeHash": "b1c3979d92aa253c2c0c550c22ddf5e0b924ff231cb86ace5dc407369e580df5",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "31672a9184f7ba38daabb4978826ff78af90a06241473aef97180246c3759047",
+        "contentHash": "d2e7652f8c5e710ed6583c8fd8c4d8dd314f43dab2a15309613c0a784c34fed2"
+      }
+    },
+    {
+      "slug": "davila7-pptx",
+      "skillId": "e70ad74d-85cc-410d-b502-30b100b9702a",
+      "path": "skills/davila7/pptx",
+      "marketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5",
+      "reportContentHash": "a9864bb2439ee46d48330551374b2a5c42770ef61e674da49e3e8b8538b7efc0",
+      "reportTreeHash": "89ad0934a0c2e9040b024548fb65ea01303c96bdbe2550ffa67b8ecf35465ac9",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "0e20b66eae59770ef91107bd201a05dceb705620ca612f598a3542a5faa308d1",
+        "contentHash": "a9864bb2439ee46d48330551374b2a5c42770ef61e674da49e3e8b8538b7efc0"
+      }
+    },
+    {
+      "slug": "dmitrypogrebnoy-generating-rbs",
+      "skillId": "6e6dc5b9-7093-421e-b9ff-d10d0e89b622",
+      "path": "skills/dmitrypogrebnoy/generating-rbs",
+      "marketplaceCommit": "b959ebfd1043a07c0c4378ab94ca4342cb0259f5",
+      "reportContentHash": "4d076ac48b16ded9252754b5895f2c0e90d1e642d19ebcb70b6c55677fc66dee",
+      "reportTreeHash": "4e5e54d9c3d121ad721ed17c9985fb7d10496375176311b0b646a562cc4cb895",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "a1b6e0906fb03316755530e0610b27ab9560c481d297368ddd26adca5ccd9bea",
+        "contentHash": "4d076ac48b16ded9252754b5895f2c0e90d1e642d19ebcb70b6c55677fc66dee"
+      }
+    },
+    {
+      "slug": "dmitrypogrebnoy-generating-sorbet",
+      "skillId": "c417bcd9-ce9c-4661-9767-64523172bd0c",
+      "path": "skills/dmitrypogrebnoy/generating-sorbet",
+      "marketplaceCommit": "810297c4fe559b9a1b22ac0a4976bd75f052d1c3",
+      "reportContentHash": "f9972bbdfc013ab5def7f3b499dd5827f3f30185cd71438a9e4e5cd6ffd9ca88",
+      "reportTreeHash": "1ec0e8cf14b714fac86b53a37250d296e77b152a46cc55e93bad150742f8d477",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "a99d703be2082d5d3c55afb485075ba800db0bc89f779abf693292b495e9f9a2",
+        "contentHash": "3474f1558fbd7dba2b3d4697e9c93a570c9eda3df82fa76acc353deb9c26e6a3"
+      }
+    },
+    {
+      "slug": "dmjgilbert-parallel-agents",
+      "skillId": "5be7f1ae-b523-40f6-a734-bb0a102622d8",
+      "path": "skills/dmjgilbert/parallel-agents",
+      "marketplaceCommit": "72d5025b022c77f7a51bdf5c1637c689c80e89d1",
+      "reportContentHash": "533509e4387f49aca468639df23fe2b8ae7619c0895f2f3dc0a017f7722efd1f",
+      "reportTreeHash": "d393af9a184d1eeb2eb4b3008babf0936c8f6e956bcb68ab0dad7511eb590e21",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "7545a58a368505e4c6cde1b24cdf40c8100dad482516246f2d1c14fbff799c2f",
+        "contentHash": "c7cc857094e2ccc2200f17104bd28f4494fcf449f4ae9fd93833c792a296d6e4"
+      }
+    },
+    {
+      "slug": "dmjgilbert-subagent-development",
+      "skillId": "4e2169f4-ee70-4e40-9b7e-a7c11ef58afa",
+      "path": "skills/dmjgilbert/subagent-development",
+      "marketplaceCommit": "72d5025b022c77f7a51bdf5c1637c689c80e89d1",
+      "reportContentHash": "e2371531388bb268ab88c5b9783e1240924479c864fda489ef6253360fe88da4",
+      "reportTreeHash": "7a2bab796dd71494955c8356b4e1631f4507657f8c7d2f8b5397a7f8d6f26d83",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "0b20802d72b5d8ee395ef98676432af928e35cbaf1ced866d78cdd33c691befb",
+        "contentHash": "7b187921f33a237d2140d36e2868cd11a20a514c16eb7867aa94b8ed4c5814da"
+      }
+    },
+    {
+      "slug": "dyai2025-docx",
+      "skillId": "725ac1a1-a939-4305-b332-b79627f7fd57",
+      "path": "skills/dyai2025/docx",
+      "marketplaceCommit": "0519034dad657fb1f7706e0550e962beeda73fdf",
+      "reportContentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933",
+      "reportTreeHash": "eb93eaa20a7cfa127dd577637a419218b9457f4a17b0022aa2fea1a56afed76a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5eafea7b1b06d4a7371bc018c5654777e12437fdc27cecb2e94c2819a241421d",
+        "contentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933"
+      }
+    },
+    {
+      "slug": "dyai2025-pptx",
+      "skillId": "ac69d5d6-5d2a-4efe-a1ec-b21b57873d6a",
+      "path": "skills/dyai2025/pptx",
+      "marketplaceCommit": "0519034dad657fb1f7706e0550e962beeda73fdf",
+      "reportContentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f",
+      "reportTreeHash": "f8b1473592ad9c6c2e0aee9fc0f9b1e6834562322548e51518ab730baaf12979",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8c233c3324f220916592a8b28e674300c7ad85dfcdcf1118f8b4aec3b963908a",
+        "contentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f"
+      }
+    },
+    {
+      "slug": "emz1998-engineering-nba-data",
+      "skillId": "4b5164f9-22e7-4857-abd2-643dd52708c0",
+      "path": "skills/emz1998/engineering-nba-data",
+      "marketplaceCommit": "1ffa7643651792ccb4bd3b15d924d2c97edff755",
+      "reportContentHash": "ccda21e48ed9b2065180bc0e365f5f343dcb830078fdbb9da9dbd4171735fb3d",
+      "reportTreeHash": "8a971efa04bd6c45ef9c4f8381e6d437180e5ea103bf06a15f686c15694ffe0a",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "cdce9a1c9e5202bef725fc9b0c3f6032845a2722ffafc92d2ff867638cd4b378",
+        "contentHash": "e428c21814ff8b5e70e467f4c0a719d7c2e96aaea362702779843f14874c64e6"
+      }
+    },
+    {
+      "slug": "fokkyp-docx-toolkit",
+      "skillId": "0333828d-9463-4d5a-8c34-8c523f2a18e8",
+      "path": "skills/fokkyp/docx-toolkit",
+      "marketplaceCommit": "30c73eac2afe762f6aa9c4553158769369d47351",
+      "reportContentHash": "7838153c2fd8870a7f1fcc8583ae3dadbcf3bb10a4e4d1c1cefc2e275f6512f6",
+      "reportTreeHash": "be18c3dab888f2e5e10630dda0c7a9fefa8debbbd062e6bea3b0d71458cb1697",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "0177063790e26cddb1514055b304c0ea04a2823dc260137fbb26c08b367f35f2",
+        "contentHash": "efaee8cf7ddb78cfe459c202a0b3f9d8f6a12faf9fb02e9f77a41382e4edfcbe"
+      }
+    },
+    {
+      "slug": "fokkyp-software-copyright-materials",
+      "skillId": "bbaf4251-c088-426d-9c59-609cafff424d",
+      "path": "skills/fokkyp/software-copyright-materials",
+      "marketplaceCommit": "1ffa7643651792ccb4bd3b15d924d2c97edff755",
+      "reportContentHash": "356b0883fb20ac8c515677597d2c834add8e4154350d3708ec2b1f003825388e",
+      "reportTreeHash": "7ab7cf950be72fc241fa3230361d81a3466281e04cfb5642a57529f2185a1845",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "6566321e11d8d882fdc4091fade021981139c9319b38fdf255706c0d87d2f837",
+        "contentHash": "5a45717f5f13f6bace83a1b4699c3a0ccaa4466113497a220b2ef465b450eea7"
+      }
+    },
+    {
+      "slug": "hau823823-gen-paylink-govilo",
+      "skillId": "542ec911-7cc5-4085-8663-43ae83ad2a15",
+      "path": "skills/hau823823/gen-paylink-govilo",
+      "marketplaceCommit": "a06681402992ceae98ba04d54cfd4ab004862696",
+      "reportContentHash": "70adabaf902d9ab66a4df6871db5a6101ebeb40a10e0d14506d7d12a9b1b43fc",
+      "reportTreeHash": "d24342aa4e4ddf7f1236a06cbb9fb62a067502e9f6012ee58aa4fedfdc442bb4",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "1472202eab4f3ff9e0cc42b8fe7d32499dd7fec2930cf08fcbd740a4c6ccff13",
+        "contentHash": "8eb3484ef60817ebdb264917712eb3da6678edbff2787dec9a9d301a6f60f054"
+      }
+    },
+    {
+      "slug": "jckjhns-skill-check",
+      "skillId": "ffa345ec-31f7-4ba6-b05c-c5d3a78f5037",
+      "path": "skills/jckjhns/skill-check",
+      "marketplaceCommit": "6c98d8e1adf5233bd8052190e71e23dd9a585772",
+      "reportContentHash": "2f7c205aa7cae3e8e4f14e4197ab85b1093272cb97e9c939420291e9b1dc0720",
+      "reportTreeHash": "1b31a79f2337142fec7e5dfe9e98d0d1b930eeea0abd97a9a8c198ed87ca6e75",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "91065dce60734df8ce9d5bd127ee70e64ed267c7fb15a687f232ecf8f3a3b010",
+        "contentHash": "0e6f2735e96f4442e07bab9e0d5b4ce6a13dcb867921f4f34dc55eef5c0f276a"
+      }
+    },
+    {
+      "slug": "k-dense-ai-docx",
+      "skillId": "33ee9b5e-bd7b-44c8-a6b1-797e97424628",
+      "path": "skills/k-dense-ai/docx",
+      "marketplaceCommit": "3e4b6c31a74a3bd1a291c98cf585d720cb9fbc88",
+      "reportContentHash": "80180632e83c8e3c11474ceb846b46811ae74cb5897ea26689a34f8148a3e159",
+      "reportTreeHash": "a5d55fec5cf82e367a0cb2096052c031a7ced477f8571b3631c10a8897122492",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "fc0186f3c2f9c7b8940d1f6b9f1240082bb6cc4ed8d22db0f3010dcfc17980b4",
+        "contentHash": "80180632e83c8e3c11474ceb846b46811ae74cb5897ea26689a34f8148a3e159"
+      }
+    },
+    {
+      "slug": "k-dense-ai-pptx",
+      "skillId": "02a32f17-c060-425b-8cd1-06dc0d8ebfb2",
+      "path": "skills/k-dense-ai/pptx",
+      "marketplaceCommit": "26421118b848d9f1efc0aa169d8a7a9e7e0a877e",
+      "reportContentHash": "0ce1396f545b67bcbeca44b4fb0af943570a30bf677473cd4b9ac291cba92111",
+      "reportTreeHash": "861fc2e9042210d5762bc15161743fd3be274d017fdabac1127c174e81d138a5",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "f5abdb688d7f0871ea1bab87fb9214dda4212a1966b439d4485a17c2035cb823",
+        "contentHash": "0ce1396f545b67bcbeca44b4fb0af943570a30bf677473cd4b9ac291cba92111"
+      }
+    },
+    {
+      "slug": "mguozhen-dingtalk-bridge",
+      "skillId": "c13df5e2-7db4-430d-9eab-b92c5822fbb5",
+      "path": "skills/mguozhen/dingtalk-bridge",
+      "marketplaceCommit": "b8ca75d2c0a7e7102978993058777d82b8ab2610",
+      "reportContentHash": "46346e1433fed717a08b1595e802469c6de4d74db12819ad1bc00626b970e8d5",
+      "reportTreeHash": "fd79c6ed317fecc6b3637fcd7f5cff1d89a40223d5fc4e038f3b4c1c9d614ccb",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c3951a396c4d8803f51b65d85b510d15ad70adf4f9b5c84aee69ab1fce06833f",
+        "contentHash": "e9a185c7903a355b7b4218a5a0d48359842b0a2940a301d68b2fd8c1031f09e4"
+      }
+    },
+    {
+      "slug": "minimax-ai-minimax-docx",
+      "skillId": "311feff7-e542-4d73-b601-0202f8ae27a5",
+      "path": "skills/minimax-ai/minimax-docx",
+      "marketplaceCommit": "6425ec35f4ac137735cff58cd7877843bba23e3b",
+      "reportContentHash": "396ee490353b1ec5a57330c229956a81e896b58e8ec31043c2156d1d19c9ba82",
+      "reportTreeHash": "9ba85a6550dc67b807c601a02b83dce27f8766621133c1b75582c75411d8a75e",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "97cb36294fa0f0e4be0a362e0cd869a176a05d7bc019dee27d0beb01081ace4f",
+        "contentHash": "45c169630f30b8f034bc7d53edf73d592fbd82e82188beec7da3ca1996a97fb5"
+      }
+    },
+    {
+      "slug": "minimax-ai-minimax-xlsx",
+      "skillId": "afba98fc-f670-4b8b-9908-d6a84fdada53",
+      "path": "skills/minimax-ai/minimax-xlsx",
+      "marketplaceCommit": "62e2a730c5cd74eab4c7164309d810de660fcea3",
+      "reportContentHash": "e5aa9ba8b9f43e4b9f135634042c8ef22cac0961bdaf1b882224e5b31ce34fc6",
+      "reportTreeHash": "c97fa1e80aede02e3ba520cefc39f33ab5a331600d16b39d9ca5ddc8b1ec5df3",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "41392ff5224209efe6b17aa6facab13c8e47f0a714a94c43ff63e0715c3abe26",
+        "contentHash": "4ffb70af6ccd00e90c3b14516d50a850ae0f2f1807a01d326aa1393e0067dd41"
+      }
+    },
+    {
+      "slug": "pptx",
+      "skillId": "4bb923a5-35e6-4836-a266-106a5b7135d0",
+      "path": "skills/pptx",
+      "marketplaceCommit": "26421118b848d9f1efc0aa169d8a7a9e7e0a877e",
+      "reportContentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f",
+      "reportTreeHash": "18a995a69f556904d76a3cb49f7f73602c18db43bb76995e61591cf8e1aafb1d",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "de64d4470704116d5f3a9c8a15a99bfd1d6eb8b2066a5bf7029054e007e3c773",
+        "contentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f"
+      }
+    },
+    {
+      "slug": "roin-orca-simple-brainstorm",
+      "skillId": "0ad96454-40bf-4f8c-add5-d62afa4a1666",
+      "path": "skills/roin-orca/simple-brainstorm",
+      "marketplaceCommit": "e397ce5a135369cd6def89cb6400d013e2f68f2f",
+      "reportContentHash": "4ba888f0962ab29d0eef01145e974f9221d094af0acb1734800915161c55a16e",
+      "reportTreeHash": "8a41e87fb1d9ebed20cf9b2f62dab417be0743c252a3933c38b863168b5bf572",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c1b0a139095b0a0302bfa60a56c13b5b38043803f17f3c5a33c2ca98b29fc93a",
+        "contentHash": "e32f162d7840364b01d9407a010542767f396718d4be858a1f9dbfe873e3b5dd"
+      }
+    },
+    {
+      "slug": "sickn33-docx",
+      "skillId": "f9c7d572-a2e0-4de3-983d-0a2d85f1109a",
+      "path": "skills/sickn33/docx",
+      "marketplaceCommit": "0519034dad657fb1f7706e0550e962beeda73fdf",
+      "reportContentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933",
+      "reportTreeHash": "1e4e3296211a1c75356602aac3e8a42be566a21c5c3ba1855870f78c4ae2c230",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "5eafea7b1b06d4a7371bc018c5654777e12437fdc27cecb2e94c2819a241421d",
+        "contentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933"
+      }
+    },
+    {
+      "slug": "sickn33-docx-official",
+      "skillId": "0ae871bc-aa67-4b5a-8cbf-f684c99623c6",
+      "path": "skills/sickn33/docx-official",
+      "marketplaceCommit": "3e4b6c31a74a3bd1a291c98cf585d720cb9fbc88",
+      "reportContentHash": "bf926759e626b711943c1171d5f7d4ca0da5f2085a5b7b88cb23973c28a2d7df",
+      "reportTreeHash": "8a8d2fa4c68f05fb1215886a4e5dce73c070fa199049e9a429a48a33787dccf5",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8c21d717b3bd89285fc5346fa6d6f321ac6f293410c2e2a43659017eea20401f",
+        "contentHash": "149bd058c8590b675aadedb56a5f9fd7393d960758084dd769e627d3d3cc6772"
+      }
+    },
+    {
+      "slug": "sickn33-loki-mode",
+      "skillId": "49b7ebbb-75b4-4a19-a8a0-aa67b30e2960",
+      "path": "skills/sickn33/loki-mode",
+      "marketplaceCommit": "c7830d47eaa856f41e62493881df761fc6900356",
+      "reportContentHash": "1961f89fc6608efab6d99eef07df8bcb5956283e2eb34d2b19016a4947e30e04",
+      "reportTreeHash": "5d38120ca95a19250999352b7a6b3ec2f6ef049bbc46d755105834723864e2db",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "bbf0b6d1c25f3f41c3d5ebd3cf02dcf2e8ce3ea62c4555356121212087a8c24f",
+        "contentHash": "d8a3e2e639a8e5bfc8970b593990b70c3a71f508650b8d7e61b74d27066a498f"
+      }
+    },
+    {
+      "slug": "sickn33-pptx",
+      "skillId": "55f5d1e0-cd00-4008-9d9d-464450f53af7",
+      "path": "skills/sickn33/pptx",
+      "marketplaceCommit": "816c62b2546ddb1c6a0453e7c781b5e095117819",
+      "reportContentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f",
+      "reportTreeHash": "c9963c47aed3de35a276b022d6866030a3f7a30d3e82fb5c365a7da8c7e3c0a6",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "8c233c3324f220916592a8b28e674300c7ad85dfcdcf1118f8b4aec3b963908a",
+        "contentHash": "b6f25545bfb358739f1532f793458b5dbc87ee009933cb7c306b2d951ab6617f"
+      }
+    },
+    {
+      "slug": "sickn33-pptx-official",
+      "skillId": "28af9065-b404-4991-a71c-acf40c1983a8",
+      "path": "skills/sickn33/pptx-official",
+      "marketplaceCommit": "0519034dad657fb1f7706e0550e962beeda73fdf",
+      "reportContentHash": "a8862107daeea8554ed7b0f48dec89909f71c0ad957355788499c3a5bcff958e",
+      "reportTreeHash": "8a71574992bd2a2f84a03f9e7df3400439793137715c80f18e0067040cf29584",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "9411b52e155d673ba5b91554823610bc28f53cb822e0a9919e4ddc85a41308f8",
+        "contentHash": "c692ad60f525869df56a7b3004b0f2fa61596552beb11845a592ad7506825dc8"
+      }
+    },
+    {
+      "slug": "xlsx",
+      "skillId": "f3f40f48-2d30-4aea-be7e-2526f3129888",
+      "path": "skills/xlsx",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "dd316db7785a6be12966c2a2d848931fbf5f518b3cdb0a66fa62ee835ead1cfc",
+      "reportTreeHash": "1e48e07580c8cc3bf3f44e26e0578a7fbacc7c1f5c8265f52f86f8f8a6602b16",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "2ea71ab3edd21e1444ba9dc7eb65a8f109cb7492b38e23f121babd5f713faf91",
+        "contentHash": "dd316db7785a6be12966c2a2d848931fbf5f518b3cdb0a66fa62ee835ead1cfc"
+      }
+    },
+    {
+      "slug": "yamadashy-agent-memory",
+      "skillId": "d4df10de-5f96-4f70-a64a-51ead25119a2",
+      "path": "skills/yamadashy/agent-memory",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "0a5873b104455ca68d62941d900e3e835c506626696dcc162e11eeae50fd9474",
+      "reportTreeHash": "7b50152c2f43b4998ec14f534585b618256d7a3abdf0d0a3024b33cc9dae3017",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "0579a70cc1a607c0a80213560ccc4b393af1e9053bc9da8fe57bad26f3cbd41e",
+        "contentHash": "bc67ae88a3019aedfb577eb1fd34295f884166e82ca40633901c56859d610af7"
+      }
+    },
+    {
+      "slug": "yaojingang-yao-meta-skill",
+      "skillId": "0a315bdc-c790-446a-a5fd-b6e7e294b262",
+      "path": "skills/yaojingang/yao-meta-skill",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "1c5881dcb6bac078a671b58744dbb03b40b7e517ab89a1b72538065c7be0721e",
+      "reportTreeHash": "69df44afa313ac963969fc78f13318e7e88bf2d944beab82e563814dd8b71bdb",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "c213f908503ea3ed417bb9c62c32ec4b0dcdf520549ad7731a5aee43fcc2329f",
+        "contentHash": "a95cceb4bdcca424d2106ca2d1e0ed14d66739106342d14d57ae7992cdcadd3c"
+      }
+    },
+    {
+      "slug": "ytw-debug-mattress-sleep-support-advisor",
+      "skillId": "2afd85ce-97c1-4e38-b287-95a57e9be71a",
+      "path": "skills/ytw-debug/mattress-sleep-support-advisor",
+      "marketplaceCommit": "774d9ae7ab625addfbf61c950147dac2bbd8bdcb",
+      "reportContentHash": "4d4584b04a063a6cdf42b548f9497b275d50102d6d9c7a19e881020efe902d94",
+      "reportTreeHash": "3f77e24aa6e9bff5007423a75f81decf94117cd5362951406011dfeaf37a1207",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "858007f7c3f653e0afa1084401a1615957cd9628b1837efc8047577d1653f818",
+        "contentHash": "8d6b61dbc08c03341e8ff0895b5f21ae19b8eef3fdb037b462474262c6aee851"
+      }
+    },
+    {
+      "slug": "yuan1z0825-nature-figure",
+      "skillId": "a526cf41-c983-45ed-bbfb-f3a628f2f216",
+      "path": "skills/yuan1z0825/nature-figure",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "54937748002e2f5f92d1aff2dad6477b5af7b71bdf11d84f93ebfe280ef4acaa",
+      "reportTreeHash": "b8219eddff45ef8ace6ac4dcddce7c968914180456cef5aa457142a297b63fd0",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "9f2dd87a2c9982373f5a2f60d970cef478b729b69d2c7c33098585617c0c9239",
+        "contentHash": "7cddee9337bc2bb6fe6b72e1cd89cf05eb00f26d947f4c1e37b52bdd566f3781"
+      }
+    },
+    {
+      "slug": "zach22-1999-zach-seller-skill-creator",
+      "skillId": "cf21d773-e3e4-44c5-88ee-f3d426a7ed43",
+      "path": "skills/zach22-1999/zach-seller-skill-creator",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "ad9ddd8d0171dde83418b97d963a691c3bd5b08975bc455fcbf84e8cd33efd0f",
+      "reportTreeHash": "ff33d25603229e86e2d066b85854a84403824b5cb04dbe9896a8cab8fd1416f3",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "e5e4b9927f5a178771df5c1513041266bf41e63d0c588c1483035cbf04383c55",
+        "contentHash": "7678ba58976ff7daff0b6cbaceb7899e59883d3d4aef58253bf93e496ea50e51"
+      }
+    },
+    {
+      "slug": "zhanlincui-docx",
+      "skillId": "847e98ff-a390-4c87-82b3-9c37db61ef6d",
+      "path": "skills/zhanlincui/docx",
+      "marketplaceCommit": "64ca8af0f54a325752f08bd54e52151061ea659a",
+      "reportContentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933",
+      "reportTreeHash": "be67c4f9c8bdab84bc66fca4f09d35d08e441ab730f4c762556dcc358a7f6531",
+      "remainingReason": "same_source_tree_unproven",
+      "governanceEligibleByLineage": false,
+      "canonicalArtifact": {
+        "treeHash": "4d34adecee2011d449c4365956e364dca5bd09a2bb64802bd022d0395a81a897",
+        "contentHash": "0bd90681fcab2e282025ee14acf508b60bbd6c41ac6c3bf83c0dc14d52c37933"
+      }
+    }
+  ]
+}

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -293,7 +293,14 @@ test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () 
   assert.match(workflow, /\[\[ "\$FRESH_GOVERNANCE_CLI_SHA256" =~ \^\[0-9a-f\]\{64\}\$ \]\]/);
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT: 'governance\/fresh-canonical-audit\/raw32-exact62-v1\.json'/);
   assert.match(workflow, /REPORT_ORIGIN_FRESH_COHORT_SHA256: '5c0f8f7eafd327b25ce059839143dfad453d0b008431777e213b2e8387f6f6f5'/);
+  assert.match(workflow, /DEFERRED_V2_FRESH_COHORT: 'governance\/fresh-canonical-audit\/deferred-v2-exact32-v1\.json'/);
+  assert.match(workflow, /DEFERRED_V2_FRESH_COHORT_SHA256: '77a0b4ee301ef7d7d1513bb874b228bd18fc037db3b6550a2c34961b15cf6ffe'/);
+  assert.match(workflow, /DEFERRED_V2_SOURCE_SHA256: 'e1856405c4a5239539a3301f9c5758b149fdb10d6c34bf1de0f2ae3c30772ede'/);
   assert.match(workflow, /Prove Report-Origin raw32 audits are replacement pointers only/);
+  assert.match(workflow, /Prove deferred v2 audits are replacement pointers only/);
+  assert.match(workflow, /invalid deferred v2 replacement proof/);
+  assert.match(workflow, /commit_addressed_v2_pointer_replacement/);
+  assert.match(workflow, /snapshot_cas_separation/);
   assert.match(workflow, /auditReplacementMode == "commit_addressed"/);
   assert.match(workflow, /invalid Report-Origin replacement proof/);
   assert.match(workflow, /fresh_audit_binding_v3/);
@@ -452,4 +459,40 @@ test('residual raw32 Fresh cohort is exact, commit-pinned, and replacement-only'
     treeHash: 'fd4757df36e1ded6b35c798c4e892c07965d1e51f3caa8360cbfe681cf57d262',
     contentHash: '3ae72e0e09ac76106c37a81955536e9c783ad6f961bf349c8da9ae3f1aba6039',
   });
+});
+
+test('deferred v2 Fresh cohort is exact, immutable, and source-addressed', () => {
+  const bytes = readFileSync(new URL(
+    '../../governance/fresh-canonical-audit/deferred-v2-exact32-v1.json', import.meta.url
+  ));
+  const cohort = JSON.parse(bytes.toString('utf8'));
+  const deferred = JSON.parse(readFileSync(new URL(
+    '../data/artifact-governance-deferred-v1.json', import.meta.url
+  ), 'utf8'));
+  assert.equal(createHash('sha256').update(bytes).digest('hex'),
+    '77a0b4ee301ef7d7d1513bb874b228bd18fc037db3b6550a2c34961b15cf6ffe');
+  assert.equal(cohort.schemaVersion, 1);
+  assert.equal(cohort.status, 'lineage_unproven');
+  assert.equal(cohort.count, 32);
+  assert.equal(cohort.rows.length, 32);
+  assert.deepEqual(cohort.rows.map((row) => row.slug), [...deferred.slugs].sort());
+  assert.equal(new Set(cohort.rows.map((row) => row.slug)).size, 32);
+  assert.equal(new Set(cohort.rows.map((row) => row.skillId)).size, 32);
+  assert.equal(new Set(cohort.rows.map((row) => row.path)).size, 32);
+  for (const row of cohort.rows) {
+    assert.equal(row.remainingReason, 'same_source_tree_unproven');
+    assert.equal(row.governanceEligibleByLineage, false);
+    assert.match(row.marketplaceCommit, /^[0-9a-f]{40}$/);
+    assert.match(row.reportContentHash, /^[0-9a-f]{64}$/);
+    assert.match(row.reportTreeHash, /^[0-9a-f]{64}$/);
+    assert.match(row.canonicalArtifact.contentHash, /^[0-9a-f]{64}$/);
+    assert.match(row.canonicalArtifact.treeHash, /^[0-9a-f]{64}$/);
+    assert.notDeepEqual(
+      { contentHash: row.reportContentHash, treeHash: row.reportTreeHash },
+      { contentHash: row.canonicalArtifact.contentHash, treeHash: row.canonicalArtifact.treeHash }
+    );
+    assert.equal(row.legacyReference, undefined);
+    execFileSync('git', ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/SKILL.md`]);
+    execFileSync('git', ['cat-file', '-e', `${row.marketplaceCommit}:${row.path}/skill-report.json`]);
+  }
 });


### PR DESCRIPTION
## What changed\n\n- freeze an exact 32-row deferred-v2 Fresh canonical cohort from live production identities and commit-addressed source trees\n- authenticate the cohort path, SHA-256, and equality with the existing deferred denylist\n- add a deferred-specific v2 pointer replacement proof while preserving strict legacy hash/file-structure CAS and canonical artifact identity\n\n## Why\n\nThe remaining artifact_revision=0 rows cannot safely pass the legacy-equivalent snapshot lane. Reusing the existing atomic Fresh canonical path lets them receive genuinely fresh v3 audits without relaxing legacy validators or changing the Skillstore DB/CLI contract.\n\n## Validation\n\n- CI=true node --test scripts/tests/fresh-canonical-audit-governance.test.mjs (7/7)\n- yq YAML parse\n- bash -n on both changed workflow run blocks\n- git diff --check\n- 32/32 commit/path SKILL.md and skill-report.json identities verified; canonical hashes calculated with the CLI 2.15.10 content-hash implementation