### PR TITLE
fix(actions): classify aliased published targets

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -436,6 +436,7 @@ jobs:
           CLASSIFICATION=$(node "$GITHUB_WORKSPACE/scripts/classify-submission-targets.mjs" \
             --marketplace-root "$GITHUB_WORKSPACE" \
             --selection-plan "$PLAN_FILE" \
+            --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json" \
             --source-ref "$SOURCE_REF")
           DISPOSITION=$(jq -er '.disposition' <<< "$CLASSIFICATION")
           REASON_CODE=$(jq -er '.reasonCode' <<< "$CLASSIFICATION")

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -7,6 +7,7 @@ import {
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { validateSlugAliasRegistry } from './discover-submission-skills.mjs';
 import { parseSelectionPlan, validateSelectionPlan } from './submission-selection-plan.mjs';
 
 const SOURCE_TYPES = new Set(['community', 'official']);
@@ -233,8 +234,8 @@ function validateCandidate(candidate, identity) {
   if (report?.meta?.slug !== expectedReportSlug) {
     fail(`published target report slug mismatch at ${reportPath}: expected ${expectedReportSlug}`);
   }
-  if (report?.skill?.name !== identity.slug) {
-    fail(`published target skill name mismatch at ${reportPath}: expected ${identity.slug}`);
+  if (report?.skill?.name !== identity.expectedName) {
+    fail(`published target skill name mismatch at ${reportPath}: expected ${identity.expectedName}`);
   }
   if (candidate.layout === 'community') {
     if (report.meta.source_type !== 'community') {
@@ -260,7 +261,12 @@ function assertNoPendingCollision(root, owner, slug) {
   }
 }
 
-export function classifySubmissionTargets({ marketplaceRoot, selectionPlan, sourceRef }) {
+export function classifySubmissionTargets({
+  marketplaceRoot,
+  selectionPlan,
+  sourceRef,
+  slugAliasRegistry = { schemaVersion: 1, aliases: [] },
+}) {
   const plan = typeof selectionPlan === 'string'
     ? parseSelectionPlan(selectionPlan)
     : validateSelectionPlan(selectionPlan);
@@ -269,11 +275,18 @@ export function classifySubmissionTargets({ marketplaceRoot, selectionPlan, sour
   if (typeof sourceRef !== 'string' || sourceRef === '') fail('source ref must be a non-empty string');
 
   const [owner] = plan.repository.split('/');
+  const aliases = new Map(validateSlugAliasRegistry(slugAliasRegistry)
+    .filter((alias) => alias.repository === plan.repository)
+    .map((alias) => [alias.path, alias]));
   const expectedLayout = OFFICIAL_REPOSITORIES.has(plan.repository) ? 'official' : 'community';
   const existingTargets = [];
   const newTargets = [];
 
   for (const skill of plan.skills) {
+    const alias = aliases.get(skill.path);
+    if (alias && alias.baseSlug !== skill.slug) {
+      fail(`slug alias does not match planned slug for ${skill.path}: expected ${alias.baseSlug}`);
+    }
     assertNoPendingCollision(root, owner, skill.slug);
     const identity = {
       repository: plan.repository,
@@ -281,6 +294,7 @@ export function classifySubmissionTargets({ marketplaceRoot, selectionPlan, sour
       skillPath: skill.path,
       owner,
       slug: skill.slug,
+      expectedName: alias?.expectedName ?? skill.slug,
     };
     const candidates = [
       {
@@ -354,10 +368,12 @@ export function classifySubmissionTargets({ marketplaceRoot, selectionPlan, sour
 function main() {
   const args = process.argv.slice(2);
   const selectionPlanPath = option(args, '--selection-plan');
+  const slugAliasesPath = option(args, '--slug-aliases-file');
   const result = classifySubmissionTargets({
     marketplaceRoot: option(args, '--marketplace-root'),
     selectionPlan: readFileSync(selectionPlanPath, 'utf8'),
     sourceRef: option(args, '--source-ref'),
+    slugAliasRegistry: JSON.parse(readFileSync(slugAliasesPath, 'utf8')),
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -46,13 +46,14 @@ function writeTarget(root, slug, {
   skillPath = `skills/${slug}`,
   malformed = false,
   targetOwner = 'example',
+  skillName = slug,
   sourceUrl = null,
   schemaValid = true,
 } = {}) {
   const relative = layout === 'community' ? `skills/${targetOwner}/${slug}` : `skills/${slug}`;
   const directory = join(root, ...relative.split('/'));
   mkdirSync(directory, { recursive: true });
-  writeFileSync(join(directory, 'SKILL.md'), `---\nname: ${slug}\n---\n`);
+  writeFileSync(join(directory, 'SKILL.md'), `---\nname: ${skillName}\n---\n`);
   if (malformed) {
     writeFileSync(join(directory, 'skill-report.json'), '{not-json\n');
   } else {
@@ -69,7 +70,7 @@ function writeTarget(root, slug, {
         source_type: layout === 'community' ? 'community' : 'official',
       },
       skill: {
-        name: slug,
+        name: skillName,
         author: layout === 'community' ? targetOwner : owner,
         description: 'fixture',
         supported_tools: ['codex'],
@@ -130,6 +131,30 @@ test('all exact community targets become a handled rejection', () => withMarketp
     existingCount: 2,
     existingTargets: ['skills/example/alpha', 'skills/example/beta'],
   });
+}));
+
+test('an exact repository-bound alias validates the published display name', () => withMarketplace((root) => {
+  const path = '装修水电避坑指南';
+  const slug = 'zhuangxiu-shuidian-bikeng';
+  const repository = 'zx029w/zhuangxiu-skills';
+  writeTarget(root, slug, {
+    repository,
+    targetOwner: 'zx029w',
+    skillPath: path,
+    skillName: path,
+  });
+  const plan = selectionPlan([{ slug, path }], repository);
+  plan.scope = { reason: 'repository_fallback', path: '.' };
+  const result = classifySubmissionTargets({
+    marketplaceRoot: root,
+    selectionPlan: plan,
+    sourceRef: 'main',
+    slugAliasRegistry: {
+      schemaVersion: 1,
+      aliases: [{ repository, path, expectedName: path, baseSlug: slug }],
+    },
+  });
+  assert.equal(result.disposition, 'all_existing');
 }));
 
 test('an exact official flat target is recognized without weakening community identity', () => withMarketplace((root) => {


### PR DESCRIPTION
## Root cause

Discovery uses the verified repository/path alias registry for Chinese-only names, but existing-target classification still required `report.skill.name === ASCII slug`. Exact legacy zhuangxiu reports correctly retain their Chinese display names, so run 30508729105 failed before it could classify 12 existing and 2 new targets.

## Fix

- Pass the same immutable alias registry into the classifier.
- For an exact repository+path alias, require the report name to equal `expectedName` and require the alias base slug to equal the planned slug.
- Keep the ordinary no-alias contract unchanged (`skill.name === slug`).

Source URL/ref/path, owner, report slug, schema, symlink, pending-collision, and mixed existing/new fail-closed checks remain unchanged.

## Verification

- Red: exact aliased published target failed with `skill name mismatch ... expected zhuangxiu-shuidian-bikeng`.
- Green: 107/107 focused submission tests pass with `CI=true`.
- Real Marketplace CLI boundary recognizes `skills/zx029w/quanwu-dingzhi-bucailei` as an exact existing target using the signed-in registry.
