### PR TITLE
chore(governance): retire deferred partial recovery lane

### DIFF
--- a/.github/workflows/govern-fresh-canonical-audits.yml
+++ b/.github/workflows/govern-fresh-canonical-audits.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         required: true
         default: dry-run
-        options: [dry-run, execute, recover, recover-cache, recover-smoke, recover-deferred32-partial]
+        options: [dry-run, execute, recover, recover-cache, recover-smoke]
       cohort_path:
         description: 'Exact authenticated repository-relative Fresh cohort JSON; dry-run only'
         type: string
@@ -576,7 +576,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   execute-boundary:
-    if: inputs.mode == 'execute' || inputs.mode == 'recover-deferred32-partial'
+    if: inputs.mode == 'execute'
     concurrency:
       group: production-skill-score-writes
       cancel-in-progress: false

--- a/scripts/tests/fresh-canonical-audit-governance.test.mjs
+++ b/scripts/tests/fresh-canonical-audit-governance.test.mjs
@@ -276,7 +276,8 @@ test('cursor requires both the immediately preceding boundary and a fully govern
 
 test('workflow is two-phase, CLI-pinned, resumable, and closes P0 channels', () => {
   const workflow = readFileSync(new URL('../../.github/workflows/govern-fresh-canonical-audits.yml', import.meta.url), 'utf8');
-  assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke, recover-deferred32-partial\]/);
+  assert.match(workflow, /options: \[dry-run, execute, recover, recover-cache, recover-smoke\]/);
+  assert.doesNotMatch(workflow, /options: \[[^\]]*recover-deferred32-partial/);
   assert.doesNotMatch(workflow, /options: \[[^\]]*recover-rpc-timeout/);
   assert.match(workflow, /execute-boundary:\n    if: inputs\.mode == 'execute'/);
   assert.match(workflow, /default: '2\.15\.10'/);


### PR DESCRIPTION
## Summary
- remove the consumed `recover-deferred32-partial` workflow input
- make the production execute job eligible only for ordinary `mode=execute`
- retain exact historical incident evidence and the permanent block against replaying dry-run 29804024756

Recovery run 29807375292 succeeded and is sealed; this PR performs no production writes.

## Verification
- focused workflow and score-writer tests: 30/30
- workflow YAML parse passed