### PR TITLE
fix(actions): chain bounded translation follow-ups

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -1054,21 +1054,25 @@ jobs:
 
           BATCH_COUNT=$(( (SYNCED_SKILL_COUNT + CACHE_FINALIZER_MAX_SKILLS - 1) / CACHE_FINALIZER_MAX_SKILLS ))
           ENGLISH_CACHE_FAILED=$([ "$ENGLISH_CACHE_FINALIZER_RESULT" = success ] && echo false || echo true)
-          echo "🌍 Triggering translation for $SYNCED_SKILL_COUNT synced skills in $BATCH_COUNT bounded batch(es)"
+          FIRST_BATCH=("${SYNCED_SLUGS[@]:0:CACHE_FINALIZER_MAX_SKILLS}")
+          printf -v BATCH_SLUGS '%s,' "${FIRST_BATCH[@]}"
+          BATCH_SLUGS=${BATCH_SLUGS%,}
 
-          for ((OFFSET=0, BATCH_NUMBER=1; OFFSET<SYNCED_SKILL_COUNT; OFFSET+=CACHE_FINALIZER_MAX_SKILLS, BATCH_NUMBER++)); do
-            BATCH=("${SYNCED_SLUGS[@]:OFFSET:CACHE_FINALIZER_MAX_SKILLS}")
-            printf -v BATCH_SLUGS '%s,' "${BATCH[@]}"
-            BATCH_SLUGS=${BATCH_SLUGS%,}
+          REMAINING_SLUGS=""
+          if [ "$SYNCED_SKILL_COUNT" -gt "$CACHE_FINALIZER_MAX_SKILLS" ]; then
+            REMAINING=("${SYNCED_SLUGS[@]:CACHE_FINALIZER_MAX_SKILLS}")
+            printf -v REMAINING_SLUGS '%s,' "${REMAINING[@]}"
+            REMAINING_SLUGS=${REMAINING_SLUGS%,}
+          fi
 
-            echo "   Batch $BATCH_NUMBER/$BATCH_COUNT: ${#BATCH[@]} skill(s)"
-            gh api repos/${{ github.repository }}/dispatches \
-              --method POST \
-              -f event_type=translate-skills \
-              -f "client_payload[skill_slugs]=$BATCH_SLUGS" \
-              -f "client_payload[triggered_by]=sync-to-supabase" \
-              -f "client_payload[english_cache_finalizer_failed]=$ENGLISH_CACHE_FAILED"
-          done
+          echo "🌍 Triggering batch 1/$BATCH_COUNT with ${#FIRST_BATCH[@]} skill(s)"
+          gh api repos/${{ github.repository }}/dispatches \
+            --method POST \
+            -f event_type=translate-skills \
+            -f "client_payload[skill_slugs]=$BATCH_SLUGS" \
+            -f "client_payload[remaining_skill_slugs]=$REMAINING_SLUGS" \
+            -f "client_payload[triggered_by]=sync-to-supabase" \
+            -f "client_payload[english_cache_finalizer_failed]=$ENGLISH_CACHE_FAILED"
 
-          echo "✅ Triggered $BATCH_COUNT bounded translation workflow run(s)"
+          echo "✅ Triggered the first of $BATCH_COUNT bounded translation workflow run(s); each successful run dispatches the next batch"
           echo "   Monitor at: https://github.com/${{ github.repository }}/actions/workflows/translate-skills.yml"

