### PR TITLE
fix(sync): fail closed on missing baseline

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -137,27 +137,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           # Find the commit SHA of the last successful sync workflow run
           # This ensures we catch ALL changes since the last sync, even if multiple PRs merged
           LAST_RUN=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=success&event=push&per_page=5" \
-            --jq '.workflow_runs[0] // {}' 2>/dev/null || echo '{}')
+            --jq '.workflow_runs[0] // {}')
           LAST_SHA=$(jq -r '.head_sha // ""' <<< "$LAST_RUN")
           LAST_CREATED_AT=$(jq -r '.created_at // ""' <<< "$LAST_RUN")
-          echo "base_run_created_at=$LAST_CREATED_AT" >> "$GITHUB_OUTPUT"
-          
-          if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" != "null" ] && [ "$LAST_SHA" != "${{ github.sha }}" ]; then
-            # Verify the commit exists in our history
-            if git cat-file -e "$LAST_SHA" 2>/dev/null; then
-              echo "Last successful sync at: $LAST_SHA"
-              echo "base_sha=$LAST_SHA" >> $GITHUB_OUTPUT
-            else
-              echo "Last sync commit $LAST_SHA not in history, falling back to HEAD~1"
-              echo "base_sha=HEAD~1" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No previous successful sync found, falling back to HEAD~1"
-            echo "base_sha=HEAD~1" >> $GITHUB_OUTPUT
+
+          if [ -z "$LAST_SHA" ] || [ -z "$LAST_CREATED_AT" ]; then
+            echo "::error::No successful push sync baseline found; refusing an incomplete fallback"
+            exit 1
           fi
+          if ! git cat-file -e "$LAST_SHA^{commit}" 2>/dev/null \
+            || ! git merge-base --is-ancestor "$LAST_SHA" "${{ github.sha }}"; then
+            echo "::error::Last successful sync $LAST_SHA is not an ancestor of ${{ github.sha }}"
+            exit 1
+          fi
+
+          echo "Last successful sync at: $LAST_SHA"
+          echo "base_sha=$LAST_SHA" >> "$GITHUB_OUTPUT"
+          echo "base_run_created_at=$LAST_CREATED_AT" >> "$GITHUB_OUTPUT"
 
       - name: Detect changed skills
         id: changes

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -142,6 +142,10 @@ test('incremental detection subtracts only verified successful manual recovery a
 
   assert.match(lastSync, /status=success&event=push/);
   assert.doesNotMatch(lastSync, /status=success&event=workflow_dispatch/);
+  assert.match(lastSync, /set -euo pipefail/);
+  assert.match(lastSync, /git merge-base --is-ancestor "\$LAST_SHA"/);
+  assert.match(lastSync, /refusing an incomplete fallback/);
+  assert.doesNotMatch(lastSync, /HEAD~1|2>\/dev\/null \|\| echo/);
   assert.match(detect, /status=success&event=workflow_dispatch/);
   assert.match(detect, /synced-slugs/);
   assert.match(detect, /sha256sum/);


### PR DESCRIPTION
## Summary
- stop swallowing failures from the successful-sync watermark query
- reject missing, unavailable, or non-ancestor baselines instead of falling back to `HEAD~1`
- keep same-SHA reruns as a safe empty diff

## Root cause and impact
Run 31828503849 could not obtain a trusted successful push baseline and silently used `HEAD~1`. It completed green after syncing only `heygen-com/hyperframes-audio`, while the immediately preceding cancelled run's `prime-skills/ai-video-generation` commit remained absent from Supabase and production.

## Safety
- fails before detection, materialization, or Supabase writes when the watermark is unavailable
- preserves the existing 25-target admission limit and verified manual-recovery artifact logic
- validates that the recorded successful SHA is an ancestor of the exact workflow SHA

## Test
`CI=true node --test scripts/tests/cache-invalidation-workflow.test.mjs` (12/12 passed)
