### PR TITLE
fix(actions): preserve push sync watermark

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           # Find the commit SHA of the last successful sync workflow run
           # This ensures we catch ALL changes since the last sync, even if multiple PRs merged
-          LAST_SHA=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&per_page=5" \
+          LAST_SHA=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&event=push&per_page=5" \
             --jq '.workflow_runs[0].head_sha' 2>/dev/null || echo "")
           
           if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" != "null" ] && [ "$LAST_SHA" != "${{ github.sha }}" ]; then

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -688,6 +688,7 @@ test('sync workflow uses an artifact-backed bounded invalidator and preserves do
   assert.doesNotMatch(invalidationJob, /needs\.sync\.outputs\.synced_slugs/);
   assert.match(finalizerJob, /needs: \[sync, calculate-scores, cache-invalidate\]/);
   assert.match(finalizerJob, /needs\.cache-invalidate\.result == 'success'/);
+  assert.match(workflow, /runs\?status=success&event=push&per_page=5/);
   assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);
   assert.match(
     triggerJob,


### PR DESCRIPTION
## Root cause

The incremental Sync workflow selected the newest successful run regardless of event. A bounded manual `workflow_dispatch` recovery on the current main could therefore advance the diff watermark even when an earlier automatic push run failed before writes, permanently hiding those unsynced Skills. Run 30199266142 exposed this with 40 targets.

## Fix

Use only successful `push` runs as the automatic incremental watermark. Manual bounded recovery remains available but cannot advance the push baseline.

No sync admission cap, validation, hash, cache, permission, or fail-closed gate is relaxed.

## Verification

- `CI=true node --test scripts/tests/invalidate-cache.test.mjs` (25/25)
- `git diff --check`