### PR TITLE
fix(actions): rotate source monitor update batches

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -229,10 +229,10 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: 2.15.8
+          version: 2.16.1
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.14.5
+          minimum-version: 2.16.1
           require-checksum: true
 
       - name: Prepare git workspace
@@ -274,6 +274,7 @@ jobs:
           SUMMARY_FILE="source-monitor-results/skill-source-monitor-${GITHUB_RUN_ID}.md"
           CLI_VERSION_OUTPUT="$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 || true)"
           MONITOR_HELP="$("$GITHUB_WORKSPACE/skillstore-cli" skill monitor-upstream --help 2>&1 || true)"
+          UPDATE_SELECTION_OFFSET=$(( GITHUB_RUN_NUMBER * MAX_UPDATES_PER_RUN ))
           echo "Downloaded CLI version: $CLI_VERSION_OUTPUT"
 
           CMD=(
@@ -285,6 +286,7 @@ jobs:
             --summaryFile "$SUMMARY_FILE"
             --concurrency "$CONCURRENCY"
             --maxLocalUpdates "$MAX_UPDATES_PER_RUN"
+            --updateSelectionOffset "$UPDATE_SELECTION_OFFSET"
           )
 
           if grep -q -- '--writeConcurrency' <<<"$MONITOR_HELP"; then
@@ -361,6 +363,7 @@ jobs:
           echo "Source scan concurrency: $CONCURRENCY"
           echo "Supabase write concurrency: $WRITE_CONCURRENCY"
           echo "Max local updates per run: $MAX_UPDATES_PER_RUN"
+          echo "Update selection offset: $UPDATE_SELECTION_OFFSET"
           echo "Checkout cache dir: $CHECKOUT_CACHE_DIR"
           echo "Archive missing: $ARCHIVE_MISSING"
           echo "Delete archived: $DELETE_ARCHIVED"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -518,7 +518,7 @@ test('download action invalidates stale local CLI cache entries', () => {
 
 test('source monitor pins its audited CLI contract and falls back when checkout-cache support is unavailable', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /version: 2\.15\.8/, 'source monitor must download the audited CLI contract version');
+	assert.match(workflow, /version: 2\.16\.1/, 'source monitor must download the audited CLI contract version');
 	assert.doesNotMatch(workflow, /cli_version:/, 'source monitor must not expose a fixed CLI version input');
 	assert.doesNotMatch(workflow, /inputs\.cli_version/, 'source monitor must not consume a fixed CLI version input');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -220,8 +220,8 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
   assert.match(checkout, /\/skills\/\*\*\/skill-report\.json/);
   assert.match(checkout, /checkout --detach --force "\$EXPECTED_SHA"/);
   assert.doesNotMatch(checkout, /actions\/checkout/);
-  assert.match(workflow, /version: 2\.15\.8/);
-  assert.match(workflow, /minimum-version: 2\.14\.5/);
+  assert.match(workflow, /version: 2\.16\.1/);
+  assert.match(workflow, /minimum-version: 2\.16\.1/);
   assert.match(workflow, /require-checksum: true/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);
   assert.match(workflow, /name: Upload monitor evidence\n\s+if: always\(\)/);
@@ -230,6 +230,8 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
 
 test('source monitor verifies every explicit requested slug before later workflow steps', () => {
   const monitor = extractRunBlock('Run source monitor');
+  assert.match(monitor, /UPDATE_SELECTION_OFFSET=\$\(\( GITHUB_RUN_NUMBER \* MAX_UPDATES_PER_RUN \)\)/);
+  assert.match(monitor, /--updateSelectionOffset "\$UPDATE_SELECTION_OFFSET"/);
   assert.match(monitor, /A slug-scoped update PR requires expected_upstream_commit/);
   assert.match(monitor, /if \[ "\$CREATE_PR" = "true" \] && \[ -n "\$SLUGS" \]; then/);
   assert.match(monitor, /CMD\+=\(--updateLocal\)/);
@@ -429,6 +431,7 @@ SUMMARY
       GITHUB_WORKSPACE: workspace,
       GITHUB_RUN_ID: '1234',
       GITHUB_OUTPUT: join(root, 'github-output'),
+      GITHUB_RUN_NUMBER: '7',
       GH_TOKEN: 'fixture',
       SLUGS: 'owner-one',
       LIMIT: '1',
@@ -454,6 +457,7 @@ SUMMARY
     assert.match(result.stdout, /Verified exact source monitor selection: 1\/1/);
     const invoked = readFileSync(argsFile, 'utf8');
     assert.match(invoked, /--updateLocal/);
+    assert.match(invoked, /--updateSelectionOffset 7/);
     assert.doesNotMatch(invoked, /(^|\s)--write(\s|$)/);
 
     rmSync(argsFile);


### PR DESCRIPTION
## Root cause

Scheduled Source Monitor run 30692251894 observed 1991 updated skills but always selected the first 100 sorted slugs. All 100 failed strict validation, so later candidates were permanently deferred while the run remained green. Rerunning the old command would repeat the same slice.

## Fix

- pin the released and checksum-verified Skillstore CLI 2.16.1
- derive a persisted circular offset from `GITHUB_RUN_NUMBER * MAX_UPDATES_PER_RUN`
- pass and log `--updateSelectionOffset` so new workflow runs advance through the bounded candidate list

No YAML, audit, hash, symlink, runner, or fail-closed gate is relaxed. A rerun of the same workflow run keeps the same slice; a new run advances the slice.

## Release dependency

- Skillstore PR #341 merged as `a32238b949c58067f289fcfcca3ef03d42663529`
- CLI release: https://github.com/aiskillstore/skillstore/releases/tag/cli-v2.16.1
- linux-x64 SHA-256: `676269713fa0be975134236a4337a7e75740add25049d8ac92893f8251e5478c`

## Verification

- Red: workflow regression failed on the old 2.15.8 pin and missing offset
- Green: `CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs` (9/9)
- release checksum matches `checksums.txt`