### PR TITLE
fix(skillstore): keep Pack re-add idempotent

### DIFF
--- a/packages/skillstore/package.json
+++ b/packages/skillstore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skillstore",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"description": "Skillstore CLI - AI Skills marketplace for Claude Code",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/skillstore/src/lib/skill-lock.ts
+++ b/packages/skillstore/src/lib/skill-lock.ts
@@ -92,6 +92,16 @@ export async function addToLock(entry: Omit<SkillLockEntry, 'updatedAt'>): Promi
 	const now = new Date().toISOString();
 
 	const existing = lock.skills[entry.slug];
+	const identityUnchanged = existing
+		&& existing.slug === entry.slug
+		&& existing.version === entry.version
+		&& (existing.authorVersion ?? null) === (entry.authorVersion ?? null)
+		&& (existing.skillstoreRevision ?? null) === (entry.skillstoreRevision ?? null)
+		&& (existing.versionStatus ?? '') === (entry.versionStatus ?? '')
+		&& (existing.treeHash ?? null) === (entry.treeHash ?? null)
+		&& existing.zipHash === entry.zipHash
+		&& existing.source === entry.source;
+	if (identityUnchanged) return;
 
 	lock.skills[entry.slug] = {
 		...entry,

--- a/packages/skillstore/src/lib/version.ts
+++ b/packages/skillstore/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.1.12';
+export const CLI_VERSION = '0.1.13';

--- a/packages/skillstore/tests/skill-lock.test.ts
+++ b/packages/skillstore/tests/skill-lock.test.ts
@@ -223,6 +223,21 @@ describe('skill-lock', () => {
 			expect(parsed.skills['test-skill'].version).toBe('2.0.0');
 			expect(parsed.skills['test-skill'].installedAt).toBe('2024-01-01T00:00:00Z'); // Original preserved
 		});
+
+		it('should not rewrite an unchanged lock identity', async () => {
+			vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockLock));
+
+			await addToLock({
+				slug: mockLockEntry.slug,
+				version: mockLockEntry.version,
+				zipHash: mockLockEntry.zipHash,
+				source: mockLockEntry.source,
+				installedAt: '2026-07-23T00:00:00Z',
+			});
+
+			expect(mkdir).not.toHaveBeenCalled();
+			expect(writeFile).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('removeFromLock', () => {


### PR DESCRIPTION
## Outcome

Prevents an unchanged Pack re-add from rewriting lockfile timestamps.

## Root cause

The CLI correctly reused signed on-disk members, but `addToLock` always refreshed `updatedAt`, so exact install readback changed on every no-op re-add.

## Fix

- compare the complete immutable lock identity before writing
- return without any filesystem write when version/revision/tree/ZIP identity is unchanged
- retain normal `updatedAt` behavior when content identity changes
- release CLI identity as `0.1.13`

## Verification

- 312 package tests passed
- `pnpm check` and `pnpm build` passed
- real temporary-HOME Pack install followed by re-add produced the exact same lockfile SHA-256

No Pack generation, publication, workflow dispatch, or production DB write was performed.