### PR TITLE
fix(actions): validate verified non-ASCII skill aliases

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -229,12 +229,13 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const matter = require('gray-matter');
+            const { validateSkillName } = require('./scripts/validate-marketplace-skill-name.cjs');
 
             /**
              * Validate that content has valid SKILL.md structure (YAML frontmatter + required fields)
              * Returns array of error messages, empty if valid
              */
-            function validateSkillMdContent(rawContent, dirName) {
+            function validateSkillMdContent(rawContent, dirName, skillMdPath) {
               const errors = [];
 
               // Check for binary content (null bytes)
@@ -267,16 +268,15 @@ jobs:
                 const { data } = matter(rawContent);
 
                 // Check required field: name
-                // Per specification: lowercase alphanumeric + hyphens only, 1-64 chars
-                const NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
                 if (!data.name) {
                   errors.push('Missing required field: name');
                 } else if (typeof data.name !== 'string') {
                   errors.push('Field \"name\" must be a string');
                 } else if (data.name.length > 64) {
                   errors.push('Field \"name\" exceeds 64 characters');
-                } else if (!NAME_PATTERN.test(data.name)) {
-                  errors.push(\`Field \"name\" must be lowercase alphanumeric with hyphens (got: \${data.name})\`);
+                } else {
+                  const nameError = validateSkillName({ repoRoot: process.cwd(), skillMdPath, name: data.name });
+                  if (nameError) errors.push(nameError);
                 }
 
                 // Check required field: description
@@ -321,7 +321,7 @@ jobs:
                 }
 
                 const dirName = path.basename(path.dirname(file));
-                const validationErrors = validateSkillMdContent(content, dirName);
+                const validationErrors = validateSkillMdContent(content, dirName, file);
 
                 if (validationErrors.length > 0) {
                   // Check if it's just a binary skip
@@ -415,8 +415,9 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const matter = require('gray-matter');
+            const { validateSkillName } = require('./scripts/validate-marketplace-skill-name.cjs');
 
-            function validateSkillMdContent(rawContent, dirName) {
+            function validateSkillMdContent(rawContent, dirName, skillMdPath) {
               const errors = [];
               if (rawContent.includes('\\x00')) return ['binary'];
               if (!rawContent.startsWith('---')) {
@@ -430,9 +431,11 @@ jobs:
               }
               try {
                 const { data } = matter(rawContent);
-                const NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
                 if (!data.name) errors.push('Missing name');
-                else if (!NAME_PATTERN.test(data.name)) errors.push('Invalid name format');
+                else {
+                  const nameError = validateSkillName({ repoRoot: process.cwd(), skillMdPath, name: data.name });
+                  if (nameError) errors.push(nameError);
+                }
                 if (!data.description) errors.push('Missing description');
               } catch (e) {
                 errors.push('YAML parse error');
@@ -461,7 +464,7 @@ jobs:
                 const content = fs.readFileSync(file, 'utf8');
                 if (!content.trim()) continue;
                 const dirName = path.basename(path.dirname(file));
-                const errors = validateSkillMdContent(content, dirName);
+                const errors = validateSkillMdContent(content, dirName, file);
                 if (errors.length > 0 && errors[0] !== 'binary') {
                   console.error(\`Still invalid: \${file} - \${errors.join(', ')}\`);
                   hasInvalidFiles = true;

--- a/scripts/tests/validate-marketplace-autofix.test.mjs
+++ b/scripts/tests/validate-marketplace-autofix.test.mjs
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
+
+const require = createRequire(import.meta.url);
+const { validateSkillName } = require('../validate-marketplace-skill-name.cjs');
 
 const workflow = readFileSync('.github/workflows/validate-marketplace.yml', 'utf8');
 
@@ -24,9 +28,75 @@ const rebind = runBlock('Rebind reports to auto-fixed SKILL.md artifacts');
 const rebindReport = runBlock('Rebind reports to auto-fixed skill-report artifacts');
 const verifyReportHashContract = runBlock('Verify skill-report hash contract after auto-fix');
 const verifyChangedReportHashContract = runBlock('Verify changed skill-report hash contracts');
+const validateSkill = runBlock('Validate SKILL.md files have proper YAML frontmatter');
+const revalidateSkill = runBlock('Re-validate SKILL.md after auto-fix');
 const commitSkill = runBlock('Commit auto-fixed SKILL.md artifacts locally');
 const commitReport = runBlock('Commit auto-fixed skill-report.json files locally');
 const publish = runBlock('Publish validated auto-fixes');
+
+test('SKILL.md validation uses the repository-bound alias validator before and after auto-fix', () => {
+  for (const block of [validateSkill, revalidateSkill]) {
+    assert.match(block, /require\('\.\/scripts\/validate-marketplace-skill-name\.cjs'\)/);
+    assert.match(block, /validateSkillName\(\{ repoRoot: process\.cwd\(\), skillMdPath, name: data\.name \}\)/);
+    assert.doesNotMatch(block, /NAME_PATTERN/);
+  }
+});
+
+test('SKILL.md validation accepts the exact checked-in repository identities', () => {
+  const result = spawnSync('bash', ['-c', validateSkill], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, CI: 'true' },
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('SKILL.md validation accepts only an exact source-bound non-ASCII alias', () => {
+  const root = mkdtempSync(join(tmpdir(), 'validate-skill-alias-'));
+  const skillDirectory = join(root, 'pending', 'zx029w', 'zhuangxiu-shuidian-bikeng');
+  const aliasesPath = join(root, 'aliases.json');
+  const reportPath = join(skillDirectory, 'skill-report.json');
+  try {
+    mkdirSync(skillDirectory, { recursive: true });
+    writeFileSync(join(skillDirectory, 'SKILL.md'), '---\nname: 装修水电避坑指南\ndescription: fixture\n---\n');
+    writeFileSync(aliasesPath, `${JSON.stringify({
+      schemaVersion: 1,
+      aliases: [{
+        repository: 'zx029w/zhuangxiu-skills',
+        path: '装修水电避坑指南',
+        expectedName: '装修水电避坑指南',
+        baseSlug: 'zhuangxiu-shuidian-bikeng',
+      }],
+    })}\n`);
+    const report = {
+      meta: {
+        slug: 'zx029w-zhuangxiu-shuidian-bikeng',
+        source_url: `https://github.com/zx029w/zhuangxiu-skills/tree/${'a'.repeat(40)}/${encodeURIComponent('装修水电避坑指南')}`,
+        source_ref: 'a'.repeat(40),
+      },
+      skill: { name: '装修水电避坑指南' },
+    };
+    writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+
+    assert.equal(validateSkillName({
+      repoRoot: root,
+      skillMdPath: join(skillDirectory, 'SKILL.md'),
+      name: '装修水电避坑指南',
+      aliasesPath,
+    }), null);
+
+    report.meta.source_url = `https://github.com/attacker/source/tree/${'a'.repeat(40)}/${encodeURIComponent('装修水电避坑指南')}`;
+    writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+    assert.match(validateSkillName({
+      repoRoot: root,
+      skillMdPath: join(skillDirectory, 'SKILL.md'),
+      name: '装修水电避坑指南',
+      aliasesPath,
+    }), /verified path alias/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test('auto-fix binds final artifact hashes before creating local commits', () => {
   assert.match(rebind, /git diff --name-only -z --diff-filter=ACMRT HEAD/);

--- a/scripts/validate-marketplace-skill-name.cjs
+++ b/scripts/validate-marketplace-skill-name.cjs
@@ -1,0 +1,73 @@
+const { readFileSync } = require('node:fs');
+const { dirname, relative, resolve, sep } = require('node:path');
+
+const CANONICAL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SOURCE_REF = /^[0-9a-f]{40,64}$/;
+
+function invalid(name) {
+  return `Field "name" must be lowercase alphanumeric with hyphens or match an exact verified path alias (got: ${name})`;
+}
+
+function validateSkillName({
+  repoRoot,
+  skillMdPath,
+  name,
+  aliasesPath = 'governance/submission-slug-aliases.json',
+}) {
+  if (typeof name !== 'string') return invalid(String(name));
+  if (CANONICAL_NAME.test(name)) return null;
+
+  const root = resolve(repoRoot);
+  const relativePath = relative(root, resolve(root, skillMdPath)).split(sep).join('/');
+  const [status, owner, baseSlug, file, ...extra] = relativePath.split('/');
+  if (!['pending', 'skills'].includes(status) || !owner || !baseSlug || file !== 'SKILL.md' || extra.length > 0) {
+    return invalid(name);
+  }
+
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(resolve(root, aliasesPath), 'utf8'));
+  } catch {
+    return invalid(name);
+  }
+  if (registry?.schemaVersion !== 1 || !Array.isArray(registry.aliases)) return invalid(name);
+
+  const aliases = registry.aliases.filter((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return false;
+    const repositoryOwner = typeof candidate.repository === 'string'
+      ? candidate.repository.split('/')[0]
+      : '';
+    return repositoryOwner === owner && candidate.baseSlug === baseSlug;
+  });
+  if (aliases.length !== 1) return invalid(name);
+
+  const alias = aliases[0];
+  if (alias.expectedName !== name || name !== name.normalize('NFC')
+    || !/^[a-z0-9_-]+\/[a-z0-9._-]+$/.test(alias.repository)
+    || typeof alias.path !== 'string' || alias.path === ''
+    || alias.path !== alias.path.normalize('NFC')
+    || alias.path.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return invalid(name);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(resolve(dirname(resolve(root, skillMdPath)), 'skill-report.json'), 'utf8'));
+  } catch {
+    return invalid(name);
+  }
+
+  const expectedSlug = `${owner}-${baseSlug}`;
+  const sourceRef = report?.meta?.source_ref;
+  if (report?.meta?.slug !== expectedSlug || report?.skill?.name !== name || !SOURCE_REF.test(sourceRef)) {
+    return invalid(name);
+  }
+  const encodedPath = alias.path.split('/').map(encodeURIComponent).join('/');
+  const expectedSource = `https://github.com/${alias.repository}/tree/${encodeURIComponent(sourceRef)}/${encodedPath}`;
+  if (report?.meta?.source_url !== expectedSource && report?.meta?.source_url !== `${expectedSource}/`) {
+    return invalid(name);
+  }
+  return null;
+}
+
+module.exports = { validateSkillName };


### PR DESCRIPTION
Root cause: submission discovery/classification accepted exact repository+path aliases, while Validate Marketplace still enforced an unrelated ASCII-only inline check. This made valid generated PRs #2881 and #2882 red after their immutable source processing succeeded.\n\nThis change keeps ordinary names strict and accepts a non-ASCII name only when the marketplace owner/base slug, alias registry entry, report slug/name, exact upstream repository, exact source SHA, and exact source path all match. Wrong-source aliases remain fail-closed. No report hash, symlink, security audit, or publication gate is relaxed.\n\nTests:\n- Red: focused validator tests failed on the old inline ASCII-only logic and missing shared alias check.\n- Green: CI=true node --test scripts/tests/validate-marketplace-autofix.test.mjs (10/10)\n- Related: CI=true node --test scripts/tests/validate-marketplace-autofix.test.mjs scripts/tests/submission-source-resolution.test.mjs scripts/tests/submission-existing-targets.test.mjs scripts/tests/workflow-action-pin-policy.test.mjs (89/89)