### PR TITLE
fix(data): restore official frontend-design identity

### DIFF
--- a/skills/frontend-design/skill-report.json
+++ b/skills/frontend-design/skill-report.json
@@ -7,7 +7,7 @@
     "source_ref": "main",
     "model": "codex",
     "analysis_version": "3.0.0",
-    "source_type": "community",
+    "source_type": "official",
     "content_hash": "1608ea77fbb6fc30d13a97d12cfa8ebf31358d40f0dd97beed24829d6b3f45dd",
     "tree_hash": "906e25bc4b8264589a3f9427a3713993ee5d11a1b7ca0af8a247a4f83816a4ce",
     "provenance": {


### PR DESCRIPTION
## Summary

- restore the historical `official` source identity for the flat `frontend-design` Skill
- preserve exact source URL, content hash, tree hash, and security audit bytes
- allow duplicate submission classification to reject the already-published official Skill without treating the report as malformed

## Evidence

- original report was official from `anthropics/claude-code`; audit PR #2225 changed only this identity to `community`
- failed submission run: https://github.com/aiskillstore/marketplace/actions/runs/30261178901
- callback persisted `rejected`; no unsafe input was published

## Verification

- `CI=true node --test scripts/tests/submission-existing-targets.test.mjs` (23/23)
- exact content hash `1608ea77f...` and tree hash `906e25bc4...` verified
- `git diff --check`