### PR TITLE
fix(sync): bound admission environment payload

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -264,7 +264,11 @@ jobs:
             echo "Diff range: $BASE_SHA..$HEAD_SHA"
           fi
           
-          echo "changed_skills=$CHANGED" >> $GITHUB_OUTPUT
+          TARGET_COUNT=$(printf '%s\n' "$CHANGED" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
+          echo "target_count=$TARGET_COUNT" >> $GITHUB_OUTPUT
+          if [ "$TARGET_COUNT" -le 25 ]; then
+            echo "changed_skills=$CHANGED" >> $GITHUB_OUTPUT
+          fi
           
           if [ -z "$CHANGED" ]; then
             echo "No skills to sync"
@@ -277,11 +281,10 @@ jobs:
       - name: Validate bounded sync admission
         if: steps.changes.outputs.skip_sync != 'true'
         env:
-          CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
+          TARGET_COUNT: ${{ steps.changes.outputs.target_count }}
         run: |
           set -euo pipefail
           MAX_SYNC_SKILLS=25
-          TARGET_COUNT=$(printf '%s\n' "$CHANGED_SKILLS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
           if [ "$TARGET_COUNT" -gt "$MAX_SYNC_SKILLS" ]; then
             echo "::error::Sync target count $TARGET_COUNT exceeds the production limit $MAX_SYNC_SKILLS; split the sync before any Supabase write"
             exit 1

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -70,7 +70,11 @@ test('workflow rejects 26 sync targets before Supabase writes and removes full s
   assert.doesNotMatch(workflow, /full_sync|find_all_skills/);
   assert.equal(shardSize, 1);
   assert.equal(maxShards, 25);
+  assert.match(detectJob, /echo "target_count=\$TARGET_COUNT" >> \$GITHUB_OUTPUT/);
+  assert.match(detectJob, /if \[ "\$TARGET_COUNT" -le 25 \]; then\s+echo "changed_skills=\$CHANGED" >> \$GITHUB_OUTPUT/);
   assert.match(admission, /MAX_SYNC_SKILLS=25/);
+  assert.match(admission, /TARGET_COUNT: \$\{\{ steps\.changes\.outputs\.target_count \}\}/);
+  assert.doesNotMatch(admission, /CHANGED_SKILLS/);
   assert.match(admission, /exceeds the production limit \$MAX_SYNC_SKILLS/);
   assert.ok(
     workflow.indexOf('      - name: Validate bounded sync admission')
@@ -86,7 +90,7 @@ test('workflow rejects 26 sync targets before Supabase writes and removes full s
     encoding: 'utf8',
     env: {
       ...process.env,
-      CHANGED_SKILLS: Array.from({ length: count }, (_, index) => `owner/skill-${index + 1}`).join(' '),
+      TARGET_COUNT: String(count),
     },
   });
   const accepted = runAdmission(25);
@@ -94,6 +98,9 @@ test('workflow rejects 26 sync targets before Supabase writes and removes full s
   const rejected = runAdmission(26);
   assert.equal(rejected.status, 1);
   assert.match(`${rejected.stdout}\n${rejected.stderr}`, /Sync target count 26 exceeds the production limit 25/);
+  const oversized = runAdmission(1000000);
+  assert.equal(oversized.status, 1);
+  assert.match(`${oversized.stdout}\n${oversized.stderr}`, /Sync target count 1000000 exceeds the production limit 25/);
 
   const plan = buildShardPlan(
     Array.from({ length: 25 }, (_, index) => `bounded-sync-${index}`),


### PR DESCRIPTION
## Summary
- count detected sync targets before exporting the list
- export the full list only for batches within the existing 25-target production limit
- pass only the numeric count into the fail-closed admission step

## Root cause
Run 31710578970 detected a stale-baseline backlog large enough that exporting the full list as `CHANGED_SKILLS` exceeded the runner process argument/environment limit. The admission shell never started, so its existing 25-target guard could not report the bounded rejection.

## Safety
- keeps the 25-target limit unchanged
- keeps admission before every Supabase write
- does not weaken source, audit, hash, or publication validation
- oversized batches fail before materialization or sync and no longer enter downstream environments

## Test
`CI=true node --test scripts/tests/cache-invalidation-workflow.test.mjs` (12/12 passed)
