### PR TITLE
fix(actions): retry submission aggregation clone

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -754,7 +754,18 @@ jobs:
           fi
 
           echo "📦 Cloning fresh repository to $WORK_DIR..."
-          git clone --depth 1 "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" "$WORK_DIR"
+          for CLONE_ATTEMPT in 1 2 3; do
+            rm -rf "$WORK_DIR"
+            if git clone --depth 1 "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git" "$WORK_DIR"; then
+              break
+            fi
+            if [ "$CLONE_ATTEMPT" -eq 3 ]; then
+              echo "::error::Fresh aggregation clone failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Fresh aggregation clone failed; retrying attempt $((CLONE_ATTEMPT + 1))/3"
+            sleep "$((CLONE_ATTEMPT * 5))"
+          done
           cd "$WORK_DIR"
 
           git config user.name "ai-skill-store[bot]"

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -239,6 +239,16 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   );
 });
 
+test('aggregation retries a transient fresh-clone failure without reusing a partial checkout', () => {
+  const aggregation = extractRunBlock(reusable, 'Merge results and create PR');
+
+  assert.match(aggregation, /for CLONE_ATTEMPT in 1 2 3/);
+  assert.match(aggregation, /rm -rf "\$WORK_DIR"/);
+  assert.match(aggregation, /git clone --depth 1/);
+  assert.match(aggregation, /sleep "\$\(\(CLONE_ATTEMPT \* 5\)\)"/);
+  assert.match(aggregation, /exit 1/);
+});
+
 test('all submission audit entrypoints pass the existing HELM credential through the reusable secret contract', () => {
   for (const [name, workflow] of [
     ['repository dispatch', caller],


### PR DESCRIPTION
Root cause: a transient GitHub TLS failure aborted the fresh aggregation clone after shard processing had already succeeded.

Changes:
- retry the idempotent fresh clone up to 3 times
- delete any partial checkout before each attempt
- keep final failure fail-closed

Verification:
- CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs (48/48)
- workflow action-pin and runner-safety tests (29/29)
- immutable action pin and runner policy checks passed