### PR TITLE
fix(actions): harden sparse runtime and frozen staging

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -141,11 +141,6 @@ jobs:
             exit 1
           fi
           cd "${RUNNER_TEMP:?}"
-          if git -C "$GITHUB_WORKSPACE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git -C "$GITHUB_WORKSPACE" sparse-checkout disable >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --local --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-            git -C "$GITHUB_WORKSPACE" config --worktree --unset-all core.sparseCheckout >/dev/null 2>&1 || true
-          fi
           find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
 

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -1064,7 +1064,7 @@ jobs:
           git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
 
           git checkout -b "$BRANCH_NAME"
-          git add -- "${SUBMISSION_PATHS[@]}"
+          git add -f -- "${SUBMISSION_PATHS[@]}"
 
           # Different commit messages for manual approval vs automatic
           if [ "${{ inputs.is_manual_approval }}" = "true" ]; then

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -55,6 +55,7 @@ jobs:
           /scripts/resolve-manual-skills.mjs
           /scripts/detect-changed-skills.mjs
           /scripts/materialize-changed-skills.mjs
+          /scripts/refresh-security-research-stats.sh
           /.github/actions/download-skillstore-cli/
           EOF
 
@@ -105,6 +106,7 @@ jobs:
             scripts/resolve-manual-skills.mjs \
             scripts/detect-changed-skills.mjs \
             scripts/materialize-changed-skills.mjs \
+            scripts/refresh-security-research-stats.sh \
             .github/actions/download-skillstore-cli/action.yml; do
             if git ls-files -v -- "$required_path" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
               echo "::error::required pinned runtime file was not materialized: $required_path"

