### PR TITLE
fix(actions): include source monitor hash dependency

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -155,6 +155,7 @@ jobs:
           /.github/actions/download-skillstore-cli/
           /.github/workflows/monitor-skill-sources.yml
           /scripts/rebind-skill-report-hashes.mjs
+          /scripts/resolve-approved-submission.mjs
           /scripts/verify-source-monitor-selection.mjs
           /skills/**/skill-report.json
           EOF
@@ -198,6 +199,7 @@ jobs:
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/monitor-skill-sources.yml"
             "scripts/rebind-skill-report-hashes.mjs"
+            "scripts/resolve-approved-submission.mjs"
             "scripts/verify-source-monitor-selection.mjs"
           )
           {

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -22,6 +22,7 @@ const runtimeFiles = [
   '.github/actions/download-skillstore-cli/action.yml',
   '.github/workflows/monitor-skill-sources.yml',
   'scripts/rebind-skill-report-hashes.mjs',
+  'scripts/resolve-approved-submission.mjs',
   'scripts/verify-source-monitor-selection.mjs',
 ];
 
@@ -81,6 +82,7 @@ function createFixture() {
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
     'scripts/rebind-skill-report-hashes.mjs': 'export const fixture = true;\n',
+    'scripts/resolve-approved-submission.mjs': 'export const fixture = true;\n',
     'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
     'skills/owner/demo/SKILL.md': '# Demo\n',
     'skills/owner/demo/skill-report.json': '{"meta":{"slug":"owner-demo"}}\n',


### PR DESCRIPTION
## Root cause

Scheduled Source Monitor run 30740745183 completed the scan, then failed in `Bind source monitor reports to packaged trees` with `ERR_MODULE_NOT_FOUND`: the immutable sparse checkout included `rebind-skill-report-hashes.mjs` but omitted its `resolve-approved-submission.mjs` import.

## Fix

- Include the exact imported script in the sparse runtime checkout.
- Add it to the immutable SHA/file/symlink/skip-worktree preflight.
- Extend the runtime fixture so this regression fails before the workflow executes.

No validation, audit, hash, symlink, runner, permission, or fail-closed behavior is relaxed.

## Verification

- RED: focused runtime test failed because the dependency was absent.
- GREEN: `CI=true node --test scripts/tests/rebind-skill-report-hashes.test.mjs scripts/tests/source-monitor-runtime-workflow.test.mjs` — 12/12 passed.
- `git diff --check` passed.

Original failure: https://github.com/aiskillstore/marketplace/actions/runs/30740745183