### PR TITLE
fix: resolve exact duplicate submission approvals

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -75,6 +75,7 @@ jobs:
           node-version: '24'
 
       - name: Find pending skills and commit to skills directory
+        id: publish
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -209,6 +210,8 @@ jobs:
           mapfile -t SKILL_PATHS < <(jq -r '.skills[].pendingDir' "$APPROVAL_PLAN")
           mapfile -t TARGET_PATHS < <(jq -r '.skills[].targetDir' "$APPROVAL_PLAN")
           SKILL_NAMES=$(jq -r '[.skills[].reportSlug | "/" + .] | join(" ")' "$APPROVAL_PLAN")
+          DUPLICATE_ONLY=$(jq -r '[.skills[] | select(.duplicate != true)] | length == 0' "$APPROVAL_PLAN")
+          echo "duplicate_only=$DUPLICATE_ONLY" >> "$GITHUB_OUTPUT"
           test "${#SKILL_PATHS[@]}" -gt 0
           test "${#SKILL_PATHS[@]}" -eq "${#TARGET_PATHS[@]}"
           echo "Frozen pending skills: ${SKILL_PATHS[*]}"
@@ -239,6 +242,19 @@ jobs:
 
             echo "Moving $PENDING_DIR to $TARGET_DIR"
 
+            IS_DUPLICATE=$(jq -r --arg pendingDir "$PENDING_DIR" \
+              '.skills[] | select(.pendingDir == $pendingDir) | .duplicate' "$APPROVAL_PLAN")
+            if [ "$IS_DUPLICATE" = "true" ]; then
+              test -d "$TARGET_DIR" && test ! -L "$TARGET_DIR" \
+                && diff -qr --exclude=skill-report.json "$PENDING_DIR" "$TARGET_DIR" || {
+                  echo "::error::Exact duplicate target changed after approval planning: $TARGET_DIR"
+                  exit 1
+                }
+              echo "Published skill already matches; removing duplicate pending submission"
+              rm -rf -- "$PENDING_DIR"
+              continue
+            fi
+
             IS_UPDATE=$(jq -r --arg pendingDir "$PENDING_DIR" \
               '.skills[] | select(.pendingDir == $pendingDir) | .update' "$APPROVAL_PLAN")
             if [ "$IS_UPDATE" = "true" ]; then
@@ -252,12 +268,6 @@ jobs:
             fi
 
             mkdir -p "$(dirname "$TARGET_DIR")"
-            if [ -d "$TARGET_DIR" ] && [ ! -L "$TARGET_DIR" ] \
-              && diff -qr --exclude=skill-report.json "$PENDING_DIR" "$TARGET_DIR"; then
-              echo "Published skill already matches; removing duplicate pending submission"
-              rm -rf -- "$PENDING_DIR"
-              continue
-            fi
             test ! -e "$TARGET_DIR" && test ! -L "$TARGET_DIR" || {
               echo "::error::Refusing to overwrite existing published target $TARGET_DIR"
               exit 1
@@ -327,9 +337,10 @@ jobs:
             }
           fi
 
-      - name: Notify skillstore - Merged
+      - name: Notify skillstore - Resolved
         if: steps.freeze_pr.outputs.submission_id != ''
         env:
+          DUPLICATE_ONLY: ${{ steps.publish.outputs.duplicate_only }}
           SUBMISSION_ID: ${{ steps.freeze_pr.outputs.submission_id }}
           SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
           SKILLSTORE_CALLBACK_TOKEN: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
@@ -342,23 +353,35 @@ jobs:
             echo "::error::Skillstore callback secrets are not configured"
             exit 1
           fi
