### PR TITLE
chore(packs): pin governed production runtimes

### DIFF
--- a/.github/workflows/generate-packs.yml
+++ b/.github/workflows/generate-packs.yml
@@ -26,11 +26,10 @@ concurrency:
 env:
   # Production v4 requires the immutable binding-aware release and verifies its
   # checksums.txt asset before the binary crosses into the evaluator boundary.
-  # Release sequencing gate: replace only after the runtime-accept capable
-  # Skillstore CLI release and an independently recorded digest are available.
-  # No release attestation exists yet, so this stays intentionally fail-closed.
-  PACK_PRODUCTION_CLI_VERSION: '__SET_AFTER_PACK_RUNTIME_ACCEPT_CLI_RELEASE__'
-  PACK_PRODUCTION_CLI_SHA256: '__SET_AFTER_PACK_RUNTIME_ACCEPT_CLI_RELEASE_SHA256__'
+  # cli-v2.16.0 was built from the reviewed main merge; this is the Linux x64
+  # digest published in that release's checksums.txt asset.
+  PACK_PRODUCTION_CLI_VERSION: '2.16.0'
+  PACK_PRODUCTION_CLI_SHA256: 'af5d54e0db3524e33e97a538bb84da2c4d36113ec72823a3f5530a111d2f467f'
   # One cap feeds the local proxy and every Claude CLI process.
   PACK_EVALUATOR_MAX_OUTPUT_TOKENS: '16384'
 

--- a/.github/workflows/pack-opportunity-admission.yml
+++ b/.github/workflows/pack-opportunity-admission.yml
@@ -10,9 +10,9 @@ permissions:
   contents: read
 
 env:
-  # Replace together after the collector CLI release is published.
-  PACK_OPPORTUNITY_ADMISSION_CLI_VERSION: '__SET_AFTER_SKILLS_SH_CLI_RELEASE__'
-  PACK_OPPORTUNITY_ADMISSION_CLI_SHA256: '__SET_AFTER_PUBLIC_DEMAND_COLLECTOR_CLI_RELEASE_SHA256__'
+  # Public-demand collection is pinned to the reviewed Linux x64 release.
+  PACK_OPPORTUNITY_ADMISSION_CLI_VERSION: '2.16.0'
+  PACK_OPPORTUNITY_ADMISSION_CLI_SHA256: 'af5d54e0db3524e33e97a538bb84da2c4d36113ec72823a3f5530a111d2f467f'
 
 concurrency:
   group: pack-opportunity-admission

--- a/.github/workflows/publish-pack-production-v4.yml
+++ b/.github/workflows/publish-pack-production-v4.yml
@@ -227,8 +227,8 @@ jobs:
       - name: Preflight the exact public Marketplace CLI release
         id: marketplace-cli-preflight
         env:
