### PR TITLE
fix: fail closed on unsafe source monitor updates

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -158,6 +158,7 @@ jobs:
           /scripts/rebind-skill-report-hashes.mjs
           /scripts/resolve-approved-submission.mjs
           /scripts/verify-source-monitor-selection.mjs
+          /scripts/verify-source-monitor-update.mjs
           /skills/**/skill-report.json
           EOF
 
@@ -203,6 +204,7 @@ jobs:
             "scripts/rebind-skill-report-hashes.mjs"
             "scripts/resolve-approved-submission.mjs"
             "scripts/verify-source-monitor-selection.mjs"
+            "scripts/verify-source-monitor-update.mjs"
           )
           {
             echo "expected_workflow_sha=$EXPECTED_WORKFLOW_SHA"
@@ -420,16 +422,27 @@ jobs:
             exit 1
           fi
 
-          git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD -- \
-            'skills/**/SKILL.md' 'skills/**/skill-report.json' > "$CHANGED_ARTIFACTS"
+          {
+            git diff --no-renames --name-only -z --diff-filter=ACDMRT HEAD -- skills
+            git ls-files --others --exclude-standard -z -- skills
+          } > "$CHANGED_ARTIFACTS"
           : > "$CHANGED_SKILLS"
           while IFS= read -r -d '' artifact_path; do
             case "$artifact_path" in
-              skills/*/skill-report.json)
-                printf '%s\0' "${artifact_path%/skill-report.json}/SKILL.md" >> "$CHANGED_SKILLS"
-                ;;
-              skills/*/SKILL.md)
-                printf '%s\0' "$artifact_path" >> "$CHANGED_SKILLS"
+              skills/*/*)
+                relative_path="${artifact_path#skills/}"
+                first="${relative_path%%/*}"
+                remaining="${relative_path#*/}"
+                second="${remaining%%/*}"
+                if [ -f "skills/$first/$second/skill-report.json" ]; then
+                  skill_dir="skills/$first/$second"
+                elif [ -f "skills/$first/skill-report.json" ]; then
+                  skill_dir="skills/$first"
+                else
+                  echo "::error::Changed path is not inside a published skill: $artifact_path"
+                  exit 1
+                fi
+                printf '%s/SKILL.md\0' "$skill_dir" >> "$CHANGED_SKILLS"
                 ;;
               *)
                 echo "::error::Unexpected source monitor artifact path: $artifact_path"
@@ -456,6 +469,18 @@ jobs:
             git add --sparse -f -- "${skill_path%/SKILL.md}/skill-report.json"
           done < "$CHANGED_SKILLS"
           echo "::notice::Bound source monitor report hashes to the exact packaged Marketplace trees"
