### PR TITLE
fix(submissions): reject overlapping skill paths early

### DIFF
--- a/scripts/submission-selection-plan.mjs
+++ b/scripts/submission-selection-plan.mjs
@@ -41,6 +41,7 @@ function validateSkills(skills) {
   const slugs = new Set();
   const paths = new Set();
   const foldedPaths = new Set();
+  const validatedPaths = [];
   for (const [index, skill] of skills.entries()) {
     if (!skill || typeof skill !== 'object' || Array.isArray(skill)
       || JSON.stringify(Object.keys(skill).sort()) !== JSON.stringify(['path', 'slug'])) {
@@ -53,9 +54,17 @@ function validateSkills(skills) {
     if (paths.has(path)) fail(`selection plan has duplicate path ${path}`);
     const foldedPath = path.normalize('NFC').toLocaleLowerCase('en-US');
     if (foldedPaths.has(foldedPath)) fail(`selection plan has an NFC/case-fold path collision at ${path}`);
+    for (const previous of validatedPaths) {
+      if (previous.foldedPath === '.' || foldedPath === '.'
+        || foldedPath.startsWith(`${previous.foldedPath}/`)
+        || previous.foldedPath.startsWith(`${foldedPath}/`)) {
+        fail(`selection plan skill paths overlap: ${previous.path} and ${path}`);
+      }
+    }
     slugs.add(skill.slug);
     paths.add(path);
     foldedPaths.add(foldedPath);
+    validatedPaths.push({ path, foldedPath });
   }
   return skills.map(({ slug, path }) => ({ slug, path }));
 }

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -366,6 +367,38 @@ test('an invalid selection plan still produces an uploadable diagnostic manifest
   ]);
   assert.equal(result.status, 0, result.stderr);
   assert.equal(readFileSync(join(resultDir, 'selection-plan.invalid.json'), 'utf8'), '{not-json\n');
+  const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
+  assert.equal(manifest.reasonCode, 'process_step_failed');
+  assert.equal(manifest.selectionPlan, null);
+}));
+
+test('overlapping skill paths fail before the submission CLI is invoked', () => withTempDirectory((root) => {
+  const fakeCli = join(root, 'fake-cli.sh');
+  const invoked = join(root, 'cli-invoked');
+  const resultDir = join(root, 'result');
+  const selectionPlan = writeSelectionPlan(root, [
+    { slug: 'monad', path: 'skills/monad' },
+    { slug: 'addresses', path: 'skills/monad/addresses' },
+  ]);
+  writeFileSync(fakeCli, '#!/usr/bin/env bash\nset -eu\ntouch "$CLI_INVOKED"\nexit 23\n');
+  chmodSync(fakeCli, 0o755);
+
+  const result = runNode(processShardScript, [
+    '--cli', fakeCli,
+    '--github-url', 'https://github.com/starchild-ai-agent/official-skills',
+    '--selection-plan', selectionPlan,
+    '--result-dir', resultDir,
+    '--marketplace-repo', 'aiskillstore/marketplace',
+    '--shard-index', '0',
+    '--retry-delay-ms', '0',
+  ], { env: { CLI_INVOKED: invoked } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(invoked), false, 'invalid overlapping plan must not invoke the CLI');
+  assert.match(
+    readFileSync(join(resultDir, 'process-output-0.log'), 'utf8'),
+    /selection plan skill paths overlap: skills\/monad and skills\/monad\/addresses/,
+  );
   const manifest = JSON.parse(readFileSync(join(resultDir, 'shard-manifest.json'), 'utf8'));
   assert.equal(manifest.reasonCode, 'process_step_failed');
   assert.equal(manifest.selectionPlan, null);

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -179,6 +179,22 @@ test('selection plan repository accepts canonical punctuation but rejects leadin
   }
 });
 
+test('selection plans reject overlapping parent and child skill paths', () => {
+  const base = {
+    schemaVersion: 1,
+    repository: 'starchild-ai-agent/official-skills',
+    sourceCommit: MAIN_SHA,
+    scope: { path: 'monad', reason: 'explicit_path' },
+  };
+  assert.throws(() => validateSelectionPlan({
+    ...base,
+    skills: [
+      { slug: 'monad', path: 'monad' },
+      { slug: 'addresses', path: 'monad/addresses' },
+    ],
+  }), /selection plan skill paths overlap: monad and monad\/addresses/);
+});
+
 test('repository-root discovery honors the Codex plugin publication scope and reports ignored mirrors', () => withDirectory((root) => {
   mkdirSync(join(root, '.codex-plugin'), { recursive: true });
   mkdirSync(join(root, 'skills', 'public-one'), { recursive: true });


### PR DESCRIPTION
## Summary

- reject ancestor/descendant Skill paths in the shared immutable selection-plan validator before CLI or AI processing
- cover the exact monad/addresses regression from run 30261175116
- keep aggregate canonical-path, symlink, hash, and fail-closed validation unchanged

## Verification

- Red: focused unit test reported Missing expected exception; shard-boundary test proved the CLI was invoked
- Green: CI=true focused tests: 2/2
- Related unit and submission-boundary suite: 80/80
- Exact upstream fixture starchild-ai-agent/official-skills@488c1366: 11 discovered, rejected at planning on monad and monad/addresses
- git diff --check

Original failure: https://github.com/aiskillstore/marketplace/actions/runs/30261175116