### PR TITLE
fix(actions): make source monitor checkout blobless

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -145,13 +145,47 @@ jobs:
           test -z "$(find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -print -quit)"
 
       - name: Checkout immutable source monitor runtime
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          ref: ${{ github.workflow_sha }}
-          token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 1
-          clean: true
-          persist-credentials: false
+        env:
+          EXPECTED_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          PATTERNS_FILE="${RUNNER_TEMP:?}/source-monitor-runtime-${GITHUB_RUN_ID:?}-${GITHUB_RUN_ATTEMPT:?}.patterns"
+          trap 'rm -f "$PATTERNS_FILE"' EXIT
+          cat > "$PATTERNS_FILE" <<'EOF'
+          /.github/actions/download-skillstore-cli/
+          /.github/workflows/monitor-skill-sources.yml
+          /scripts/rebind-skill-report-hashes.mjs
+          /scripts/verify-source-monitor-selection.mjs
+          /skills/**/skill-report.json
+          EOF
+
+          CHECKOUT_SUCCEEDED=false
+          for CHECKOUT_ATTEMPT in 1 2 3; do
+            cd "${RUNNER_TEMP:?}"
+            find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+            git init "$GITHUB_WORKSPACE"
+            git -C "$GITHUB_WORKSPACE" remote add origin "${GITHUB_SERVER_URL:?}/${GITHUB_REPOSITORY:?}.git"
+            git -C "$GITHUB_WORKSPACE" config gc.auto 0
+            git -C "$GITHUB_WORKSPACE" config http.version HTTP/1.1
+            git -C "$GITHUB_WORKSPACE" sparse-checkout init --no-cone
+            git -C "$GITHUB_WORKSPACE" sparse-checkout set --no-cone --stdin < "$PATTERNS_FILE"
+            if git -C "$GITHUB_WORKSPACE" -c protocol.version=2 fetch \
+                --no-tags --no-recurse-submodules --filter=blob:none --depth=1 \
+                origin "$EXPECTED_SHA" \
+              && git -C "$GITHUB_WORKSPACE" cat-file -e "$EXPECTED_SHA^{commit}" \
+              && git -C "$GITHUB_WORKSPACE" checkout --detach --force "$EXPECTED_SHA"; then
+              CHECKOUT_SUCCEEDED=true
+              break
+            fi
+            if [ "$CHECKOUT_ATTEMPT" -lt 3 ]; then
+              echo "::warning::Immutable source monitor checkout failed; retrying attempt $((CHECKOUT_ATTEMPT + 1))/3"
+              sleep "$((CHECKOUT_ATTEMPT * 5))"
+            fi
+          done
+          test "$CHECKOUT_SUCCEEDED" = true || {
+            echo "::error::Immutable source monitor checkout failed after 3 attempts"
+            exit 1
+          }
 
       - name: Verify immutable source monitor runtime
         env:
@@ -175,8 +209,8 @@ jobs:
           } > "$DIAGNOSTIC_DIR/post-checkout.txt"
 
           test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
-          test "$(git config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true"
-          test ! -f "$(git rev-parse --git-path info/sparse-checkout)"
+          test "$(git config --bool core.sparseCheckout)" = true
+          test -f "$(git rev-parse --git-path info/sparse-checkout)"
           if git ls-files -v -- "${REQUIRED_RUNTIME_FILES[@]}" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
             echo "::error::Immutable source monitor runtime contains skip-worktree files"
             exit 1
@@ -400,13 +434,15 @@ jobs:
 
           LC_ALL=C sort -z -u "$CHANGED_SKILLS" -o "$CHANGED_SKILLS"
           while IFS= read -r -d '' skill_path; do
-            git add -A -f -- "${skill_path%/SKILL.md}"
+            skill_dir="${skill_path%/SKILL.md}"
+            git ls-files -z -- "$skill_dir" | git update-index -z --no-skip-worktree --stdin
+            git add --sparse -A -f -- "$skill_dir"
           done < "$CHANGED_SKILLS"
           node scripts/rebind-skill-report-hashes.mjs \
             --repo-root "$PWD" \
             --skill-paths-file "$CHANGED_SKILLS"
           while IFS= read -r -d '' skill_path; do
