### PR TITLE
fix(ci): close runner and Dependabot policy gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/on-tag-release.yml
+++ b/.github/workflows/on-tag-release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write
@@ -337,7 +337,7 @@ jobs:
 
   sync-to-supabase:
     needs: release
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/scripts/check-workflow-runner-safety.mjs
+++ b/scripts/check-workflow-runner-safety.mjs
@@ -49,6 +49,15 @@ function pullRequestTypes(config) {
   return Array.isArray(types) ? types : [];
 }
 
+function hasTagTrigger(config) {
+  return Boolean(
+    config
+    && typeof config === 'object'
+    && !Array.isArray(config)
+    && (Object.hasOwn(config, 'tags') || Object.hasOwn(config, 'tags-ignore'))
+  );
+}
+
 function trustedClosedMergeMetadataJob(pullRequest, job) {
   const types = pullRequestTypes(pullRequest);
   if (types.length !== 1 || types[0] !== 'closed') return false;
@@ -110,6 +119,8 @@ function inspectWorkflow(root, path) {
   const workflow = document.toJS({ maxAliasCount: 100 });
   const pullRequest = eventConfig(workflow.on, 'pull_request');
   const pullRequestTarget = eventConfig(workflow.on, 'pull_request_target');
+  const push = eventConfig(workflow.on, 'push');
+  const tagOrRelease = hasTagTrigger(push) || eventConfig(workflow.on, 'release') !== null;
   const jobs = workflow.jobs && typeof workflow.jobs === 'object' ? workflow.jobs : {};
 
   if (pullRequestTarget !== null) {
@@ -124,6 +135,15 @@ function inspectWorkflow(root, path) {
   for (const [jobName, job] of Object.entries(jobs)) {
     if (!job || typeof job !== 'object') continue;
     const jobLine = lineOf(document, lineCounter, ['jobs', jobName]);
+
+    if (tagOrRelease && !isGithubHosted(job['runs-on'])) {
+      add(
+        violations,
+        file,
+        jobLine,
+        `tag/release job ${jobName} must use a literal GitHub-hosted runner so the self-hosted group can remain default-branch-only`,
+      );
+    }
 
     if (pullRequest !== null) {
       const trustedMetadata = trustedClosedMergeMetadataJob(pullRequest, job);

--- a/scripts/tests/workflow-action-pin-policy.test.mjs
+++ b/scripts/tests/workflow-action-pin-policy.test.mjs
@@ -492,13 +492,13 @@ test(
   },
 );
 
-test('Dependabot updates root GitHub Actions pins weekly', () => {
+test('Dependabot updates root GitHub Actions pins weekly without automatic major upgrades', () => {
   const dependabot = readFileSync(
     join(REPO_ROOT, '.github', 'dependabot.yml'),
     'utf8',
   );
   assert.match(
     dependabot,
-    /^version: 2\nupdates:\n  - package-ecosystem: "github-actions"\n    directory: "\/"\n    schedule:\n      interval: "weekly"$/m,
+    /^version: 2\nupdates:\n  - package-ecosystem: "github-actions"\n    directory: "\/"\n    schedule:\n      interval: "weekly"\n    ignore:\n      - dependency-name: "\*"\n        update-types:\n          - "version-update:semver-major"$/m,
   );
 });

--- a/scripts/tests/workflow-runner-safety.test.mjs
+++ b/scripts/tests/workflow-runner-safety.test.mjs
@@ -132,6 +132,49 @@ test('trusted main push may use self-hosted without making it pull_request reach
   );
 });
 
+test('tag and release workflows cannot require a non-default-ref self-hosted runner grant', () => {
+  withWorkflow(
+    [
+      'name: unsafe tag release',
+      'on:',
+      '  push:',
+      '    tags: ["v*"]',
+      '  release:',
+      '    types: [published]',
+      'jobs:',
+      '  publish:',
+      '    runs-on: self-hosted',
+      '    steps:',
+      '      - run: echo unsafe-dynamic-tag-ref',
+    ].join('\n'),
+    (root) => {
+      const result = runChecker(root);
+      assert.notEqual(result.status, 0);
+      assert.match(`${result.stdout}\n${result.stderr}`, /tag\/release.*GitHub-hosted/i);
+    },
+  );
+});
+
+test('tag release jobs pass on a literal GitHub-hosted runner', () => {
+  withWorkflow(
+    [
+      'name: hosted tag release',
+      'on:',
+      '  push:',
+      '    tags: ["v*"]',
+      'jobs:',
+      '  publish:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: echo hosted-tag-release',
+    ].join('\n'),
+    (root) => {
+      const result = runChecker(root);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    },
+  );
+});
+
 test('pull_request_target is forbidden even when fork head is fetched indirectly', () => {
   withWorkflow(
     [


### PR DESCRIPTION
## Root causes

1. The org Default runner group can only whitelist workflows at an exact branch, tag, or SHA. Marketplace had one self-hosted workflow triggered from dynamic `v*` tag refs, so applying the required `@refs/heads/main` boundary would break tag releases.
2. The first Dependabot scan opened five cross-major GitHub Action upgrades. Contract tests correctly rejected checkout/upload/download major drift, creating recurring red PR noise.

## Changes

- Move both jobs in `on-tag-release.yml` to GitHub-hosted runners.
- Extend the structural runner policy so tag/release workflows cannot introduce non-default-ref self-hosted jobs.
- Add positive and negative runner regression fixtures.
- Keep automated GitHub Action updates within the current major; major upgrades remain explicit review work.

This preserves all main/schedule/manual self-hosted production workflows while making the external runner group safe to restrict to selected Marketplace workflows at `refs/heads/main`. Skillstore currently has no self-hosted workflows.

## Verification

- `CI=true npm ci --ignore-scripts --offline`
- runner/action policy tests: 29/29
- complete scripts suite before the Dependabot-only config assertion: 562 total, 560 pass, 0 fail, 2 skip
- runner policy: 38 workflows pass
- Action pin policy: pass
- Dependabot YAML structural parse: pass
- `git diff --check`: pass

After merge: restrict org runner group `Default` to the exact remaining Marketplace workflow paths pinned to `refs/heads/main`; verify API readback; close superseded cross-major Dependabot PRs.