--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -805,6 +805,83 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  dispatch-next-batch:
+    needs: [translate, merge-results, finalize-cache]
+    if: >-
+      always() &&
+      github.event_name == 'repository_dispatch' &&
+      vars.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true' &&
+      github.event.client_payload.remaining_skill_slugs != '' &&
+      needs.translate.result == 'success' &&
+      needs.merge-results.result == 'success' &&
+      needs.merge-results.outputs.total_errors == '0' &&
+      (needs.finalize-cache.result == 'success' || needs.finalize-cache.result == 'skipped')
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Dispatch next bounded translation batch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REMAINING_SKILL_SLUGS: ${{ github.event.client_payload.remaining_skill_slugs }}
+          ENGLISH_CACHE_FINALIZER_FAILED: ${{ github.event.client_payload.english_cache_finalizer_failed }}
+          CACHE_FINALIZER_MAX_SKILLS: ${{ vars.CACHE_FINALIZER_MAX_SKILLS || '5' }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$CACHE_FINALIZER_MAX_SKILLS" =~ ^[1-9][0-9]*$ ]] ||
+             [ "$CACHE_FINALIZER_MAX_SKILLS" -gt 25 ]; then
+            echo "::error::CACHE_FINALIZER_MAX_SKILLS must be an integer from 1 to 25"
+            exit 1
+          fi
+          if [[ ! "$REMAINING_SKILL_SLUGS" =~ ^[a-z0-9/_-]+(,[a-z0-9/_-]+)*$ ]]; then
+            echo "::error::Invalid remaining translation slug queue"
+            exit 1
+          fi
+          case "$ENGLISH_CACHE_FINALIZER_FAILED" in
+            true|false) ;;
+            *)
+              echo "::error::Invalid English cache finalizer result"
+              exit 1
+              ;;
+          esac
+
+          IFS=',' read -r -a QUEUED_SLUGS <<< "$REMAINING_SKILL_SLUGS"
+          SEEN_SLUGS=$'\n'
+          for SLUG in "${QUEUED_SLUGS[@]}"; do
+            if [[ "$SEEN_SLUGS" == *$'\n'"$SLUG"$'\n'* ]]; then
+              echo "::error::Duplicate slug in remaining translation queue: $SLUG"
+              exit 1
+            fi
+            SEEN_SLUGS="${SEEN_SLUGS}${SLUG}"$'\n'
+          done
+
+          NEXT_BATCH=("${QUEUED_SLUGS[@]:0:CACHE_FINALIZER_MAX_SKILLS}")
+          printf -v NEXT_BATCH_SLUGS '%s,' "${NEXT_BATCH[@]}"
+          NEXT_BATCH_SLUGS=${NEXT_BATCH_SLUGS%,}
+
+          REST_SLUGS=""
+          if [ "${#QUEUED_SLUGS[@]}" -gt "$CACHE_FINALIZER_MAX_SKILLS" ]; then
+            REST=("${QUEUED_SLUGS[@]:CACHE_FINALIZER_MAX_SKILLS}")
+            printf -v REST_SLUGS '%s,' "${REST[@]}"
+            REST_SLUGS=${REST_SLUGS%,}
+          fi
+
+          echo "🌍 Dispatching the next bounded translation batch with ${#NEXT_BATCH[@]} skill(s)"
+          gh api repos/${{ github.repository }}/dispatches \
+            --method POST \
+            -f event_type=translate-skills \
+            -f "client_payload[skill_slugs]=$NEXT_BATCH_SLUGS" \
+            -f "client_payload[remaining_skill_slugs]=$REST_SLUGS" \
+            -f "client_payload[triggered_by]=sync-to-supabase" \
+            -f "client_payload[english_cache_finalizer_failed]=$ENGLISH_CACHE_FINALIZER_FAILED"
+
   notify:
     needs: [detect-and-plan, translate, merge-results, finalize-cache]
     if: always() && needs.detect-and-plan.outputs.has_changes == 'true'

--- a/scripts/tests/finalize-translation-cache.test.mjs
+++ b/scripts/tests/finalize-translation-cache.test.mjs
@@ -32,8 +32,9 @@ function workflowRunScript(workflow, stepName) {
   const runStart = workflow.indexOf(runMarker, start);
   assert.notEqual(runStart, -1, `run block not found: ${stepName}`);
   const bodyStart = runStart + runMarker.length;
-  const nextStep = workflow.indexOf('\n      - name:', bodyStart);
-  const body = workflow.slice(bodyStart, nextStep === -1 ? workflow.length : nextStep);
+  const tail = workflow.slice(bodyStart);
+  const boundary = tail.search(/\n(?:      - name:|  [a-zA-Z][a-zA-Z0-9_-]*:)/);
+  const body = tail.slice(0, boundary === -1 ? tail.length : boundary);
   return body
     .split('\n')
     .map((line) => line.startsWith('          ') ? line.slice(10) : line)
@@ -321,12 +322,18 @@ test('workflow DAG has one serialized finalizer and no fire-and-forget warm', ()
   assert.match(warm, /Unsupported locale/);
 });
 