-          # Release sequencing gate: replace only after this exact npm package is public.
-          MARKETPLACE_CLI_VERSION: '__SET_AFTER_MARKETPLACE_CLI_RELEASE__'
+          # Exact npm release whose provenance and registry integrity are checked below.
+          MARKETPLACE_CLI_VERSION: '0.1.13'
         run: |
           set -euo pipefail
           if ! [[ "$MARKETPLACE_CLI_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then

--- a/scripts/pack-production-manual-publish.mjs
+++ b/scripts/pack-production-manual-publish.mjs
@@ -14,8 +14,8 @@ const REPOSITORY = 'aiskillstore/marketplace';
 const WORKFLOW_NAME = 'Generate Pack';
 const WORKFLOW_PATH = '.github/workflows/generate-packs.yml';
 const SOURCE_ARTIFACT_NAME = 'pack-production-final';
-// Release sequencing gate: replace only after this exact npm package is public.
-const CLI_PACKAGE = 'skillstore@__SET_AFTER_MARKETPLACE_CLI_RELEASE__';
+// Exact public npm release; registry integrity and provenance are rechecked at runtime.
+const CLI_PACKAGE = 'skillstore@0.1.13';
 const CLI_VERSION = CLI_PACKAGE.slice('skillstore@'.length);
 const INSTALL_READBACK_SCHEMA = 'marketplace.pack-production-install-readback/v1';
 const RUNTIME_READBACK_SCHEMA = 'marketplace.pack-production-runtime-readback/v1';

--- a/scripts/tests/generate-packs-workflow.test.mjs
+++ b/scripts/tests/generate-packs-workflow.test.mjs
@@ -35,6 +35,8 @@ function assertPinnedSecretActions(source) {
 test('admission uses public demand evidence and a checksum-authenticated read-only CLI token', () => {
   assert.match(admission, /permissions:\n  actions: read\n  contents: read/);
   assert.match(admission, /github\.event_name == 'workflow_dispatch' \|\| vars\.PACK_PRODUCTION_AUTOMATION_ENABLED == 'true'/);
+  assert.match(admission, /PACK_OPPORTUNITY_ADMISSION_CLI_VERSION: '2\.16\.0'/);
+  assert.match(admission, /PACK_OPPORTUNITY_ADMISSION_CLI_SHA256: 'af5d54e0db3524e33e97a538bb84da2c4d36113ec72823a3f5530a111d2f467f'/);
   const token = section(admission, '      - name: Create a read-only token', '      - name: Download the fixed public-discovery CLI');
   assert.match(token, new RegExp(`actions/create-github-app-token@${pinnedActions.appToken} # v3`));
   assert.match(token, /repositories: marketplace,skillstore/);
@@ -185,8 +187,9 @@ test('pre-publication runtime acceptance executes one staged result as the isola
   assert.match(evaluate, /sudo -u packeval env -i[\s\S]*skillstore-cli pack runtime-accept/);
   assert.match(evaluate, /--identity-file "\$RUNTIME_ROOT\/identities\.json"/);
   assert.match(evaluate, /runtime-acceptance\.json/);
-  assert.match(generate, /PACK_PRODUCTION_CLI_VERSION: '__SET_AFTER_PACK_RUNTIME_ACCEPT_CLI_RELEASE__'/);
-  assert.match(generate, /PACK_PRODUCTION_CLI_SHA256: '__SET_AFTER_PACK_RUNTIME_ACCEPT_CLI_RELEASE_SHA256__'/);
+  assert.match(generate, /PACK_PRODUCTION_CLI_VERSION: '2\.16\.0'/);
+  assert.match(generate, /PACK_PRODUCTION_CLI_SHA256: 'af5d54e0db3524e33e97a538bb84da2c4d36113ec72823a3f5530a111d2f467f'/);
+  assert.doesNotMatch(generate, /__SET_AFTER_/);
 });
 
 test('evaluation checkpoints cancellation evidence and never uploads raw run logs', () => {
@@ -253,7 +256,7 @@ test('manual publication authenticates and bounds one final generation artifact'
     '      - name: Preflight the exact public Marketplace CLI release',
     '      - name: Download the reviewed immutable approval handoff',
   );
-  assert.match(cliPreflight, /MARKETPLACE_CLI_VERSION: '__SET_AFTER_MARKETPLACE_CLI_RELEASE__'/);
+  assert.match(cliPreflight, /MARKETPLACE_CLI_VERSION: '0\.1\.13'/);
   assert.match(cliPreflight, /must be an exact non-placeholder semver release/);
   assert.match(cliPreflight, /npm view --registry=https:\/\/registry\.npmjs\.org "skillstore@\$MARKETPLACE_CLI_VERSION" --json/);
   assert.match(cliPreflight, /\.dist\.integrity[\s\S]*sha512-/);

--- a/scripts/tests/pack-production-manual-publish.test.mjs
+++ b/scripts/tests/pack-production-manual-publish.test.mjs
@@ -34,7 +34,7 @@ const RUN_ID = '123456789';
 const SOURCE_SHA = 'a'.repeat(40);
 const ARTIFACT_DIGEST = `sha256:${'b'.repeat(64)}`;
 const SKILL_CONTENTS = [Buffer.from('# Skill one\n'), Buffer.from('# Skill two\n')];
-const CLI_VERSION = '__SET_AFTER_MARKETPLACE_CLI_RELEASE__';
+const CLI_VERSION = '0.1.13';
 const CLI_PACKAGE = `skillstore@${CLI_VERSION}`;
 
 function registryProofFixture() {
@@ -1055,7 +1055,7 @@ test('workflow separates public authority, credential-free runtime, and hosted c
     publish.indexOf('      - name: Preflight the exact public Marketplace CLI release'),
     publish.indexOf('      - name: Download the reviewed immutable approval handoff'),
   );
-  assert.match(cliPreflight, /MARKETPLACE_CLI_VERSION: '__SET_AFTER_MARKETPLACE_CLI_RELEASE__'/);
+  assert.match(cliPreflight, /MARKETPLACE_CLI_VERSION: '0\.1\.13'/);
   assert.match(cliPreflight, /\^\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\$/);
   assert.match(cliPreflight, /npm view --registry=https:\/\/registry\.npmjs\.org "skillstore@\$MARKETPLACE_CLI_VERSION" --json/);
   assert.match(cliPreflight, /\.dist\.integrity[\s\S]*sha512-/);
@@ -1125,7 +1125,8 @@ test('workflow separates public authority, credential-free runtime, and hosted c
   assert.match(completion, /Upload completed production evidence\n\s+if: always\(\)/);
   assert.match(workflow, /Upload exact public publication evidence\n\s+if: always\(\)/);
   const publisher = readFileSync(join(REPO_ROOT, 'scripts/pack-production-manual-publish.mjs'), 'utf8');
-  assert.match(publisher, /CLI_PACKAGE = 'skillstore@__SET_AFTER_MARKETPLACE_CLI_RELEASE__'/);
+  assert.match(publisher, /CLI_PACKAGE = 'skillstore@0\.1\.13'/);
+  assert.doesNotMatch(publisher, /__SET_AFTER_/);
   assert.doesNotMatch(publisher, /skillstore@0\.1\.11/);
   const production = readFileSync(join(REPO_ROOT, 'scripts/pack-production.mjs'), 'utf8');
   const finalize = production.slice(


### PR DESCRIPTION
## Outcome

Completes the Pack-production **program** release wiring without generating or publishing a Pack.

## Exact runtime identities

- Skillstore CLI `2.16.0`
- Linux x64 SHA-256 `af5d54e0db3524e33e97a538bb84da2c4d36113ec72823a3f5530a111d2f467f`
- Marketplace npm CLI `skillstore@0.1.13`

## Safety boundary

- `PACK_PRODUCTION_AUTOMATION_ENABLED` remains unset
- `PACK_PRODUCTION_AUTO_PUBLISH_ENABLED` remains `false`
- no Admission, Generate Pack, publication, canary, backfill, or production DB write was executed
- checksum, npm integrity/provenance, signature, install, runtime, artifact, and readback gates remain fail-closed

## Verification

- 122 focused Pack-governance tests: 121 passed, 1 Linux-only signal test skipped on macOS
- YAML parse, JavaScript syntax, and diff checks passed
- product, reliability, and security expert reviews: GO; no P0/P1
- live vars/readback: latest scheduled Admission and Generate runs are both skipped

This PR makes the software deployable while deliberately leaving production Pack creation disabled.