### PR TITLE
fix(actions): batch translation follow-ups within safety cap

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -1011,34 +1011,64 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SYNCED_SKILL_COUNT: ${{ needs.sync.outputs.synced_skill_count }}
           ENGLISH_CACHE_FINALIZER_RESULT: ${{ needs.finalize-english-cache.result }}
+          CACHE_FINALIZER_MAX_SKILLS: ${{ vars.CACHE_FINALIZER_MAX_SKILLS || '5' }}
         run: |
-          SLUG_COUNT="$SYNCED_SKILL_COUNT"
-          THRESHOLD=500
+          set -euo pipefail
 
-          echo "🌍 Triggering translation for $SLUG_COUNT synced skills"
-
-          if [ "$SLUG_COUNT" -le "$THRESHOLD" ]; then
-            # Small batch: pass slugs directly in payload
-            SYNCED_SLUGS=$(paste -sd, ./translation-plan/synced-slugs.txt)
-            echo "   Mode: direct (≤$THRESHOLD slugs)"
-            gh api repos/${{ github.repository }}/dispatches \
-              --method POST \
-              -f event_type=translate-skills \
-              -f "client_payload[skill_slugs]=$SYNCED_SLUGS" \
-              -f "client_payload[triggered_by]=sync-to-supabase" \
-              -f "client_payload[english_cache_finalizer_failed]=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)"
-            MODE="direct"
-          else
-            # Large batch: use artifact to avoid payload size limits
-            echo "   Mode: artifact (>$THRESHOLD slugs)"
-            gh api repos/${{ github.repository }}/dispatches \
-              --method POST \
-              -f event_type=translate-skills \
-              -f "client_payload[source_run_id]=${{ github.run_id }}" \
-              -f "client_payload[triggered_by]=sync-to-supabase" \
-              -f "client_payload[english_cache_finalizer_failed]=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)"
-            MODE="artifact (source: ${{ github.run_id }})"
+          SLUG_FILE=./translation-plan/synced-slugs.txt
+          if [[ ! "$SYNCED_SKILL_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid synced skill count: $SYNCED_SKILL_COUNT"
+            exit 1
+          fi
+          if [[ ! "$CACHE_FINALIZER_MAX_SKILLS" =~ ^[1-9][0-9]*$ ]] ||
+             [ "$CACHE_FINALIZER_MAX_SKILLS" -gt 25 ]; then
+            echo "::error::CACHE_FINALIZER_MAX_SKILLS must be an integer from 1 to 25"
+            exit 1
+          fi
+          if [ ! -f "$SLUG_FILE" ]; then
+            echo "::error::Synced slug plan not found: $SLUG_FILE"
+            exit 1
           fi
 
-          echo "✅ Translation workflow triggered (mode: $MODE)"
+          SYNCED_SLUGS=()
+          while IFS= read -r SLUG || [ -n "$SLUG" ]; do
+            SYNCED_SLUGS+=("$SLUG")
+          done < "$SLUG_FILE"
+          if [ "${#SYNCED_SLUGS[@]}" -ne "$SYNCED_SKILL_COUNT" ]; then
+            echo "::error::Synced slug plan has ${#SYNCED_SLUGS[@]} entries; expected $SYNCED_SKILL_COUNT"
+            exit 1
+          fi
+
+          SEEN_SLUGS=$'\n'
+          for SLUG in "${SYNCED_SLUGS[@]}"; do
+            if [[ ! "$SLUG" =~ ^[a-z0-9/_-]+$ ]]; then
+              echo "::error::Invalid slug in synced plan: $SLUG"
+              exit 1
+            fi
+            if [[ "$SEEN_SLUGS" == *$'\n'"$SLUG"$'\n'* ]]; then
+              echo "::error::Duplicate slug in synced plan: $SLUG"
+              exit 1
+            fi
+            SEEN_SLUGS="${SEEN_SLUGS}${SLUG}"$'\n'
+          done
+
+          BATCH_COUNT=$(( (SYNCED_SKILL_COUNT + CACHE_FINALIZER_MAX_SKILLS - 1) / CACHE_FINALIZER_MAX_SKILLS ))
+          ENGLISH_CACHE_FAILED=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)
+          echo "🌍 Triggering translation for $SYNCED_SKILL_COUNT synced skills in $BATCH_COUNT bounded batch(es)"
+
+          for ((OFFSET=0, BATCH_NUMBER=1; OFFSET<SYNCED_SKILL_COUNT; OFFSET+=CACHE_FINALIZER_MAX_SKILLS, BATCH_NUMBER++)); do
+            BATCH=("${SYNCED_SLUGS[@]:OFFSET:CACHE_FINALIZER_MAX_SKILLS}")
+            printf -v BATCH_SLUGS '%s,' "${BATCH[@]}"
+            BATCH_SLUGS=${BATCH_SLUGS%,}
+
+            echo "   Batch $BATCH_NUMBER/$BATCH_COUNT: ${#BATCH[@]} skill(s)"
+            gh api repos/${{ github.repository }}/dispatches \
+              --method POST \
+              -f event_type=translate-skills \
+              -f "client_payload[skill_slugs]=$BATCH_SLUGS" \
+              -f "client_payload[triggered_by]=sync-to-supabase" \
+              -f "client_payload[english_cache_finalizer_failed]=$ENGLISH_CACHE_FAILED"
+          done
+
+          echo "✅ Triggered $BATCH_COUNT bounded translation workflow run(s)"
           echo "   Monitor at: https://github.com/${{ github.repository }}/actions/workflows/translate-skills.yml"

--- a/scripts/tests/finalize-translation-cache.test.mjs
+++ b/scripts/tests/finalize-translation-cache.test.mjs
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -14,6 +23,22 @@ import {
 } from '../finalize-translation-cache.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function workflowRunScript(workflow, stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `workflow step not found: ${stepName}`);
+  const runMarker = '        run: |\n';
+  const runStart = workflow.indexOf(runMarker, start);
+  assert.notEqual(runStart, -1, `run block not found: ${stepName}`);
+  const bodyStart = runStart + runMarker.length;
+  const nextStep = workflow.indexOf('\n      - name:', bodyStart);
+  const body = workflow.slice(bodyStart, nextStep === -1 ? workflow.length : nextStep);
+  return body
+    .split('\n')
+    .map((line) => line.startsWith('          ') ? line.slice(10) : line)
+    .join('\n');
+}
 
 function jsonResponse(payload, status = 200) {
   return new Response(JSON.stringify(payload), {
@@ -294,6 +319,57 @@ test('workflow DAG has one serialized finalizer and no fire-and-forget warm', ()
   assert.match(warm, /^      locales:/m);
   assert.match(warm, /default: 'en'/);
   assert.match(warm, /Unsupported locale/);
+});
+
+test('sync dispatches translations in bounded complete batches', () => {
+  const workflow = readFileSync(
+    resolve(REPO_ROOT, '.github/workflows/sync-to-supabase.yml'),
+    'utf8'
+  );
+  const script = workflowRunScript(workflow, 'Trigger translation workflow')
+    .replaceAll('${{ github.repository }}', 'aiskillstore/marketplace');
+  const temp = mkdtempSync(resolve(tmpdir(), 'translation-dispatch-'));
+
+  try {
+    const planDir = resolve(temp, 'translation-plan');
+    mkdirSync(planDir);
+    const slugs = Array.from({ length: 20 }, (_, index) => `owner-skill-${index + 1}`);
+    writeFileSync(resolve(planDir, 'synced-slugs.txt'), `${slugs.join('\n')}\n`);
+
+    const fakeGh = resolve(temp, 'gh');
+    writeFileSync(fakeGh, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$GH_CALLS"\n');
+    chmodSync(fakeGh, 0o755);
+
+    const result = spawnSync('bash', ['-c', script], {
+      cwd: temp,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${temp}:${process.env.PATH}`,
+        GH_CALLS: resolve(temp, 'gh-calls.txt'),
+        SYNCED_SKILL_COUNT: '20',
+        CACHE_FINALIZER_MAX_SKILLS: '5',
+        ENGLISH_CACHE_FINALIZER_RESULT: 'success',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const calls = readFileSync(resolve(temp, 'gh-calls.txt'), 'utf8').trim().split('\n');
+    assert.equal(calls.length, 4);
+    const dispatched = calls.flatMap((call) => {
+      assert.match(call, /client_payload\[triggered_by\]=sync-to-supabase/);
+      assert.match(call, /client_payload\[english_cache_finalizer_failed\]=false/);
+      const match = call.match(/client_payload\[skill_slugs\]=([^ ]+)/);
+      assert.ok(match, `missing skill payload: ${call}`);
+      const batch = match[1].split(',');
+      assert.equal(batch.length, 5);
+      return batch;
+    });
+    assert.deepEqual(dispatched, slugs);
+    assert.equal(new Set(dispatched).size, slugs.length);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
 });
 
 test('translation mutation gate is fail-closed for automation and rollout caps', () => {


### PR DESCRIPTION
## Root cause

Sync run 29882594553 dispatched all 20 synced slugs to one translation run. The translation workflow correctly enforces CACHE_FINALIZER_MAX_SKILLS=5, so run 29883223113 was green while translate, merge-results, and finalize-cache were all skipped.

## Fix

- validate the exact synced slug artifact and configured 1-25 safety cap
- reject count mismatches, invalid slugs, and duplicates
- dispatch complete batches no larger than CACHE_FINALIZER_MAX_SKILLS
- keep the existing translation mutation gate and cache finalizer caps unchanged

## Verification

- CI=true node --test scripts/tests/finalize-translation-cache.test.mjs (11/11)
- regression test executes the workflow shell block with 20 slugs and proves four batches of five with no omission or duplication
- git diff --check