### PR TITLE
fix(actions): consume bounded scrape failures

### DIFF
--- a/.github/workflows/scrape-skills-sh.yml
+++ b/.github/workflows/scrape-skills-sh.yml
@@ -56,8 +56,8 @@ on:
         default: false
 
 env:
-  CLI_VERSION: '2.16.2'
-  CLI_SHA256: '537fca9a42ab691c266532f61afe95f8f29cc7fc42b7728740df94981d1f173c'
+  CLI_VERSION: '2.16.3'
+  CLI_SHA256: '77f9bb79304e7dfea6c792b6278b255840ab9b5d889ea621c89480275943794e'
 
 jobs:
   scrape:
@@ -148,7 +148,7 @@ jobs:
           echo "   Dry run: $DRY_RUN"
 
           HELP="$("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --help 2>&1 || true)"
-          CMD=("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --limit "$LIMIT" --output json)
+          CMD=("$GITHUB_WORKSPACE/skillstore-cli" skill scrape-skills-sh --limit "$LIMIT" --output json --summary)
 
           if printf '%s\n' "$HELP" | grep -q -- "--pages"; then
             CMD+=(--pages "$PAGES")
@@ -197,7 +197,7 @@ jobs:
             exit 1
           fi
 
-          # Parse JSON from a file so large results do not travel through one shell variable.
+          # Parse JSON from a file so summaries do not travel through one shell variable.
           TOTAL=$(jq -r '.total // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
           EXISTING=$(jq -r '.existing // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
           NEW=$(jq -r '.new // 0' "$OUTPUT_FILE" 2>/dev/null || echo "0")
@@ -254,7 +254,7 @@ jobs:
 
           if [ "$EXIT_CODE" -ne 0 ]; then
             echo "::group::scrape-skills-sh failures"
-            jq -c '[.skills[] | select(.status == "failed") | {slug, source, skillId, error}][:20]' "$OUTPUT_FILE"
+            jq -c '.failures' "$OUTPUT_FILE"
             echo "::endgroup::"
             echo "::error::scrape-skills-sh exited with code $EXIT_CODE"
             exit "$EXIT_CODE"

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -463,13 +463,13 @@ test('every workflow that invokes the score wrapper is enumerated and holds the 
 		'free-form metric views input must enter shell only through the environment');
 	assert.doesNotMatch(scrapeRun.slice(scrapeRun.indexOf('run: |')), /\$\{\{\s*inputs\./,
 		'skills.sh shell must not directly interpolate workflow inputs');
-	assert.doesNotMatch(scrapeRun, /--summary/,
-		'skills.sh output must retain per-skill failures for incident diagnosis');
-	assert.match(scrapeRun, /jq -c '\[\.skills\[\] \| select\(\.status == "failed"\) \| \{slug, source, skillId, error\}\]\[:20\]' "\$OUTPUT_FILE"/,
+	assert.match(scrapeRun, /--output json --summary/,
+		'skills.sh output must omit successful rows while retaining bounded failures');
+	assert.match(scrapeRun, /jq -c '\.failures' "\$OUTPUT_FILE"/,
 		'failed runs must print a bounded exact failure identity list');
-	assert.match(scrape, /CLI_VERSION:\s*'2\.16\.2'/,
+	assert.match(scrape, /CLI_VERSION:\s*'2\.16\.3'/,
 		'skills.sh production writes must use an audited CLI version');
-	assert.match(scrape, /CLI_SHA256:\s*'537fca9a42ab691c266532f61afe95f8f29cc7fc42b7728740df94981d1f173c'/,
+	assert.match(scrape, /CLI_SHA256:\s*'77f9bb79304e7dfea6c792b6278b255840ab9b5d889ea621c89480275943794e'/,
 		'skills.sh production writes must bind the audited CLI binary digest');
 	assert.match(scrape, /minimum-version:\s*\$\{\{ env\.CLI_VERSION \}\}/);
 	assert.match(scrape, /require-checksum:\s*'true'/);


### PR DESCRIPTION
## Summary
- pin the scheduled skills.sh writer to released CLI 2.16.3 and its exact Linux x64 SHA-256
- restore `--summary` now that it retains up to 25 exact failure identities
- print only the bounded `failures` array on failure

## Verification
- `CI=true node --test scripts/tests/recalculate-scores.test.mjs`
- `CI=true node --test scripts/tests/workflow-action-pin-policy.test.mjs`

## Release binding
- Skillstore PR: https://github.com/aiskillstore/skillstore/pull/348
- Tag: `cli-v2.16.3`
- Release run: https://github.com/aiskillstore/skillstore/actions/runs/31062395430
- Linux x64 SHA-256: `77f9bb79304e7dfea6c792b6278b255840ab9b5d889ea621c89480275943794e`