+          EVENT="merged"
+          REASON=""
+          if [ "$DUPLICATE_ONLY" = "true" ]; then
+            EVENT="rejected"
+            REASON="All reviewed skills already exist at the same immutable source and canonical tree."
+          fi
           PAYLOAD=$(jq -n \
             --arg submission_id "$SUBMISSION_ID" \
+            --arg event "$EVENT" \
             --arg pr_url "$PR_URL" \
             --arg pr_number "$PR_NUMBER" \
             --arg merged_by "$MERGED_BY" \
+            --arg reason "$REASON" \
             --arg workflow_run_id "${{ github.run_id }}" \
             --arg workflow_run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             '{
               submission_id: $submission_id,
-              event: "merged",
+              event: $event,
               pr_url: $pr_url,
               pr_number: ($pr_number | tonumber),
-              merged_by: $merged_by,
               workflow_run_id: ($workflow_run_id | tonumber),
               workflow_run_url: $workflow_run_url
-            }')
-          echo "📤 Notifying skillstore: submission $SUBMISSION_ID merged"
+            } + if $event == "rejected" then {
+              rejected_by: $merged_by,
+              reason: $reason
+            } else {
+              merged_by: $merged_by
+            } end')
+          echo "📤 Notifying skillstore: submission $SUBMISSION_ID $EVENT"
           curl --fail-with-body --silent --show-error \
             --retry 3 --retry-delay 2 --retry-max-time 120 --retry-connrefused \
             --connect-timeout 10 --max-time 30 \

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -296,7 +296,8 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
 
     const targetDir = `skills/${segments.slice(1).join('/')}`;
     const targetPath = resolve(root, targetDir);
-    const update = existsSync(targetPath);
+    let update = existsSync(targetPath);
+    let duplicate = false;
     let previousSourceRef = null;
     if (update) {
       const targetStat = lstatSync(targetPath);
@@ -315,27 +316,39 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
       }
       const nextIdentity = sourceIdentity(report, `${pendingDir}/skill-report.json`);
       const previousIdentity = sourceIdentity(publishedReport, `${targetDir}/skill-report.json`);
-      const expectedPreviousTreeHash = report?.meta?.previous_tree_hash;
-      const expectedPreviousSourceRef = report?.meta?.previous_source_ref;
-      if (!/^[0-9a-f]{64}$/.test(expectedPreviousTreeHash ?? '')
-        || typeof expectedPreviousSourceRef !== 'string' || expectedPreviousSourceRef === ''
-        || publishedTreeHash !== expectedPreviousTreeHash
-        || previousIdentity.ref !== expectedPreviousSourceRef) {
-        fail(`${pendingDir} reviewed update snapshot does not match the published target`);
+      duplicate = publishedTreeHash === actualTreeHash
+        && report.meta.source_type === publishedReport?.meta?.source_type
+        && report.meta.slug === publishedReport?.meta?.slug
+        && nextIdentity.repository === previousIdentity.repository
+        && nextIdentity.path === previousIdentity.path
+        && /^[0-9a-f]{40}$/.test(nextIdentity.ref)
+        && nextIdentity.ref === previousIdentity.ref;
+      if (duplicate) {
+        update = false;
+      } else {
+        const expectedPreviousTreeHash = report?.meta?.previous_tree_hash;
+        const expectedPreviousSourceRef = report?.meta?.previous_source_ref;
+        if (!/^[0-9a-f]{64}$/.test(expectedPreviousTreeHash ?? '')
+          || typeof expectedPreviousSourceRef !== 'string' || expectedPreviousSourceRef === ''
+          || publishedTreeHash !== expectedPreviousTreeHash
+          || previousIdentity.ref !== expectedPreviousSourceRef) {
+          fail(`${pendingDir} reviewed update snapshot does not match the published target`);
+        }
+        if (report.meta.source_type !== publishedReport?.meta?.source_type
+          || report.meta.slug !== publishedReport?.meta?.slug
+          || nextIdentity.repository !== previousIdentity.repository
+          || nextIdentity.path !== previousIdentity.path) {
+          fail(`${pendingDir} source identity does not match the published target`);
+        }
+        if (!/^[0-9a-f]{40}$/.test(nextIdentity.ref) || nextIdentity.ref === previousIdentity.ref) {
+          fail(`${pendingDir} update must use a new immutable source commit`);
+        }
+        previousSourceRef = expectedPreviousSourceRef;
       }
-      if (report.meta.source_type !== publishedReport?.meta?.source_type
-        || report.meta.slug !== publishedReport?.meta?.slug
-        || nextIdentity.repository !== previousIdentity.repository
-        || nextIdentity.path !== previousIdentity.path) {
-        fail(`${pendingDir} source identity does not match the published target`);
-      }
-      if (!/^[0-9a-f]{40}$/.test(nextIdentity.ref) || nextIdentity.ref === previousIdentity.ref) {
-        fail(`${pendingDir} update must use a new immutable source commit`);
-      }
-      previousSourceRef = expectedPreviousSourceRef;
     }
     return {
       contentHash: actualContentHash,
+      duplicate,
       treeHash: actualTreeHash,
       pendingDir,
       reportSlug: report.meta.slug,

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -156,6 +156,33 @@ test('authorizes a reviewed update only when repository and source path stay sta
   );
 }));
 
