### PR TITLE
fix(actions): avoid hydrating sparse workspaces during cleanup

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -159,11 +159,6 @@ jobs:
             exit 1
           fi
           cd "${RUNNER_TEMP:?}"
-          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-          fi
           find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
 
@@ -579,11 +574,6 @@ jobs:
           fi
 
           cd "${RUNNER_TEMP:?}"
-          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-          fi
           find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
 
@@ -799,11 +789,6 @@ jobs:
             exit 1
           fi
           cd "${RUNNER_TEMP:?}"
-          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-          fi
           find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
 

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -147,6 +147,11 @@ test('discovery checkout fetches only immutable runtime blobs before exact targe
     writeFileSync(join(fixture.workspace, 'stale-runner-file'), 'stale\n');
 
     const reset = extractRunBlock(reusable, 'Clear inherited marketplace checkout');
+    assert.doesNotMatch(
+      reset,
+      /sparse-checkout disable/,
+      'clearing a partial clone must not hydrate omitted blobs before deletion',
+    );
     run('bash', ['-c', reset], {
       cwd: fixture.workspace,
       env: {


### PR DESCRIPTION
## Root cause

Each submission job clears the persistent self-hosted workspace before creating the new sparse checkout. The clear step first ran `git sparse-checkout disable` on the previous partial clone. That command materializes omitted paths and can lazily download the full 36k-file Marketplace tree before deletion, recreating the GnuTLS/early-EOF failure and leaving runners offline in the cleanup step.

## Fix

Delete the workspace contents directly from `RUNNER_TEMP` without disabling sparse checkout first. The existing exact-workspace guard, bounded top-level deletion, empty-workspace assertion, immutable sparse fetch, required-file SHA checks, path validation, and symlink/hash gates remain unchanged.

## Verification

- Red: focused workflow test failed because the cleanup block contained `sparse-checkout disable`.
- Green: 83/83 focused submission unit/workflow tests pass with `CI=true`.
- Diff removes 15 lines and adds one regression assertion; no dependency or validation relaxation.
