### PR TITLE
fix(actions): close bounded sync recovery backlog

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -89,8 +89,11 @@ jobs:
         run: |
           # Find the commit SHA of the last successful sync workflow run
           # This ensures we catch ALL changes since the last sync, even if multiple PRs merged
-          LAST_SHA=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&event=push&per_page=5" \
-            --jq '.workflow_runs[0].head_sha' 2>/dev/null || echo "")
+          LAST_RUN=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&event=push&per_page=5" \
+            --jq '.workflow_runs[0] // {}' 2>/dev/null || echo '{}')
+          LAST_SHA=$(jq -r '.head_sha // ""' <<< "$LAST_RUN")
+          LAST_CREATED_AT=$(jq -r '.created_at // ""' <<< "$LAST_RUN")
+          echo "base_run_created_at=$LAST_CREATED_AT" >> "$GITHUB_OUTPUT"
           
           if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" != "null" ] && [ "$LAST_SHA" != "${{ github.sha }}" ]; then
             # Verify the commit exists in our history
@@ -110,9 +113,12 @@ jobs:
         id: changes
         env:
           BASE_SHA: ${{ steps.last_sync.outputs.base_sha }}
+          BASE_RUN_CREATED_AT: ${{ steps.last_sync.outputs.base_run_created_at }}
           HEAD_SHA: ${{ github.sha }}
           INPUT_SLUGS: ${{ inputs.slugs }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           echo "Comparing HEAD against: $BASE_SHA"
           
           if [ -n "$INPUT_SLUGS" ]; then
@@ -127,10 +133,83 @@ jobs:
           else
             # Resolve both the diff and the published-skill inventory from pinned
             # Git trees. A self-hosted runner checkout may be sparse or mutable;
-            # it must never turn a real commit diff into an empty sync plan.
+            # it must never turn a real commit diff into an empty sync plan. A
+            # successful bounded manual recovery can subtract only its verified
+            # artifact slugs whose entire pinned skill tree is still unchanged.
+            MAX_RECOVERY_RUNS=100
+            RECOVERIES_FILE="$RUNNER_TEMP/recovered-syncs.json"
+            jq -n '[]' > "$RECOVERIES_FILE"
+
+            if [ -n "$BASE_RUN_CREATED_AT" ]; then
+              RUNS_RESPONSE=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&event=workflow_dispatch&per_page=$MAX_RECOVERY_RUNS")
+              PAGE_COUNT=$(jq '.workflow_runs | length' <<< "$RUNS_RESPONSE")
+              OLDEST_CREATED_AT=$(jq -r '.workflow_runs[-1].created_at // ""' <<< "$RUNS_RESPONSE")
+              if [ "$PAGE_COUNT" -eq "$MAX_RECOVERY_RUNS" ] && [[ "$OLDEST_CREATED_AT" > "$BASE_RUN_CREATED_AT" ]]; then
+                echo "::error::More than $MAX_RECOVERY_RUNS successful manual recoveries exist after the push baseline"
+                exit 1
+              fi
+
+              RECOVERY_RUNS=$(jq --arg baseline "$BASE_RUN_CREATED_AT" --arg repository "${{ github.repository }}" '
+                [.workflow_runs[]
+                  | select(.created_at > $baseline)
+                  | select(.head_branch == "main")
+                  | select(.head_repository.full_name == $repository)
+                  | {runId: .id, headSha: .head_sha}]
+              ' <<< "$RUNS_RESPONSE")
+
+              while IFS=$'\t' read -r run_id run_head; do
+                [ -n "$run_id" ] || continue
+                ARTIFACTS=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/artifacts?per_page=100")
+                ARTIFACT_COUNT=$(jq '[.artifacts[] | select(.name == "synced-slugs" and .expired == false)] | length' <<< "$ARTIFACTS")
+                if [ "$ARTIFACT_COUNT" -eq 0 ]; then
+                  continue
+                fi
+                if [ "$ARTIFACT_COUNT" -ne 1 ]; then
+                  echo "::error::Recovery run $run_id has duplicate synced-slugs artifacts"
+                  exit 1
+                fi
+
+                ARTIFACT=$(jq -c '[.artifacts[] | select(.name == "synced-slugs" and .expired == false)][0]' <<< "$ARTIFACTS")
+                artifact_id=$(jq -r '.id' <<< "$ARTIFACT")
+                artifact_digest=$(jq -r '.digest // ""' <<< "$ARTIFACT")
+                artifact_size=$(jq -r '.size_in_bytes // 0' <<< "$ARTIFACT")
+                if [ "$artifact_size" -le 0 ] || [ "$artifact_size" -gt 1048576 ]; then
+                  echo "::error::Recovery artifact $artifact_id has invalid bounded size: $artifact_size"
+                  exit 1
+                fi
+
+                ZIP_PATH="$RUNNER_TEMP/recovered-sync-$run_id.zip"
+                gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > "$ZIP_PATH"
+                actual_digest="sha256:$(sha256sum "$ZIP_PATH" | cut -d' ' -f1)"
+                if [ "$actual_digest" != "$artifact_digest" ]; then
+                  echo "::error::Recovery artifact $artifact_id digest mismatch"
+                  exit 1
+                fi
+                if [ "$(unzip -Z1 "$ZIP_PATH")" != "synced-slugs.txt" ]; then
+                  echo "::error::Recovery artifact $artifact_id has an unexpected archive manifest"
+                  exit 1
+                fi
+
+                SLUGS_JSON=$(unzip -p "$ZIP_PATH" synced-slugs.txt | jq -Rs '
+                  split("\n") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))
+                ')
+                NEXT_RECOVERIES=$(mktemp "$RUNNER_TEMP/recovered-syncs.XXXXXX")
+                jq \
+                  --argjson runId "$run_id" \
+                  --arg headSha "$run_head" \
+                  --argjson artifactId "$artifact_id" \
+                  --arg digest "$artifact_digest" \
+                  --argjson slugs "$SLUGS_JSON" \
+                  '. + [{runId: $runId, headSha: $headSha, artifactId: $artifactId, digest: $digest, slugs: $slugs}]' \
+                  "$RECOVERIES_FILE" > "$NEXT_RECOVERIES"
+                mv "$NEXT_RECOVERIES" "$RECOVERIES_FILE"
+              done < <(jq -r '.[] | [.runId, .headSha] | @tsv' <<< "$RECOVERY_RUNS")
+            fi
+
             CHANGED=$(node ./scripts/detect-changed-skills.mjs \
               --base "$BASE_SHA" \
-              --head "$HEAD_SHA")
+              --head "$HEAD_SHA" \
+              --recoveries "$RECOVERIES_FILE")
             echo "mode=incremental" >> $GITHUB_OUTPUT
             echo "Diff range: $BASE_SHA..$HEAD_SHA"
           fi