-test('sync dispatches translations in bounded complete batches', () => {
-  const workflow = readFileSync(
+test('sync chains bounded translation batches without concurrent pending runs', () => {
+  const syncWorkflow = readFileSync(
     resolve(REPO_ROOT, '.github/workflows/sync-to-supabase.yml'),
     'utf8'
   );
-  const script = workflowRunScript(workflow, 'Trigger translation workflow')
+  const translationWorkflow = readFileSync(
+    resolve(REPO_ROOT, '.github/workflows/translate-skills.yml'),
+    'utf8'
+  );
+  const initialScript = workflowRunScript(syncWorkflow, 'Trigger translation workflow')
+    .replaceAll('${{ github.repository }}', 'aiskillstore/marketplace');
+  const nextScript = workflowRunScript(translationWorkflow, 'Dispatch next bounded translation batch')
     .replaceAll('${{ github.repository }}', 'aiskillstore/marketplace');
   const temp = mkdtempSync(resolve(tmpdir(), 'translation-dispatch-'));
 
@@ -340,21 +347,39 @@ test('sync dispatches translations in bounded complete batches', () => {
     writeFileSync(fakeGh, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$GH_CALLS"\n');
     chmodSync(fakeGh, 0o755);
 
-    const result = spawnSync('bash', ['-c', script], {
+    const baseEnv = {
+      ...process.env,
+      PATH: `${temp}:${process.env.PATH}`,
+      GH_CALLS: resolve(temp, 'gh-calls.txt'),
+      CACHE_FINALIZER_MAX_SKILLS: '5',
+      ENGLISH_CACHE_FINALIZER_FAILED: 'false',
+    };
+    const result = spawnSync('bash', ['-c', initialScript], {
       cwd: temp,
       encoding: 'utf8',
       env: {
-        ...process.env,
-        PATH: `${temp}:${process.env.PATH}`,
-        GH_CALLS: resolve(temp, 'gh-calls.txt'),
+        ...baseEnv,
         SYNCED_SKILL_COUNT: '20',
-        CACHE_FINALIZER_MAX_SKILLS: '5',
         ENGLISH_CACHE_FINALIZER_RESULT: 'success',
       },
     });
     assert.equal(result.status, 0, result.stderr || result.stdout);
 
-    const calls = readFileSync(resolve(temp, 'gh-calls.txt'), 'utf8').trim().split('\n');
+    let calls = readFileSync(resolve(temp, 'gh-calls.txt'), 'utf8').trim().split('\n');
+    assert.equal(calls.length, 1, 'sync must dispatch only one run into the concurrency group');
+    while (true) {
+      const remaining = calls.at(-1).match(/client_payload\[remaining_skill_slugs\]=([^ ]*)/);
+      assert.ok(remaining, `missing remaining queue: ${calls.at(-1)}`);
+      if (remaining[1] === '') break;
+      const chained = spawnSync('bash', ['-c', nextScript], {
+        cwd: temp,
+        encoding: 'utf8',
+        env: { ...baseEnv, REMAINING_SKILL_SLUGS: remaining[1] },
+      });
+      assert.equal(chained.status, 0, chained.stderr || chained.stdout);
+      calls = readFileSync(resolve(temp, 'gh-calls.txt'), 'utf8').trim().split('\n');
+    }
+
     assert.equal(calls.length, 4);
     const dispatched = calls.flatMap((call) => {
       assert.match(call, /client_payload\[triggered_by\]=sync-to-supabase/);


### PR DESCRIPTION
## Root cause

PR #2745 correctly bounded each translation payload, but GitHub concurrency groups retain at most one running and one pending run. Dispatching four runs back-to-back caused pending runs 29884154569 and 29884154579 to be cancelled even with cancel-in-progress=false.

## Fix

- sync dispatches only the first bounded batch and carries the remaining validated queue
- after translation succeeds with zero errors and cache finalization succeeds (or legitimately skips because there were no mutations), the completed run dispatches exactly one next batch
- keep automatic translation disabled by default and keep the existing 1-25 mutation/finalizer caps unchanged
- stop the chain on translation errors or cache-finalizer failure

## Verification

- CI=true node --test scripts/tests/finalize-translation-cache.test.mjs (11/11)
- regression test executes both workflow shell blocks and proves 20 slugs become four sequential 5-item dispatches with no omission or duplicate
- changed workflow YAML parsed
- git diff --check