--- a/scripts/resolve-manual-skills.mjs
+++ b/scripts/resolve-manual-skills.mjs
@@ -112,22 +112,28 @@ export function resolveManualSkillPaths({ repositoryRoot = '.', commit, skills }
     : parseManualSkillIdentifiers(skills);
   const byPath = new Map();
   const bySlug = new Map();
+  const reports = reportBlobsAtCommit(repositoryRoot, exactCommit);
 
-  for (const report of reportBlobsAtCommit(repositoryRoot, exactCommit)) {
+  for (const report of reports) {
     const relativePath = posix.dirname(report.treePath).slice('skills/'.length);
     if (!relativePath || relativePath === '.') continue;
     addMapping(byPath, relativePath, relativePath);
     addMapping(bySlug, relativePath.replaceAll('/', '-'), relativePath);
+  }
 
-    try {
-      const document = JSON.parse(
-        git(repositoryRoot, ['cat-file', 'blob', report.oid], { encoding: 'utf8' }),
-      );
-      if (typeof document?.meta?.slug === 'string' && document.meta.slug.trim()) {
-        addMapping(bySlug, document.meta.slug.trim(), relativePath);
+  if (requested.some((identifier) => !byPath.has(identifier) && !bySlug.has(identifier))) {
+    for (const report of reports) {
+      const relativePath = posix.dirname(report.treePath).slice('skills/'.length);
+      try {
+        const document = JSON.parse(
+          git(repositoryRoot, ['cat-file', 'blob', report.oid], { encoding: 'utf8' }),
+        );
+        if (typeof document?.meta?.slug === 'string' && document.meta.slug.trim()) {
+          addMapping(bySlug, document.meta.slug.trim(), relativePath);
+        }
+      } catch {
+        // Path-derived lookup remains available for malformed legacy reports.
       }
-    } catch {
-      // Path-derived lookup remains available for malformed legacy reports.
     }
   }
 

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -153,6 +153,7 @@ test('sync uses a blobless sparse checkout before invoking pinned-tree resolvers
   assert.match(checkout, /for CHECKOUT_ATTEMPT in 1 2 3/);
   assert.match(checkout, /--filter=blob:none/);
   assert.match(checkout, /sparse-checkout init --no-cone/);
+  assert.match(checkout, /scripts\/refresh-security-research-stats\.sh/);
   assert.match(checkout, /checkout --detach --force "\$EXPECTED_SHA"/);
   assert.match(runtime, /checked_out_sha=\$\(git rev-parse HEAD\)/);
   assert.doesNotMatch(runtime, /sparse-checkout disable|git reset --hard/);
@@ -160,6 +161,7 @@ test('sync uses a blobless sparse checkout before invoking pinned-tree resolvers
   assert.match(runtime, /scripts\/resolve-manual-skills\.mjs/);
   assert.match(runtime, /scripts\/detect-changed-skills\.mjs/);
   assert.match(runtime, /scripts\/materialize-changed-skills\.mjs/);
+  assert.match(runtime, /scripts\/refresh-security-research-stats\.sh/);
   assert.match(runtime, /\.github\/actions\/download-skillstore-cli\/action\.yml/);
   assert.match(runtime, /git rev-parse "\$EXPECTED_SHA:\$required_path"/);
   assert.match(runtime, /git hash-object "\$required_path"/);

--- a/scripts/tests/resolve-manual-skills.test.mjs
+++ b/scripts/tests/resolve-manual-skills.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
@@ -57,6 +57,29 @@ test('resolves paths and report slugs from the exact Git tree when skills is abs
     );
   } finally {
     rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('path-derived slugs do not hydrate report blobs from a partial clone', () => {
+  const { repositoryRoot, commit } = makeRepository();
+  const bin = mkdtempSync(join(tmpdir(), 'resolve-manual-skills-git-'));
+  const marker = join(bin, 'cat-file-blob-called');
+  const realGit = execFileSync('which', ['git'], { encoding: 'utf8' }).trim();
+  const wrapper = join(bin, 'git');
+  writeFileSync(wrapper, `#!/bin/sh\nif [ "$1" = cat-file ] && [ "$2" = blob ]; then : > '${marker}'; fi\nexec '${realGit}' "$@"\n`);
+  chmodSync(wrapper, 0o755);
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = `${bin}:${previousPath}`;
+    assert.deepEqual(
+      resolveManualSkillPaths({ repositoryRoot, commit, skills: 'owner-demo,other/tool' }),
+      ['other/tool', 'owner/demo'],
+    );
+    assert.equal(existsSync(marker), false);
+  } finally {
+    process.env.PATH = previousPath;
+    rmSync(repositoryRoot, { recursive: true, force: true });
+    rmSync(bin, { recursive: true, force: true });
   }
 });
 

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -98,6 +98,8 @@ function createFixture() {
 }
 
 test('source monitor clears inherited sparse state and verifies an immutable full checkout', () => {
+  const cleanup = extractRunBlock('Clear inherited source monitor checkout');
+  assert.doesNotMatch(cleanup, /sparse-checkout disable|git reset --hard/);
   const fixture = createFixture();
   try {
     run('git', ['-C', fixture.workspace, 'sparse-checkout', 'init', '--cone']);
@@ -105,7 +107,7 @@ test('source monitor clears inherited sparse state and verifies an immutable ful
     assert.equal(existsSync(join(fixture.workspace, runtimeFiles[0])), false);
     writeFileSync(join(fixture.workspace, 'stale-runner-file'), 'stale\n');
 
-    run('bash', ['-c', extractRunBlock('Clear inherited source monitor checkout')], {
+    run('bash', ['-c', cleanup], {
       cwd: fixture.workspace,
       env: {
         ...process.env,

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -219,12 +219,30 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);
   assert.match(reusable, /PLAN_EVIDENCE=\(\)/);
   assert.match(reusable, /selection-plan\.invalid\.json/);
-  assert.match(reusable, /git add -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
+  assert.match(reusable, /git add -f -- "\$\{SUBMISSION_PATHS\[@\]\}"/);
   assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
   assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);
   assert.match(reusable, /Enforce shard terminal status/);
   assert.match(reusable, /Published target already exists; use the explicit update workflow/);
 });
+
+test('submission staging preserves frozen tracked files hidden by a copied .gitignore', () => withTempDirectory((root) => {
+  const pendingDir = 'pending/owner/skill';
+  mkdirSync(join(root, pendingDir, 'dist'), { recursive: true });
+  writeFileSync(join(root, pendingDir, '.gitignore'), 'dist/\n');
+  writeFileSync(join(root, pendingDir, 'SKILL.md'), '# Skill\n');
+  writeFileSync(join(root, pendingDir, 'dist/cli.js'), 'export default true;\n');
+  for (const args of [
+    ['init', '-q'],
+    ['add', '-f', '--', pendingDir],
+  ]) {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+  }
+  const staged = spawnSync('git', ['diff', '--cached', '--name-only'], { cwd: root, encoding: 'utf8' });
+  assert.equal(staged.status, 0, staged.stderr);
+  assert.match(staged.stdout, /pending\/owner\/skill\/dist\/cli\.js/);
+}));
 
 test('real CLI two-round failure produces a failed manifest and cannot aggregate as no-op', () => withTempDirectory((root) => {
   const fakeCli = join(root, 'fake-cli.sh');


### PR DESCRIPTION
## Summary
- materialize the security snapshot refresh helper in Incremental Sync sparse checkouts
- avoid hydrating every report blob for canonical manual slugs and avoid expanding inherited sparse Source Monitor workspaces during cleanup
- force-stage only immutable selection-plan submission directories so tracked runtime files hidden by copied ignore rules remain in frozen PRs

## Root causes
- Sync green runs hid snapshot refresh exit 127 because the helper was absent from the sparse checkout
- Source Monitor expanded then deleted a large inherited sparse workspace before checkout
- manual canonical slug resolution downloaded every report blob in a blobless clone
- submission PR #2888 omitted 17 tracked dist files because copied ignore rules affected aggregation staging

## Verification
- CI=true node --test focused Sync, resolver, and Source Monitor tests: 26/26
- CI=true node --test submission scope tests: 39/39
- action pin policy: 21/21 plus checker pass
- security research refresh tests: 7/7
- node --check, bash -n, and git diff --check pass

No hash, symlink, selection-plan, path, strict validation, or publication safety gate is relaxed.