@@ -676,7 +755,7 @@ jobs:
         with:
           name: synced-slugs
           path: synced-slugs.txt
-          retention-days: 1
+          retention-days: 30
 
   # ============================================================
   # CALCULATE QUALITY SCORES

--- a/scripts/detect-changed-skills.mjs
+++ b/scripts/detect-changed-skills.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { posix } from 'node:path';
 import { pathToFileURL } from 'node:url';
+
+const SHA256_DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const SHA_RE = /^[0-9a-f]{40}$/;
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 
 function readOption(args, name) {
   const index = args.indexOf(name);
@@ -19,6 +24,57 @@ function gitPaths(repositoryRoot, args) {
     maxBuffer: 64 * 1024 * 1024,
   });
   return output.toString('utf8').split('\0').filter(Boolean);
+}
+
+function gitText(repositoryRoot, args) {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function exactCommit(repositoryRoot, commit, label) {
+  if (!SHA_RE.test(commit)) throw new Error(`${label} is not an exact commit SHA`);
+  const resolved = gitText(repositoryRoot, ['rev-parse', '--verify', `${commit}^{commit}`]);
+  if (resolved !== commit) throw new Error(`${label} did not resolve exactly`);
+  return resolved;
+}
+
+function isAncestor(repositoryRoot, ancestor, head) {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', ancestor, head], {
+      cwd: repositoryRoot,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function treeObject(repositoryRoot, commit, skillPath) {
+  try {
+    const oid = gitText(repositoryRoot, ['rev-parse', '--verify', `${commit}:skills/${skillPath}`]);
+    return gitText(repositoryRoot, ['cat-file', '-t', oid]) === 'tree' ? oid : null;
+  } catch {
+    return null;
+  }
+}
+
+function reportSlug(repositoryRoot, commit, skillPath) {
+  try {
+    const report = JSON.parse(gitText(repositoryRoot, [
+      'show',
+      `${commit}:skills/${skillPath}/skill-report.json`,
+    ]));
+    return typeof report?.meta?.slug === 'string' && SLUG_RE.test(report.meta.slug)
+      ? report.meta.slug
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 export function publishedSkillDirectory(reportPath) {
@@ -84,11 +140,71 @@ export function detectChangedSkillPathsFromGit({ repositoryRoot = '.', base, hea
   return resolveChangedSkillPaths(changedPaths, headPaths);
 }
 
+export function filterRecoveredSkillPathsFromGit({
+  repositoryRoot = '.',
+  head,
+  skillPaths,
+  recoveries,
+}) {
+  const exactHead = exactCommit(repositoryRoot, head, 'head');
+  if (!Array.isArray(skillPaths) || !Array.isArray(recoveries) || recoveries.length > 100) {
+    throw new Error('recovery filter input is invalid or exceeds 100 runs');
+  }
+
+  const headsBySlug = new Map();
+  for (const recovery of recoveries) {
+    if (!Number.isSafeInteger(recovery?.runId) || recovery.runId <= 0
+      || !Number.isSafeInteger(recovery?.artifactId) || recovery.artifactId <= 0
+      || !SHA256_DIGEST_RE.test(recovery?.digest ?? '')
+      || !Array.isArray(recovery?.slugs)
+      || recovery.slugs.length === 0
+      || recovery.slugs.length > 25) {
+      throw new Error('recovery manifest contains invalid run or artifact evidence');
+    }
+    const recoveryHead = exactCommit(repositoryRoot, recovery.headSha, `recovery run ${recovery.runId} head`);
+    if (!isAncestor(repositoryRoot, recoveryHead, exactHead)) continue;
+
+    const uniqueSlugs = new Set();
+    for (const slug of recovery.slugs) {
+      if (typeof slug !== 'string' || !SLUG_RE.test(slug)) {
+        throw new Error(`invalid recovery slug in run ${recovery.runId}`);
+      }
+      if (uniqueSlugs.has(slug)) throw new Error(`duplicate recovery slug in run ${recovery.runId}: ${slug}`);
+      uniqueSlugs.add(slug);
+      if (!headsBySlug.has(slug)) headsBySlug.set(slug, new Set());
+      headsBySlug.get(slug).add(recoveryHead);
+    }
+  }
+
+  return [...new Set(skillPaths)].filter((skillPath) => {
+    if (publishedSkillDirectory(`skills/${skillPath}/skill-report.json`) !== skillPath) {
+      throw new Error(`invalid changed skill path: ${skillPath}`);
+    }
+    const slug = reportSlug(repositoryRoot, exactHead, skillPath);
+    const currentTree = treeObject(repositoryRoot, exactHead, skillPath);
+    if (!slug || !currentTree) return true;
+    return ![...(headsBySlug.get(slug) ?? [])]
+      .some((recoveryHead) => treeObject(repositoryRoot, recoveryHead, skillPath) === currentTree);
+  }).sort();
+}
+
 function main() {
   const args = process.argv.slice(2);
   const base = readOption(args, '--base');
   const head = readOption(args, '--head');
-  const changedSkills = detectChangedSkillPathsFromGit({ base, head });
+  const recoveriesIndex = args.indexOf('--recoveries');
+  const recoveriesPath = recoveriesIndex >= 0 ? args[recoveriesIndex + 1] : null;
+  if (recoveriesIndex >= 0 && (!recoveriesPath || recoveriesPath.startsWith('--'))) {
+    throw new Error('missing required option --recoveries');
+  }
+  const detected = detectChangedSkillPathsFromGit({ base, head });
+  const changedSkills = recoveriesPath
+    ? filterRecoveredSkillPathsFromGit({
+        head,
+        skillPaths: detected,
+        recoveries: JSON.parse(readFileSync(recoveriesPath, 'utf8')),
+      })
+    : detected;
   process.stdout.write(`${changedSkills.join(' ')}\n`);
 }
 

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -128,6 +128,22 @@ test('incremental detection resolves both sides from pinned Git trees', () => {
   assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
 });
 
+test('incremental detection subtracts only verified successful manual recovery artifacts', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const lastSync = section(workflow, '      - name: Find last successful sync commit', '      - name: Detect changed skills');
+  const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+
+  assert.match(lastSync, /status=success&event=push/);
+  assert.doesNotMatch(lastSync, /status=success&event=workflow_dispatch/);
+  assert.match(detect, /status=success&event=workflow_dispatch/);
+  assert.match(detect, /synced-slugs/);
+  assert.match(detect, /sha256sum/);
+  assert.match(detect, /artifact_digest/);
+  assert.match(detect, /--recoveries "\$RECOVERIES_FILE"/);
+  assert.match(detect, /MAX_RECOVERY_RUNS=100/);
+  assert.match(workflow, /retention-days: 30/);
+});
+
 test('sync normalizes a retained sparse checkout before invoking pinned-tree resolvers', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const checkout = section(workflow, '      - name: Checkout repository', '      - name: Generate GitHub App Token');

--- a/scripts/tests/detect-changed-skills.test.mjs
+++ b/scripts/tests/detect-changed-skills.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   detectChangedSkillPathsFromGit,
+  filterRecoveredSkillPathsFromGit,
   resolveChangedSkillPaths,
 } from '../detect-changed-skills.mjs';
 
@@ -62,6 +63,66 @@ test('uses pinned commit trees instead of the mutable runner working tree', () =
     assert.deepEqual(
       detectChangedSkillPathsFromGit({ repositoryRoot, base, head }),
       ['owner/demo'],
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('subtracts only successful manual recovery slugs whose pinned skill tree is unchanged', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'recovered-sync-git-'));
+  try {
+    git(repositoryRoot, ['init', '--initial-branch=main']);
+    git(repositoryRoot, ['config', 'user.name', 'Skillstore Test']);
+    git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
+
+    write(repositoryRoot, 'skills/owner/recovered/SKILL.md', '# Recovered\n');
+    write(repositoryRoot, 'skills/owner/recovered/skill-report.json', JSON.stringify({
+      meta: { slug: 'owner-recovered' },
+    }));
+    write(repositoryRoot, 'skills/owner/changed/SKILL.md', '# Before\n');
+    write(repositoryRoot, 'skills/owner/changed/skill-report.json', JSON.stringify({
+      meta: { slug: 'owner-changed' },
+    }));
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'manual recovery tree']);
+    const recoveryHead = git(repositoryRoot, ['rev-parse', 'HEAD']);
+
+    write(repositoryRoot, 'skills/owner/changed/SKILL.md', '# After\n');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'later skill change']);
+    const head = git(repositoryRoot, ['rev-parse', 'HEAD']);
+
+    assert.deepEqual(
+      filterRecoveredSkillPathsFromGit({
+        repositoryRoot,
+        head,
+        skillPaths: ['owner/recovered', 'owner/changed'],
+        recoveries: [{
+          runId: 123,
+          headSha: recoveryHead,
+          artifactId: 456,
+          digest: `sha256:${'a'.repeat(64)}`,
+          slugs: ['owner-recovered', 'owner-changed'],
+        }],
+      }),
+      ['owner/changed'],
+    );
+
+    assert.throws(
+      () => filterRecoveredSkillPathsFromGit({
+        repositoryRoot,
+        head,
+        skillPaths: ['owner/recovered'],
+        recoveries: [{
+          runId: 123,
+          headSha: recoveryHead,
+          artifactId: 456,
+          digest: `sha256:${'a'.repeat(64)}`,
+          slugs: ['owner-recovered', 'owner-recovered'],
+        }],
+      }),
+      /duplicate recovery slug/,
     );
   } finally {
     rmSync(repositoryRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- keep successful push runs as the only automatic watermark
- subtract only successful manual `synced-slugs` artifacts whose SHA-256 digest is verified and whose complete Skill Git tree is unchanged
- retain the 25-Skill admission cap and extend recovery artifact retention to 30 days

## Evidence
- failures 30265264660 / 30265267932 repeatedly detected 41 / 42 targets from stale push baseline `f9e2c34b...`
- actual recovery artifacts 30229910140 + 30319626311 reduce the exact current backlog from 42 to only `101-skills/agent-browser` and `starchild-ai-agent/treasures`

## Tests
- `CI=true node --test scripts/tests/detect-changed-skills.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` (16/16)
- `node --check scripts/detect-changed-skills.mjs`
- workflow YAML parse and `git diff --check`
- exact production-shaped check: detected 42, verified recovered 40, remaining 2