### PR TITLE
fix(actions): bind and diagnose skills.sh scrape

### DIFF
--- a/.github/workflows/scrape-skills-sh.yml
+++ b/.github/workflows/scrape-skills-sh.yml
@@ -56,7 +56,8 @@ on:
         default: false
 
 env:
-  CLI_VERSION: 'latest'
+  CLI_VERSION: '2.16.2'
+  CLI_SHA256: '537fca9a42ab691c266532f61afe95f8f29cc7fc42b7728740df94981d1f173c'
 
 jobs:
   scrape:
@@ -87,6 +88,9 @@ jobs:
           version: ${{ env.CLI_VERSION }}
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
+          minimum-version: ${{ env.CLI_VERSION }}
+          require-checksum: 'true'
+          expected-sha256: ${{ env.CLI_SHA256 }}
 
       - name: Ensure jq
         run: |
@@ -144,7 +148,7 @@ jobs:
           echo "   Dry run: $DRY_RUN"
 
           HELP="$("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --help 2>&1 || true)"
-          CMD=("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --limit "$LIMIT" --output json --summary)
+          CMD=("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --limit "$LIMIT" --output json)
 
           if printf '%s\n' "$HELP" | grep -q -- "--pages"; then
             CMD+=(--pages "$PAGES")
@@ -193,7 +197,7 @@ jobs:
             exit 1
           fi
 
-          # Parse JSON from a file so large summaries do not travel through one shell variable.
+          # Parse JSON from a file so large results do not travel through one shell variable.
           TOTAL=$(jq -r '.total // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
           EXISTING=$(jq -r '.existing // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
           NEW=$(jq -r '.new // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
@@ -249,8 +253,8 @@ jobs:
           echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
 
           if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "::group::scrape-skills-sh stdout"
-            sed -n '1,200p' "$OUTPUT_FILE"
+            echo "::group::scrape-skills-sh failures"
+            jq -c '[.skills[] | select(.status == "failed") | {slug, source, skillId, error}][:20]' "$OUTPUT_FILE"
             echo "::endgroup::"
             echo "::error::scrape-skills-sh exited with code $EXIT_CODE"
             exit "$EXIT_CODE"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -463,6 +463,17 @@ test('every workflow that invokes the score wrapper is enumerated and holds the 
 		'free-form metric views input must enter shell only through the environment');
 	assert.doesNotMatch(scrapeRun.slice(scrapeRun.indexOf('run: |')), /\$\{\{\s*inputs\./,
 		'skills.sh shell must not directly interpolate workflow inputs');
+	assert.doesNotMatch(scrapeRun, /--summary/,
+		'skills.sh output must retain per-skill failures for incident diagnosis');
+	assert.match(scrapeRun, /jq -c '\[\.skills\[\] \| select\(\.status == "failed"\) \| \{slug, source, skillId, error\}\]\[:20\]' "\$OUTPUT_FILE"/,
+		'failed runs must print a bounded exact failure identity list');
+	assert.match(scrape, /CLI_VERSION:\s*'2\.16\.2'/,
+		'skills.sh production writes must use an audited CLI version');
+	assert.match(scrape, /CLI_SHA256:\s*'537fca9a42ab691c266532f61afe95f8f29cc7fc42b7728740df94981d1f173c'/,
+		'skills.sh production writes must bind the audited CLI binary digest');
+	assert.match(scrape, /minimum-version:\s*\$\{\{ env\.CLI_VERSION \}\}/);
+	assert.match(scrape, /require-checksum:\s*'true'/);
+	assert.match(scrape, /expected-sha256:\s*\$\{\{ env\.CLI_SHA256 \}\}/);
 });
 
 test('malicious cli_version input cannot become shell syntax or select an unpinned binary', () => {


### PR DESCRIPTION
## Summary
- pin the production-writing skills.sh scrape to CLI 2.16.2 and its published SHA-256
- retain per-skill results and print a bounded exact failure identity list
- preserve non-zero exits and all existing validation

## Evidence
- failing run: https://github.com/aiskillstore/marketplace/actions/runs/30997550916
- CI=true node --test scripts/tests/recalculate-scores.test.mjs (23/23)
- CI=true node --test scripts/tests/workflow-action-pin-policy.test.mjs (21/21)
- YAML parse check passed