+
+      - name: Verify source monitor update safety
+        env:
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
+          CREATE_PR: ${{ github.event_name == 'schedule' && 'true' || inputs.create_pr }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ] || [ "$CREATE_PR" != "true" ]; then
+            echo "Source monitor update safety verification skipped because no update PR will be created."
+            exit 0
+          fi
+          node scripts/verify-source-monitor-update.mjs --repo-root "$GITHUB_WORKSPACE"
 
       - name: Generate Fresh GitHub App Token for PR
         id: pr-app-token

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -25,6 +25,7 @@ const runtimeFiles = [
   'scripts/rebind-skill-report-hashes.mjs',
   'scripts/resolve-approved-submission.mjs',
   'scripts/verify-source-monitor-selection.mjs',
+  'scripts/verify-source-monitor-update.mjs',
 ];
 
 test('source monitor shares the production governance writer mutex', () => {
@@ -86,6 +87,7 @@ function createFixture() {
     'scripts/rebind-skill-report-hashes.mjs': 'export const fixture = true;\n',
     'scripts/resolve-approved-submission.mjs': 'export const fixture = true;\n',
     'scripts/verify-source-monitor-selection.mjs': 'export const fixture = true;\n',
+    'scripts/verify-source-monitor-update.mjs': 'export const fixture = true;\n',
     'skills/owner/demo/SKILL.md': '# Demo\n',
     'skills/owner/demo/skill-report.json': '{"meta":{"slug":"owner-demo"}}\n',
     'skills/owner/demo/references/large.txt': 'not needed by the monitor runtime checkout\n',
@@ -258,21 +260,76 @@ test('source monitor verifies every explicit requested slug before later workflo
   );
 });
 
-test('source monitor binds every changed report to its packaged tree before creating a PR', () => {
+test('source monitor binds every changed report and verifies update safety before creating a PR', () => {
   const binding = extractRunBlock('Bind source monitor reports to packaged trees');
-  assert.match(binding, /git diff --no-renames --name-only -z --diff-filter=ACMRT HEAD/);
-  assert.match(binding, /skills\/\*\*\/SKILL\.md/);
-  assert.match(binding, /skills\/\*\*\/skill-report\.json/);
+  assert.match(binding, /git diff --no-renames --name-only -z --diff-filter=ACDMRT HEAD -- skills/);
+  assert.match(binding, /git ls-files --others --exclude-standard -z -- skills/);
+  assert.match(binding, /skills\/\$first\/\$second\/skill-report\.json/);
+  assert.match(binding, /skills\/\$first\/skill-report\.json/);
+  assert.match(binding, /printf '%s\/SKILL\.md\\0'/);
   assert.match(binding, /scripts\/rebind-skill-report-hashes\.mjs/);
   assert.match(binding, /--skill-paths-file/);
   assert.match(binding, /--diff-filter=D/);
   assert.match(binding, /update-index -z --no-skip-worktree --stdin/);
   assert.match(binding, /git add --sparse -A -f/);
+  const safety = extractRunBlock('Verify source monitor update safety');
+  assert.match(safety, /node scripts\/verify-source-monitor-update\.mjs --repo-root "\$GITHUB_WORKSPACE"/);
   assert.ok(
     workflow.indexOf('name: Bind source monitor reports to packaged trees')
-      < workflow.indexOf('name: Create source monitor PR'),
-    'packaged report hashes must be rebound before the source monitor PR is created',
+      < workflow.indexOf('name: Verify source monitor update safety'),
+    'packaged report hashes must be rebound before source monitor update safety is checked',
   );
+  assert.ok(
+    workflow.indexOf('name: Verify source monitor update safety')
+      < workflow.indexOf('name: Create source monitor PR'),
+    'source monitor update safety must pass before the PR is created',
+  );
+});
+
+function assertPayloadOnlyBinding(skillDirectory) {
+  const root = mkdtempSync(join(tmpdir(), 'source-monitor-payload-only-'));
+  const workspace = join(root, 'workspace');
+  const absoluteSkillDirectory = join(workspace, skillDirectory);
+  try {
+    mkdirSync(join(workspace, 'scripts'), { recursive: true });
+    mkdirSync(join(absoluteSkillDirectory, 'references'), { recursive: true });
+    copyFileSync('scripts/rebind-skill-report-hashes.mjs', join(workspace, 'scripts/rebind-skill-report-hashes.mjs'));
+    copyFileSync('scripts/resolve-approved-submission.mjs', join(workspace, 'scripts/resolve-approved-submission.mjs'));
+    writeFileSync(join(absoluteSkillDirectory, 'SKILL.md'), '# Payload only\n');
+    writeFileSync(join(absoluteSkillDirectory, 'references', 'guide.md'), '# Old\n');
+    writeFileSync(join(absoluteSkillDirectory, 'skill-report.json'), `${JSON.stringify({
+      meta: {
+        source_url: 'https://github.com/owner/repository',
+        source_ref: 'main',
+        content_hash: 'old',
+        tree_hash: 'old',
+      },
+    })}\n`);
+    run('git', ['init', '-q', workspace]);
+    run('git', ['-C', workspace, 'config', 'user.name', 'Fixture']);
+    run('git', ['-C', workspace, 'config', 'user.email', 'fixture@example.com']);
+    run('git', ['-C', workspace, 'add', '.']);
+    run('git', ['-C', workspace, 'commit', '-qm', 'fixture']);
+
+    writeFileSync(join(absoluteSkillDirectory, 'references', 'guide.md'), '# New\n');
+    run('bash', ['-c', extractRunBlock('Bind source monitor reports to packaged trees')], {
+      cwd: workspace,
+      env: { ...process.env, RUNNER_TEMP: root, GITHUB_RUN_ID: '1234', DRY_RUN: 'false', CREATE_PR: 'true' },
+    });
+
+    const staged = run('git', ['-C', workspace, 'diff', '--cached', '--name-only']).stdout.trim().split('\n');
+    assert.ok(staged.includes(`${skillDirectory}/references/guide.md`));
+    assert.ok(staged.includes(`${skillDirectory}/skill-report.json`));
+    const report = JSON.parse(readFileSync(join(absoluteSkillDirectory, 'skill-report.json'), 'utf8'));
+    assert.equal(report.meta.tree_hash, calculateCanonicalTreeHash(workspace, skillDirectory));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('source monitor rebinds namespaced and flat payload-only updates', () => {
+  assertPayloadOnlyBinding('skills/owner/payload-only');
+  assertPayloadOnlyBinding('skills/payload-only-flat');
 });
 
 test('source monitor commits upstream files hidden by a copied skill .gitignore', () => {

--- a/scripts/tests/source-monitor-update-safety.test.mjs
+++ b/scripts/tests/source-monitor-update-safety.test.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, sep } from 'node:path';
+import { test } from 'node:test';
+
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
+import { verifySourceMonitorUpdate } from '../verify-source-monitor-update.mjs';
+
+function write(path, content) {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function report({
+  slug,
+  sourceUrl = `https://github.com/example/repo/tree/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/skills/${slug}`,
+  sourceRef = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  contentHash = `${slug.charCodeAt(0).toString(16).padStart(2, '0')}`.repeat(32),
+  treeHash = `${slug.charCodeAt(slug.length - 1).toString(16).padStart(2, '0')}`.repeat(32),
+  riskLevel = 'safe',
+  isBlocked = false,
+  safeToPublish = true,
+  license = 'MIT',
+} = {}) {
+  return JSON.stringify({
+    schema_version: '2.0',
+    meta: {
+      slug,
+      source_url: sourceUrl,
+      source_ref: sourceRef,
+      upstream_commit_sha: sourceRef,
+      content_hash: contentHash,
+      tree_hash: treeHash,
+    },
+    skill: { name: slug, license },
+    security_audit: {
+      risk_level: riskLevel,
+      is_blocked: isBlocked,
+      safe_to_publish: safeToPublish,
+      agent_auto_install_policy: isBlocked ? 'blocked' : 'allowed',
+      manual_install_policy: isBlocked ? 'allowed_with_warning' : 'allowed',
+    },
+  }, null, 2);
+}
+
+function bindReport(root, directory, options) {
+  const skillPath = join(directory, 'SKILL.md');
+  const skillDirectory = relative(root, directory).split(sep).join('/');
+  write(join(directory, 'skill-report.json'), report({
+    ...options,
+    contentHash: createHash('sha256').update(readFileSync(skillPath)).digest('hex'),
+    treeHash: calculateCanonicalTreeHash(root, skillDirectory),
+  }));
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'source-monitor-update-safety-'));
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Fixture'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'fixture@example.com'], { cwd: root });
+  return root;
+}
+
+function commit(root) {
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'fixture'], { cwd: root });
+}
+
+test('accepts a coherent source-monitor payload update', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'coherent');
+    write(join(dir, 'SKILL.md'), '# Coherent\n\nSee [guide](references/guide.md).\n');
+    write(join(dir, 'references', 'guide.md'), '# Old\n');
+    bindReport(root, dir, { slug: 'owner-coherent' });
+    commit(root);
+
+    write(join(dir, 'references', 'guide.md'), '# New\n');
+    bindReport(root, dir, {
+      slug: 'owner-coherent',
+      sourceRef: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      sourceUrl: 'https://github.com/example/repo/tree/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/skills/coherent',
+    });
+
+    const result = verifySourceMonitorUpdate({ repositoryRoot: root });
+    assert.equal(result.changedSkills, 1);
+    assert.equal(result.deletedPaths, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('accepts a coherent flat published skill update', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'flat-skill');
+    write(join(dir, 'SKILL.md'), '# Flat\n');
+    write(join(dir, 'references', 'guide.md'), '# Old\n');
+    bindReport(root, dir, { slug: 'flat-skill' });
+    commit(root);
+
+    write(join(dir, 'references', 'guide.md'), '# New\n');
+    bindReport(root, dir, { slug: 'flat-skill' });
+
+    const result = verifySourceMonitorUpdate({ repositoryRoot: root });
+    assert.equal(result.changedSkills, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects deletion of a path still referenced by SKILL.md', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'dangling');
+    write(join(dir, 'SKILL.md'), '# Dangling\n\nFollow `references/guide.md`.\n');
+    write(join(dir, 'references', 'guide.md'), '# Guide\n');
+    bindReport(root, dir, { slug: 'owner-dangling' });
+    commit(root);
+
+    rmSync(join(dir, 'references', 'guide.md'));
+    bindReport(root, dir, {
+      slug: 'owner-dangling',
+      sourceRef: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      sourceUrl: 'https://github.com/example/repo/tree/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/skills/dangling',
+    });
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /SKILL\.md references missing path: skills\/owner\/dangling\/references\/guide\.md/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a package lifecycle or bin target that no longer exists', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'package-skill');
+    write(join(dir, 'SKILL.md'), '# Package\n');
+    write(join(dir, 'scripts', 'install.js'), 'console.log("install");\n');
+    write(join(dir, 'package.json'), JSON.stringify({
+      bin: { 'package-skill': 'scripts/install.js' },
+      scripts: { postinstall: 'node scripts/install.js' },
+      files: ['scripts/install.js'],
+      license: 'Apache-2.0',
+    }, null, 2));
+    bindReport(root, dir, { slug: 'owner-package-skill', license: 'Apache-2.0' });
+    commit(root);
+
+    rmSync(join(dir, 'scripts', 'install.js'));
+    bindReport(root, dir, {
+      slug: 'owner-package-skill',
+      sourceRef: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      sourceUrl: 'https://github.com/example/repo/tree/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/skills/package-skill',
+      license: 'MIT',
+    });
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /package target is missing: skills\/owner\/package-skill\/scripts\/install\.js/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects contradictory audit policy between flat and namespaced identical source trees', () => {
+  const root = fixture();
+  try {
+    const shared = {
+      sourceUrl: 'https://github.com/example/repo/tree/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/skill',
+      sourceRef: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contentHash: '1'.repeat(64),
+      treeHash: '2'.repeat(64),
+    };
+    for (const [slug, segments] of [
+      ['flat-alias-one', ['flat-alias-one']],
+      ['owner-alias-two', ['owner', 'alias-two']],
+    ]) {
+      const dir = join(root, 'skills', ...segments);
+      write(join(dir, 'SKILL.md'), '# Alias\n');
+      bindReport(root, dir, { slug, ...shared, riskLevel: 'safe' });
+    }
+    commit(root);
+
+    const changed = join(root, 'skills', 'flat-alias-one');
+    bindReport(root, changed, { slug: 'flat-alias-one', ...shared, riskLevel: 'medium' });
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /identical source tree has contradictory audit policy: flat-alias-one, owner-alias-two/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects an unreviewed destructive shrink of a published skill', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'shrunk');
+    write(join(dir, 'SKILL.md'), '# Shrunk\n');
+    for (let index = 0; index < 10; index += 1) {
+      write(join(dir, 'references', `${index}.md`), `# ${index}\n`);
+    }
+    bindReport(root, dir, { slug: 'owner-shrunk' });
+    commit(root);
+
+    for (let index = 0; index < 9; index += 1) {
+      rmSync(join(dir, 'references', `${index}.md`));
+    }
+    bindReport(root, dir, {
+      slug: 'owner-shrunk',
+      sourceRef: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      sourceUrl: 'https://github.com/example/repo/tree/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/skills/shrunk',
+    });
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /destructive source update requires explicit review: skills\/owner\/shrunk deleted=9 baseline=12/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects an untracked change outside published skill directories', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'bounded');
+    write(join(dir, 'SKILL.md'), '# Bounded\n');
+    bindReport(root, dir, { slug: 'owner-bounded' });
+    commit(root);
+
+    write(join(dir, 'SKILL.md'), '# Bounded\n\nUpdated.\n');
+    bindReport(root, dir, { slug: 'owner-bounded' });
+    write(join(root, 'scripts', 'injected.mjs'), 'throw new Error("unexpected");\n');
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /source monitor changed path outside published skills: scripts\/injected\.mjs/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a payload-only update with a stale report tree hash', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'stale-binding');
+    write(join(dir, 'SKILL.md'), '# Stale binding\n');
+    write(join(dir, 'references', 'guide.md'), '# Old\n');
+    bindReport(root, dir, { slug: 'owner-stale-binding' });
+    commit(root);
+
+    write(join(dir, 'references', 'guide.md'), '# New\n');
+
+    assert.throws(
+      () => verifySourceMonitorUpdate({ repositoryRoot: root }),
+      /source monitor must rebind skill report: skills\/owner\/stale-binding/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-source-monitor-update.mjs
+++ b/scripts/verify-source-monitor-update.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { posix, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { publishedSkillDirectory, resolveChangedSkillPaths } from './detect-changed-skills.mjs';
+import { calculateCanonicalTreeHash } from './resolve-approved-submission.mjs';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function git(root, args) {
+  const result = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    fail(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+function safeRelative(path) {
+  if (
+    typeof path !== 'string'
+    || path === ''
+    || path.startsWith('/')
+    || path.includes('\\')
+    || /[\u0000-\u001f\u007f]/u.test(path)
+    || path.split('/').some((segment) => segment === '..')
+    || posix.normalize(path) !== path
+  ) {
+    fail(`unsafe source monitor path: ${String(path)}`);
+  }
+  return path;
+}
+
+function changedEntries(root) {
+  const output = git(root, ['diff', '--name-status', '-z', '--no-renames', 'HEAD']);
+  const fields = output.split('\0').filter(Boolean);
+  if (fields.length % 2 !== 0) fail('malformed git name-status output');
+  const entries = [];
+  for (let index = 0; index < fields.length; index += 2) {
+    const status = fields[index];
+    if (!/^[ADMT]$/u.test(status)) fail(`unsupported source monitor change status: ${status}`);
+    entries.push({ status, path: safeRelative(fields[index + 1]) });
+  }
+  for (const path of git(root, ['ls-files', '--others', '--exclude-standard', '-z'])
+    .split('\0').filter(Boolean).map(safeRelative)) {
+    entries.push({ status: 'A', path });
+  }
+  return entries.sort((left, right) => left.path.localeCompare(right.path, 'en'));
+}
+
+function existingRegular(path, label) {
+  if (!existsSync(path)) fail(`${label} is missing: ${path}`);
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label} must be a regular file: ${path}`);
+}
+
+function normalizeReference(raw) {
+  let value = raw.trim().replace(/^['"]|['"]$/gu, '');
+  value = value.split('#', 1)[0].split('?', 1)[0];
+  try {
+    value = decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+  value = value.replace(/[)\]}>.,;:!?]+$/u, '');
+  if (
+    value === ''
+    || /^(?:https?:|mailto:|data:|#)/iu.test(value)
+    || value.startsWith('/')
+    || value.includes('\\')
+    || value.split('/').some((segment) => segment === '..')
+  ) return null;
+  return value;
+}
+
+function referencedPaths(skillText) {
+  const references = new Set();
+  for (const match of skillText.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)/gu)) {
+    const value = normalizeReference(match[1]);
+    if (value) references.add(value);
+  }
+  for (const match of skillText.matchAll(/\b((?:references|scripts|assets|commands|prompts|tests)\/[A-Za-z0-9._~!$&'()+,;=@%/-]+)/gu)) {
+    const value = normalizeReference(match[1]);
+    if (value) references.add(value);
+  }
+  return [...references].sort((left, right) => left.localeCompare(right, 'en'));
+}
+
+function validateReferences(root, directory) {
+  const skillPath = resolve(root, directory, 'SKILL.md');
+  existingRegular(skillPath, 'changed SKILL.md');
+  const text = readFileSync(skillPath, 'utf8');
+  for (const reference of referencedPaths(text)) {
+    const relative = safeRelative(`${directory}/${reference}`);
+    const absolute = resolve(root, relative);
+    if (!existsSync(absolute)) fail(`SKILL.md references missing path: ${relative}`);
+    const stat = lstatSync(absolute);
+    if (stat.isSymbolicLink() || (!stat.isFile() && !stat.isDirectory())) {
+      fail(`SKILL.md references unsafe path: ${relative}`);
+    }
+  }
+}
+
+function packageTargets(pkg) {
+  const targets = new Set();
+  if (typeof pkg.bin === 'string') targets.add(pkg.bin);
+  else if (pkg.bin && typeof pkg.bin === 'object' && !Array.isArray(pkg.bin)) {
+    for (const value of Object.values(pkg.bin)) if (typeof value === 'string') targets.add(value);
+  }
+  if (pkg.scripts && typeof pkg.scripts === 'object' && !Array.isArray(pkg.scripts)) {
+    for (const command of Object.values(pkg.scripts)) {
+      if (typeof command !== 'string') continue;
+      for (const match of command.matchAll(/(?:^|&&|\|\|)\s*node\s+(['"]?[^\s'";&|]+['"]?)/gu)) {
+        targets.add(match[1].replace(/^['"]|['"]$/gu, ''));
+      }
+    }
+  }
+  return [...targets];
+}
+
+function validatePackage(root, directory, report) {
+  const packagePath = resolve(root, directory, 'package.json');
+  if (!existsSync(packagePath)) return;
+  existingRegular(packagePath, 'package.json');
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+  } catch (error) {
+    fail(`invalid package.json at ${directory}: ${error.message}`);
+  }
+  for (const rawTarget of packageTargets(pkg)) {
+    const target = normalizeReference(rawTarget);
+    if (!target || /[*{}[\]]/u.test(target)) continue;
+    const relative = safeRelative(`${directory}/${target}`);
+    const absolute = resolve(root, relative);
+    if (!existsSync(absolute) || lstatSync(absolute).isSymbolicLink() || !lstatSync(absolute).isFile()) {
+      fail(`package target is missing: ${relative}`);
+    }
+  }
+  if (
+    typeof pkg.license === 'string'
+    && typeof report?.skill?.license === 'string'
+    && pkg.license !== report.skill.license
+  ) {
+    fail(`package/report license mismatch at ${directory}: package=${pkg.license}, report=${report.skill.license}`);
+  }
+}
+
+function reportFor(root, directory) {
+  const path = resolve(root, directory, 'skill-report.json');
+  existingRegular(path, 'skill report');
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`invalid skill report at ${directory}: ${error.message}`);
+  }
+}
+
+function auditPolicy(report) {
+  const audit = report?.security_audit ?? {};
+  return JSON.stringify({
+    risk_level: audit.risk_level,
+    is_blocked: audit.is_blocked,
+    safe_to_publish: audit.safe_to_publish,
+    agent_auto_install_policy: audit.agent_auto_install_policy,
+    manual_install_policy: audit.manual_install_policy,
+  });
+}
+
+function immutableIdentity(report) {
+  const meta = report?.meta ?? {};
+  const values = [meta.source_url, meta.upstream_commit_sha ?? meta.source_ref, meta.content_hash, meta.tree_hash];
+  if (values.some((value) => typeof value !== 'string' || value === '')) return null;
+  return values.join('\0');
+}
+
+function validateDuplicatePolicy(records, changedDirectories) {
+  const byIdentity = new Map();
+  for (const record of records) {
+    const identity = immutableIdentity(record.report);
+    if (identity === null) continue;
+    const group = byIdentity.get(identity) ?? [];
+    group.push(record);
+    byIdentity.set(identity, group);
+  }
+  for (const group of byIdentity.values()) {
+    if (group.length < 2 || !group.some(({ directory }) => changedDirectories.has(directory))) continue;
+    const policies = new Set(group.map(({ report }) => auditPolicy(report)));
+    if (policies.size > 1) {
+      const slugs = group.map(({ report }) => report.meta.slug).sort((left, right) => left.localeCompare(right, 'en'));
+      fail(`identical source tree has contradictory audit policy: ${slugs.join(', ')}`);
+    }
+  }
+}
+
+function validateHashBinding(root, directory, report, entries) {
+  const reportPath = `${directory}/skill-report.json`;
+  if (!entries.some(({ status, path }) => path === reportPath && status !== 'D')) {
+    fail(`source monitor must rebind skill report: ${directory}`);
+  }
+  const skillPath = resolve(root, directory, 'SKILL.md');
+  existingRegular(skillPath, 'changed SKILL.md');
+  const contentHash = createHash('sha256').update(readFileSync(skillPath)).digest('hex');
+  if (report?.meta?.content_hash !== contentHash) {
+    fail(`source monitor report content_hash is stale: ${directory}`);
+  }
+  if (report?.meta?.tree_hash !== calculateCanonicalTreeHash(root, directory)) {
+    fail(`source monitor report tree_hash is stale: ${directory}`);
+  }
+}
+
+function publishedReportPaths(root, entries) {
+  const reportPaths = new Set(git(root, [
+    'ls-files', '-z', '--',
+    ':(glob)skills/*/skill-report.json',
+    ':(glob)skills/*/*/skill-report.json',
+  ]).split('\0').filter(Boolean).map(safeRelative));
+  for (const { path } of entries) {
+    if (posix.basename(path) === 'skill-report.json') reportPaths.add(path);
+  }
+  return [...reportPaths].sort((left, right) => left.localeCompare(right, 'en'));
+}
+
+function publishedRecords(root, reportPaths) {
+  return reportPaths.map((path) => {
+    const identity = publishedSkillDirectory(path);
+    if (identity === null) fail(`invalid published skill report path: ${path}`);
+    const directory = `skills/${identity}`;
+    return { directory, report: reportFor(root, directory) };
+  });
+}
+
+function validateDestructiveChange(root, directory, entries, allowDestructiveSkills) {
+  const baseline = git(root, ['ls-tree', '-r', '--name-only', 'HEAD', '--', directory])
+    .split('\n').filter(Boolean).length;
+  const deleted = entries.filter(({ status, path }) => status === 'D' && path.startsWith(`${directory}/`)).length;
+  if (
+    baseline >= 10
+    && deleted >= 5
+    && deleted / baseline > 0.5
+    && !allowDestructiveSkills.has(directory)
+  ) {
+    fail(`destructive source update requires explicit review: ${directory} deleted=${deleted} baseline=${baseline}`);
+  }
+  return deleted;
+}
+
+export function verifySourceMonitorUpdate({ repositoryRoot, allowDestructiveSkills = [] }) {
+  const root = resolve(repositoryRoot);
+  const allowed = new Set(allowDestructiveSkills.map(safeRelative));
+  const entries = changedEntries(root);
+  const reportPaths = publishedReportPaths(root, entries);
+  const directories = resolveChangedSkillPaths(entries.map(({ path }) => path), reportPaths)
+    .map((directory) => `skills/${directory}`);
+  const invalid = entries.find(({ path }) => (
+    !directories.some((directory) => path.startsWith(`${directory}/`))
+  ));
+  if (invalid) fail(`source monitor changed path outside published skills: ${invalid.path}`);
+  if (directories.length === 0) fail('source monitor produced no changed skill directories');
+  for (const directory of allowed) {
+    if (!directories.includes(directory)) fail(`destructive update allowlist does not match a changed skill: ${directory}`);
+  }
+
+  let deletedPaths = 0;
+  for (const directory of directories) {
+    deletedPaths += validateDestructiveChange(root, directory, entries, allowed);
+    validateReferences(root, directory);
+    const report = reportFor(root, directory);
+    validateHashBinding(root, directory, report, entries);
+    validatePackage(root, directory, report);
+  }
+  validateDuplicatePolicy(publishedRecords(root, reportPaths), new Set(directories));
+  return { changedSkills: directories.length, changedPaths: entries.length, deletedPaths };
+}
+
+function options(args) {
+  const value = (name) => {
+    const index = args.indexOf(name);
+    if (index === -1 || index === args.length - 1 || args[index + 1].startsWith('--')) {
+      fail(`missing required option ${name}`);
+    }
+    return args[index + 1];
+  };
+  const destructive = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== '--allow-destructive-skill') continue;
+    if (index === args.length - 1 || args[index + 1].startsWith('--')) {
+      fail('missing value for --allow-destructive-skill');
+    }
+    destructive.push(args[index + 1]);
+  }
+  return { repositoryRoot: value('--repo-root'), allowDestructiveSkills: destructive };
+}
+
+const isMain = process.argv[1]
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  try {
+    const result = verifySourceMonitorUpdate(options(process.argv.slice(2)));
+    process.stdout.write(`Verified source monitor update safety: ${result.changedSkills} skill(s), ${result.changedPaths} path(s), ${result.deletedPaths} deletion(s)\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- reject tracked or untracked updates outside published skill paths
- require the matching skill-report.json for every changed skill
- validate content and canonical tree hashes, including duplicate aliases
- resolve both flat and owner-namespaced published skill directories

## Verification

- focused source-monitor safety and workflow tests: 19 passed
- full CI-equivalent node test suite: 594 passed, 2 skipped, 0 failed
