### PR TITLE
fix: support audited immutable listing updates

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -11,6 +11,26 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
+      - name: Verify trusted submission PR provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
+          jq -e --arg repository "$REPOSITORY" '
+            .merged == true and
+            .user.id == 254047988 and
+            .user.login == "ai-skill-store[bot]" and
+            .head.repo.full_name == $repository and
+            (.head.ref | startswith("submission/")) and
+            any(.labels[]; .name == "pending-review")
+          ' <<< "$PR" >/dev/null || {
+            echo "::error::Merged pending-review PR does not have trusted submission provenance"
+            exit 1
+          }
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -187,6 +207,13 @@ jobs:
               exit 1
             }
           done
+          while IFS= read -r TARGET_DIR; do
+            [ -n "$TARGET_DIR" ] || continue
+            git diff --quiet "$MERGE_COMMIT_SHA" HEAD -- "$TARGET_DIR" || {
+              echo "::error::Published update target changed after the reviewed merge: $TARGET_DIR"
+              exit 1
+            }
+          done < <(jq -r '.skills[] | select(.update == true) | .targetDir' "$APPROVAL_PLAN")
 
           echo "=== Moving skills from pending to skills ==="
           for PENDING_DIR in "${SKILL_PATHS[@]}"; do
@@ -194,6 +221,18 @@ jobs:
               '.skills[] | select(.pendingDir == $pendingDir) | .targetDir' "$APPROVAL_PLAN")
 
             echo "Moving $PENDING_DIR to $TARGET_DIR"
+
+            IS_UPDATE=$(jq -r --arg pendingDir "$PENDING_DIR" \
+              '.skills[] | select(.pendingDir == $pendingDir) | .update' "$APPROVAL_PLAN")
+            if [ "$IS_UPDATE" = "true" ]; then
+              test -d "$TARGET_DIR" && test ! -L "$TARGET_DIR" || {
+                echo "::error::Reviewed update target is missing or unsafe: $TARGET_DIR"
+                exit 1
+              }
+              rm -rf -- "$TARGET_DIR"
+              mv "$PENDING_DIR" "$TARGET_DIR"
+              continue
+            fi
 
             mkdir -p "$(dirname "$TARGET_DIR")"
             if [ -d "$TARGET_DIR" ] && [ ! -L "$TARGET_DIR" ] \
@@ -230,12 +269,33 @@ jobs:
             # conflict or an exhausted retry window is a hard failure; never report
             # a merged callback after dropping the publication commit.
             PUSHED=false
+            verify_update_parent() {
+              local target_dir expected_tree expected_ref parent_report parent_tree
+              while IFS= read -r target_dir; do
+                [ -n "$target_dir" ] || continue
+                expected_tree=$(jq -er '.meta.previous_tree_hash' "$target_dir/skill-report.json")
+                expected_ref=$(jq -er '.meta.previous_source_ref' "$target_dir/skill-report.json")
+                parent_report=$(git show "HEAD^:$target_dir/skill-report.json")
+                parent_tree=$(node scripts/resolve-approved-submission.mjs \
+                  --tree-hash-at-commit \
+                  --repo-root "$PWD" \
+                  --commit HEAD^ \
+                  --skill-dir "$target_dir")
+                jq -e --arg treeHash "$expected_tree" --arg sourceRef "$expected_ref" \
+                  '.meta.tree_hash == $treeHash and .meta.source_ref == $sourceRef' \
+                  <<< "$parent_report" >/dev/null && [ "$parent_tree" = "$expected_tree" ] || {
+                    echo "::error::Published update target changed before push: $target_dir"
+                    exit 1
+                  }
+              done < <(jq -r '.skills[] | select(.update == true) | .targetDir' "$APPROVAL_PLAN")
+            }
             # Keep every merged approval lossless under bursty main-branch writes.
             # ponytail: optimistic remote serialization; add a durable queue only if
             # contention still exceeds this bounded retry window.
             for i in {1..12}; do
               git fetch origin main
               git rebase origin/main
+              verify_update_parent
               if git push origin HEAD:main; then
                 echo "✅ Successfully pushed to main"
                 PUSHED=true

