### PR TITLE
fix(skillstore): restore signed Pack installs

### DIFF
--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/skillstore/src/commands/add.ts
+++ b/packages/skillstore/src/commands/add.ts
@@ -494,10 +494,10 @@ async function addPlugin(slug: string, options: AddOptions): Promise<void> {
 			verifyHash: !skipVerify,
 		});
 		const downloadResult = memberTransaction.summary;
+		printDownloadSummary(downloadResult);
 		if (!dryRun && downloadResult.failed > 0) {
 			throw new Error(`Failed to stage ${downloadResult.failed} Pack member${downloadResult.failed === 1 ? '' : 's'}`);
 		}
-		printDownloadSummary(downloadResult);
 
 		// Step 5: Link canonical skills into each selected agent directory.
 		const successfulSkillSlugs = downloadResult.results.filter((r) => r.success).map((r) => r.slug);

--- a/packages/skillstore/src/lib/plugin-api.ts
+++ b/packages/skillstore/src/lib/plugin-api.ts
@@ -20,14 +20,25 @@ export interface ManifestSkillArtifactFile {
 	url: string;
 	sha256?: string;
 	bytes?: number;
+	mode?: '100644' | '100755';
 }
 
 export const MAX_ARTIFACT_FILE_BYTES = 10 * 1024 * 1024;
