### PR TITLE
[codex] release Marketplace CLI 0.1.11

### DIFF
--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.10",
+	"version": "0.1.11",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/skillstore/src/lib/version.ts
+++ b/packages/skillstore/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.1.10';
+export const CLI_VERSION = '0.1.11';

--- a/packages/skillstore/tests/pack-install-truth.test.ts
+++ b/packages/skillstore/tests/pack-install-truth.test.ts
@@ -140,7 +140,7 @@ describe('Pack install reporting', () => {
 			attemptId: attempt?.attemptId,
 			status: 'complete',
 			targetAgents: ['codex'],
-			cliVersion: '0.1.10',
+			cliVersion: CLI_VERSION,
 		});
 	});
 


### PR DESCRIPTION
Bumps the Marketplace npm CLI for governed Pack installation and orchestration. Reuses CLI_VERSION in the reporting assertion. Validation: check, build, and 35 focused tests passed. Release only; no Workflow dispatch or Pack generation.