--- a/.github/workflows/publication-provenance.yml
+++ b/.github/workflows/publication-provenance.yml
@@ -1,0 +1,71 @@
+name: Publication Provenance
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  publication-admission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Admit only trusted publication branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          FILES="${RUNNER_TEMP:?}/publication-files-${GITHUB_RUN_ID:?}.bin"
+          trap 'rm -f "$FILES"' EXIT
+          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --slurp \
+            | jq -j '.[][].filename, "\u0000"' > "$FILES"
+
+          publication_kind=''
+          while IFS= read -r -d '' path; do
+            [[ "$path" != *$'\n'* && "$path" != *$'\r'* && "$path" != *'\\'* ]] || {
+              echo "::error::Unsafe changed path"
+              exit 1
+            }
+            case "$path" in
+              pending/*)
+                [ -z "$publication_kind" ] || [ "$publication_kind" = pending ] || {
+                  echo "::error::A PR cannot mix pending and published Skill changes"
+                  exit 1
+                }
+                publication_kind=pending
+                ;;
+              skills/*)
+                [ -z "$publication_kind" ] || [ "$publication_kind" = skills ] || {
+                  echo "::error::A PR cannot mix pending and published Skill changes"
+                  exit 1
+                }
+                publication_kind=skills
+                ;;
+            esac
+          done < "$FILES"
+
+          [ -n "$publication_kind" ] || exit 0
+          [ "$AUTHOR_ID" = 254047988 ] \
+            && [ "$AUTHOR_LOGIN" = 'ai-skill-store[bot]' ] \
+            && [ "$HEAD_REPOSITORY" = "$REPOSITORY" ] || {
+              echo "::error::Publication files must come from the trusted Skillstore App"
+              exit 1
+            }
+
+          while IFS= read -r -d '' path; do
+            case "$publication_kind:$HEAD_REF:$path" in
+              pending:submission/*:pending/*|skills:skill-source-monitor/*:skills/*) ;;
+              *)
+                echo "::error::Publication PR contains an unauthorized branch or path: $path"
+                exit 1
+                ;;
+            esac
+          done < "$FILES"

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -149,6 +149,7 @@ jobs:
       target_reason: ${{ steps.targets.outputs.reason_code }}
       existing_count: ${{ steps.targets.outputs.existing_count }}
       existing_targets: ${{ steps.targets.outputs.existing_targets }}
+      update_snapshots: ${{ steps.targets.outputs.update_snapshots }}
     steps:
       - name: Clear inherited discovery checkout
         run: |
@@ -270,6 +271,7 @@ jobs:
           OWNER=$(jq -er '.owner' <<< "$RESOLVED")
           REPO=$(jq -er '.repo' <<< "$RESOLVED")
           REF=$(jq -er '.ref' <<< "$RESOLVED")
+          REF_TYPE=$(jq -er '.refType' <<< "$RESOLVED")
           REF_SHA=$(jq -er '.refSha' <<< "$RESOLVED")
           SKILL_PATH=$(jq -er '.skillPath' <<< "$RESOLVED")
           EXPLICIT_PATH=$(jq -r '
@@ -280,11 +282,19 @@ jobs:
             end
           ' <<< "$RESOLVED")
           NORMALIZED_URL=$(jq -er '.normalizedUrl' <<< "$RESOLVED")
+          VERIFIED_SHA=$(gh api "repos/$OWNER_REPO/commits/$REF_SHA" --jq '.sha')
+          test "$VERIFIED_SHA" = "$REF_SHA" || {
+            echo "::error::Source commit could not be verified exactly: $REF_SHA"
+            exit 1
+          }
           SOURCE_DIR="${RUNNER_TEMP:?}/submission-source-${{ github.run_id }}-${{ github.run_attempt }}"
           rm -rf "$SOURCE_DIR"
-          git clone --depth 1 --branch "$REF" "https://github.com/$OWNER/$REPO.git" "$SOURCE_DIR"
+          git init "$SOURCE_DIR"
+          git -C "$SOURCE_DIR" remote add origin "https://github.com/$OWNER/$REPO.git"
+          git -C "$SOURCE_DIR" fetch --no-tags --depth 1 origin "$REF_SHA"
+          git -C "$SOURCE_DIR" checkout --detach FETCH_HEAD
           test "$(git -C "$SOURCE_DIR" rev-parse HEAD)" = "$REF_SHA" || {
-            echo "::error::Resolved source ref moved during clone: $REF"
+            echo "::error::Resolved source checkout does not match $REF_TYPE $REF"
             exit 1
           }
 
@@ -443,10 +453,12 @@ jobs:
           SELECTED_COUNT=$(jq -er '.selectedCount' <<< "$CLASSIFICATION")
           EXISTING_COUNT=$(jq -er '.existingCount' <<< "$CLASSIFICATION")
           EXISTING_TARGETS=$(jq -er '.existingTargets | join(",")' <<< "$CLASSIFICATION")
+          UPDATE_SNAPSHOTS=$(jq -cer '.updateSnapshots // []' <<< "$CLASSIFICATION")
           echo "disposition=$DISPOSITION" >> "$GITHUB_OUTPUT"
           echo "reason_code=$REASON_CODE" >> "$GITHUB_OUTPUT"
           echo "existing_count=$EXISTING_COUNT" >> "$GITHUB_OUTPUT"
           echo "existing_targets=$EXISTING_TARGETS" >> "$GITHUB_OUTPUT"
+          echo "update_snapshots=$UPDATE_SNAPSHOTS" >> "$GITHUB_OUTPUT"
           if [ "$DISPOSITION" = "all_existing" ]; then
             echo "::notice title=SUBMISSION_ALREADY_PUBLISHED::All $EXISTING_COUNT selected targets already exist; skipping CLI, AI, shards, artifacts, branch, and PR"
           fi
@@ -884,6 +896,8 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           SHARD_MATRIX: ${{ needs.discover-and-plan.outputs.matrix }}
+          UPDATE_TARGETS: ${{ needs.discover-and-plan.outputs.existing_targets }}
+          UPDATE_SNAPSHOTS: ${{ needs.discover-and-plan.outputs.update_snapshots }}
         run: |
           set -euo pipefail
 
@@ -996,6 +1010,12 @@ jobs:
           cd "$WORK_DIR"
 
           echo "=== Copying only frozen submission results ==="
+          is_update_target() {
+            case ",$UPDATE_TARGETS," in
+              *",$1,"*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
           for pending_dir in "${SUBMISSION_PATHS[@]}"; do
             test ! -e "$WORK_DIR/$pending_dir" || {
               echo "::error::Pending path already exists on main: $pending_dir"
@@ -1003,12 +1023,39 @@ jobs:
             }
             target_dir=$(jq -r --arg pendingDir "$pending_dir" \
               '.skills[] | select(.pendingDir == $pendingDir) | .targetDir' "$APPROVAL_PLAN")
-            test ! -e "$WORK_DIR/$target_dir" || {
-              echo "::error::Published target already exists; use the explicit update workflow: $target_dir"
-              exit 1
-            }
+            if is_update_target "$target_dir"; then
+              test -d "$WORK_DIR/$target_dir" && test ! -L "$WORK_DIR/$target_dir" || {
+                echo "::error::Frozen update target is missing or unsafe: $target_dir"
+                exit 1
+              }
+              SNAPSHOT=$(jq -cer --arg targetDir "$target_dir" \
+                '[.[] | select(.targetDir == $targetDir)] | if length == 1 then .[0] else error("missing update snapshot") end' \
+                <<< "$UPDATE_SNAPSHOTS")
+              EXPECTED_TREE_HASH=$(jq -er '.treeHash' <<< "$SNAPSHOT")
+              EXPECTED_SOURCE_REF=$(jq -er '.sourceRef' <<< "$SNAPSHOT")
+              CURRENT_REPORT="$WORK_DIR/$target_dir/skill-report.json"
+              jq -e --arg treeHash "$EXPECTED_TREE_HASH" --arg sourceRef "$EXPECTED_SOURCE_REF" \
+                '.meta.tree_hash == $treeHash and .meta.source_ref == $sourceRef' \
+                "$CURRENT_REPORT" >/dev/null || {
+                  echo "::error::Published update target changed after classification: $target_dir"
+                  exit 1
+                }
+            else
+              test ! -e "$WORK_DIR/$target_dir" && test ! -L "$WORK_DIR/$target_dir" || {
+                echo "::error::Unexpected published target collision: $target_dir"
+                exit 1
+              }
+            fi
             mkdir -p "$WORK_DIR/$(dirname "$pending_dir")"
             cp -R "$MERGED_RESULTS/$pending_dir" "$WORK_DIR/$pending_dir"
+            if is_update_target "$target_dir"; then
+              REPORT="$WORK_DIR/$pending_dir/skill-report.json"
+              TEMP_REPORT="${REPORT}.tmp"
+              jq --arg treeHash "$EXPECTED_TREE_HASH" --arg sourceRef "$EXPECTED_SOURCE_REF" \
+                '.meta.previous_tree_hash = $treeHash | .meta.previous_source_ref = $sourceRef' \
+                "$REPORT" > "$TEMP_REPORT"
+              mv "$TEMP_REPORT" "$REPORT"
+            fi
           done
 
           PROCESSED_COUNT=0
@@ -1076,13 +1123,13 @@ jobs:
           if [ "$PROCESSED_COUNT" -eq 1 ]; then
             FIRST_SKILL=$(echo "$PROCESSED_SKILLS" | cut -d',' -f1)
             git commit -m "Add pending skill: $FIRST_SKILL [submission: ${{ inputs.submission_id }}] $APPROVAL_INFO"
-            PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")New skill: $FIRST_SKILL ($HIGHEST_RISK risk)"
+            PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")$([ -n "$UPDATE_TARGETS" ] && echo "Update" || echo "New") skill: $FIRST_SKILL ($HIGHEST_RISK risk)"
           else
             git commit -m "Add $PROCESSED_COUNT pending skills from $REPO_NAME [submission: ${{ inputs.submission_id }}] $APPROVAL_INFO"
             if [ "$IS_SHARDED" = "true" ]; then
-              PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")New skills: $PROCESSED_COUNT skills from $REPO_NAME ($HIGHEST_RISK) [parallel: ${SHARD_COUNT} shards]"
+              PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")$([ -n "$UPDATE_TARGETS" ] && echo "Update" || echo "New") skills: $PROCESSED_COUNT skills from $REPO_NAME ($HIGHEST_RISK) [parallel: ${SHARD_COUNT} shards]"
             else
-              PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")New skills: $PROCESSED_COUNT skills from $REPO_NAME ($HIGHEST_RISK risk)"
+              PR_TITLE="$([ "${{ inputs.is_manual_approval }}" = "true" ] && echo "[APPROVED] " || echo "")$([ -n "$UPDATE_TARGETS" ] && echo "Update" || echo "New") skills: $PROCESSED_COUNT skills from $REPO_NAME ($HIGHEST_RISK risk)"
             fi
           fi
 

--- a/schemas/skill-report.schema.json
+++ b/schemas/skill-report.schema.json
@@ -85,6 +85,16 @@
           "type": ["string", "null"],
           "pattern": "^[a-f0-9]{40}$",
           "description": "Immutable upstream Git commit used to build this report"
+        },
+        "previous_tree_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "Canonical tree hash of the published revision this audited update replaces"
+        },
+        "previous_source_ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source reference of the published revision this audited update replaces"
         }
       }
     },

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -8,6 +8,7 @@ import {
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { validateSlugAliasRegistry } from './discover-submission-skills.mjs';
+import { calculateCanonicalTreeHash } from './resolve-approved-submission.mjs';
 import { parseSelectionPlan, validateSelectionPlan } from './submission-selection-plan.mjs';
 
 const SOURCE_TYPES = new Set(['community', 'official']);
@@ -183,18 +184,15 @@ function sourceMismatch(message) {
   throw new SourceIdentityMismatchError(message);
 }
 
-function assertSourceIdentity(report, { repository, sourceRef, skillPath }, reportPath) {
+function assertSourceIdentity(report, { repository, skillPath }, reportPath) {
   const sourceUrl = report?.meta?.source_url;
   const reportRef = report?.meta?.source_ref;
   if (typeof sourceUrl !== 'string' || typeof reportRef !== 'string' || reportRef === '') {
     fail(`published skill report is missing source_url or source_ref: ${reportPath}`);
   }
-  if (reportRef !== sourceRef) {
-    sourceMismatch(`published target source ref mismatch at ${reportPath}: expected ${sourceRef}, got ${reportRef}`);
-  }
 
   const segments = decodedSegments(sourceUrl);
-  const canonicalPath = `/${repository}/tree/${encodeURIComponent(sourceRef)}${skillPath === '.'
+  const canonicalPath = `/${repository}/tree/${encodeURIComponent(reportRef)}${skillPath === '.'
     ? ''
     : `/${skillPath.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`}`;
   const parsedPath = new URL(sourceUrl).pathname;
@@ -216,9 +214,10 @@ function assertSourceIdentity(report, { repository, sourceRef, skillPath }, repo
   }
   const actualPath = actualPathSegments.join('/');
   const actualRef = remainder.slice(0, remainder.length - pathSegments.length).join('/');
-  if (actualRef !== sourceRef || actualPath !== (skillPath === '.' ? '' : skillPath)) {
+  if (actualRef !== reportRef || actualPath !== (skillPath === '.' ? '' : skillPath)) {
     sourceMismatch(`published target source path mismatch at ${reportPath}: expected ${skillPath}`);
   }
+  return reportRef;
 }
 
 function validateCandidate(candidate, identity) {
@@ -249,8 +248,13 @@ function validateCandidate(candidate, identity) {
     fail(`flat published target must be official at ${reportPath}`);
   }
 
-  assertSourceIdentity(report, identity, reportPath);
-  return candidate.relativePath;
+  const sourceRef = assertSourceIdentity(report, identity, reportPath);
+  return {
+    directory: candidate.directory,
+    relativePath: candidate.relativePath,
+    sourceRef,
+    treeHash: report.meta.tree_hash,
+  };
 }
 
 function assertNoPendingCollision(root, owner, slug) {
@@ -280,6 +284,9 @@ export function classifySubmissionTargets({
     .map((alias) => [alias.path, alias]));
   const expectedLayout = OFFICIAL_REPOSITORIES.has(plan.repository) ? 'official' : 'community';
   const existingTargets = [];
+  const sameRevisionTargets = [];
+  const updateTargets = [];
+  const updateSnapshots = [];
   const newTargets = [];
 
   for (const skill of plan.skills) {
@@ -334,13 +341,30 @@ export function classifySubmissionTargets({
     }
 
     if (expectedTarget !== null && alternateExact !== null) {
-      fail(`ambiguous published target identity for ${skill.slug}: ${expectedTarget}, ${alternateExact}`);
+      fail(`ambiguous published target identity for ${skill.slug}: ${expectedTarget.relativePath}, ${alternateExact.relativePath}`);
     }
     if (expectedTarget === null && alternateExact !== null) {
-      fail(`published target identity for ${skill.slug} exists at unexpected path: ${alternateExact}`);
+      fail(`published target identity for ${skill.slug} exists at unexpected path: ${alternateExact.relativePath}`);
     }
     if (expectedTarget !== null) {
-      existingTargets.push(expectedTarget);
+      existingTargets.push(expectedTarget.relativePath);
+      if (expectedTarget.sourceRef === sourceRef) {
+        sameRevisionTargets.push(expectedTarget.relativePath);
+      } else {
+        if (sourceRef !== plan.sourceCommit || !/^[0-9a-f]{40}$/.test(sourceRef)) {
+          fail('existing targets must be updated with an immutable commit URL');
+        }
+        if (!HASH.test(expectedTarget.treeHash ?? '')
+          || calculateCanonicalTreeHash(root, expectedTarget.relativePath) !== expectedTarget.treeHash) {
+          fail(`published update target tree_hash is missing or stale: ${expectedTarget.relativePath}`);
+        }
+        updateTargets.push(expectedTarget.relativePath);
+        updateSnapshots.push({
+          targetDir: expectedTarget.relativePath,
+          treeHash: expectedTarget.treeHash,
+          sourceRef: expectedTarget.sourceRef,
+        });
+      }
       continue;
     }
     newTargets.push(expectedCandidate.relativePath);
@@ -349,20 +373,27 @@ export function classifySubmissionTargets({
   if (existingTargets.length > 0 && newTargets.length > 0) {
     fail(`partial published-target collision: ${existingTargets.length} existing, ${newTargets.length} new`);
   }
+  if (sameRevisionTargets.length > 0 && updateTargets.length > 0) {
+    fail(`mixed current and updated targets: ${sameRevisionTargets.length} current, ${updateTargets.length} updates`);
+  }
 
-  const disposition = existingTargets.length === plan.skills.length && plan.skills.length > 0
+  const disposition = sameRevisionTargets.length === plan.skills.length && plan.skills.length > 0
     ? 'all_existing'
     : 'processable';
-  return {
+  const result = {
     schemaVersion: 1,
     disposition,
     reasonCode: disposition === 'all_existing'
       ? 'all_selected_targets_already_published'
-      : 'no_selected_targets_already_published',
+      : updateTargets.length > 0
+        ? 'all_selected_targets_are_updates'
+        : 'no_selected_targets_already_published',
     selectedCount: plan.skills.length,
     existingCount: existingTargets.length,
     existingTargets: existingTargets.sort((left, right) => left.localeCompare(right, 'en')),
   };
+  if (updateSnapshots.length > 0) result.updateSnapshots = updateSnapshots;
+  return result;
 }
 
 function main() {

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { posix, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -50,6 +51,47 @@ function readJson(path, label) {
   }
 }
 
+function sourceIdentity(report, label) {
+  const sourceUrl = report?.meta?.source_url;
+  const sourceRef = report?.meta?.source_ref;
+  if (typeof sourceUrl !== 'string' || typeof sourceRef !== 'string' || sourceRef === '') {
+    fail(`${label} is missing source_url or source_ref`);
+  }
+  let url;
+  try {
+    url = new URL(sourceUrl);
+  } catch {
+    fail(`${label} has an invalid source_url`);
+  }
+  if (url.protocol !== 'https:' || url.hostname !== 'github.com' || url.search || url.hash
+    || url.username || url.password || url.port) {
+    fail(`${label} source_url must be a plain HTTPS GitHub URL`);
+  }
+  let segments;
+  try {
+    segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  } catch {
+    fail(`${label} source_url contains invalid percent encoding`);
+  }
+  const [owner, repo, kind, encodedRef, ...skillPath] = segments;
+  if (!owner || !repo || kind !== 'tree' || encodedRef !== sourceRef
+    || skillPath.some((segment) => segment.includes('/'))
+    || segments.some((segment) => segment === '.' || segment === '..' || segment.includes('\\') || /[\u0000-\u001f\u007f]/u.test(segment))) {
+    fail(`${label} source_url does not match source_ref`);
+  }
+  const canonicalPath = `/${owner}/${repo}/tree/${encodeURIComponent(sourceRef)}${skillPath.length > 0
+    ? `/${skillPath.map(encodeURIComponent).join('/')}`
+    : ''}`;
+  if (url.pathname !== canonicalPath && url.pathname !== `${canonicalPath}/`) {
+    fail(`${label} source_url is not canonical`);
+  }
+  return {
+    repository: `${owner}/${repo}`.toLowerCase(),
+    path: skillPath.join('/'),
+    ref: sourceRef,
+  };
+}
+
 function sha256(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
@@ -91,6 +133,59 @@ function collectCanonicalEntries(repositoryRoot, directory, baseDirectory) {
 export function calculateCanonicalTreeHash(repositoryRoot, skillDirectory) {
   const entries = collectCanonicalEntries(repositoryRoot, skillDirectory, skillDirectory)
     .sort((a, b) => a.path.localeCompare(b.path, 'en', { sensitivity: 'variant' }));
+  return createHash('sha256').update(entries.map((entry) => JSON.stringify(entry)).join('\n')).digest('hex');
+}
+
+function gitBuffer(repositoryRoot, args) {
+  const result = spawnSync('git', ['-C', repositoryRoot, ...args], {
+    encoding: 'buffer',
+    maxBuffer: 100 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(' ')} failed: ${result.stderr.toString('utf8').trim()}`);
+  }
+  return result.stdout;
+}
+
+export function calculateCanonicalTreeHashAtCommit(repositoryRoot, commit, skillDirectory) {
+  const normalizedDirectory = normalizeFrozenPath(skillDirectory);
+  if (!normalizedDirectory?.startsWith('skills/')) fail('committed skill directory must be under skills/');
+  const resolvedCommit = gitBuffer(repositoryRoot, ['rev-parse', '--verify', `${commit}^{commit}`])
+    .toString('utf8').trim();
+  if (!/^[0-9a-f]{40}$/.test(resolvedCommit)) fail(`invalid resolved commit: ${resolvedCommit}`);
+  const listing = gitBuffer(repositoryRoot, [
+    'ls-tree', '-rz', '--full-tree', resolvedCommit, '--', normalizedDirectory,
+  ]);
+  let listingText;
+  try {
+    listingText = new TextDecoder('utf-8', { fatal: true }).decode(listing);
+  } catch {
+    fail(`committed skill tree contains a non-UTF-8 path: ${normalizedDirectory}`);
+  }
+  const entries = [];
+  for (const record of listingText.split('\0').filter(Boolean)) {
+    const tab = record.indexOf('\t');
+    const header = record.slice(0, tab).split(' ');
+    const path = record.slice(tab + 1);
+    if (tab < 0 || header.length !== 3 || !path.startsWith(`${normalizedDirectory}/`)) {
+      fail(`invalid committed tree entry for ${normalizedDirectory}`);
+    }
+    const [mode, type, object] = header;
+    const treePath = path.slice(normalizedDirectory.length + 1);
+    if (treePath === 'skill-report.json' || treePath.split('/').some(isSystemTempFile)
+      || treePath.split('/').includes('.git')) continue;
+    if (type !== 'blob' || !['100644', '100755'].includes(mode) || !/^[0-9a-f]{40,64}$/.test(object)) {
+      fail(`committed skill tree contains an unsupported entry: ${path}`);
+    }
+    const bytes = gitBuffer(repositoryRoot, ['cat-file', 'blob', object]);
+    entries.push({
+      path: treePath,
+      mode,
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+      size: bytes.byteLength,
+    });
+  }
+  entries.sort((a, b) => a.path.localeCompare(b.path, 'en', { sensitivity: 'variant' }));
   return createHash('sha256').update(entries.map((entry) => JSON.stringify(entry)).join('\n')).digest('hex');
 }
 
@@ -200,6 +295,45 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
     }
 
     const targetDir = `skills/${segments.slice(1).join('/')}`;
+    const targetPath = resolve(root, targetDir);
+    const update = existsSync(targetPath);
+    let previousSourceRef = null;
+    if (update) {
+      const targetStat = lstatSync(targetPath);
+      if (targetStat.isSymbolicLink() || !targetStat.isDirectory()) {
+        fail(`${targetDir} must be a non-symlink directory`);
+      }
+      const publishedReportPath = resolve(targetPath, 'skill-report.json');
+      if (!existsSync(publishedReportPath) || lstatSync(publishedReportPath).isSymbolicLink()
+        || !lstatSync(publishedReportPath).isFile()) {
+        fail(`${targetDir}/skill-report.json is missing or unsafe`);
+      }
+      const publishedReport = readJson(publishedReportPath, `${targetDir}/skill-report.json`);
+      const publishedTreeHash = calculateCanonicalTreeHash(root, targetDir);
+      if (publishedReport?.meta?.tree_hash !== publishedTreeHash) {
+        fail(`${targetDir} published tree_hash does not match the canonical skill tree`);
+      }
+      const nextIdentity = sourceIdentity(report, `${pendingDir}/skill-report.json`);
+      const previousIdentity = sourceIdentity(publishedReport, `${targetDir}/skill-report.json`);
+      const expectedPreviousTreeHash = report?.meta?.previous_tree_hash;
+      const expectedPreviousSourceRef = report?.meta?.previous_source_ref;
+      if (!/^[0-9a-f]{64}$/.test(expectedPreviousTreeHash ?? '')
+        || typeof expectedPreviousSourceRef !== 'string' || expectedPreviousSourceRef === ''
+        || publishedTreeHash !== expectedPreviousTreeHash
+        || previousIdentity.ref !== expectedPreviousSourceRef) {
+        fail(`${pendingDir} reviewed update snapshot does not match the published target`);
+      }
+      if (report.meta.source_type !== publishedReport?.meta?.source_type
+        || report.meta.slug !== publishedReport?.meta?.slug
+        || nextIdentity.repository !== previousIdentity.repository
+        || nextIdentity.path !== previousIdentity.path) {
+        fail(`${pendingDir} source identity does not match the published target`);
+      }
+      if (!/^[0-9a-f]{40}$/.test(nextIdentity.ref) || nextIdentity.ref === previousIdentity.ref) {
+        fail(`${pendingDir} update must use a new immutable source commit`);
+      }
+      previousSourceRef = expectedPreviousSourceRef;
+    }
     return {
       contentHash: actualContentHash,
       treeHash: actualTreeHash,
@@ -207,6 +341,8 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
       reportSlug: report.meta.slug,
       sourceType,
       targetDir,
+      update,
+      previousSourceRef,
     };
   });
 
@@ -224,6 +360,14 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
 
 function main() {
   const args = process.argv.slice(2);
+  if (args.includes('--tree-hash-at-commit')) {
+    process.stdout.write(`${calculateCanonicalTreeHashAtCommit(
+      readOption(args, '--repo-root'),
+      readOption(args, '--commit'),
+      readOption(args, '--skill-dir'),
+    )}\n`);
+    return;
+  }
   const repositoryRoot = readOption(args, '--repo-root');
   const filesPath = readOption(args, '--files');
   const outputPath = readOption(args, '--output');

--- a/scripts/resolve-submission-source.mjs
+++ b/scripts/resolve-submission-source.mjs
@@ -122,6 +122,26 @@ export function resolveSubmissionSource({ githubUrl, defaultRef, refsText }) {
 
   const tail = segments.slice(3);
   if (tail.length === 0) fail(`GitHub ${mode} URL is missing a ref: ${githubUrl}`);
+  if (/^[0-9a-f]{40}$/.test(tail[0])) {
+    let skillPath = tail.slice(1);
+    if (mode === 'blob') {
+      if (skillPath.length === 0) fail('GitHub blob URL is missing a file path');
+      const file = skillPath.at(-1);
+      if (file.toLowerCase() !== 'skill.md') fail(`submission blob URL must point to SKILL.md, got ${file}`);
+      skillPath = skillPath.slice(0, -1);
+    }
+    return {
+      schemaVersion: 1,
+      owner,
+      repo,
+      ref: tail[0],
+      refType: 'commit',
+      refSha: tail[0],
+      skillPath: mode === 'blob' && skillPath.length === 0 ? '.' : skillPath.join('/'),
+      explicitPath: mode === 'blob' || skillPath.length > 0,
+      normalizedUrl: normalizedTreeUrl(owner, repo, tail[0], skillPath),
+    };
+  }
   const candidates = [];
   for (let split = 1; split <= tail.length; split += 1) {
     const candidate = tail.slice(0, split).join('/');

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
 
 import {
   calculateCanonicalTreeHash,
+  calculateCanonicalTreeHashAtCommit,
   resolveApprovedSubmission,
 } from '../resolve-approved-submission.mjs';
 
@@ -22,6 +24,10 @@ function addSkill(root, pendingDir, {
   hash = null,
   slug = 'owner-skill',
   sourceType = 'community',
+  sourceRef = '1'.repeat(40),
+  sourceUrl = null,
+  previousSourceRef = null,
+  previousTreeHash = null,
   treeHash = null,
   withReference = false,
 } = {}) {
@@ -32,7 +38,11 @@ function addSkill(root, pendingDir, {
       content_hash: hash ?? createHash('sha256').update(content).digest('hex'),
       slug,
       source_type: sourceType,
+      source_ref: sourceRef,
+      source_url: sourceUrl ?? `https://github.com/owner/repo/tree/${sourceRef}/skills/skill`,
       tree_hash: treeHash ?? calculateCanonicalTreeHash(root, pendingDir),
+      ...(previousSourceRef ? { previous_source_ref: previousSourceRef } : {}),
+      ...(previousTreeHash ? { previous_tree_hash: previousTreeHash } : {}),
     },
     security_audit: { is_blocked: blocked, safe_to_publish: false },
   })}\n`);
@@ -46,6 +56,30 @@ function withRepository(run) {
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+function git(root, ...args) {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test('calculates a canonical skill hash from immutable Git blobs', () => withRepository((root) => {
+  addSkill(root, 'skills/owner/skill', { slug: 'owner-skill', withReference: true });
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'add', '.');
+  git(root, 'commit', '-qm', 'fixture');
+  assert.equal(
+    calculateCanonicalTreeHashAtCommit(root, 'HEAD', 'skills/owner/skill'),
+    calculateCanonicalTreeHash(root, 'skills/owner/skill'),
+  );
+  write(root, 'skills/owner/skill/references/note.md', '# Changed\n');
+  assert.notEqual(
+    calculateCanonicalTreeHashAtCommit(root, 'HEAD', 'skills/owner/skill'),
+    calculateCanonicalTreeHash(root, 'skills/owner/skill'),
+  );
+}));
 
 test('resolves only frozen PR files and ignores unrelated pending submissions', () => withRepository((root) => {
   addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
@@ -72,6 +106,54 @@ test('supports an official flat pending skill', () => withRepository((root) => {
     changedFiles: ['pending/official-skill/SKILL.md', 'pending/official-skill/skill-report.json'],
   });
   assert.equal(plan.skills[0].targetDir, 'skills/official-skill');
+}));
+
+test('authorizes a reviewed update only when repository and source path stay stable', () => withRepository((root) => {
+  const oldCommit = '1'.repeat(40);
+  const newCommit = '2'.repeat(40);
+  addSkill(root, 'skills/owner/skill', {
+    slug: 'owner-skill',
+    sourceRef: oldCommit,
+    sourceUrl: `https://github.com/owner/repo/tree/${oldCommit}/skills/skill`,
+  });
+  addSkill(root, 'pending/owner/skill', {
+    slug: 'owner-skill',
+    content: '# Updated\n',
+    sourceRef: newCommit,
+    sourceUrl: `https://github.com/owner/repo/tree/${newCommit}/skills/skill`,
+    previousSourceRef: oldCommit,
+    previousTreeHash: calculateCanonicalTreeHash(root, 'skills/owner/skill'),
+  });
+
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: ['pending/owner/skill/SKILL.md', 'pending/owner/skill/skill-report.json'],
+  });
+  assert.equal(plan.skills[0].update, true);
+  assert.equal(plan.skills[0].previousSourceRef, oldCommit);
+
+  const reportPath = join(root, 'pending/owner/skill/skill-report.json');
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  report.meta.previous_tree_hash = '0'.repeat(64);
+  writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/SKILL.md', 'pending/owner/skill/skill-report.json'],
+    }),
+    /reviewed update snapshot does not match/,
+  );
+
+  report.meta.previous_tree_hash = calculateCanonicalTreeHash(root, 'skills/owner/skill');
+  report.meta.source_url = `https://github.com/owner/other/tree/${newCommit}/skills/skill`;
+  writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/SKILL.md', 'pending/owner/skill/skill-report.json'],
+    }),
+    /source identity does not match the published target/,
+  );
 }));
 
 test('rejects root-level and over-nested pending SKILL.md paths', () => withRepository((root) => {

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test } from 'node:test';
 import { classifySubmissionTargets } from '../classify-submission-targets.mjs';
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
 
 const SOURCE_COMMIT = '1'.repeat(40);
 
@@ -68,6 +69,7 @@ function writeTarget(root, slug, {
         model: 'fixture',
         analysis_version: '3.0.0',
         source_type: layout === 'community' ? 'community' : 'official',
+        tree_hash: calculateCanonicalTreeHash(root, relative),
       },
       skill: {
         name: skillName,
@@ -133,6 +135,48 @@ test('all exact community targets become a handled rejection', () => withMarketp
   });
 }));
 
+test('same source identity at a new immutable commit is processed as an update', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT);
+  assert.deepEqual(result, {
+    schemaVersion: 1,
+    disposition: 'processable',
+    reasonCode: 'all_selected_targets_are_updates',
+    selectedCount: 1,
+    existingCount: 1,
+    existingTargets: ['skills/example/alpha'],
+    updateSnapshots: [{
+      targetDir: 'skills/example/alpha',
+      treeHash: calculateCanonicalTreeHash(root, 'skills/example/alpha'),
+      sourceRef: '2'.repeat(40),
+    }],
+  });
+}));
+
+test('the same immutable source commit remains a handled no-op', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: SOURCE_COMMIT });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT);
+  assert.equal(result.disposition, 'all_existing');
+  assert.equal(result.reasonCode, 'all_selected_targets_already_published');
+}));
+
+test('an existing source can only be updated from an immutable commit URL', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), 'main'),
+    /existing targets must be updated with an immutable commit URL/,
+  );
+}));
+
+test('an update refuses a published target whose recorded tree hash is stale', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
+  writeFileSync(join(root, 'skills/example/alpha/SKILL.md'), '---\nname: alpha\n---\nchanged\n');
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT),
+    /tree_hash is missing or stale/,
+  );
+}));
+
 test('an exact repository-bound alias validates the published display name', () => withMarketplace((root) => {
   const path = '装修水电避坑指南';
   const slug = 'zhuangxiu-shuidian-bikeng';
@@ -174,7 +218,7 @@ test('mixed existing and new targets fail closed instead of processing a subset'
 
 for (const mismatch of [
   { name: 'repository', options: { repository: 'other/source' }, pattern: /source (?:repository mismatch|URL is not canonical)|source_url is not canonical/ },
-  { name: 'ref', options: { sourceRef: 'release' }, pattern: /source ref mismatch/ },
+  { name: 'ref', options: { sourceRef: 'release' }, pattern: /immutable commit URL/ },
   { name: 'path', options: { skillPath: 'skills/other' }, pattern: /source (?:path mismatch|URL is not canonical)|source_url is not canonical/ },
 ]) {
   test(`a published target with a ${mismatch.name} mismatch fails closed`, () => withMarketplace((root) => {

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -17,6 +17,7 @@ import { test } from 'node:test';
 const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
 const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
 const approvalCaller = readFileSync('.github/workflows/approve-submission.yml', 'utf8');
+const publicationProvenance = readFileSync('.github/workflows/publication-provenance.yml', 'utf8');
 const cliCompatibilityDescription =
   'Reserved compatibility input; submission processing is pinned to CLI 2.15.12';
 const runtimeFiles = [
@@ -404,6 +405,25 @@ test('submission source metadata lookup retries transient GitHub failures', () =
   assert.match(clone, /test -s "\$REFS_FILE"/);
 });
 
+test('submission checkout verifies and fetches the exact resolved commit', () => {
+  const clone = extractRunBlock(reusable, 'Clone source repository');
+  assert.match(clone, /REF_TYPE=\$\(jq -er '\.refType'/);
+  assert.match(clone, /gh api "repos\/\$OWNER_REPO\/commits\/\$REF_SHA" --jq '\.sha'/);
+  assert.match(clone, /git -C "\$SOURCE_DIR" fetch --no-tags --depth 1 origin "\$REF_SHA"/);
+  assert.match(clone, /git -C "\$SOURCE_DIR" checkout --detach FETCH_HEAD/);
+  assert.doesNotMatch(clone, /git clone --depth 1 --branch/);
+});
+
+test('publication PR admission accepts only trusted bot-owned publication branches', () => {
+  assert.match(publicationProvenance, /publication-admission:/);
+  assert.match(publicationProvenance, /AUTHOR_ID.*github\.event\.pull_request\.user\.id/);
+  assert.match(publicationProvenance, /AUTHOR_LOGIN.*github\.event\.pull_request\.user\.login/);
+  assert.match(publicationProvenance, /HEAD_REPOSITORY.*github\.event\.pull_request\.head\.repo\.full_name/);
+  assert.match(publicationProvenance, /pending:submission\/\*:pending\/\*/);
+  assert.match(publicationProvenance, /skills:skill-source-monitor\/\*:skills\/\*/);
+  assert.match(publicationProvenance, /A PR cannot mix pending and published Skill changes/);
+});
+
 test('repository dispatch caller preserves reusable failure and callback status contracts', () => {
   assert.match(caller, /notify:\n\s+needs: process-skills\n\s+if: always\(\) && github\.event_name == 'repository_dispatch'/);
   assert.match(caller, /name: Notify skillstore - PR created\n\s+if: needs\.process-skills\.outputs\.pr_url/);
@@ -443,9 +463,12 @@ test('existing-target classification is a pre-CLI gate with a handled rejection 
   );
   assert.match(reusable, /existing_targets:/);
   const latePendingGuard = reusable.indexOf('Pending path already exists on main');
-  const latePublishedGuard = reusable.indexOf('Published target already exists; use the explicit update workflow');
+  const latePublishedGuard = reusable.indexOf('Frozen update target is missing or unsafe');
   const lateCopy = reusable.indexOf('cp -R "$MERGED_RESULTS/$pending_dir"');
   assert.ok(latePendingGuard > 0 && latePendingGuard < lateCopy);
   assert.ok(latePublishedGuard > latePendingGuard && latePublishedGuard < lateCopy);
-  assert.match(reusable, /Published target already exists; use the explicit update workflow/);
+  assert.match(reusable, /Unexpected published target collision/);
+  assert.match(reusable, /UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.existing_targets \}\}/);
+  assert.match(reusable, /previous_tree_hash = \$treeHash/);
+  assert.match(reusable, /previous_source_ref = \$sourceRef/);
 });

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -224,7 +224,8 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.doesNotMatch(reusable, /continue-on-error:\s*true/);
   assert.doesNotMatch(reusable, /skill process[\s\S]{0,500}\|\| true/);
   assert.match(reusable, /Enforce shard terminal status/);
