### PR TITLE
fix: 恢复 Marketplace Codex 审核 HELM 凭据

### DIFF
--- a/.github/workflows/approve-submission.yml
+++ b/.github/workflows/approve-submission.yml
@@ -36,10 +36,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'CLI version (default: latest)'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
         required: false
         type: string
-        default: 'latest'
+        default: '2.15.12'
       max_parallel:
         description: 'Max parallel shards (default: 6)'
         type: string
@@ -118,6 +118,7 @@ jobs:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+      HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
       SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -29,10 +29,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'CLI version (default: latest)'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
         required: false
         type: string
-        default: 'latest'
+        default: '2.15.12'
       max_parallel:
         description: 'Max parallel shards (default: 6)'
         type: string
@@ -57,7 +57,7 @@ jobs:
       github_url: ${{ github.event.client_payload.github_url || inputs.github_url }}
       submission_id: ${{ github.event.client_payload.submission_id || github.run_id }}
       model: ${{ inputs.model || '' }}
-      cli_version: ${{ inputs.cli_version || 'latest' }}
+      cli_version: ${{ inputs.cli_version || '2.15.12' }}
       max_parallel: ${{ inputs.max_parallel || '6' }}
       is_manual_approval: false
       approved_by: ''
@@ -65,6 +65,7 @@ jobs:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       SKILLSTORE_AGENTS: ${{ vars.SKILLSTORE_AGENTS }}
+      HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
       SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -25,10 +25,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Reserved compatibility input; this selection-plan rollout is pinned to CLI 2.15.7'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
         required: false
         type: string
-        default: '2.15.7'
+        default: '2.15.12'
       max_parallel:
         description: 'Maximum parallel shards'
         required: false
@@ -91,6 +91,8 @@ on:
         required: true
       SKILLSTORE_AGENTS:
         required: false
+      HELM_API_KEY:
+        required: true
       SUPABASE_URL:
         required: true
       SUPABASE_SERVICE_KEY:
@@ -532,11 +534,11 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          # Rollout pin: selection-plan processing requires the exact 2.15.7 contract.
-          version: '2.15.7'
+          # Dependency gate: do not merge before cli-v2.15.12 is released.
+          version: '2.15.12'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.15.7
+          minimum-version: 2.15.12
           require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}
@@ -544,6 +546,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKILLSTORE_AGENTS: ${{ secrets.SKILLSTORE_AGENTS }}
+          HELM_API_KEY: ${{ secrets.HELM_API_KEY }}
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SELECTION_PLAN_JSON: ${{ toJSON(matrix.selection_plan) }}

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -16,6 +16,9 @@ import { test } from 'node:test';
 
 const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
 const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
+const approvalCaller = readFileSync('.github/workflows/approve-submission.yml', 'utf8');
+const cliCompatibilityDescription =
+  'Reserved compatibility input; submission processing is pinned to CLI 2.15.12';
 const runtimeFiles = [
   'schemas/skill-report.schema.json',
   'governance/submission-slug-aliases.json',
@@ -70,6 +73,23 @@ function extractRunBlock(workflow, stepName) {
     body.push(line.length > runIndent + 2 ? line.slice(runIndent + 2) : '');
   }
   return body.join('\n');
+}
+
+function extractNamedBlock(workflow, name) {
+  const lines = workflow.split('\n');
+  const nameIndex = lines.findIndex((line) => line.trim() === name);
+  assert.notEqual(nameIndex, -1, `missing workflow block: ${name}`);
+
+  const blockIndent = lines[nameIndex].search(/\S/);
+  let endIndex = lines.length;
+  for (let index = nameIndex + 1; index < lines.length; index += 1) {
+    const indent = lines[index].search(/\S/);
+    if (indent !== -1 && indent <= blockIndent) {
+      endIndex = index;
+      break;
+    }
+  }
+  return lines.slice(nameIndex, endIndex).join('\n');
 }
 
 function createFixture() {
@@ -202,8 +222,8 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/classify-submission-targets\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
-  assert.match(reusable, /minimum-version: 2\.15\.7/);
-  assert.match(reusable, /Rollout pin: selection-plan processing requires the exact 2\.15\.7 contract/);
+  assert.match(reusable, /minimum-version: 2\.15\.12/);
+  assert.match(reusable, /Dependency gate: do not merge before cli-v2\.15\.12 is released/);
   assert.match(reusable, /trap cleanup_input_plan EXIT/);
   assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
   assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);
@@ -217,6 +237,73 @@ test('all submission entrypoints and the aggregation import closure are immutabl
     readFileSync('scripts/aggregate-submission-shards.mjs', 'utf8'),
     /from '\.\/resolve-approved-submission\.mjs'/,
   );
