### PR TITLE
fix(actions): sparsify incremental sync checkout

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -32,11 +32,58 @@ jobs:
       synced_skill_count: ${{ steps.synced-plan.outputs.skill_count }}
       skip_sync: ${{ steps.changes.outputs.skip_sync }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          # Full history needed to diff against last successful sync
-          fetch-depth: 0
+      - name: Clear inherited sync checkout
+        run: |
+          set -euo pipefail
+          EXPECTED_WORKSPACE="${RUNNER_WORKSPACE:?}/${GITHUB_REPOSITORY#*/}"
+          if [ "${GITHUB_WORKSPACE:?}" != "$EXPECTED_WORKSPACE" ]; then
+            echo "::error::Refusing to clear unexpected workspace: $GITHUB_WORKSPACE"
+            exit 1
+          fi
+          cd "${RUNNER_TEMP:?}"
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
+
+      - name: Checkout immutable sync runtime
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          PATTERNS_FILE="${RUNNER_TEMP:?}/sync-runtime-${GITHUB_RUN_ID:?}-${GITHUB_RUN_ATTEMPT:?}.patterns"
+          trap 'rm -f "$PATTERNS_FILE"' EXIT
+          cat > "$PATTERNS_FILE" <<'EOF'
+          /scripts/resolve-manual-skills.mjs
+          /scripts/detect-changed-skills.mjs
+          /scripts/materialize-changed-skills.mjs
+          /.github/actions/download-skillstore-cli/
+          EOF
+
+          CHECKOUT_SUCCEEDED=false
+          for CHECKOUT_ATTEMPT in 1 2 3; do
+            cd "${RUNNER_TEMP:?}"
+            find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+            git init "$GITHUB_WORKSPACE"
+            git -C "$GITHUB_WORKSPACE" remote add origin "${GITHUB_SERVER_URL:?}/${GITHUB_REPOSITORY:?}.git"
+            git -C "$GITHUB_WORKSPACE" config gc.auto 0
+            git -C "$GITHUB_WORKSPACE" sparse-checkout init --no-cone
+            git -C "$GITHUB_WORKSPACE" sparse-checkout set --no-cone --stdin < "$PATTERNS_FILE"
+            if git -C "$GITHUB_WORKSPACE" -c protocol.version=2 fetch \
+                --no-tags --prune --no-recurse-submodules --filter=blob:none \
+                origin '+refs/heads/main:refs/remotes/origin/main' \
+              && git -C "$GITHUB_WORKSPACE" cat-file -e "$EXPECTED_SHA^{commit}" \
+              && git -C "$GITHUB_WORKSPACE" checkout --detach --force "$EXPECTED_SHA"; then
+              CHECKOUT_SUCCEEDED=true
+              break
+            fi
+            if [ "$CHECKOUT_ATTEMPT" -lt 3 ]; then
+              echo "::warning::Immutable sync checkout failed; retrying attempt $((CHECKOUT_ATTEMPT + 1))/3"
+              sleep "$((CHECKOUT_ATTEMPT * 5))"
+            fi
+          done
+          test "$CHECKOUT_SUCCEEDED" = true || {
+            echo "::error::Immutable sync checkout failed after 3 attempts"
+            exit 1
+          }
 
       - name: Normalize pinned sync runtime checkout
         env:
@@ -52,16 +99,17 @@ jobs:
             echo "::error::checkout SHA mismatch: expected=$EXPECTED_SHA actual=$checked_out_sha"
             exit 1
           fi
-          # Self-hosted runners can retain sparse-checkout state even when this
-          # job did not request it. The resolvers are pinned-tree readers, so
-          # restore their exact workflow-commit bytes before any plan is made.
-          git sparse-checkout disable
-          git reset --hard "$EXPECTED_SHA"
+          test "$(git config --bool core.sparseCheckout)" = true
+          test -f "$(git rev-parse --git-path info/sparse-checkout)"
           for required_path in \
             scripts/resolve-manual-skills.mjs \
             scripts/detect-changed-skills.mjs \
             scripts/materialize-changed-skills.mjs \
             .github/actions/download-skillstore-cli/action.yml; do
+            if git ls-files -v -- "$required_path" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
+              echo "::error::required pinned runtime file was not materialized: $required_path"
+              exit 1
+            fi
             if [ ! -f "$required_path" ] || [ -L "$required_path" ]; then
               echo "::error::required pinned runtime file is missing or not regular: $required_path"
               exit 1

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -144,15 +144,19 @@ test('incremental detection subtracts only verified successful manual recovery a
   assert.match(workflow, /retention-days: 30/);
 });
 
-test('sync normalizes a retained sparse checkout before invoking pinned-tree resolvers', () => {
+test('sync uses a blobless sparse checkout before invoking pinned-tree resolvers', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
-  const checkout = section(workflow, '      - name: Checkout repository', '      - name: Generate GitHub App Token');
+  const checkout = section(workflow, '      - name: Clear inherited sync checkout', '      - name: Normalize pinned sync runtime checkout');
   const runtime = section(workflow, '      - name: Normalize pinned sync runtime checkout', '      - name: Generate GitHub App Token');
   const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
 
-  assert.match(checkout, /fetch-depth: 0/);
+  assert.match(checkout, /for CHECKOUT_ATTEMPT in 1 2 3/);
+  assert.match(checkout, /--filter=blob:none/);
+  assert.match(checkout, /sparse-checkout init --no-cone/);
+  assert.match(checkout, /checkout --detach --force "\$EXPECTED_SHA"/);
   assert.match(runtime, /checked_out_sha=\$\(git rev-parse HEAD\)/);
-  assert.match(runtime, /git sparse-checkout disable[\s\S]*git reset --hard "\$EXPECTED_SHA"/);
+  assert.doesNotMatch(runtime, /sparse-checkout disable|git reset --hard/);
+  assert.match(runtime, /git config --bool core\.sparseCheckout/);
   assert.match(runtime, /scripts\/resolve-manual-skills\.mjs/);
   assert.match(runtime, /scripts\/detect-changed-skills\.mjs/);
   assert.match(runtime, /scripts\/materialize-changed-skills\.mjs/);


### PR DESCRIPTION
## Root cause

Exact-main Sync run 30512585914 spent 21 minutes in `actions/checkout` before any write step. The workflow requested full history and then explicitly disabled sparse checkout, hydrating the full 36k-file Marketplace tree. The run was safely cancelled while still in checkout; every database, callback, score, and cache step remained unstarted.

## Fix

- keep the full main commit history required for last-successful-sync diffs
- fetch it with `--filter=blob:none`
- sparse-check out only the three pinned-tree resolvers and the existing CLI download action
- retry from a freshly cleared workspace up to three times
- keep exact SHA, regular-file, blob-identity, skip-worktree, bounded-target, and single-write-attempt checks
- continue using the existing exact-path materializer for the detected Skill set

## Verification

- Red: existing contract required full hydration
- Green: 46/46 focused sync/planner/materializer/action-pin tests
- parsed workflow shell/YAML validation passed
- real blobless sparse checkout of exact main `5d763e3a26c5577f4ceb2e6d5af1eb9be54965dc` succeeded without materializing the Skill tree
- git diff --check passed