### PR TITLE
fix(actions): retry submission source metadata

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -209,9 +209,24 @@ jobs:
           REPOSITORY_ID=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
             --github-url "$SUBMISSION_URL" --repository-only)
           OWNER_REPO=$(jq -er '"\(.owner)/\(.repo)"' <<< "$REPOSITORY_ID")
-          DEFAULT_REF=$(gh api "repos/$OWNER_REPO" --jq '.default_branch')
           REFS_FILE="${RUNNER_TEMP:?}/submission-refs-${{ github.run_id }}-${{ github.run_attempt }}.txt"
-          git ls-remote --heads --tags "https://github.com/$OWNER_REPO.git" > "$REFS_FILE"
+          DEFAULT_REF=''
+          for SOURCE_METADATA_ATTEMPT in 1 2 3; do
+            rm -f "$REFS_FILE"
+            if DEFAULT_REF=$(gh api "repos/$OWNER_REPO" --jq '.default_branch') \
+              && git ls-remote --heads --tags "https://github.com/$OWNER_REPO.git" > "$REFS_FILE"; then
+              break
+            fi
+            rm -f "$REFS_FILE"
+            if [ "$SOURCE_METADATA_ATTEMPT" -eq 3 ]; then
+              echo "::error::Source metadata lookup failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Source metadata lookup failed; retrying attempt $((SOURCE_METADATA_ATTEMPT + 1))/3"
+            sleep "$((SOURCE_METADATA_ATTEMPT * 5))"
+          done
+          test -n "$DEFAULT_REF"
+          test -s "$REFS_FILE"
           RESOLVED=$(node "$GITHUB_WORKSPACE/scripts/resolve-submission-source.mjs" \
             --github-url "$SUBMISSION_URL" \
             --default-ref "$DEFAULT_REF" \

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -343,6 +343,16 @@ test('clone step accepts repository-root false and explicit-path true without we
   assert.notEqual(invalid.status, 0);
 });
 
+test('submission source metadata lookup retries transient GitHub failures', () => {
+  const clone = extractRunBlock(reusable, 'Clone source repository');
+
+  assert.match(clone, /for SOURCE_METADATA_ATTEMPT in 1 2 3/);
+  assert.match(clone, /DEFAULT_REF=\$\(gh api "repos\/\$OWNER_REPO" --jq '\.default_branch'\)/);
+  assert.match(clone, /git ls-remote --heads --tags .* > "\$REFS_FILE"/);
+  assert.match(clone, /Source metadata lookup failed; retrying attempt/);
+  assert.match(clone, /test -s "\$REFS_FILE"/);
+});
+
 test('repository dispatch caller preserves reusable failure and callback status contracts', () => {
   assert.match(caller, /notify:\n\s+needs: process-skills\n\s+if: always\(\) && github\.event_name == 'repository_dispatch'/);
   assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);


### PR DESCRIPTION
## Root cause

Two Process Skill Submission runs failed before discovery because the shared source step made a single `gh api` request during a self-hosted-runner TLS failure wave.

## Fix

Retry the existing idempotent default-branch and refs lookup up to three times, removing partial refs output between attempts. All source identity, hash, path, symlink, and publication gates remain unchanged.

## Verification

- Red: focused workflow test failed because no metadata retry existed
- Green: `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs` (49/49)