### PR TITLE
fix(actions): filter submission discovery checkout

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1
+          filter: blob:none
           clean: true
           persist-credentials: false
 

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -161,8 +161,11 @@ test('process checkout clears inherited sparse state before cloning the immutabl
     assert.equal(existsSync(join(fixture.workspace, 'schemas/skill-report.schema.json')), true);
     assert.equal(run('git', ['-C', fixture.workspace, 'config', '--bool', 'core.sparseCheckout'], { allowFailure: true }).stdout.trim(), '');
 
-    assert.match(reusable, /ref: \$\{\{ github\.workflow_sha \}\}/);
-    assert.match(reusable, /fetch-depth: 1/);
+    const checkout = extractNamedBlock(reusable, '- name: Checkout immutable discovery runtime');
+    assert.match(checkout, /ref: \$\{\{ github\.workflow_sha \}\}/);
+    assert.match(checkout, /fetch-depth: 1/);
+    assert.match(checkout, /filter: blob:none/);
+    assert.doesNotMatch(checkout, /sparse-checkout:/);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Root cause

The reusable discovery job downloaded every blob in the 36k-file Marketplace repository. During the current TLS/HTTP2 failure wave, all three built-in checkout attempts repeatedly failed mid-pack before source discovery.

## Fix

Use Git partial clone `filter: blob:none` for this read-only discovery checkout. The complete tree remains available and immutable runtime files are fetched on demand and hash-verified exactly as before. No sparse checkout or validation gate is changed.

## Verification

- Red: focused test failed because the checkout did not use the partial-clone filter
- Green: `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs` (49/49)