+test('resolves an exact concurrent duplicate without weakening update snapshots', () => withRepository((root) => {
+  const sourceRef = '1'.repeat(40);
+  addSkill(root, 'skills/owner/skill', { slug: 'owner-skill', sourceRef });
+  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', sourceRef });
+
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: ['pending/owner/skill/SKILL.md', 'pending/owner/skill/skill-report.json'],
+  });
+  assert.equal(plan.skills[0].duplicate, true);
+  assert.equal(plan.skills[0].update, false);
+
+  write(root, 'pending/owner/skill/SKILL.md', '# Changed\n');
+  const reportPath = join(root, 'pending/owner/skill/skill-report.json');
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  report.meta.content_hash = createHash('sha256').update('# Changed\n').digest('hex');
+  report.meta.tree_hash = calculateCanonicalTreeHash(root, 'pending/owner/skill');
+  writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/SKILL.md', 'pending/owner/skill/skill-report.json'],
+    }),
+    /reviewed update snapshot does not match/,
+  );
+}));
+
 test('rejects root-level and over-nested pending SKILL.md paths', () => withRepository((root) => {
   write(root, 'pending/SKILL.md', '# Broken\n');
   assert.throws(

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -750,9 +750,13 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.match(approval, /ls-tree HEAD/);
   assert.match(approval, /symlink or non-directory path component/);
   assert.match(approval, /node scripts\/resolve-approved-submission\.mjs/);
+  assert.match(approval, /id: publish/);
+  assert.match(approval, /select\(\.duplicate != true\)/);
   assert.match(approval, /mapfile -t SKILL_PATHS/);
   assert.match(approval, /diff -qr --exclude=skill-report\.json "\$PENDING_DIR" "\$TARGET_DIR"/);
   assert.match(approval, /rm -rf -- "\$PENDING_DIR"/);
+  assert.match(approval, /EVENT="rejected"/);
+  assert.match(approval, /same immutable source and canonical tree/);
   assert.match(approval, /Reviewed update target is missing or unsafe/);
   assert.match(approval, /git diff --quiet "\$MERGE_COMMIT_SHA" HEAD -- "\$PENDING_DIR"/);
   assert.match(approval, /Published update target changed after the reviewed merge/);


### PR DESCRIPTION
## Summary
- classify only exact immutable-source and canonical-tree matches as concurrent duplicates
- remove duplicate pending trees while preserving update snapshot fail-closed behavior
- reject duplicate-only submissions through the existing Skillstore callback instead of leaving them in review

## Evidence
- reproduces run 31713435377 / PR #3034 against all 10 frozen pending trees
- exact PR #3034 plan: 10 duplicates, 0 updates, 0 non-duplicates

## Tests
- `CI=true node --test scripts/tests/resolve-approved-submission.test.mjs scripts/tests/submission-scope-workflows.test.mjs` (52 passed)
- `yq eval . .github/workflows/on-pr-merge.yml`
- extracted callback shell passed `bash -n`