### PR TITLE
fix(actions): admit one full locale warm

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -40,7 +40,7 @@ on:
         type: string
         default: '128'
       byte_budget:
-        description: 'Hard cap for downloaded response bytes (1-20971520)'
+        description: 'Hard cap for downloaded response bytes (1-33554432)'
         required: true
         type: string
         default: '20971520'
@@ -120,8 +120,8 @@ jobs:
             echo "::error::request_budget must be an integer between 1 and 128"
             exit 1
           fi
-          if ! [[ "$BYTE_BUDGET" =~ ^[1-9][0-9]*$ ]] || [ "$BYTE_BUDGET" -gt 20971520 ]; then
-            echo "::error::byte_budget must be an integer between 1 and 20971520"
+          if ! [[ "$BYTE_BUDGET" =~ ^[1-9][0-9]*$ ]] || [ "$BYTE_BUDGET" -gt 33554432 ]; then
+            echo "::error::byte_budget must be an integer between 1 and 33554432"
             exit 1
           fi
           if [ "$WARM_ZIP" != "true" ] && [ "$WARM_ZIP" != "false" ]; then

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -1146,7 +1146,7 @@ test('workflow checks out scripts, requires bounded skill scope, and has no reti
   assert.match(workflow, /default: '20971520'/);
   assert.match(workflow, /concurrency must be a positive integer no greater than 4/);
   assert.match(workflow, /request_budget must be an integer between 1 and 128/);
-  assert.match(workflow, /byte_budget must be an integer between 1 and 20971520/);
+  assert.match(workflow, /byte_budget must be an integer between 1 and 33554432/);
   assert.match(workflow, /CACHE_WRITE_HEADER: x-kv-write/);
   assert.match(workflow, /CACHE_KEY_HEADER: x-kv-key/);
   assert.match(workflow, /CACHE_VERSION_HEADER: x-kv-version/);
@@ -1215,6 +1215,16 @@ test('workflow rejects oversized and underbudget force invalidation before the i
       INPUT_SLUGS: Array.from({ length: 21 }, (_, index) => `skill-${index + 1}`).join('\n'),
     });
     assert.equal(exactBudget.status, 0, `${exactBudget.stdout}\n${exactBudget.stderr}`);
+
+    const expandedByteBudget = runScope({ BYTE_BUDGET: '33554432' });
+    assert.equal(expandedByteBudget.status, 0, `${expandedByteBudget.stdout}\n${expandedByteBudget.stderr}`);
+
+    const oversizedByteBudget = runScope({ BYTE_BUDGET: '33554433' });
+    assert.equal(oversizedByteBudget.status, 1);
+    assert.match(
+      `${oversizedByteBudget.stdout}\n${oversizedByteBudget.stderr}`,
+      /byte_budget must be an integer between 1 and 33554432/
+    );
 
     const forceZip = runScope({ WARM_ZIP: 'true' });
     assert.equal(forceZip.status, 1);


### PR DESCRIPTION
## Root cause

Warm-cache invalidation is slug-wide, while the 20 MiB verification ceiling cannot fit the smallest complete recovery unit for a large Skill: one slug across all 10 translated locales. Splitting locales is unsafe because each subsequent force run invalidates the locales verified by the previous run.

Production evidence from run 29887734187:
- exact build `151be45775029cf03ede812505887858a52709ea.cdd4262f`
- 10/10 API endpoints verified
- only 7/10 page endpoints fit
- stopped safely at 20,648,126 / 20,971,520 bytes
- projected complete verification is about 24.7 MiB

## Fix

- keep the default at 20 MiB
- raise only the allowed explicit hard ceiling to 32 MiB
- retain the 128-request cap, 25-Skill force cap, exact MISS+STORED → HIT → HIT proof, build pinning, response-size validation, and fail-closed byte accounting
- test acceptance at exactly 32 MiB and rejection one byte above

## Verification

- `CI=true node --test scripts/tests/warm-skill-cache.test.mjs` (43/43)