### PR TITLE
fix(actions): complete and bound source monitor runtime

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -27,10 +27,10 @@ on:
         type: number
         default: 2
       max_updates_per_run:
-        description: 'Maximum updated skills to refresh into a marketplace PR in one run; 0 means unlimited'
+        description: 'Maximum updated skills to refresh into a marketplace PR in one run, 1-25'
         required: false
         type: number
-        default: 100
+        default: 25
       dry_run:
         description: 'Preview only; do not write Supabase, update local files, or create PRs'
         required: false
@@ -154,6 +154,7 @@ jobs:
           cat > "$PATTERNS_FILE" <<'EOF'
           /.github/actions/download-skillstore-cli/
           /.github/workflows/monitor-skill-sources.yml
+          /schemas/skill-report.schema.json
           /scripts/rebind-skill-report-hashes.mjs
           /scripts/resolve-approved-submission.mjs
           /scripts/verify-source-monitor-selection.mjs
@@ -198,6 +199,7 @@ jobs:
           REQUIRED_RUNTIME_FILES=(
             ".github/actions/download-skillstore-cli/action.yml"
             ".github/workflows/monitor-skill-sources.yml"
+            "schemas/skill-report.schema.json"
             "scripts/rebind-skill-report-hashes.mjs"
             "scripts/resolve-approved-submission.mjs"
             "scripts/verify-source-monitor-selection.mjs"
@@ -258,7 +260,7 @@ jobs:
           LIMIT: ${{ inputs.limit || 0 }}
           CONCURRENCY: ${{ inputs.concurrency || 8 }}
           WRITE_CONCURRENCY: ${{ inputs.write_concurrency || 2 }}
-          MAX_UPDATES_PER_RUN: ${{ inputs.max_updates_per_run || 100 }}
+          MAX_UPDATES_PER_RUN: ${{ inputs.max_updates_per_run || 25 }}
           CHECKOUT_CACHE_DIR: ${{ inputs.checkout_cache_dir || '/home/runner/_work/_cache/skill-source-monitor' }}
           DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
           CREATE_PR: ${{ github.event_name == 'schedule' && 'true' || inputs.create_pr }}
@@ -272,6 +274,10 @@ jobs:
           set -euo pipefail
 
           mkdir -p source-monitor-results "$CHECKOUT_CACHE_DIR"
+          if (( MAX_UPDATES_PER_RUN < 1 || MAX_UPDATES_PER_RUN > 25 )); then
+            echo "::error::max_updates_per_run must be between 1 and 25"
+            exit 1
+          fi
           JSONL_FILE="source-monitor-results/skill-source-monitor-${GITHUB_RUN_ID}.jsonl"
           SUMMARY_FILE="source-monitor-results/skill-source-monitor-${GITHUB_RUN_ID}.md"
           CLI_VERSION_OUTPUT="$("$GITHUB_WORKSPACE/skillstore-cli" --version 2>&1 || true)"
@@ -558,7 +564,7 @@ jobs:
           SLUGS: ${{ inputs.slugs || '' }}
           CONCURRENCY: ${{ inputs.concurrency || 8 }}
           WRITE_CONCURRENCY: ${{ inputs.write_concurrency || 2 }}
-          MAX_UPDATES_PER_RUN: ${{ inputs.max_updates_per_run || 100 }}
+          MAX_UPDATES_PER_RUN: ${{ inputs.max_updates_per_run || 25 }}
           CHECKOUT_CACHE_DIR: ${{ inputs.checkout_cache_dir || '/home/runner/_work/_cache/skill-source-monitor' }}
           ARCHIVE_MISSING: ${{ inputs.archive_missing || false }}
           DELETE_ARCHIVED: ${{ inputs.delete_archived || false }}

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -21,6 +21,7 @@ const workflow = readFileSync('.github/workflows/monitor-skill-sources.yml', 'ut
 const runtimeFiles = [
   '.github/actions/download-skillstore-cli/action.yml',
   '.github/workflows/monitor-skill-sources.yml',
+  'schemas/skill-report.schema.json',
   'scripts/rebind-skill-report-hashes.mjs',
   'scripts/resolve-approved-submission.mjs',
   'scripts/verify-source-monitor-selection.mjs',
@@ -81,6 +82,7 @@ function createFixture() {
   const files = {
     '.github/actions/download-skillstore-cli/action.yml': 'name: fixture action\n',
     '.github/workflows/monitor-skill-sources.yml': 'name: fixture workflow\n',
+    'schemas/skill-report.schema.json': '{}\n',
     'scripts/rebind-skill-report-hashes.mjs': 'export const fixture = true;\n',
     'scripts/resolve-approved-submission.mjs': 'export const fixture = true;\n',
     'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
@@ -228,6 +230,14 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);
   assert.match(workflow, /name: Upload monitor evidence\n\s+if: always\(\)/);
   for (const file of runtimeFiles) assert.match(workflow, new RegExp(file.replaceAll('.', '\\.')));
+});
+
+test('source monitor cannot publish a batch larger than incremental sync admits', () => {
+  assert.match(workflow, /max_updates_per_run:[\s\S]{0,220}default: 25/);
+  assert.equal((workflow.match(/inputs\.max_updates_per_run \|\| 25/g) ?? []).length, 2);
+  const monitor = extractRunBlock('Run source monitor');
+  assert.match(monitor, /MAX_UPDATES_PER_RUN < 1 \|\| MAX_UPDATES_PER_RUN > 25/);
+  assert.match(monitor, /max_updates_per_run must be between 1 and 25/);
 });
 
 test('source monitor verifies every explicit requested slug before later workflow steps', () => {


### PR DESCRIPTION
## Root cause

The immutable Source Monitor checkout omitted `schemas/skill-report.schema.json`. Run 30896053495 therefore finished green while 40 selected updates failed schema validation. The same run published 60 updates, exceeding incremental Sync's 25-skill production admission limit.

## Fix

- materialize and hash-verify the report schema in the sparse runtime
- cap Source Monitor updates at 25, matching the existing Sync fail-closed limit
- preserve all immutable checkout, hash, symlink, and production writer gates

## Focused verification

- `CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs` (10/10)