+});
+
+test('all submission audit entrypoints pass the existing HELM credential through the reusable secret contract', () => {
+  for (const [name, workflow] of [
+    ['repository dispatch', caller],
+    ['manual approval', approvalCaller],
+  ]) {
+    const processJob = extractNamedBlock(workflow, 'process-skills:');
+    const forwardedSecrets = extractNamedBlock(processJob, 'secrets:');
+    assert.match(processJob, /uses: \.\/\.github\/workflows\/reusable-process-skills\.yml/);
+    assert.match(
+      forwardedSecrets,
+      /^\s*HELM_API_KEY: \$\{\{ secrets\.HELM_API_KEY \}\}$/m,
+      `${name} must forward the repository HELM_API_KEY`,
+    );
+    assert.equal(
+      (workflow.match(/secrets\.HELM_API_KEY/g) ?? []).length,
+      1,
+      `${name} must expose HELM_API_KEY only to the reusable workflow call`,
+    );
+  }
+
+  const workflowCall = extractNamedBlock(reusable, 'workflow_call:');
+  const secretContract = extractNamedBlock(workflowCall, 'secrets:');
+  const helmContract = extractNamedBlock(secretContract, 'HELM_API_KEY:');
+  assert.match(helmContract, /^\s*HELM_API_KEY:\n\s+required: true$/);
+});
+
+test('HELM credential is injected only into the Process shard step environment', () => {
+  const processShard = extractNamedBlock(reusable, '- name: Process shard ${{ matrix.shard }}');
+  const processEnvironment = extractNamedBlock(processShard, 'env:');
+
+  assert.match(
+    processEnvironment,
+    /^\s*HELM_API_KEY: \$\{\{ secrets\.HELM_API_KEY \}\}$/m,
+  );
+  assert.equal(
+    (reusable.match(/secrets\.HELM_API_KEY/g) ?? []).length,
+    1,
+    'only the Process shard step may read the reusable HELM secret',
+  );
+  assert.equal(
+    (reusable.match(/^\s*HELM_API_KEY:/gm) ?? []).length,
+    2,
+    'HELM_API_KEY may appear only in workflow_call.secrets and the Process shard env',
+  );
+});
+
+test('submission processing compatibility inputs and CLI download are pinned to 2.15.12', () => {
+  for (const [name, workflow] of [
+    ['repository dispatch', caller],
+    ['manual approval', approvalCaller],
+    ['reusable workflow', reusable],
+  ]) {
+    const cliInput = extractNamedBlock(workflow, 'cli_version:');
+    assert.match(
+      cliInput,
+      new RegExp(`description: '${cliCompatibilityDescription.replaceAll('.', '\\.')}'`),
+      `${name} compatibility input must describe the fixed CLI dependency`,
+    );
+    assert.match(cliInput, /default: '2\.15\.12'/);
+  }
+
+  const download = extractNamedBlock(reusable, '- name: Download Skillstore CLI');
+  assert.match(download, /version: '2\.15\.12'/);
+  assert.match(download, /minimum-version: 2\.15\.12/);
+  assert.doesNotMatch(download, /inputs\.cli_version|version: ['"]?latest/);
 });
 
 test('clone step accepts repository-root false and explicit-path true without weakening type validation', () => {


### PR DESCRIPTION
## 背景 / 问题描述

Lukin 反馈 Marketplace 审核优先使用 Codex，但 RollingGo 两个 submission 实际显示为 Claude。

需要区分两个独立问题：

1. [Marketplace PR #2755](https://github.com/aiskillstore/marketplace/pull/2755) 已合并；它的 `approve-skill` 失败是同 slug 已由 #2754 发布后触发的覆盖保护，错误为 `Refusing to overwrite existing published target`。本 PR不写入、不重跑 #2755。
2. 真正的 Codex 审核凭据回归发生在 submission runs [#29898316399](https://github.com/aiskillstore/marketplace/actions/runs/29898316399) 与 [#29898972564](https://github.com/aiskillstore/marketplace/actions/runs/29898972564)：两次都是先调用 Codex，因子进程缺少 `HELM_API_KEY` 立即失败，然后 fallback 到 Claude。Codex 服务本身没有被证明不可用；Cloud/Claude 出现是 fallback 的结果。

根因有两层：Marketplace reusable workflow 没有从仓库 Secret 注入现有 `HELM_API_KEY`；SkillStore CLI 2.15.7 的安全过滤又会从通用 Agent 子进程剥离该变量。配套 [SkillStore PR #331](https://github.com/aiskillstore/skillstore/pull/331) 只在 `credentialScope=audit + agent=codex` 时恢复父进程现有 HELM key，本 PR补齐 Marketplace 侧接线。

## 做了什么

1. 自动 submission 与人工 approval 两个入口都把现有仓库 `HELM_API_KEY` 传给 reusable workflow。
2. reusable secret contract 将 `HELM_API_KEY` 声明为 required。
3. 仅在 `Process shard` step 的父进程环境注入 `HELM_API_KEY`；不放到 workflow/job/global env，不传给 callback、discovery、aggregation，也不改变 Supabase/GitHub/Claude/Gemini 凭据边界。
4. submission processing exact pin 与 minimum pin 从 CLI 2.15.7 更新到 2.15.12；该版本必须包含 SkillStore PR #331。
5. 保留现有 `SKILLSTORE_AGENTS` 配置与 Codex → Claude fallback；不禁用 Codex、不增加预算限制。

## 为什么改

GitHub Secret 仅存在于仓库配置，并不会自动进入 reusable workflow 或 `Process shard`。即使 runner 主环境曾有 key，旧 CLI 也会在启动 Agent 子进程前主动过滤 `HELM_API_KEY`。两侧缺一不可：CLI 负责安全地把 key 限定到 audit+Codex child，Marketplace 负责把现有 Secret 送到可信父进程。

## Acceptance Criteria

- [x] 自动 submission 入口把现有 `HELM_API_KEY` 映射到 reusable workflow。— 验收：`scripts/tests/submission-runtime-workflow.test.mjs::submission audit callers pass HELM through a required reusable contract into only the Process shard step`
- [x] 人工 approval 入口采用相同映射。— 验收：同上
- [x] reusable workflow 要求 HELM secret，且 key 只进入 `Process shard` step env。— 验收：同上
- [x] callback、discovery、aggregation、workflow/job/global env 不新增 HELM key。— 验收：同上
- [x] submission processing exact/minimum pin 固定为 CLI `2.15.12`，外层 compatibility input 同步更新。— 验收：`scripts/tests/submission-runtime-workflow.test.mjs::submission processing is pinned to fixed CLI 2.15.12 and callers do not advertise latest`
- [x] Codex/Claude Agent 配置与 fallback 不变；无预算限制改动。— 验收：diff scope + focused contract test
- [x] Node 全量测试、YAML parse、`git diff --check` 与二进制 evidence 扫描通过。— 验收：见“验证证据”
- [x] exact-head CI 绿。— CI：[validate #29905804236](https://github.com/aiskillstore/marketplace/actions/runs/29905804236) + [test #29905804355](https://github.com/aiskillstore/marketplace/actions/runs/29905804355)

## RED / GREEN

### RED（先写测试）

在 `origin/main@22685c4445d3159608981a83d4788c4f9740f2e5` 先只加合同测试：

```bash
node --test scripts/tests/submission-runtime-workflow.test.mjs
```

结果：`10 tests / 2 failed`。失败精确对应：缺 HELM reusable contract/caller/shard 接线，以及仍固定 CLI 2.15.7。

### GREEN

同一命令：`10/10 PASS`。

## 验证证据

- `node --test scripts/tests/submission-runtime-workflow.test.mjs`：`10/10 PASS`
- `node --test scripts/tests/*.test.mjs`：`489 PASS / 2 SKIP / 0 FAIL`
- Ruby Psych parse 三个 workflow YAML：PASS
- `git diff --check`：PASS
- 二进制 evidence 扫描：PASS，diff 无 png/jpg/jpeg/gif/webp/mp4/mov/webm 等文件
- 未读取或打印真实 Secret 值；测试只检查 workflow contract 文本
- CI：[validate #29905804236](https://github.com/aiskillstore/marketplace/actions/runs/29905804236) SUCCESS；[test #29905804355](https://github.com/aiskillstore/marketplace/actions/runs/29905804355) SUCCESS

## 依赖 / 阻塞

**禁止在以下条件满足前合并或做生产 canary：**

1. SkillStore PR #331 review PASS 并合并；
2. 发布包含该修复且带 checksum 的 `cli-v2.15.12`；
3. 本 PR exact-head CI 绿。

当前 `cli-v2.15.12` 尚未发布，因此本 PR是依赖阻塞状态。提前合并会使 submission 下载不存在的 exact release 并 fail closed。

## 风险点

- **数据写入**：本 PR不写 Supabase/SkillStore 数据；合并后正常 submission workflow 仍会按既有逻辑创建 pending PR。
- **权限 / 安全**：HELM key 进入可信 shard 父进程；真正的 audit+Codex child-only remap 依赖 CLI #331。没有恢复 `env: process.env` 到所有 Agent，没有把 key 给 Claude/Gemini。
- **并发 / 事务**：不改变 sharding、retry、callback 或 existing-target 保护。
- **用户体验**：修复后 Codex 可继续作为首选；Claude fallback 行为保持现状。
- **回滚方式**：revert 本 PR即可恢复 2.15.7 pin 与旧凭据接线；无 migration。

## 人类 review 关注点

请 reviewer 重点判断：

1. HELM secret 是否严格只进入 `Process shard` step，没有扩散到其他 workflow 阶段；
2. Marketplace 2.15.12 pin 是否与 SkillStore PR #331 的实际发布产物、checksum 完全一致；
3. CLI #331 的 `audit + codex` child-only remap 是否足以阻断不可信 Skill 通过 Claude/Gemini 或无 scope 调用读取 HELM key；
4. 是否接受保持现有 Claude fallback，本 PR不额外引入 degraded 状态或预算策略。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [x] 需要依赖发布确认

原因：修改生产 submission workflow 的第三方凭据传递与 CLI runtime pin，属于第三方服务集成配置/凭据路径变更。Trent PASS、CLI 2.15.12 release、Marketplace CI 绿后，再由人类决定合并与 canary；本 PR不自动合并、不 release、不触发生产 submission。

Wiki delta: none