-            git add -- "${skill_path%/SKILL.md}/skill-report.json"
+            git add --sparse -f -- "${skill_path%/SKILL.md}/skill-report.json"
           done < "$CHANGED_SKILLS"
           echo "::notice::Bound source monitor report hashes to the exact packaged Marketplace trees"
 

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -74,7 +74,7 @@ function createFixture() {
   mkdirSync(seed, { recursive: true });
   mkdirSync(runnerWorkspace, { recursive: true });
   mkdirSync(runnerTemp, { recursive: true });
-  run('git', ['init', '-q', seed]);
+  run('git', ['init', '-q', '-b', 'main', seed]);
   run('git', ['-C', seed, 'config', 'user.name', 'Fixture']);
   run('git', ['-C', seed, 'config', 'user.email', 'fixture@example.com']);
   const files = {
@@ -82,6 +82,9 @@ function createFixture() {
     '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
     'scripts/rebind-skill-report-hashes.mjs': 'export const fixture = true;\n',
     'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
+    'skills/owner/demo/SKILL.md': '# Demo\n',
+    'skills/owner/demo/skill-report.json': '{"meta":{"slug":"owner-demo"}}\n',
+    'skills/owner/demo/references/large.txt': 'not needed by the monitor runtime checkout\n',
     'README.md': 'fixture\n',
   };
   for (const [path, content] of Object.entries(files)) {
@@ -97,7 +100,23 @@ function createFixture() {
   return { root, origin, runnerWorkspace, runnerTemp, workspace, diagnosticDir, head };
 }
 
-test('source monitor clears inherited sparse state and verifies an immutable full checkout', () => {
+function checkoutFixture(fixture) {
+  const checkout = extractRunBlock('Checkout immutable source monitor runtime')
+    .replace('"${GITHUB_SERVER_URL:?}/${GITHUB_REPOSITORY:?}.git"', `"${fixture.origin}"`);
+  run('bash', ['-c', checkout], {
+    cwd: fixture.runnerTemp,
+    env: {
+      ...process.env,
+      GITHUB_WORKSPACE: fixture.workspace,
+      RUNNER_TEMP: fixture.runnerTemp,
+      GITHUB_RUN_ID: '1234',
+      GITHUB_RUN_ATTEMPT: '1',
+      EXPECTED_SHA: fixture.head,
+    },
+  });
+}
+
+test('source monitor clears inherited state and verifies an immutable blobless sparse checkout', () => {
   const cleanup = extractRunBlock('Clear inherited source monitor checkout');
   assert.doesNotMatch(cleanup, /sparse-checkout disable|git reset --hard/);
   const fixture = createFixture();
@@ -121,7 +140,9 @@ test('source monitor clears inherited sparse state and verifies an immutable ful
 
     assert.deepEqual(readdirSync(fixture.workspace), []);
     assert.match(readFileSync(join(fixture.diagnosticDir, 'pre-checkout.txt'), 'utf8'), /skip_worktree_count=/);
-    run('git', ['clone', '-q', '--no-local', fixture.origin, fixture.workspace]);
+    checkoutFixture(fixture);
+    assert.equal(existsSync(join(fixture.workspace, 'skills/owner/demo/skill-report.json')), true);
+    assert.equal(existsSync(join(fixture.workspace, 'skills/owner/demo/references/large.txt')), false);
     run('bash', ['-c', extractRunBlock('Verify immutable source monitor runtime')], {
       cwd: fixture.workspace,
       env: {
@@ -140,6 +161,18 @@ test('source monitor clears inherited sparse state and verifies an immutable ful
 test('source monitor runtime preflight rejects missing, modified, symlinked, skip-worktree, and wrong-head files', () => {
   const fixture = createFixture();
   try {
+    run('bash', ['-c', extractRunBlock('Clear inherited source monitor checkout')], {
+      cwd: fixture.workspace,
+      env: {
+        ...process.env,
+        GITHUB_WORKSPACE: fixture.workspace,
+        RUNNER_WORKSPACE: fixture.runnerWorkspace,
+        RUNNER_TEMP: fixture.runnerTemp,
+        GITHUB_REPOSITORY: `aiskillstore/${basename(fixture.workspace)}`,
+        DIAGNOSTIC_DIR: fixture.diagnosticDir,
+      },
+    });
+    checkoutFixture(fixture);
     const preflight = extractRunBlock('Verify immutable source monitor runtime');
     const base = {
       cwd: fixture.workspace,
@@ -164,9 +197,9 @@ test('source monitor runtime preflight rejects missing, modified, symlinked, ski
       rmSync(absolute);
       run('git', ['-C', fixture.workspace, 'checkout', '--', file]);
     }
-    run('git', ['-C', fixture.workspace, 'update-index', '--skip-worktree', runtimeFiles[0]]);
+    run('git', ['-C', fixture.workspace, 'sparse-checkout', 'set', '--no-cone', '/skills/**/skill-report.json']);
     assert.notEqual(run('bash', ['-c', preflight], { ...base, allowFailure: true }).status, 0);
-    run('git', ['-C', fixture.workspace, 'update-index', '--no-skip-worktree', runtimeFiles[0]]);
+    checkoutFixture(fixture);
     assert.notEqual(run('bash', ['-c', preflight], {
       ...base,
       env: { ...base.env, EXPECTED_WORKFLOW_SHA: '0000000000000000000000000000000000000000' },
@@ -179,9 +212,14 @@ test('source monitor runtime preflight rejects missing, modified, symlinked, ski
 
 test('source monitor binds checkout and artifacts to immutable runtime evidence', () => {
   assert.ok(workflow.indexOf('name: Initialize source monitor diagnostics') < workflow.indexOf('name: Generate GitHub App Token'));
-  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
-  assert.match(workflow, /fetch-depth: 1/);
-  assert.match(workflow, /persist-credentials: false/);
+  const checkout = extractRunBlock('Checkout immutable source monitor runtime');
+  assert.match(workflow, /EXPECTED_SHA: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(checkout, /--filter=blob:none/);
+  assert.match(checkout, /config http\.version HTTP\/1\.1/);
+  assert.match(checkout, /sparse-checkout init --no-cone/);
+  assert.match(checkout, /\/skills\/\*\*\/skill-report\.json/);
+  assert.match(checkout, /checkout --detach --force "\$EXPECTED_SHA"/);
+  assert.doesNotMatch(checkout, /actions\/checkout/);
   assert.match(workflow, /version: 2\.15\.8/);
   assert.match(workflow, /minimum-version: 2\.14\.5/);
   assert.match(workflow, /require-checksum: true/);
@@ -214,6 +252,8 @@ test('source monitor binds every changed report to its packaged tree before crea
   assert.match(binding, /scripts\/rebind-skill-report-hashes\.mjs/);
   assert.match(binding, /--skill-paths-file/);
   assert.match(binding, /--diff-filter=D/);
+  assert.match(binding, /update-index -z --no-skip-worktree --stdin/);
+  assert.match(binding, /git add --sparse -A -f/);
   assert.ok(
     workflow.indexOf('name: Bind source monitor reports to packaged trees')
       < workflow.indexOf('name: Create source monitor PR'),
@@ -232,6 +272,7 @@ test('source monitor commits upstream files hidden by a copied skill .gitignore'
     copyFileSync('scripts/rebind-skill-report-hashes.mjs', join(workspace, 'scripts/rebind-skill-report-hashes.mjs'));
     copyFileSync('scripts/resolve-approved-submission.mjs', join(workspace, 'scripts/resolve-approved-submission.mjs'));
     writeFileSync(join(absoluteSkillDirectory, 'SKILL.md'), '# old\n');
+    writeFileSync(join(absoluteSkillDirectory, 'legacy.txt'), 'removed upstream\n');
     writeFileSync(join(absoluteSkillDirectory, 'skill-report.json'), `${JSON.stringify({
       meta: {
         source_url: 'https://github.com/owner/repository',
@@ -246,8 +287,24 @@ test('source monitor commits upstream files hidden by a copied skill .gitignore'
     run('git', ['-C', workspace, 'add', '.']);
     run('git', ['-C', workspace, 'commit', '-qm', 'fixture']);
 
+    run('git', ['-C', workspace, 'sparse-checkout', 'init', '--no-cone']);
+    run('git', ['-C', workspace, 'sparse-checkout', 'set', '--no-cone', '/scripts/', '/skills/**/skill-report.json']);
+    assert.equal(existsSync(join(absoluteSkillDirectory, 'SKILL.md')), false);
+    assert.equal(existsSync(join(absoluteSkillDirectory, 'legacy.txt')), false);
+
+    rmSync(absoluteSkillDirectory, { recursive: true, force: true });
+    mkdirSync(absoluteSkillDirectory, { recursive: true });
+
     writeFileSync(join(absoluteSkillDirectory, '.gitignore'), 'references/\n');
     writeFileSync(join(absoluteSkillDirectory, 'SKILL.md'), '# updated\n');
+    writeFileSync(join(absoluteSkillDirectory, 'skill-report.json'), `${JSON.stringify({
+      meta: {
+        source_url: 'https://github.com/owner/repository',
+        source_ref: 'main',
+        content_hash: 'old',
+        tree_hash: 'old',
+      },
+    })}\n`);
     mkdirSync(join(absoluteSkillDirectory, 'references'));
     writeFileSync(join(absoluteSkillDirectory, 'references', 'ignored.md'), 'tracked upstream resource\n');
 
@@ -259,9 +316,11 @@ test('source monitor commits upstream files hidden by a copied skill .gitignore'
     const staged = run('git', ['-C', workspace, 'diff', '--cached', '--name-only']).stdout.trim().split('\n');
     assert.ok(staged.includes(`${skillDirectory}/references/ignored.md`));
     assert.ok(staged.includes(`${skillDirectory}/skill-report.json`));
+    assert.ok(staged.includes(`${skillDirectory}/legacy.txt`));
     run('git', ['-C', workspace, 'commit', '-qm', 'source monitor update']);
     const committed = run('git', ['-C', workspace, 'ls-tree', '-r', '--name-only', 'HEAD']).stdout.trim().split('\n');
     assert.ok(committed.includes(`${skillDirectory}/references/ignored.md`));
+    assert.ok(!committed.includes(`${skillDirectory}/legacy.txt`));
     const report = JSON.parse(readFileSync(join(absoluteSkillDirectory, 'skill-report.json'), 'utf8'));
     assert.equal(report.meta.tree_hash, calculateCanonicalTreeHash(workspace, skillDirectory));
   } finally {


### PR DESCRIPTION
## Summary
- replace the failing full-tree Source Monitor checkout with the same bounded blobless non-cone sparse Git strategy already proven by Incremental Sync
- materialize only immutable runtime files and existing skill reports; keep exact workflow SHA, regular-file, blob-hash, symlink, and skip-worktree checks
- before staging a changed skill, clear skip-worktree only for that exact directory and force-stage it with --sparse so additions, deletions, and copied ignore rules cannot hide upstream files

## Root cause and evidence
- original run 30529952295 failed its full checkout with HTTP/2 CANCEL, early EOF, and invalid index-pack
- exact-main dry-run 30597337862 again remained in actions/checkout for 21m56s and was canceled before any scan or write; terminal logs showed the same HTTP/2 CANCEL -> early EOF -> invalid index-pack chain
- a real GitHub checkout of this patch fetched the exact commit/tree in 5.85s and materialized 5,399 reports in 144.71s, 37.06 MiB total, leaving 31,285 unrelated files skipped

## Verification
- Red: focused regression had 5 failures before the workflow change
- Green: focused Source Monitor tests 9/9
- adjacent Source Monitor/score/selection/action-pin tests 59/59
- workflow action pin checker and git diff --check pass

No audit, source identity, tree/content/report hash, symlink, path, archive, write, or publication gate is relaxed.