### PR TITLE
fix(actions): bound audit translation follow-ups

### DIFF
--- a/.github/workflows/translate-skills.yml
+++ b/.github/workflows/translate-skills.yml
@@ -28,6 +28,10 @@ on:
         description: "Force re-translation of existing translations"
         type: boolean
         default: false
+      translate_audits:
+        description: "Also process one bounded batch of queued security-audit translations"
+        type: boolean
+        default: true
       locale:
         description: "Optional single locale for a bounded canary (for example zh-hans); empty translates all target locales"
         type: string
@@ -573,7 +577,11 @@ jobs:
           fi
 
       - name: Translate queued security audits
-        if: always() && matrix.shard == 0 && inputs.locale == ''
+        if: >-
+          always() &&
+          matrix.shard == 0 &&
+          inputs.locale == '' &&
+          (github.event_name != 'workflow_dispatch' || inputs.translate_audits)
         continue-on-error: true
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -595,6 +603,8 @@ jobs:
           set +e
           AUDIT_RESULT=$("$GITHUB_WORKSPACE/skillstore-cli" skill translate-audit \
             --concurrency "$CONCURRENCY" \
+            --batch-size 50 \
+            --max-jobs 50 \
             --output json \
             $MODEL_FLAG)
           AUDIT_EXIT=$?

--- a/scripts/tests/finalize-translation-cache.test.mjs
+++ b/scripts/tests/finalize-translation-cache.test.mjs
@@ -274,6 +274,12 @@ test('workflow DAG has one serialized finalizer and no fire-and-forget warm', ()
   assert.match(translation, /CACHE_FINALIZER_AUTOMATION_ENABLED/);
   assert.match(translation, /CACHE_FINALIZER_MAX_SKILLS/);
   assert.match(translation, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(translation, /translate_audits:/);
+  assert.match(
+    translation,
+    /github\.event_name != 'workflow_dispatch' \|\| inputs\.translate_audits/
+  );
+  assert.match(translation, /skill translate-audit[\s\S]*--batch-size 50[\s\S]*--max-jobs 50/);
   assert.match(
     translation,
     /fromJSON\(vars\.CACHE_FINALIZER_MAX_SKILLS \|\| '5'\) >= 1/


### PR DESCRIPTION
## Root cause

The content-translation workflow invoked `skill translate-audit` without a run-level budget. CLI 2.15.10 therefore kept claiming 50 jobs at a time and began draining the complete 45k+ audit queue. GitHub force-cancel also did not stop the self-hosted runner process, so the exact job process had to be terminated on its runner.

## Fix

- pass explicit `--batch-size 50 --max-jobs 50` to the fixed Skillstore CLI
- add a manual `translate_audits` switch so exact content-translation recovery can exclude unrelated audit work
- keep repository-dispatch automation processing one bounded audit batch
- add workflow contract assertions for the hard budget and manual opt-out

## Verification

- `CI=true node --test scripts/tests/finalize-translation-cache.test.mjs` (11/11)

## Release ordering

Merge only after Skillstore CLI 2.15.11 is published from a green exact release SHA.