### PR TITLE
fix(actions): skip disabled translation dispatch

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -989,7 +989,7 @@ jobs:
   # ============================================================
   trigger-translate:
     needs: [sync, cache-invalidate, finalize-english-cache]
-    if: always() && needs.sync.result == 'success' && needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
+    if: always() && vars.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true' && needs.sync.result == 'success' && needs.cache-invalidate.result == 'success' && needs.sync.outputs.skip_sync != 'true' && needs.sync.outputs.synced_skill_count != '0' && !contains(github.event.head_commit.message || '', '[bulk-source-monitor]')
     runs-on: self-hosted
     timeout-minutes: 15
     steps:

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -691,7 +691,7 @@ test('sync workflow uses an artifact-backed bounded invalidator and preserves do
   assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
   assert.match(
     triggerJob,
-    /if: always\(\) && needs\.sync\.result == 'success' && needs\.cache-invalidate\.result == 'success'/,
+    /if: always\(\) && vars\.CACHE_FINALIZER_AUTOMATION_ENABLED == 'true' && needs\.sync\.result == 'success' && needs\.cache-invalidate\.result == 'success'/,
   );
 });
 


### PR DESCRIPTION
## Root cause

`sync-to-supabase.yml` dispatched `translate-skills` even while `CACHE_FINALIZER_AUTOMATION_ENABLED` was absent/disabled. The translation mutation gate then skipped every write, cache-finalizer, and follow-up job, producing green no-op runs and dropping the remaining bounded queue.

## Fix

- gate the initial repository dispatch with the existing fail-closed rollout variable
- retain bounded manual translation recovery while automation is disabled
- add a workflow contract regression

No validation, cache-finalization, hash, or security gate is relaxed.

## Verification

- `CI=true node --test scripts/tests/finalize-translation-cache.test.mjs` (11/11)
- `git diff --check`