### PR TITLE
fix(actions): bind source monitor reports to packaged trees

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -168,6 +168,7 @@ jobs:
           REQUIRED_RUNTIME_FILES=(
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/monitor-skill-sources.yml"
+            "scripts/rebind-skill-report-hashes.mjs"
             "scripts/verify-source-monitor-selection.mjs"
           )
           {
@@ -358,6 +359,55 @@ jobs:
 
           echo "jsonl_file=$JSONL_FILE" >> "$GITHUB_OUTPUT"
           echo "summary_file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Bind source monitor reports to packaged trees
+        env:
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
+          CREATE_PR: ${{ github.event_name == 'schedule' && 'true' || inputs.create_pr }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DRY_RUN" = "true" ] || [ "$CREATE_PR" != "true" ]; then
+            echo "Packaged tree hash binding skipped because no update PR will be created."
+            exit 0
+          fi
+
+          CHANGED_ARTIFACTS="$RUNNER_TEMP/source-monitor-changed-artifacts-${GITHUB_RUN_ID}.bin"
+          CHANGED_SKILLS="$RUNNER_TEMP/source-monitor-changed-skills-${GITHUB_RUN_ID}.bin"
+
+          if ! git diff --no-renames --quiet --diff-filter=D HEAD -- 'skills/**/skill-report.json'; then
+            echo "::error::Source monitor deleted a published report; refusing an unbound update PR"
+            exit 1
+          fi
+
+          git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD -- \
+            'skills/**/SKILL.md' 'skills/**/skill-report.json' > "$CHANGED_ARTIFACTS"
+          : > "$CHANGED_SKILLS"
+          while IFS= read -r -d '' artifact_path; do
+            case "$artifact_path" in
+              skills/*/skill-report.json)
+                printf '%s\0' "${artifact_path%/skill-report.json}/SKILL.md" >> "$CHANGED_SKILLS"
+                ;;
+              skills/*/SKILL.md)
+                printf '%s\0' "$artifact_path" >> "$CHANGED_SKILLS"
+                ;;
+              *)
+                echo "::error::Unexpected source monitor artifact path: $artifact_path"
+                exit 1
+                ;;
+            esac
+          done < "$CHANGED_ARTIFACTS"
+
+          if [ ! -s "$CHANGED_SKILLS" ]; then
+            echo "No changed published reports require packaged tree hash binding."
+            exit 0
+          fi
+
+          LC_ALL=C sort -z -u "$CHANGED_SKILLS" -o "$CHANGED_SKILLS"
+          node scripts/rebind-skill-report-hashes.mjs \
+            --repo-root "$PWD" \
+            --skill-paths-file "$CHANGED_SKILLS"
+          echo "::notice::Bound source monitor report hashes to the exact packaged Marketplace trees"
 
       - name: Generate Fresh GitHub App Token for PR
         id: pr-app-token

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -523,6 +523,51 @@ jobs:
             }
           "
 
