### PR TITLE
fix(actions): clean identical approval duplicates

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -196,6 +196,12 @@ jobs:
             echo "Moving $PENDING_DIR to $TARGET_DIR"
 
             mkdir -p "$(dirname "$TARGET_DIR")"
+            if [ -d "$TARGET_DIR" ] && [ ! -L "$TARGET_DIR" ] \
+              && diff -qr --exclude=skill-report.json "$PENDING_DIR" "$TARGET_DIR"; then
+              echo "Published skill already matches; removing duplicate pending submission"
+              rm -rf -- "$PENDING_DIR"
+              continue
+            fi
             test ! -e "$TARGET_DIR" && test ! -L "$TARGET_DIR" || {
               echo "::error::Refusing to overwrite existing published target $TARGET_DIR"
               exit 1

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -738,6 +738,8 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.match(approval, /symlink or non-directory path component/);
   assert.match(approval, /node scripts\/resolve-approved-submission\.mjs/);
   assert.match(approval, /mapfile -t SKILL_PATHS/);
+  assert.match(approval, /diff -qr --exclude=skill-report\.json "\$PENDING_DIR" "\$TARGET_DIR"/);
+  assert.match(approval, /rm -rf -- "\$PENDING_DIR"/);
   assert.match(approval, /Refusing to overwrite existing published target/);
   assert.match(approval, /git diff --quiet "\$MERGE_COMMIT_SHA" HEAD -- "\$PENDING_DIR"/);
   assert.match(approval, /git add -A -f -- "\$\{SKILL_PATHS\[@\]\}" "\$\{TARGET_PATHS\[@\]\}"/);


### PR DESCRIPTION
## Root cause
A later merged submission can re-add a pending skill that is already published by an earlier approval. The overwrite guard correctly fails, but leaves an identical pending duplicate and a red approval job.

## Fix
When every non-report file is byte-identical, keep the published copy and delete only the duplicate pending tree. Any content mismatch still fails closed.

## Validation
- CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs
- git diff --check