### PR TITLE
fix(actions): add bounded merged approval recovery

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -4,23 +4,37 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Exact merged submission PR to recover
+        required: true
+        type: string
 
 jobs:
   approve-skill:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pending-review')
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pending-review'))
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - name: Verify trusted submission PR provenance
+        id: freeze_pr
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Recovery requires one exact positive PR number"
+            exit 1
+          }
           PR=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
           jq -e --arg repository "$REPOSITORY" '
             .merged == true and
+            .base.ref == "main" and
             .user.id == 254047988 and
             .user.login == "ai-skill-store[bot]" and
             .head.repo.full_name == $repository and
@@ -30,6 +44,23 @@ jobs:
             echo "::error::Merged pending-review PR does not have trusted submission provenance"
             exit 1
           }
+
+          MERGE_COMMIT_SHA=$(jq -er '.merge_commit_sha' <<< "$PR")
+          PR_URL=$(jq -er '.html_url' <<< "$PR")
+          MERGED_BY=$(jq -er '.merged_by.login' <<< "$PR")
+          SUBMISSION_ID=$(jq -r '.body // ""' <<< "$PR" \
+            | grep -oE 'Submission ID.*`[0-9a-f-]{36}`' \
+            | grep -oE '[0-9a-f-]{36}' || true)
+          [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [ "$PR_URL" = "https://github.com/$REPOSITORY/pull/$PR_NUMBER" ]
+          [[ "$MERGED_BY" =~ ^[A-Za-z0-9-]+$ ]]
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "merge_commit_sha=$MERGE_COMMIT_SHA"
+            echo "submission_id=$SUBMISSION_ID"
+            echo "pr_url=$PR_URL"
+            echo "merged_by=$MERGED_BY"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -43,28 +74,14 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Extract submission ID from PR body
-        id: extract_submission
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          # Extract submission ID from PR body: **Submission ID**: `UUID`
-          SUBMISSION_ID=$(echo "$PR_BODY" | grep -oE 'Submission ID.*`[0-9a-f-]{36}`' | grep -oE '[0-9a-f-]{36}' || echo "")
-          echo "submission_id=$SUBMISSION_ID" >> $GITHUB_OUTPUT
-          if [ -n "$SUBMISSION_ID" ]; then
-            echo "📋 Found submission ID: $SUBMISSION_ID"
-          else
-            echo "⚠️ No submission ID found in PR body"
-          fi
-
       - name: Find pending skills and commit to skills directory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
+          PR_NUMBER: ${{ steps.freeze_pr.outputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
-          SUBMISSION_ID: ${{ steps.extract_submission.outputs.submission_id }}
+          SUBMISSION_ID: ${{ steps.freeze_pr.outputs.submission_id }}
         run: |
           set -euo pipefail
 
@@ -311,27 +328,43 @@ jobs:
           fi
 
       - name: Notify skillstore - Merged
-        if: steps.extract_submission.outputs.submission_id != ''
+        if: steps.freeze_pr.outputs.submission_id != ''
         env:
-          SUBMISSION_ID: ${{ steps.extract_submission.outputs.submission_id }}
+          SUBMISSION_ID: ${{ steps.freeze_pr.outputs.submission_id }}
           SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
           SKILLSTORE_CALLBACK_TOKEN: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+          PR_URL: ${{ steps.freeze_pr.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.freeze_pr.outputs.pr_number }}
+          MERGED_BY: ${{ steps.freeze_pr.outputs.merged_by }}
         run: |
+          set -euo pipefail
+          if [ -z "$SKILLSTORE_API_URL" ] || [ -z "$SKILLSTORE_CALLBACK_TOKEN" ]; then
+            echo "::error::Skillstore callback secrets are not configured"
+            exit 1
+          fi
+          PAYLOAD=$(jq -n \
+            --arg submission_id "$SUBMISSION_ID" \
+            --arg pr_url "$PR_URL" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg merged_by "$MERGED_BY" \
+            --arg workflow_run_id "${{ github.run_id }}" \
+            --arg workflow_run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              submission_id: $submission_id,
+              event: "merged",
+              pr_url: $pr_url,
+              pr_number: ($pr_number | tonumber),
+              merged_by: $merged_by,
+              workflow_run_id: ($workflow_run_id | tonumber),
+              workflow_run_url: $workflow_run_url
+            }')
           echo "📤 Notifying skillstore: submission $SUBMISSION_ID merged"
-          curl -sS -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
+          curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-delay 2 --retry-max-time 120 --retry-connrefused \
+            --connect-timeout 10 --max-time 30 \
+            -X POST "$SKILLSTORE_API_URL/api/submit/callback" \
             -H "Authorization: Bearer $SKILLSTORE_CALLBACK_TOKEN" \
             -H "Content-Type: application/json" \
             -H "User-Agent: GitHub-Actions/SkillstoreBot" \
             -H "X-Skillstore-Callback: true" \
-            -d '{
-              "submission_id": "'"$SUBMISSION_ID"'",
-              "event": "merged",
-              "pr_url": "'"$PR_URL"'",
-              "pr_number": '"$PR_NUMBER"',
-              "merged_by": "'"$MERGED_BY"'",
-              "workflow_run_id": ${{ github.run_id }},
-              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }' || echo "::warning::Failed to notify skillstore"
+            -d "$PAYLOAD"

--- a/scripts/check-workflow-runner-safety.mjs
+++ b/scripts/check-workflow-runner-safety.mjs
@@ -58,10 +58,14 @@ function hasTagTrigger(config) {
   );
 }
 
-function trustedClosedMergeMetadataJob(pullRequest, job) {
+function trustedClosedMergeMetadataJob(pullRequest, workflowDispatch, job) {
   const types = pullRequestTypes(pullRequest);
   if (types.length !== 1 || types[0] !== 'closed') return false;
-  const condition = expressionText(job.if);
+  let condition = expressionText(job.if);
+  const manualMainRecovery = /^\(\s*github\.event_name\s*==\s*'workflow_dispatch'\s*&&\s*github\.ref\s*==\s*'refs\/heads\/main'\s*\)\s*\|\|\s*/;
+  if (workflowDispatch !== null && manualMainRecovery.test(condition)) {
+    condition = condition.replace(manualMainRecovery, '').replace(/^\(\s*/, '').replace(/\s*\)$/, '');
+  }
   if (/\|\||(^|[^=!])!(?!=)/.test(condition)) return false;
   const requiresMerged = condition.split('&&').some((term) => (
     /^\s*github\.event\.pull_request\.merged\s*==\s*true\s*$/.test(term)
@@ -118,6 +122,7 @@ function inspectWorkflow(root, path) {
 
   const workflow = document.toJS({ maxAliasCount: 100 });
   const pullRequest = eventConfig(workflow.on, 'pull_request');
+  const workflowDispatch = eventConfig(workflow.on, 'workflow_dispatch');
   const pullRequestTarget = eventConfig(workflow.on, 'pull_request_target');
   const push = eventConfig(workflow.on, 'push');
   const tagOrRelease = hasTagTrigger(push) || eventConfig(workflow.on, 'release') !== null;
@@ -146,7 +151,7 @@ function inspectWorkflow(root, path) {
     }
 
     if (pullRequest !== null) {
-      const trustedMetadata = trustedClosedMergeMetadataJob(pullRequest, job);
+      const trustedMetadata = trustedClosedMergeMetadataJob(pullRequest, workflowDispatch, job);
       if (isSelfHosted(job['runs-on']) && !trustedMetadata) {
         add(
           violations,

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -731,12 +731,19 @@ test('submission callers emit distinct terminal callbacks for legal no-op, rejec
 });
 
 test('merged approval scope comes only from immutable PR changed files', () => {
+  assert.match(approval, /workflow_dispatch:[\s\S]*pr_number:/);
+  assert.match(approval, /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/);
   assert.match(approval, /Verify trusted submission PR provenance/);
+  assert.match(approval, /id: freeze_pr/);
+  assert.match(approval, /Recovery requires one exact positive PR number/);
+  assert.match(approval, /\.base\.ref == "main"/);
   assert.match(approval, /\.user\.id == 254047988/);
   assert.match(approval, /\.user\.login == "ai-skill-store\[bot\]"/);
   assert.match(approval, /\.head\.repo\.full_name == \$repository/);
   assert.match(approval, /\.head\.ref \| startswith\("submission\/"\)/);
   assert.match(approval, /pulls\/\$PR_NUMBER\/files\?per_page=100/);
+  assert.match(approval, /steps\.freeze_pr\.outputs\.merge_commit_sha/);
+  assert.match(approval, /steps\.freeze_pr\.outputs\.submission_id/);
   assert.match(approval, /for CLONE_ATTEMPT in 1 2 3/);
   assert.match(approval, /git clone --depth 1 --filter=blob:none --no-checkout/);
   assert.match(approval, /sparse-checkout set --no-cone --stdin/);
@@ -761,4 +768,7 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.doesNotMatch(approval, /cherry-pick HEAD@\{1\} \|\| true/);
   assert.doesNotMatch(approval, /find pending/);
   assert.match(approval, /rm -rf -- "\$TARGET_DIR"/);
+  assert.match(approval, /curl --fail-with-body --silent --show-error/);
+  assert.match(approval, /--retry 3/);
+  assert.doesNotMatch(approval, /Failed to notify skillstore/);
 });

--- a/scripts/tests/workflow-runner-safety.test.mjs
+++ b/scripts/tests/workflow-runner-safety.test.mjs
@@ -86,6 +86,31 @@ test('job conditions cannot make self-hosted safe for a pull_request workflow', 
   );
 });
 
+test('trusted closed merge may share a self-hosted job with exact main recovery', () => {
+  withWorkflow(
+    [
+      'name: merged approval recovery',
+      'on:',
+      '  pull_request:',
+      '    types: [closed]',
+      '  workflow_dispatch:',
+      '    inputs:',
+      '      pr_number:',
+      '        required: true',
+      'jobs:',
+      '  approve:',
+      "    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pending-review'))",
+      '    runs-on: self-hosted',
+      '    steps:',
+      '      - run: echo trusted-merged-pr-metadata',
+    ].join('\n'),
+    (root) => {
+      const result = runChecker(root);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    },
+  );
+});
+
 test('GitHub-hosted read-only exact-head pull_request job passes', () => {
   withWorkflow(
     [


### PR DESCRIPTION
## Root cause
Nine merged submission PRs failed during runner setup because GitHub action download SSL resolution failed. The one-shot pull_request closed workflow had no current-main recovery entrypoint, leaving reviewed files in pending/ and submissions in in_review.

## Fix
- allow one exact merged PR number through workflow_dispatch on main
- re-fetch and freeze trusted bot/branch/label/base/merge provenance before any write
- reuse the existing immutable PR-file scope and push safety checks
- make the Skillstore merged callback fail closed with bounded retries
- keep the runner-safety checker restrictive while recognizing only this exact main recovery condition

## Verification
- CI=true node --test scripts/tests/submission-scope-workflows.test.mjs (40/40)
- CI=true node --test scripts/tests/workflow-runner-safety.test.mjs (9/9)

After merge, recovery will run sequentially for PRs #3051-#3059 from the new main SHA; no failed run is rerun.