### PR TITLE
fix(data): register remaining zhuangxiu path aliases

### DIFF
--- a/governance/submission-slug-aliases.json
+++ b/governance/submission-slug-aliases.json
@@ -57,6 +57,12 @@
     },
     {
       "repository": "zx029w/zhuangxiu-skills",
+      "path": "装修水电避坑指南",
+      "expectedName": "装修水电避坑指南",
+      "baseSlug": "zhuangxiu-shuidian-bikeng"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
       "path": "装修避坑问答",
       "expectedName": "装修避坑问答",
       "baseSlug": "zhuangxiu-bikeng-wenda"
@@ -72,6 +78,12 @@
       "path": "装修增项避雷",
       "expectedName": "装修增项避雷",
       "baseSlug": "zhuangxiu-zengxiang-bilei"
+    },
+    {
+      "repository": "zx029w/zhuangxiu-skills",
+      "path": "适童化装修指南",
+      "expectedName": "适童化装修指南",
+      "baseSlug": "shictonghua-zhuangxiu-zhinan"
     }
   ]
 }

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test } from 'node:test';
@@ -12,6 +12,10 @@ import { validateSelectionPlan } from '../submission-selection-plan.mjs';
 
 const MAIN_SHA = '1'.repeat(40);
 const READY_SHA = '2'.repeat(40);
+const SLUG_ALIAS_REGISTRY = JSON.parse(readFileSync(
+  new URL('../../governance/submission-slug-aliases.json', import.meta.url),
+  'utf8',
+));
 
 function refs(...entries) {
   return `${entries.map(([sha, ref]) => `${sha}\t${ref}`).join('\n')}\n`;
@@ -406,6 +410,25 @@ test('pure Chinese path and frontmatter use an exact repository-bound alias', ()
     repository: 'zx029w/zhuangxiu-skills',
   }), /no verified path alias/);
 }));
+
+test('the zhuangxiu registry covers the current Chinese-only submission paths', () => {
+  for (const [path, baseSlug] of [
+    ['装修水电避坑指南', 'zhuangxiu-shuidian-bikeng'],
+    ['适童化装修指南', 'shictonghua-zhuangxiu-zhinan'],
+  ]) {
+    withDirectory((root) => {
+      mkdirSync(join(root, path));
+      writeFileSync(join(root, path, 'SKILL.md'), `---\nname: ${path}\n---\n`);
+      assert.deepEqual(discoverSubmissionSkills({
+        sourceDir: root,
+        skillPath: path,
+        explicitPath: true,
+        repository: 'zx029w/zhuangxiu-skills',
+        slugAliasRegistry: SLUG_ALIAS_REGISTRY,
+      }).skills, [{ slug: baseSlug, path }]);
+    });
+  }
+});
 
 test('aliases cannot override ASCII identities and exact expected names fail closed', () => withDirectory((root) => {
   mkdirSync(join(root, 'skill'));


### PR DESCRIPTION
## Root cause

The repository-bound alias registry covered 12 of 14 Chinese-only paths in `zx029w/zhuangxiu-skills`. Discovery therefore failed closed on the first uncovered path, `装修水电避坑指南`, in run 30507497536.

## Fix

- Register the two missing exact path/name identities.
- Use their upstream `identifier` values as the canonical ASCII base slugs.
- Add a regression that loads the real registry and resolves both paths.

No slug derivation, hash, symlink, selection-plan, or publication validation was relaxed.

## Verification

- Red: focused test failed with `装修水电避坑指南/SKILL.md resolves to an empty slug and has no verified path alias`.
- Green: 83/83 focused submission tests pass with `CI=true`.
- Exact upstream SHA `ac43d40e0dc986457d51f5a92fc48ef677fcd236`: 14 physical skills, 14 selected; both new paths resolve to their exact registered slugs.