+
+export interface ManifestSkillArtifactSource {
+	type: 'github';
+	owner: string;
+	repo: string;
+	ref: string;
+	commit: string;
+	path: string;
+}
 
 export interface ManifestSkillArtifact {
 	type?: string;
 	files?: ManifestSkillArtifactFile[];
 	sha256?: string;
+	source?: ManifestSkillArtifactSource;
 }
 
 export interface ManifestSkill {
@@ -442,6 +453,7 @@ export async function downloadSkillFile(
 		maxBytes?: number;
 		expectedBytes?: number;
 		onBytes?: (bytes: number) => void;
+		approvedExternalUrl?: string;
 	} = {}
 ): Promise<Uint8Array> {
 	const apiUrl = new URL(config.apiBaseUrl);
@@ -449,7 +461,17 @@ export async function downloadSkillFile(
 	const isLoopback = fullUrl.hostname === 'localhost'
 		|| fullUrl.hostname === '127.0.0.1'
 		|| fullUrl.hostname === '[::1]';
-	if (fullUrl.origin !== apiUrl.origin || (fullUrl.protocol !== 'https:' && !isLoopback)) {
+	const approvedExternalUrl = limits.approvedExternalUrl
+		? new URL(limits.approvedExternalUrl)
+		: null;
+	const isApprovedExternal = approvedExternalUrl?.href === fullUrl.href
+		&& fullUrl.origin === 'https://raw.githubusercontent.com'
+		&& fullUrl.protocol === 'https:'
+		&& !fullUrl.username
+		&& !fullUrl.password;
+	const isApprovedSameOrigin = fullUrl.origin === apiUrl.origin
+		&& (fullUrl.protocol === 'https:' || isLoopback);
+	if (!isApprovedSameOrigin && !isApprovedExternal) {
 		throw new Error(`Refusing artifact URL outside the configured Skillstore origin: ${downloadUrl}`);
 	}
 	const maxBytes = limits.maxBytes ?? MAX_ARTIFACT_FILE_BYTES;
@@ -482,11 +504,13 @@ export async function downloadSkillFile(
 			throw new Error('Invalid artifact Content-Length');
 		}
 		const length = Number(contentLength);
-		if (!Number.isSafeInteger(length) || length > maxBytes) {
+		const contentEncoding = response.headers.get('content-encoding')?.trim().toLowerCase();
+		const hasEncodedRepresentation = !!contentEncoding && contentEncoding !== 'identity';
+		if (!Number.isSafeInteger(length) || (!hasEncodedRepresentation && length > maxBytes)) {
 			controller.abort();
 			throw new Error(`Artifact exceeds ${maxBytes} byte limit`);
 		}
-		if (limits.expectedBytes !== undefined && length !== limits.expectedBytes) {
+		if (!hasEncodedRepresentation && limits.expectedBytes !== undefined && length !== limits.expectedBytes) {
 			controller.abort();
 			throw new Error(`Artifact byte count does not match signed manifest: expected ${limits.expectedBytes}, got ${length}`);
 		}

--- a/packages/skillstore/src/lib/plugin-download.ts
+++ b/packages/skillstore/src/lib/plugin-download.ts
@@ -1,8 +1,12 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, rm, writeFile, lstat, readFile, readdir, readlink, rename } from 'node:fs/promises';
+import { chmod, mkdir, rm, writeFile, lstat, readFile, readdir, readlink, rename } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import type { PluginConfig } from './plugin-config.js';
-import type { ManifestSkill, ManifestSkillArtifactFile } from './plugin-api.js';
+import type {
+	ManifestSkill,
+	ManifestSkillArtifactFile,
+	ManifestSkillArtifactSource,
+} from './plugin-api.js';
 import { downloadSkillFile, MAX_ARTIFACT_FILE_BYTES } from './plugin-api.js';
 import { verifyContentHash } from './plugin-verify.js';
 import { logger } from './plugin-logger.js';
@@ -36,6 +40,9 @@ export interface DownloadSummary {
 export const MAX_PACK_SKILLS = 100;
 export const MAX_PACK_ARTIFACT_FILES = 256;
 export const MAX_PACK_ARTIFACT_BYTES = 50 * 1024 * 1024;
+const MAX_LEGACY_UNSIGNED_MODE_FILES = 12;
+const MARKETPLACE_GITHUB_OWNER = 'aiskillstore';
+const MARKETPLACE_GITHUB_REPO = 'marketplace';
 
 interface StagedSkill {
 	skillDir: string;
@@ -130,15 +137,116 @@ function getArtifactFiles(skill: ManifestSkill): ManifestSkillArtifactFile[] {
 	}];
 }
 
+function githubSourcePath(source: ManifestSkillArtifactSource): string {
+	if (source.type !== 'github') throw new Error('Unsupported Pack artifact source type');
+	if (!/^[A-Za-z0-9_.-]+$/.test(source.owner) || !/^[A-Za-z0-9_.-]+$/.test(source.repo)) {
+		throw new Error('Invalid GitHub Pack artifact owner or repository');
+	}
+	if (source.owner !== MARKETPLACE_GITHUB_OWNER || source.repo !== MARKETPLACE_GITHUB_REPO) {
+		throw new Error('Pack artifact source is outside the approved Marketplace mirror');
+	}
+	if (!/^[0-9a-f]{40}$/.test(source.commit) || source.ref !== source.commit) {
+		throw new Error('Pack artifact source must use one immutable GitHub commit');
+	}
+	if (
+		!source.path
+		|| source.path.includes('\\')
+		|| /[\u0000-\u001f\u007f]/u.test(source.path)
+		|| source.path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+	) {
+		throw new Error('Invalid GitHub Pack artifact source path');
+	}
+	return source.path.split('/').map(encodeURIComponent).join('/');
+}
+
+function approvedExternalArtifactUrl(
+	config: PluginConfig,
+	skill: ManifestSkill,
+	file: ManifestSkillArtifactFile
+): string | undefined {
+	const apiOrigin = new URL(config.apiBaseUrl).origin;
+	const url = new URL(file.url, apiOrigin);
+	if (url.origin === apiOrigin) return undefined;
+	if (url.origin !== 'https://raw.githubusercontent.com') {
+		throw new Error(`Refusing Pack artifact URL outside approved origins: ${file.url}`);
+	}
+	const source = skill.artifact?.source;
+	if (!source) throw new Error(`External Pack artifact is missing signed GitHub provenance: ${file.path}`);
+	const sourcePath = githubSourcePath(source);
+	const artifactPath = normalizedArtifactPath(file.path).split('/').map(encodeURIComponent).join('/');
+	const expected = new URL(
+		`https://raw.githubusercontent.com/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/${source.commit}/${sourcePath}/${artifactPath}`
+	);
+	if (url.href !== expected.href || url.search || url.hash || url.username || url.password) {
+		throw new Error(`Pack artifact URL does not match signed GitHub provenance: ${file.path}`);
+	}
+	return expected.href;
+}
+
 function normalizedArtifactPath(filePath: string): string {
-	return resolveSkillFilePath('/skill-root', filePath).slice('/skill-root/'.length).split(sep).join('/');
+	const rootPath = resolve('/skill-root');
+	const targetPath = resolveSkillFilePath(rootPath, filePath);
+	return relative(rootPath, targetPath).split(sep).join('/');
 }
 
 function treeHash(entries: Array<{ path: string; mode: string; sha256: string; size: number }>): string {
-	return createHash('sha256').update(entries
+	return createHash('sha256').update([...entries]
 		.sort((left, right) => left.path.localeCompare(right.path, 'en', { sensitivity: 'variant' }))
 		.map((entry) => JSON.stringify(entry))
 		.join('\n')).digest('hex');
+}
+
+interface DownloadedArtifactEntry {
+	file: ManifestSkillArtifactFile;
+	targetPath: string;
+	content: Uint8Array;
+}
+
+function resolveSignedArtifactModes(
+	skill: ManifestSkill,
+	entries: DownloadedArtifactEntry[]
+): Array<'100644' | '100755'> {
+	if (!/^[0-9a-f]{64}$/.test(skill.treeHash ?? '')) {
+		throw new Error(`Pack member is missing an exact signed tree hash: ${skill.slug}`);
+	}
+	const unresolved = entries
+		.map((entry, index) => ({ entry, index }))
+		.filter(({ entry }) => entry.file.mode === undefined);
+	if (unresolved.length > MAX_LEGACY_UNSIGNED_MODE_FILES) {
+		throw new Error(`Pack member file modes are not signed and cannot be derived safely: ${skill.slug}`);
+	}
+
+	let matched: Array<'100644' | '100755'> | null = null;
+	const combinations = 2 ** unresolved.length;
+	for (let mask = 0; mask < combinations; mask += 1) {
+		let bit = 0;
+		const modes = entries.map((entry): '100644' | '100755' => {
+			if (entry.file.mode) return entry.file.mode;
+			const mode = (mask & (1 << bit)) === 0 ? '100644' : '100755';
+			bit += 1;
+			return mode;
+		});
+		const digest = treeHash(entries.map((entry, index) => ({
+			path: normalizedArtifactPath(entry.file.path),
+			mode: modes[index],
+			sha256: sha256Hex(entry.content),
+			size: entry.content.byteLength,
+		})));
+		if (digest !== skill.treeHash) continue;
+		if (matched) throw new Error(`Pack member file modes are ambiguous: ${skill.slug}`);
+		matched = modes;
+	}
+	if (!matched) throw new Error(`Pack member file modes do not match signed tree hash: ${skill.slug}`);
+	return matched;
+}
+
+async function applySignedArtifactModes(skill: ManifestSkill, entries: DownloadedArtifactEntry[]): Promise<void> {
+	const modes = resolveSignedArtifactModes(skill, entries);
+	if (process.platform === 'win32') return;
+	await Promise.all(entries.map((entry, index) => chmod(
+		entry.targetPath,
+		modes[index] === '100755' ? 0o755 : 0o644
+	)));
 }
 
 /**
@@ -157,13 +265,16 @@ export async function verifyInstalledPackMember(skillDir: string, skill: Manifes
 			throw new Error(`Existing skill cannot be reused without signed file hashes: ${skill.slug}`);
 		}
 		if (expected.has(path)) throw new Error(`Existing skill has duplicate signed artifact path: ${skill.slug}`);
+		if (file.mode !== undefined && file.mode !== '100644' && file.mode !== '100755') {
+			throw new Error(`Existing skill has an invalid signed file mode: ${skill.slug}`);
+		}
 		expected.set(path, file);
 	}
 	if (skill.contentHash !== expected.get('SKILL.md')?.sha256) {
 		throw new Error(`Existing skill content identity does not match signed manifest: ${skill.slug}`);
 	}
 
-	const entries: Array<{ path: string; mode: string; sha256: string; size: number }> = [];
+	const entries: Array<{ path: string; mode: '100644' | '100755'; sha256: string; size: number; content: Uint8Array }> = [];
 	const root = resolve(skillDir);
 	const walk = async (directory: string): Promise<void> => {
 		const children = await readdir(directory, { withFileTypes: true });
@@ -184,6 +295,7 @@ export async function verifyInstalledPackMember(skillDir: string, skill: Manifes
 				mode: (stat.mode & 0o111) === 0 ? '100644' : '100755',
 				sha256: sha256Hex(bytes),
 				size: bytes.byteLength,
+				content: bytes,
 			});
 		}
 	};
@@ -191,16 +303,31 @@ export async function verifyInstalledPackMember(skillDir: string, skill: Manifes
 
 	if (entries.length !== expected.size || entries.some((entry) => {
 		const signed = expected.get(entry.path);
-		return !signed || signed.sha256 !== entry.sha256 || signed.bytes !== entry.size;
+		return !signed
+			|| signed.sha256 !== entry.sha256
+			|| signed.bytes !== entry.size;
 	})) {
 		throw new Error(`Existing skill does not match signed artifact files: ${skill.slug}`);
 	}
-	if (treeHash(entries) !== skill.treeHash) {
+	const signedModes = resolveSignedArtifactModes(skill, entries.map((entry) => ({
+		file: expected.get(entry.path)!,
+		targetPath: '',
+		content: entry.content,
+	})));
+	if (process.platform !== 'win32' && entries.some((entry, index) => entry.mode !== signedModes[index])) {
+		throw new Error(`Existing skill file modes do not match signed manifest: ${skill.slug}`);
+	}
+	if (treeHash(entries.map((entry, index) => ({
+		path: entry.path,
+		mode: signedModes[index],
+		sha256: entry.sha256,
+		size: entry.size,
+	}))) !== skill.treeHash) {
 		throw new Error(`Existing skill tree hash does not match signed manifest: ${skill.slug}`);
 	}
 }
 
-function validatePackManifest(skills: ManifestSkill[]): void {
+function validatePackManifest(config: PluginConfig, skills: ManifestSkill[]): void {
 	if (skills.length > MAX_PACK_SKILLS) {
 		throw new Error(`Pack has too many Skills (maximum ${MAX_PACK_SKILLS})`);
 	}
@@ -227,6 +354,10 @@ function validatePackManifest(skills: ManifestSkill[]): void {
 			if (!Number.isSafeInteger(file.bytes) || file.bytes! < 0 || file.bytes! > MAX_ARTIFACT_FILE_BYTES) {
 				throw new Error(`Invalid signed byte count for artifact file ${file.path}`);
 			}
+			if (file.mode !== undefined && file.mode !== '100644' && file.mode !== '100755') {
+				throw new Error(`Invalid signed mode for artifact file ${file.path}`);
+			}
+			approvedExternalArtifactUrl(config, skill, file);
 			declaredBytes += file.bytes!;
 			if (declaredBytes > MAX_PACK_ARTIFACT_BYTES) {
 				throw new Error(`Pack artifacts exceed ${MAX_PACK_ARTIFACT_BYTES} byte limit`);
@@ -282,7 +413,7 @@ export async function stagePackSkillDownloads(
 	} = {}
 ): Promise<PackSkillDownloadTransaction> {
 	const { overwrite = false, verifyHash = true } = options;
-	validatePackManifest(skills);
+	validatePackManifest(config, skills);
 	const results: SkillDownloadResult[] = [];
 	const staged: StagedSkill[] = [];
 	let success = 0;
@@ -435,12 +566,15 @@ async function stageSingleSkill(
 		await mkdir(parent, { recursive: true });
 		await mkdir(stageDir, { recursive: false, mode: 0o700 });
 
+		const downloadedEntries: DownloadedArtifactEntry[] = [];
 		for (const { file, targetPath } of artifactFiles) {
 			const expectedBytes = skill.artifact ? file.bytes : undefined;
+			const approvedExternalUrl = approvedExternalArtifactUrl(config, skill, file);
 			const content = await downloadSkillFile(config, file.url, {
 				maxBytes: expectedBytes ?? MAX_ARTIFACT_FILE_BYTES,
 				expectedBytes,
 				onBytes: consumeBytes,
+				approvedExternalUrl,
 			});
 
 			if (options.verifyHash) {
@@ -457,7 +591,9 @@ async function stageSingleSkill(
 
 			await mkdir(dirname(targetPath), { recursive: true });
 			await writeFile(targetPath, content);
+			downloadedEntries.push({ file, targetPath, content });
 		}
+		if (skill.artifact) await applySignedArtifactModes(skill, downloadedEntries);
 
 		return {
 			result: { slug: skill.slug, success: true, path: skillDir },

--- a/packages/skillstore/src/lib/version.ts
+++ b/packages/skillstore/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.1.11';
+export const CLI_VERSION = '0.1.12';

--- a/packages/skillstore/tests/pack-member-transaction.test.ts
+++ b/packages/skillstore/tests/pack-member-transaction.test.ts
@@ -1,9 +1,13 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { stagePackSkillDownloads, stagePackTargetLinks } from '../src/lib/plugin-download.js';
+import {
+	stagePackSkillDownloads,
+	stagePackTargetLinks,
+	verifyInstalledPackMember,
+} from '../src/lib/plugin-download.js';
 import type { PluginConfig } from '../src/lib/plugin-config.js';
 import type { ManifestSkill } from '../src/lib/plugin-api.js';
 
@@ -136,6 +140,54 @@ describe('Pack member transaction', () => {
 
 		expect(transaction.summary).toMatchObject({ success: 0, skipped: 1, failed: 0 });
 		expect(mocks.downloadSkillFile).not.toHaveBeenCalled();
+		await transaction.rollback();
+	});
+
+	it('derives and applies legacy executable modes only when they match the signed tree hash', async () => {
+		const { config, members } = await fixture();
+		const skillMd = new TextEncoder().encode('# Skill');
+		const script = new TextEncoder().encode('#!/usr/bin/env python3\nprint("ok")\n');
+		const files = [
+			{ path: 'SKILL.md', url: '/skill', bytes: skillMd, mode: '100644' },
+			{ path: 'scripts/run.py', url: '/script', bytes: script, mode: '100755' },
+		] as const;
+		const member: ManifestSkill = {
+			...members[0],
+			contentHash: createHash('sha256').update(skillMd).digest('hex'),
+			treeHash: createHash('sha256').update([...files]
+				.sort((left, right) => left.path.localeCompare(right.path, 'en', { sensitivity: 'variant' }))
+				.map((file) => JSON.stringify({
+					path: file.path,
+					mode: file.mode,
+					sha256: createHash('sha256').update(file.bytes).digest('hex'),
+					size: file.bytes.byteLength,
+				})).join('\n')).digest('hex'),
+			artifact: {
+				type: 'skill-files',
+				files: files.map((file) => ({
+					path: file.path,
+					url: file.url,
+					sha256: createHash('sha256').update(file.bytes).digest('hex'),
+					bytes: file.bytes.byteLength,
+				})),
+			},
+		};
+		mocks.downloadSkillFile.mockImplementation(async (_config: PluginConfig, url: string) =>
+			url === '/skill' ? skillMd : script
+		);
+
+		const transaction = await stagePackSkillDownloads(config, [member]);
+		expect(transaction.summary).toMatchObject({ success: 1, failed: 0 });
+		await transaction.activate();
+		const scriptPath = join(config.installDir, member.slug, 'scripts/run.py');
+		await expect(verifyInstalledPackMember(join(config.installDir, member.slug), member)).resolves.toBeUndefined();
+		if (process.platform !== 'win32') {
+			expect((await stat(join(config.installDir, member.slug, 'SKILL.md'))).mode & 0o777).toBe(0o644);
+			expect((await stat(scriptPath)).mode & 0o777).toBe(0o755);
+			await chmod(scriptPath, 0o644);
+			await expect(verifyInstalledPackMember(join(config.installDir, member.slug), member))
+				.rejects.toThrow('file modes do not match signed manifest');
+		}
 		await transaction.rollback();
 	});
 

--- a/packages/skillstore/tests/plugin-api.test.ts
+++ b/packages/skillstore/tests/plugin-api.test.ts
@@ -529,6 +529,18 @@ describe('plugin-api', () => {
 			expect(mockFetch).not.toHaveBeenCalled();
 		});
 
+		it('allows only an exact, explicitly approved immutable raw GitHub URL', async () => {
+			const url = 'https://raw.githubusercontent.com/aiskillstore/marketplace/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/skills/example/SKILL.md';
+			mockFetch.mockResolvedValueOnce(new Response('ok'));
+			await expect(downloadSkillFile(config, url, { approvedExternalUrl: url }))
+				.resolves.toEqual(new TextEncoder().encode('ok'));
+			expect(String(mockFetch.mock.calls[0][0])).toBe(url);
+
+			await expect(downloadSkillFile(config, url, {
+				approvedExternalUrl: url.replace('SKILL.md', 'OTHER.md'),
+			})).rejects.toThrow('outside the configured Skillstore origin');
+		});
+
 		it('should throw error on download failure', async () => {
 			mockFetch.mockResolvedValueOnce({
 				ok: false,
@@ -560,6 +572,18 @@ describe('plugin-api', () => {
 			mockFetch.mockResolvedValueOnce(new Response('abcd'));
 			await expect(downloadSkillFile(config, '/skill.bin', { maxBytes: 3 }))
 				.rejects.toThrow('exceeds 3 byte limit');
+		});
+
+		it('compares limits and signed bytes with the decoded body when Content-Length describes compression', async () => {
+			mockFetch.mockResolvedValueOnce(new Response('abcd', {
+				headers: {
+					'content-encoding': 'gzip',
+					'content-length': '11',
+				},
+			}));
+
+			await expect(downloadSkillFile(config, '/skill.bin', { expectedBytes: 4, maxBytes: 10 }))
+				.resolves.toEqual(new TextEncoder().encode('abcd'));
 		});
 
 		it('allows only an explicitly configured localhost test origin over HTTP', async () => {

--- a/packages/skillstore/tests/plugin-download.test.ts
+++ b/packages/skillstore/tests/plugin-download.test.ts
@@ -13,6 +13,7 @@ import type { ManifestSkill } from '../src/lib/plugin-api.js';
 
 // Mock fs/promises
 vi.mock('node:fs/promises', () => ({
+	chmod: vi.fn(),
 	mkdir: vi.fn(),
 	rm: vi.fn(),
 	writeFile: vi.fn(),
@@ -52,6 +53,18 @@ const mockRm = vi.mocked(rm);
 const mockWriteFile = vi.mocked(writeFile);
 const mockLstat = vi.mocked(lstat);
 const mockRename = vi.mocked(rename);
+
+function artifactTreeHash(files: Array<{ path: string; mode: '100644' | '100755'; bytes: Uint8Array }>): string {
+	return createHash('sha256').update([...files]
+		.sort((left, right) => left.path.localeCompare(right.path, 'en', { sensitivity: 'variant' }))
+		.map((file) => JSON.stringify({
+			path: file.path,
+			mode: file.mode,
+			sha256: createHash('sha256').update(file.bytes).digest('hex'),
+			size: file.bytes.byteLength,
+		}))
+		.join('\n')).digest('hex');
+}
 
 describe('plugin-download', () => {
 	let config: PluginConfig;
@@ -223,10 +236,15 @@ describe('plugin-download', () => {
 		it('should install all artifact files under the skill directory', async () => {
 			const skillMd = new TextEncoder().encode('# Skill');
 			const reference = new TextEncoder().encode('Reference');
+			const treeFiles = [
+				{ path: 'SKILL.md', mode: '100644' as const, bytes: skillMd },
+				{ path: 'references/guide.md', mode: '100644' as const, bytes: reference },
+			];
 			const artifactSkill: ManifestSkill = {
 				slug: 'artifact-skill',
 				name: 'Artifact Skill',
-				contentHash: '',
+				contentHash: createHash('sha256').update(skillMd).digest('hex'),
+				treeHash: artifactTreeHash(treeFiles),
 				downloadUrl: '/fallback',
 				artifact: {
 					type: 'skill-files',
@@ -236,12 +254,14 @@ describe('plugin-download', () => {
 							url: '/files/SKILL.md',
 							sha256: createHash('sha256').update(skillMd).digest('hex'),
 							bytes: skillMd.byteLength,
+							mode: '100644',
 						},
 						{
 							path: 'references/guide.md',
 							url: '/files/references/guide.md',
 							sha256: createHash('sha256').update(reference).digest('hex'),
 							bytes: reference.byteLength,
+							mode: '100644',
 						},
 					],
 				},
@@ -272,6 +292,50 @@ describe('plugin-download', () => {
 			await expect(downloadAllSkills(config, [unhashedSkill])).rejects.toThrow('Missing exact SHA-256');
 			expect(mockDownloadSkillFile).not.toHaveBeenCalled();
 			expect(mockWriteFile).not.toHaveBeenCalled();
+		});
+
+		it('downloads raw GitHub files only when URL and signed provenance match exactly', async () => {
+			const commit = 'a'.repeat(40);
+			const bytes = new TextEncoder().encode('# verified');
+			const sha256 = createHash('sha256').update(bytes).digest('hex');
+			const url = `https://raw.githubusercontent.com/aiskillstore/marketplace/${commit}/skills/example/SKILL.md`;
+			const skill: ManifestSkill = {
+				slug: 'example',
+				name: 'Example',
+				contentHash: sha256,
+				treeHash: artifactTreeHash([{ path: 'SKILL.md', mode: '100644', bytes }]),
+				downloadUrl: url,
+				artifact: {
+					type: 'skill-files',
+					source: {
+						type: 'github',
+						owner: 'aiskillstore',
+						repo: 'marketplace',
+						ref: commit,
+						commit,
+						path: 'skills/example',
+					},
+					files: [{ path: 'SKILL.md', url, sha256, bytes: bytes.byteLength, mode: '100644' }],
+				},
+			};
+			mockDownloadSkillFile.mockResolvedValue(bytes);
+
+			await expect(downloadAllSkills(config, [skill])).resolves.toMatchObject({ success: 1, failed: 0 });
+			expect(mockDownloadSkillFile).toHaveBeenCalledWith(config, url, expect.objectContaining({
+				approvedExternalUrl: url,
+				expectedBytes: bytes.byteLength,
+			}));
+
+			const mismatched = structuredClone(skill);
+			mismatched.artifact!.source!.commit = 'b'.repeat(40);
+			mismatched.artifact!.source!.ref = 'b'.repeat(40);
+			await expect(downloadAllSkills(config, [mismatched]))
+				.rejects.toThrow('does not match signed GitHub provenance');
+
+			const outsideMirror = structuredClone(skill);
+			outsideMirror.artifact!.source!.owner = 'someone-else';
+			await expect(downloadAllSkills(config, [outsideMirror]))
+				.rejects.toThrow('outside the approved Marketplace mirror');
 		});
 
 		it('should reject artifact paths outside the skill directory before writing files', async () => {


### PR DESCRIPTION
## Outcome

Restores CLI installation of signed production Packs while keeping external downloads fail-closed.

## Changes

- bind raw GitHub artifact URLs to the signed Marketplace owner/repo/commit/path
- validate decoded byte count and SHA-256 without comparing compressed wire length to decoded size
- derive legacy file modes only when one unique assignment matches the signed tree hash
- enforce executable modes and exact existing-member readback on Unix, with portable Windows verification
- print failed member summaries before transactional rollback
- release CLI identity as `0.1.12`

## Verification

- 311 package tests passed
- `pnpm check` passed
- `pnpm build` passed
- live temporary-HOME install of existing `browser-automation-testing-pack`: 3/3 members, exact lock readback, executable script mode `0755`
- product, security, and reliability expert reviews: GO, no P0/P1

No Pack generation, publication, workflow dispatch, or production DB write was performed.