### PR TITLE
fix(sync): close manual recovery callback

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -660,12 +660,16 @@ jobs:
         if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
         env:
           BASE_SHA: ${{ steps.last_sync.outputs.base_sha }}
+          SYNC_MODE: ${{ steps.changes.outputs.mode }}
+          CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
         run: |
           node <<'NODE'
           const fs = require('fs');
           const { execFileSync } = require('child_process');
 
-          const baseSha = process.env.BASE_SHA || 'HEAD~1';
+          const baseSha = process.env.BASE_SHA;
+          const syncMode = process.env.SYNC_MODE;
+          const changedSkills = (process.env.CHANGED_SKILLS || '').split(/\s+/).filter(Boolean);
           const syncedSlugs = new Set(
             fs.readFileSync('synced-slugs.txt', 'utf8')
               .split(/\r?\n/)
@@ -716,10 +720,14 @@ jobs:
             return skillPath.replace(/\//g, '-');
           }
 
-          const commits = safeGit(['rev-list', '--reverse', `${baseSha}..HEAD`])
-            .split('\n')
-            .map((commit) => commit.trim())
-            .filter(Boolean);
+          const commits = syncMode === 'manual-slugs'
+            ? [...new Set(changedSkills
+                .map((skillPath) => safeGit(['log', '-1', '--format=%H', '--grep=\\[submission:', '--', `skills/${skillPath}`]))
+                .filter(Boolean))]
+            : safeGit(['rev-list', '--reverse', `${baseSha}..HEAD`])
+                .split('\n')
+                .map((commit) => commit.trim())
+                .filter(Boolean);
 
           const bySubmission = new Map();
 
@@ -771,8 +779,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "$SKILLSTORE_API_URL" ] || [ -z "$SKILLSTORE_CALLBACK_TOKEN" ]; then
-            echo "::warning::Skillstore callback secrets are not configured; skipping published notifications"
-            exit 0
+            echo "::error::Skillstore callback secrets are not configured"
+            exit 1
           fi
 
           jq -c '.[]' published-submissions.json | while read -r row; do
@@ -794,12 +802,12 @@ jobs:
               }')
 
             echo "📤 Notifying skillstore: submission $SUBMISSION_ID published ($SKILL_SLUGS)"
-            curl -sS -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
+            curl --fail-with-body -sS -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
               -H "Authorization: Bearer $SKILLSTORE_CALLBACK_TOKEN" \
               -H "Content-Type: application/json" \
               -H "User-Agent: GitHub-Actions/SkillstoreBot" \
               -H "X-Skillstore-Callback: true" \
-              -d "$PAYLOAD" || echo "::warning::Failed to notify skillstore for $SUBMISSION_ID"
+              -d "$PAYLOAD"
           done
 
       - name: Upload synced slugs artifact

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -155,6 +155,21 @@ test('incremental detection subtracts only verified successful manual recovery a
   assert.match(workflow, /retention-days: 30/);
 });
 
+test('manual recovery resolves its original submission and fails closed on callback errors', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const resolvePublished = section(workflow, '      - name: Resolve published submissions', '      - name: Notify skillstore - Published submissions');
+  const notifyPublished = section(workflow, '      - name: Notify skillstore - Published submissions', '      - name: Upload synced slugs artifact');
+
+  assert.match(resolvePublished, /SYNC_MODE: \$\{\{ steps\.changes\.outputs\.mode \}\}/);
+  assert.match(resolvePublished, /CHANGED_SKILLS: \$\{\{ steps\.changes\.outputs\.changed_skills \}\}/);
+  assert.match(resolvePublished, /syncMode === 'manual-slugs'/);
+  assert.match(resolvePublished, /--grep=\\\\\[submission:/);
+  assert.doesNotMatch(resolvePublished, /BASE_SHA \|\| 'HEAD~1'/);
+  assert.match(notifyPublished, /curl --fail-with-body -sS/);
+  assert.match(notifyPublished, /callback secrets are not configured[\s\S]*exit 1/);
+  assert.doesNotMatch(notifyPublished, /Failed to notify skillstore|\|\| echo/);
+});
+
 test('sync uses a blobless sparse checkout before invoking pinned-tree resolvers', () => {
   const workflow = readFileSync(WORKFLOW, 'utf8');
   const checkout = section(workflow, '      - name: Clear inherited sync checkout', '      - name: Normalize pinned sync runtime checkout');


### PR DESCRIPTION
## Summary
- resolve the originating submission commit for bounded manual-slug recoveries
- remove the stale `HEAD~1` fallback from callback resolution
- fail the workflow when callback configuration or the callback HTTP request fails

## Root cause and impact
The exact-slug recovery run 31855803519 restored `prime-skills-ai-video-generation`, but callback resolution only searched commits after the latest successful push baseline. Because the recovered skill's submission commit predates that baseline, the run resolved zero callbacks and left submission `1dfed897-d0be-4ec5-ad29-8861bcfef4fd` in `approved` instead of `published`.

## Safety
- manual mode searches only the at-most-25 validated canonical skill paths
- automatic incremental mode keeps its existing baseline range behavior
- callback failures are no longer hidden behind a green run

## Test
`CI=true node --test scripts/tests/cache-invalidation-workflow.test.mjs` (13/13 passed)