+      - name: Verify changed skill-report hash contracts
+        working-directory: ${{ env.WORK_DIR }}
+        env:
+          VALIDATION_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$VALIDATION_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] \
+            || [ "$VALIDATION_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "::notice::No immutable comparison SHA is available; changed report hash verification is not applicable"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "$VALIDATION_BASE_SHA"
+          CHANGED_ARTIFACTS="$RUNNER_TEMP/changed-report-artifact-paths-${GITHUB_RUN_ID}.bin"
+          git diff --no-renames --name-only -z --diff-filter=ACMRT \
+            "$VALIDATION_BASE_SHA" HEAD -- \
+            'skills/**/SKILL.md' 'skills/**/skill-report.json' \
+            'pending/**/SKILL.md' 'pending/**/skill-report.json' > "$CHANGED_ARTIFACTS"
+
+          node --input-type=module - "$CHANGED_ARTIFACTS" <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { existsSync, readFileSync } from 'node:fs';
+          import { dirname } from 'node:path';
+          import { calculateCanonicalTreeHash } from './scripts/resolve-approved-submission.mjs';
+
+          const changedPaths = readFileSync(process.argv[2], 'utf8').split('\0').filter(Boolean);
+          const reportPaths = [...new Set(changedPaths.map((path) => `${dirname(path)}/skill-report.json`))].sort();
+          for (const reportPath of reportPaths) {
+            const skillDirectory = dirname(reportPath);
+            const skillPath = `${skillDirectory}/SKILL.md`;
+            if (!existsSync(skillPath)) throw new Error(`${skillPath} is missing for changed report`);
+            const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+            const contentHash = createHash('sha256').update(readFileSync(skillPath)).digest('hex');
+            const treeHash = calculateCanonicalTreeHash(process.cwd(), skillDirectory);
+            if (report?.meta?.content_hash !== contentHash) {
+              throw new Error(`${reportPath} content_hash does not match packaged SKILL.md bytes`);
+            }
+            if (report?.meta?.tree_hash !== treeHash) {
+              throw new Error(`${reportPath} tree_hash does not match the packaged skill tree`);
+            }
+          }
+          console.log(`Verified packaged hash contracts for ${reportPaths.length} changed report(s)`);
+          NODE
+
       - name: Auto-fix skill-report.json validation errors (with retry)
         if: steps.validate-skill-reports.outcome == 'failure' && env.AUTO_FIX_ENABLED == 'true'
         id: revalidate

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -20,6 +20,7 @@ const workflow = readFileSync('.github/workflows/monitor-skill-sources.yml', 'ut
 const runtimeFiles = [
   '.github/actions/download-skillstore-cli/action.yml',
   '.github/workflows/monitor-skill-sources.yml',
+  'scripts/rebind-skill-report-hashes.mjs',
   'scripts/verify-source-monitor-selection.mjs',
 ];
 
@@ -78,6 +79,7 @@ function createFixture() {
   const files = {
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
+    'scripts/rebind-skill-report-hashes.mjs': 'export const fixture = true;\n',
     'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
     'README.md': 'fixture\n',
   };
@@ -198,6 +200,21 @@ test('source monitor verifies every explicit requested slug before later workflo
   assert.ok(
     monitor.indexOf('verify-source-monitor-selection.mjs') < monitor.indexOf('jsonl_file=$JSONL_FILE'),
     'explicit selection verification must run before publishing step outputs',
+  );
+});
+
+test('source monitor binds every changed report to its packaged tree before creating a PR', () => {
+  const binding = extractRunBlock('Bind source monitor reports to packaged trees');
+  assert.match(binding, /git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD/);
+  assert.match(binding, /skills\/\*\*\/SKILL\.md/);
+  assert.match(binding, /skills\/\*\*\/skill-report\.json/);
+  assert.match(binding, /scripts\/rebind-skill-report-hashes\.mjs/);
+  assert.match(binding, /--skill-paths-file/);
+  assert.match(binding, /--diff-filter=D/);
+  assert.ok(
+    workflow.indexOf('name: Bind source monitor reports to packaged trees')
+      < workflow.indexOf('name: Create source monitor PR'),
+    'packaged report hashes must be rebound before the source monitor PR is created',
   );
 });
 

--- a/scripts/tests/validate-marketplace-autofix.test.mjs
+++ b/scripts/tests/validate-marketplace-autofix.test.mjs
@@ -23,6 +23,7 @@ function runBlock(stepName) {
 const rebind = runBlock('Rebind reports to auto-fixed SKILL.md artifacts');
 const rebindReport = runBlock('Rebind reports to auto-fixed skill-report artifacts');
 const verifyReportHashContract = runBlock('Verify skill-report hash contract after auto-fix');
+const verifyChangedReportHashContract = runBlock('Verify changed skill-report hash contracts');
 const commitSkill = runBlock('Commit auto-fixed SKILL.md artifacts locally');
 const commitReport = runBlock('Commit auto-fixed skill-report.json files locally');
 const publish = runBlock('Publish validated auto-fixes');
@@ -50,6 +51,18 @@ test('report auto-fix rebinds every changed report and verifies its hash contrac
     workflow,
     /Commit auto-fixed skill-report\.json files locally\n        if: [^\n]*steps\.revalidate-report-hash-contract\.outcome == 'success'/,
   );
+});
+
+test('normal validation rejects changed reports that do not match packaged bytes', () => {
+  assert.match(verifyChangedReportHashContract, /github event|comparison SHA|VALIDATION_BASE_SHA/);
+  assert.match(verifyChangedReportHashContract, /git fetch --no-tags --depth=1 origin/);
+  assert.match(verifyChangedReportHashContract, /git diff --no-renames --name-only -z --diff-filter=ACMRT/);
+  assert.match(verifyChangedReportHashContract, /skills\/\*\*\/SKILL\.md/);
+  assert.match(verifyChangedReportHashContract, /pending\/\*\*\/SKILL\.md/);
+  assert.match(verifyChangedReportHashContract, /dirname\(path\).*skill-report\.json/);
+  assert.match(verifyChangedReportHashContract, /content_hash does not match packaged SKILL\.md bytes/);
+  assert.match(verifyChangedReportHashContract, /tree_hash does not match the packaged skill tree/);
+  assert.ok(verifyChangedReportHashContract.includes(String.raw`.split('\0')`));
 });
 
 test('report auto-fix restores erased hashes without changing source lineage', () => {

--- a/skills/0nl1n1n/sitemapkit/skill-report.json
+++ b/skills/0nl1n1n/sitemapkit/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "b81153761f011d7bf956dcd6c890ee5d6eba8e3c9344bed728a94dd264878f18",
-    "tree_hash": "90d6db990c318eae4c3772a5d3db4286f9dc57426fe238bcba9775c17f66c6a2",
+    "tree_hash": "fc4938c93bc40aa3076e3ca0112652d3cec7ff10e890f73303f5326a12a74d50",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/101-skills/agent-browser/skill-report.json
+++ b/skills/101-skills/agent-browser/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "433ed471ceca49f696ba72856894860594a5dccbcac82da61797ae7a3a3ebfef",
-    "tree_hash": "9217592db0c540dbb41db26b2a752f111a2b3008d156a9cfe4edc7f56b71639d",
+    "tree_hash": "efb3a5c2872f1f029609b8b1b25768a3862f787750acdbbc6626ac4a262e5cae",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/aaronabuusama/prompting/skill-report.json
+++ b/skills/aaronabuusama/prompting/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "ceaa98f4ff0ee951fc4410de8a7832fb841a8c1a7d4bbae8bf2efbb5fae9b950",
-    "tree_hash": "9e91af3665c8d7e864e0489bff34ce5bf2b8514e7f9f9c559f21d7ec616d8150",
+    "tree_hash": "f0bff9d6be56d4e1be4749a0377f01c2f9bcab76eacdf3c220606ee47cea4bbd",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/aaronabuusama/smc-harness/skill-report.json
+++ b/skills/aaronabuusama/smc-harness/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "8a871efe4e95efc79edfccf2da3c2dc3a0998927e704711883cf87647f8c3460",
-    "tree_hash": "3865ab0fffd43af7d068ea39ad0b61c711a5a173c3859dbef941b2534a8333a8",
+    "tree_hash": "ff204ebed83412aa20322e61e104c1a3a4143f66195c007b3788b3e76cc05051",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/bayramannakov/claude-reflect/skill-report.json
+++ b/skills/bayramannakov/claude-reflect/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "7d035c84ea96ba9808bc9731533e1bafdbbdf113317ef151ead458d18242067b",
-    "tree_hash": "c1c005b1e493712aa2af162cd32990ced39a56e98f9e733d094a4088191d23bd",
+    "tree_hash": "86e6fac3dec9f16db3e5a6537e605c095a28f6203160124c5cd4fd0ba32221b6",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [

--- a/skills/bikach/security-guardian/skill-report.json
+++ b/skills/bikach/security-guardian/skill-report.json
@@ -9,7 +9,7 @@
     "analysis_version": "3.0.0",
     "source_type": "community",
     "content_hash": "0cf1007a6ffeb36d569a8ecc93e0ab05074dca695504ea14af327fd2819eaf21",
-    "tree_hash": "3bfc7e21846490d96e7eec8cd21e33c4db0a49523824fdfeb30b66ce33d5a2c8",
+    "tree_hash": "ab33b27c602d59b76df9d54c5cf780923841f8a11b70540b54e849c25b19e82d",
     "provenance": {
       "model_effective": "claude",
       "fallback_chain": [


### PR DESCRIPTION
## Summary
- restore the six source-monitor reports to the canonical hashes of the exact Marketplace package trees
- rebind source-monitor report hashes before its update PR is created
- reject changed `SKILL.md` or `skill-report.json` artifacts whose hashes do not match packaged bytes during normal validation

## Root cause
Source monitor run 29817318626 wrote hashes for upstream full trees into reports while the Marketplace packages intentionally contain curated subsets. PR #2729 passed because normal validation checked JSON Schema but did not compare changed report hashes with packaged bytes. Incremental sync then correctly failed closed for the six mismatches.

## Safety
- no Skill payload bytes changed
- no strict validation, snapshot, hash, or fail-closed gate was weakened
- source URL/ref and security reports are preserved
- validation is bounded to artifacts changed from the immutable PR/push base, avoiding legacy-wide mutation

## Tests
- `CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs scripts/tests/rebind-skill-report-hashes.test.mjs scripts/tests/validate-marketplace-autofix.test.mjs` (18/18)
- exact content/tree hash readback for all six repaired packages
- `git diff --check`