-  assert.match(reusable, /Published target already exists; use the explicit update workflow/);
+  assert.match(reusable, /Frozen update target is missing or unsafe/);
+  assert.match(reusable, /Unexpected published target collision/);
 });
 
 test('submission staging preserves frozen tracked files hidden by a copied .gitignore', () => withTempDirectory((root) => {
@@ -730,6 +731,11 @@ test('submission callers emit distinct terminal callbacks for legal no-op, rejec
 });
 
 test('merged approval scope comes only from immutable PR changed files', () => {
+  assert.match(approval, /Verify trusted submission PR provenance/);
+  assert.match(approval, /\.user\.id == 254047988/);
+  assert.match(approval, /\.user\.login == "ai-skill-store\[bot\]"/);
+  assert.match(approval, /\.head\.repo\.full_name == \$repository/);
+  assert.match(approval, /\.head\.ref \| startswith\("submission\/"\)/);
   assert.match(approval, /pulls\/\$PR_NUMBER\/files\?per_page=100/);
   assert.match(approval, /for CLONE_ATTEMPT in 1 2 3/);
   assert.match(approval, /git clone --depth 1 --filter=blob:none --no-checkout/);
@@ -740,8 +746,13 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.match(approval, /mapfile -t SKILL_PATHS/);
   assert.match(approval, /diff -qr --exclude=skill-report\.json "\$PENDING_DIR" "\$TARGET_DIR"/);
   assert.match(approval, /rm -rf -- "\$PENDING_DIR"/);
-  assert.match(approval, /Refusing to overwrite existing published target/);
+  assert.match(approval, /Reviewed update target is missing or unsafe/);
   assert.match(approval, /git diff --quiet "\$MERGE_COMMIT_SHA" HEAD -- "\$PENDING_DIR"/);
+  assert.match(approval, /Published update target changed after the reviewed merge/);
+  assert.match(approval, /verify_update_parent/);
+  assert.match(approval, /--tree-hash-at-commit/);
+  assert.match(approval, /\[ "\$parent_tree" = "\$expected_tree" \]/);
+  assert.match(approval, /Published update target changed before push/);
   assert.match(approval, /git add -A -f -- "\$\{SKILL_PATHS\[@\]\}" "\$\{TARGET_PATHS\[@\]\}"/);
   assert.match(approval, /PUSHED=false/);
   assert.match(approval, /test "\$PUSHED" = true/);
@@ -749,5 +760,5 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.match(approval, /RANDOM % 3/);
   assert.doesNotMatch(approval, /cherry-pick HEAD@\{1\} \|\| true/);
   assert.doesNotMatch(approval, /find pending/);
-  assert.doesNotMatch(approval, /rm -rf "\$TARGET_DIR"/);
+  assert.match(approval, /rm -rf -- "\$TARGET_DIR"/);
 });

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -52,6 +52,26 @@ test('tree URLs resolve the exact non-default ref before percent-decoding the sk
   });
 });
 
+test('tree URLs accept an immutable commit without treating it as an advertised ref', () => {
+  const commit = '3'.repeat(40);
+  const result = resolveSubmissionSource({
+    githubUrl: `https://github.com/example/repo/tree/${commit}/skills/demo`,
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main']),
+  });
+  assert.deepEqual(result, {
+    schemaVersion: 1,
+    owner: 'example',
+    repo: 'repo',
+    ref: commit,
+    refType: 'commit',
+    refSha: commit,
+    skillPath: 'skills/demo',
+    explicitPath: true,
+    normalizedUrl: `https://github.com/example/repo/tree/${commit}/skills/demo`,
+  });
+});
+
 test('slash refs are encoded for the CLI and ambiguous ref/path splits fail closed', () => {
   const slash = resolveSubmissionSource({
     githubUrl: 'https://github.com/example/repo/tree/feature/ready/skills/demo',


### PR DESCRIPTION
## Summary

- accept exact 40-character commit URLs and fetch the verified commit detached
- treat same-repository/path/slug revisions as reviewed updates while preserving no-op behavior
- freeze the previous source/tree identity and revalidate it through merge/rebase
- admit publication PRs only from trusted App-owned automation branches

Related to #2939. This changes the normal submission mechanism; it does not merge contributor publication PRs.

## Verification

- `CI=true node --test --test-timeout=600000 scripts/tests/resolve-approved-submission.test.mjs scripts/tests/submission-existing-targets.test.mjs scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs scripts/tests/submission-source-resolution.test.mjs` (127/127)
- `git diff --check`
- independent security review: CLEAN