### PR TITLE
fix(submissions): support moved skills in mixed batches

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -308,8 +308,7 @@ jobs:
                   --repo-root "$PWD" \
                   --commit HEAD^ \
                   --skill-dir "$target_dir")
-                jq -e --arg treeHash "$expected_tree" --arg sourceRef "$expected_ref" \
-                  '.meta.tree_hash == $treeHash and .meta.source_ref == $sourceRef' \
+                jq -e --arg sourceRef "$expected_ref" '.meta.source_ref == $sourceRef' \
                   <<< "$parent_report" >/dev/null && [ "$parent_tree" = "$expected_tree" ] || {
                     echo "::error::Published update target changed before push: $target_dir"
                     exit 1

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -61,7 +61,7 @@ on:
         description: 'Machine-readable terminal outcome reason'
         value: ${{ jobs.discover-and-plan.outputs.target_disposition == 'all_existing' && jobs.discover-and-plan.outputs.target_reason || jobs.merge-and-create-pr.outputs.outcome_reason }}
       existing_targets:
-        description: 'Comma-separated exact targets for a handled existing-target rejection'
+        description: 'Comma-separated exact published targets found during classification'
         value: ${{ jobs.discover-and-plan.outputs.existing_targets }}
       source_sha:
         description: 'Immutable source commit used for discovery'
@@ -139,7 +139,7 @@ jobs:
       github_url: ${{ steps.discover.outputs.github_url }}
       source_sha: ${{ steps.clone.outputs.ref_sha }}
       scope_path: ${{ steps.discover.outputs.scope_path }}
-      selection_plan: ${{ steps.discover.outputs.selection_plan }}
+      selection_plan: ${{ steps.targets.outputs.processing_plan }}
       physical_count: ${{ steps.discover.outputs.physical_count }}
       selected_count: ${{ steps.discover.outputs.skill_count }}
       ignored_count: ${{ steps.discover.outputs.ignored_count }}
@@ -149,6 +149,7 @@ jobs:
       target_reason: ${{ steps.targets.outputs.reason_code }}
       existing_count: ${{ steps.targets.outputs.existing_count }}
       existing_targets: ${{ steps.targets.outputs.existing_targets }}
+      update_targets: ${{ steps.targets.outputs.update_targets }}
       update_snapshots: ${{ steps.targets.outputs.update_snapshots }}
     steps:
       - name: Clear inherited discovery checkout
@@ -435,7 +436,6 @@ jobs:
         id: targets
         env:
           FULL_SELECTION_PLAN: ${{ steps.discover.outputs.selection_plan }}
-          SOURCE_REF: ${{ steps.clone.outputs.branch }}
         run: |
           set -euo pipefail
           PLAN_FILE="${RUNNER_TEMP:?}/target-plan-${{ github.run_id }}-${{ github.run_attempt }}.json"
@@ -446,18 +446,21 @@ jobs:
           CLASSIFICATION=$(node "$GITHUB_WORKSPACE/scripts/classify-submission-targets.mjs" \
             --marketplace-root "$GITHUB_WORKSPACE" \
             --selection-plan "$PLAN_FILE" \
-            --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json" \
-            --source-ref "$SOURCE_REF")
+            --slug-aliases-file "$GITHUB_WORKSPACE/governance/submission-slug-aliases.json")
           DISPOSITION=$(jq -er '.disposition' <<< "$CLASSIFICATION")
           REASON_CODE=$(jq -er '.reasonCode' <<< "$CLASSIFICATION")
           SELECTED_COUNT=$(jq -er '.selectedCount' <<< "$CLASSIFICATION")
+          PROCESSING_PLAN=$(jq -cer '.processingPlan' <<< "$CLASSIFICATION")
           EXISTING_COUNT=$(jq -er '.existingCount' <<< "$CLASSIFICATION")
           EXISTING_TARGETS=$(jq -er '.existingTargets | join(",")' <<< "$CLASSIFICATION")
+          UPDATE_TARGETS=$(jq -cer '.updateTargets' <<< "$CLASSIFICATION")
           UPDATE_SNAPSHOTS=$(jq -cer '.updateSnapshots // []' <<< "$CLASSIFICATION")
           echo "disposition=$DISPOSITION" >> "$GITHUB_OUTPUT"
           echo "reason_code=$REASON_CODE" >> "$GITHUB_OUTPUT"
+          echo "processing_plan=$PROCESSING_PLAN" >> "$GITHUB_OUTPUT"
           echo "existing_count=$EXISTING_COUNT" >> "$GITHUB_OUTPUT"
           echo "existing_targets=$EXISTING_TARGETS" >> "$GITHUB_OUTPUT"
+          echo "update_targets=$UPDATE_TARGETS" >> "$GITHUB_OUTPUT"
           echo "update_snapshots=$UPDATE_SNAPSHOTS" >> "$GITHUB_OUTPUT"
           if [ "$DISPOSITION" = "all_existing" ]; then
             echo "::notice title=SUBMISSION_ALREADY_PUBLISHED::All $EXISTING_COUNT selected targets already exist; skipping CLI, AI, shards, artifacts, branch, and PR"
@@ -496,7 +499,7 @@ jobs:
         id: plan
         if: steps.targets.outputs.disposition == 'processable'
         env:
-          FULL_SELECTION_PLAN: ${{ steps.discover.outputs.selection_plan }}
+          FULL_SELECTION_PLAN: ${{ steps.targets.outputs.processing_plan }}
           EXPLICIT_PATH: ${{ steps.clone.outputs.explicit_path }}
         run: |
           COUNT=$(jq -er '.skills | length' <<< "$FULL_SELECTION_PLAN")
@@ -896,7 +899,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           SHARD_MATRIX: ${{ needs.discover-and-plan.outputs.matrix }}
-          UPDATE_TARGETS: ${{ needs.discover-and-plan.outputs.existing_targets }}
+          UPDATE_TARGETS: ${{ needs.discover-and-plan.outputs.update_targets }}
           UPDATE_SNAPSHOTS: ${{ needs.discover-and-plan.outputs.update_snapshots }}
         run: |
           set -euo pipefail
@@ -1010,11 +1013,16 @@ jobs:
           cd "$WORK_DIR"
 
           echo "=== Copying only frozen submission results ==="
+          jq -e --argjson targets "$UPDATE_TARGETS" '
+            (map(.targetDir) | sort) == ($targets | sort)
+            and (map(.targetDir) | unique | length) == length
+            and ($targets | unique | length) == ($targets | length)
+          ' <<< "$UPDATE_SNAPSHOTS" >/dev/null || {
+            echo "::error::Update target and snapshot sets do not match"
+            exit 1
+          }
           is_update_target() {
-            case ",$UPDATE_TARGETS," in
-              *",$1,"*) return 0 ;;
-              *) return 1 ;;
-            esac
+            jq -e --arg targetDir "$1" 'index($targetDir) != null' <<< "$UPDATE_TARGETS" >/dev/null
           }
           for pending_dir in "${SUBMISSION_PATHS[@]}"; do
             test ! -e "$WORK_DIR/$pending_dir" || {
@@ -1034,9 +1042,13 @@ jobs:
               EXPECTED_TREE_HASH=$(jq -er '.treeHash' <<< "$SNAPSHOT")
               EXPECTED_SOURCE_REF=$(jq -er '.sourceRef' <<< "$SNAPSHOT")
               CURRENT_REPORT="$WORK_DIR/$target_dir/skill-report.json"
-              jq -e --arg treeHash "$EXPECTED_TREE_HASH" --arg sourceRef "$EXPECTED_SOURCE_REF" \
-                '.meta.tree_hash == $treeHash and .meta.source_ref == $sourceRef' \
-                "$CURRENT_REPORT" >/dev/null || {
+              CURRENT_TREE_HASH=$(node "$GITHUB_WORKSPACE/scripts/resolve-approved-submission.mjs" \
+                --tree-hash-at-commit \
+                --repo-root "$WORK_DIR" \
+                --commit HEAD \
+                --skill-dir "$target_dir")
+              jq -e --arg sourceRef "$EXPECTED_SOURCE_REF" '.meta.source_ref == $sourceRef' \
+                "$CURRENT_REPORT" >/dev/null && [ "$CURRENT_TREE_HASH" = "$EXPECTED_TREE_HASH" ] || {
                   echo "::error::Published update target changed after classification: $target_dir"
                   exit 1
                 }

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -184,7 +184,7 @@ function sourceMismatch(message) {
   throw new SourceIdentityMismatchError(message);
 }
 
-function assertSourceIdentity(report, { repository, skillPath }, reportPath) {
+function assertSourceIdentity(report, { repository }, reportPath) {
   const sourceUrl = report?.meta?.source_url;
   const reportRef = report?.meta?.source_ref;
   if (typeof sourceUrl !== 'string' || typeof reportRef !== 'string' || reportRef === '') {
@@ -192,32 +192,28 @@ function assertSourceIdentity(report, { repository, skillPath }, reportPath) {
   }
 
   const segments = decodedSegments(sourceUrl);
-  const canonicalPath = `/${repository}/tree/${encodeURIComponent(reportRef)}${skillPath === '.'
-    ? ''
-    : `/${skillPath.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`}`;
-  const parsedPath = new URL(sourceUrl).pathname;
-  if (parsedPath !== canonicalPath && parsedPath !== `${canonicalPath}/`) {
-    sourceMismatch(`published target source_url is not canonical at ${reportPath}: expected ${canonicalPath}`);
-  }
-  const [owner, repo, kind, ...remainder] = segments;
+  const [owner, repo, kind, actualRef, ...actualPathSegments] = segments;
   if (`${owner ?? ''}/${repo ?? ''}` !== repository || kind !== 'tree') {
     sourceMismatch(`published target source repository mismatch at ${reportPath}: expected ${repository}`);
   }
-
-  const pathSegments = skillPath === '.' ? [] : skillPath.split('/');
-  if (remainder.length <= pathSegments.length) {
+  if (actualRef === undefined) {
     fail(`published target source_url has no source ref at ${reportPath}`);
   }
-  const actualPathSegments = pathSegments.length === 0 ? [] : remainder.slice(-pathSegments.length);
   if (actualPathSegments.some((segment) => segment.includes('/'))) {
     fail(`published target source_url encodes a path separator inside a path segment at ${reportPath}`);
   }
-  const actualPath = actualPathSegments.join('/');
-  const actualRef = remainder.slice(0, remainder.length - pathSegments.length).join('/');
-  if (actualRef !== reportRef || actualPath !== (skillPath === '.' ? '' : skillPath)) {
-    sourceMismatch(`published target source path mismatch at ${reportPath}: expected ${skillPath}`);
+  if (actualRef !== reportRef) {
+    fail(`published target source_url does not match source_ref at ${reportPath}`);
   }
-  return reportRef;
+  const sourcePath = actualPathSegments.join('/');
+  const canonicalPath = `/${repository}/tree/${encodeURIComponent(reportRef)}${sourcePath === ''
+    ? ''
+    : `/${actualPathSegments.map((segment) => encodeURIComponent(segment)).join('/')}`}`;
+  const parsedPath = new URL(sourceUrl).pathname;
+  if (parsedPath !== canonicalPath && parsedPath !== `${canonicalPath}/`) {
+    fail(`published target source_url is not canonical at ${reportPath}`);
+  }
+  return { sourcePath, sourceRef: reportRef };
 }
 
 function validateCandidate(candidate, identity) {
@@ -248,12 +244,11 @@ function validateCandidate(candidate, identity) {
     fail(`flat published target must be official at ${reportPath}`);
   }
 
-  const sourceRef = assertSourceIdentity(report, identity, reportPath);
+  const sourceIdentity = assertSourceIdentity(report, identity, reportPath);
   return {
     directory: candidate.directory,
     relativePath: candidate.relativePath,
-    sourceRef,
-    treeHash: report.meta.tree_hash,
+    ...sourceIdentity,
   };
 }
 
@@ -268,7 +263,6 @@ function assertNoPendingCollision(root, owner, slug) {
 export function classifySubmissionTargets({
   marketplaceRoot,
   selectionPlan,
-  sourceRef,
   slugAliasRegistry = { schemaVersion: 1, aliases: [] },
 }) {
   const plan = typeof selectionPlan === 'string'
@@ -276,7 +270,7 @@ export function classifySubmissionTargets({
     : validateSelectionPlan(selectionPlan);
   assertDirectory(marketplaceRoot, 'marketplace root');
   const root = resolve(marketplaceRoot);
-  if (typeof sourceRef !== 'string' || sourceRef === '') fail('source ref must be a non-empty string');
+  const sourceRef = plan.sourceCommit;
 
   const [owner] = plan.repository.split('/');
   const aliases = new Map(validateSlugAliasRegistry(slugAliasRegistry)
@@ -287,6 +281,7 @@ export function classifySubmissionTargets({
   const sameRevisionTargets = [];
   const updateTargets = [];
   const updateSnapshots = [];
+  const processingSkills = [];
   const newTargets = [];
 
   for (const skill of plan.skills) {
@@ -348,49 +343,42 @@ export function classifySubmissionTargets({
     }
     if (expectedTarget !== null) {
       existingTargets.push(expectedTarget.relativePath);
-      if (expectedTarget.sourceRef === sourceRef) {
+      if (expectedTarget.sourceRef === sourceRef && expectedTarget.sourcePath === skill.path) {
         sameRevisionTargets.push(expectedTarget.relativePath);
       } else {
-        if (sourceRef !== plan.sourceCommit || !/^[0-9a-f]{40}$/.test(sourceRef)) {
-          fail('existing targets must be updated with an immutable commit URL');
-        }
-        if (!HASH.test(expectedTarget.treeHash ?? '')
-          || calculateCanonicalTreeHash(root, expectedTarget.relativePath) !== expectedTarget.treeHash) {
-          fail(`published update target tree_hash is missing or stale: ${expectedTarget.relativePath}`);
-        }
+        const treeHash = calculateCanonicalTreeHash(root, expectedTarget.relativePath);
         updateTargets.push(expectedTarget.relativePath);
+        processingSkills.push(skill);
         updateSnapshots.push({
           targetDir: expectedTarget.relativePath,
-          treeHash: expectedTarget.treeHash,
+          treeHash,
           sourceRef: expectedTarget.sourceRef,
         });
       }
       continue;
     }
     newTargets.push(expectedCandidate.relativePath);
-  }
-
-  if (existingTargets.length > 0 && newTargets.length > 0) {
-    fail(`partial published-target collision: ${existingTargets.length} existing, ${newTargets.length} new`);
-  }
-  if (sameRevisionTargets.length > 0 && updateTargets.length > 0) {
-    fail(`mixed current and updated targets: ${sameRevisionTargets.length} current, ${updateTargets.length} updates`);
+    processingSkills.push(skill);
   }
 
   const disposition = sameRevisionTargets.length === plan.skills.length && plan.skills.length > 0
     ? 'all_existing'
     : 'processable';
+  let reasonCode = 'no_selected_targets_already_published';
+  if (disposition === 'all_existing') reasonCode = 'all_selected_targets_already_published';
+  else if (updateTargets.length === plan.skills.length) reasonCode = 'all_selected_targets_are_updates';
+  else if (updateTargets.length > 0 && newTargets.length > 0) reasonCode = 'selected_targets_include_new_and_updates';
+  else if (updateTargets.length > 0) reasonCode = 'selected_targets_include_updates';
+  else if (newTargets.length < plan.skills.length) reasonCode = 'selected_targets_include_new';
   const result = {
     schemaVersion: 1,
     disposition,
-    reasonCode: disposition === 'all_existing'
-      ? 'all_selected_targets_already_published'
-      : updateTargets.length > 0
-        ? 'all_selected_targets_are_updates'
-        : 'no_selected_targets_already_published',
+    reasonCode,
     selectedCount: plan.skills.length,
+    processingPlan: { ...plan, skills: processingSkills },
     existingCount: existingTargets.length,
     existingTargets: existingTargets.sort((left, right) => left.localeCompare(right, 'en')),
+    updateTargets: updateTargets.sort((left, right) => left.localeCompare(right, 'en')),
   };
   if (updateSnapshots.length > 0) result.updateSnapshots = updateSnapshots;
   return result;
@@ -403,7 +391,6 @@ function main() {
   const result = classifySubmissionTargets({
     marketplaceRoot: option(args, '--marketplace-root'),
     selectionPlan: readFileSync(selectionPlanPath, 'utf8'),
-    sourceRef: option(args, '--source-ref'),
     slugAliasRegistry: JSON.parse(readFileSync(slugAliasesPath, 'utf8')),
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -311,9 +311,6 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
       }
       const publishedReport = readJson(publishedReportPath, `${targetDir}/skill-report.json`);
       const publishedTreeHash = calculateCanonicalTreeHash(root, targetDir);
-      if (publishedReport?.meta?.tree_hash !== publishedTreeHash) {
-        fail(`${targetDir} published tree_hash does not match the canonical skill tree`);
-      }
       const nextIdentity = sourceIdentity(report, `${pendingDir}/skill-report.json`);
       const previousIdentity = sourceIdentity(publishedReport, `${targetDir}/skill-report.json`);
       duplicate = publishedTreeHash === actualTreeHash
@@ -336,12 +333,12 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
         }
         if (report.meta.source_type !== publishedReport?.meta?.source_type
           || report.meta.slug !== publishedReport?.meta?.slug
-          || nextIdentity.repository !== previousIdentity.repository
-          || nextIdentity.path !== previousIdentity.path) {
+          || nextIdentity.repository !== previousIdentity.repository) {
           fail(`${pendingDir} source identity does not match the published target`);
         }
-        if (!/^[0-9a-f]{40}$/.test(nextIdentity.ref) || nextIdentity.ref === previousIdentity.ref) {
-          fail(`${pendingDir} update must use a new immutable source commit`);
+        if (!/^[0-9a-f]{40}$/.test(nextIdentity.ref)
+          || (nextIdentity.ref === previousIdentity.ref && nextIdentity.path === previousIdentity.path)) {
+          fail(`${pendingDir} update must use an immutable source commit or a new source path`);
         }
         previousSourceRef = expectedPreviousSourceRef;
       }

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -108,21 +108,26 @@ test('supports an official flat pending skill', () => withRepository((root) => {
   assert.equal(plan.skills[0].targetDir, 'skills/official-skill');
 }));
 
-test('authorizes a reviewed update only when repository and source path stay stable', () => withRepository((root) => {
+test('authorizes a reviewed same-repository update when the source path moves', () => withRepository((root) => {
   const oldCommit = '1'.repeat(40);
   const newCommit = '2'.repeat(40);
   addSkill(root, 'skills/owner/skill', {
     slug: 'owner-skill',
     sourceRef: oldCommit,
-    sourceUrl: `https://github.com/owner/repo/tree/${oldCommit}/skills/skill`,
+    sourceUrl: `https://github.com/owner/repo/tree/${oldCommit}/legacy/skill`,
   });
+  const previousTreeHash = calculateCanonicalTreeHash(root, 'skills/owner/skill');
+  const publishedReportPath = join(root, 'skills/owner/skill/skill-report.json');
+  const publishedReport = JSON.parse(readFileSync(publishedReportPath, 'utf8'));
+  publishedReport.meta.tree_hash = '0'.repeat(64);
+  writeFileSync(publishedReportPath, `${JSON.stringify(publishedReport)}\n`);
   addSkill(root, 'pending/owner/skill', {
     slug: 'owner-skill',
     content: '# Updated\n',
     sourceRef: newCommit,
-    sourceUrl: `https://github.com/owner/repo/tree/${newCommit}/skills/skill`,
+    sourceUrl: `https://github.com/owner/repo/tree/${newCommit}/skills/new-skill`,
     previousSourceRef: oldCommit,
-    previousTreeHash: calculateCanonicalTreeHash(root, 'skills/owner/skill'),
+    previousTreeHash,
   });
 
   const plan = resolveApprovedSubmission({
@@ -144,8 +149,8 @@ test('authorizes a reviewed update only when repository and source path stay sta
     /reviewed update snapshot does not match/,
   );
 
-  report.meta.previous_tree_hash = calculateCanonicalTreeHash(root, 'skills/owner/skill');
-  report.meta.source_url = `https://github.com/owner/other/tree/${newCommit}/skills/skill`;
+  report.meta.previous_tree_hash = previousTreeHash;
+  report.meta.source_url = `https://github.com/owner/other/tree/${newCommit}/skills/new-skill`;
   writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
   assert.throws(
     () => resolveApprovedSubmission({

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -107,44 +107,53 @@ function writeTarget(root, slug, {
   return directory;
 }
 
-function classify(root, plan = selectionPlan(), sourceRef = 'main') {
-  return classifySubmissionTargets({ marketplaceRoot: root, selectionPlan: plan, sourceRef });
+function classify(root, plan = selectionPlan()) {
+  return classifySubmissionTargets({ marketplaceRoot: root, selectionPlan: plan });
 }
 
 test('zero existing targets preserves the complete processable selection', () => withMarketplace((root) => {
-  assert.deepEqual(classify(root), {
+  const plan = selectionPlan();
+  assert.deepEqual(classify(root, plan), {
     schemaVersion: 1,
     disposition: 'processable',
     reasonCode: 'no_selected_targets_already_published',
     selectedCount: 2,
+    processingPlan: plan,
     existingCount: 0,
     existingTargets: [],
+    updateTargets: [],
   });
 }));
 
 test('all exact community targets become a handled rejection', () => withMarketplace((root) => {
-  writeTarget(root, 'alpha');
-  writeTarget(root, 'beta');
-  assert.deepEqual(classify(root), {
+  writeTarget(root, 'alpha', { sourceRef: SOURCE_COMMIT });
+  writeTarget(root, 'beta', { sourceRef: SOURCE_COMMIT });
+  const plan = selectionPlan();
+  assert.deepEqual(classify(root, plan), {
     schemaVersion: 1,
     disposition: 'all_existing',
     reasonCode: 'all_selected_targets_already_published',
     selectedCount: 2,
+    processingPlan: { ...plan, skills: [] },
     existingCount: 2,
     existingTargets: ['skills/example/alpha', 'skills/example/beta'],
+    updateTargets: [],
   });
 }));
 
 test('same source identity at a new immutable commit is processed as an update', () => withMarketplace((root) => {
   writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
-  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT);
+  const plan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]);
+  const result = classify(root, plan);
   assert.deepEqual(result, {
     schemaVersion: 1,
     disposition: 'processable',
     reasonCode: 'all_selected_targets_are_updates',
     selectedCount: 1,
+    processingPlan: plan,
     existingCount: 1,
     existingTargets: ['skills/example/alpha'],
+    updateTargets: ['skills/example/alpha'],
     updateSnapshots: [{
       targetDir: 'skills/example/alpha',
       treeHash: calculateCanonicalTreeHash(root, 'skills/example/alpha'),
@@ -155,26 +164,26 @@ test('same source identity at a new immutable commit is processed as an update',
 
 test('the same immutable source commit remains a handled no-op', () => withMarketplace((root) => {
   writeTarget(root, 'alpha', { sourceRef: SOURCE_COMMIT });
-  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT);
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
   assert.equal(result.disposition, 'all_existing');
   assert.equal(result.reasonCode, 'all_selected_targets_already_published');
 }));
 
-test('an existing source can only be updated from an immutable commit URL', () => withMarketplace((root) => {
-  writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
-  assert.throws(
-    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), 'main'),
-    /existing targets must be updated with an immutable commit URL/,
-  );
+test('a same-repository source path move is processed as an update', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: 'main', skillPath: 'legacy/alpha' });
+  const plan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]);
+  const result = classify(root, plan);
+  assert.equal(result.disposition, 'processable');
+  assert.equal(result.reasonCode, 'all_selected_targets_are_updates');
+  assert.deepEqual(result.updateTargets, ['skills/example/alpha']);
+  assert.deepEqual(result.processingPlan, plan);
 }));
 
-test('an update refuses a published target whose recorded tree hash is stale', () => withMarketplace((root) => {
+test('an update snapshots the authoritative tree when legacy report metadata is stale', () => withMarketplace((root) => {
   writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
   writeFileSync(join(root, 'skills/example/alpha/SKILL.md'), '---\nname: alpha\n---\nchanged\n');
-  assert.throws(
-    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]), SOURCE_COMMIT),
-    /tree_hash is missing or stale/,
-  );
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.updateSnapshots[0].treeHash, calculateCanonicalTreeHash(root, 'skills/example/alpha'));
 }));
 
 test('an exact repository-bound alias validates the published display name', () => withMarketplace((root) => {
@@ -186,13 +195,13 @@ test('an exact repository-bound alias validates the published display name', () 
     targetOwner: 'zx029w',
     skillPath: path,
     skillName: path,
+    sourceRef: SOURCE_COMMIT,
   });
   const plan = selectionPlan([{ slug, path }], repository);
   plan.scope = { reason: 'repository_fallback', path: '.' };
   const result = classifySubmissionTargets({
     marketplaceRoot: root,
     selectionPlan: plan,
-    sourceRef: 'main',
     slugAliasRegistry: {
       schemaVersion: 1,
       aliases: [{ repository, path, expectedName: path, baseSlug: slug }],
@@ -202,7 +211,7 @@ test('an exact repository-bound alias validates the published display name', () 
 }));
 
 test('an exact official flat target is recognized without weakening community identity', () => withMarketplace((root) => {
-  writeTarget(root, 'alpha', { layout: 'official', repository: 'anthropics/skills' });
+  writeTarget(root, 'alpha', { layout: 'official', repository: 'anthropics/skills', sourceRef: SOURCE_COMMIT });
   const result = classify(
     root,
     selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }], 'anthropics/skills'),
@@ -211,15 +220,48 @@ test('an exact official flat target is recognized without weakening community id
   assert.deepEqual(result.existingTargets, ['skills/alpha']);
 }));
 
-test('mixed existing and new targets fail closed instead of processing a subset', () => withMarketplace((root) => {
-  writeTarget(root, 'alpha');
-  assert.throws(() => classify(root), /partial published-target collision: 1 existing, 1 new/);
+test('OpenAI path moves and new targets are processed in one complete batch', () => withMarketplace((root) => {
+  const repository = 'openai/codex';
+  const slugs = ['imagegen', 'openai-docs', 'plugin-creator', 'review-agent', 'skill-creator', 'skill-installer'];
+  const oldRoot = 'codex-rs/core/src/skills/assets/samples';
+  const newRoot = 'codex-rs/skills/src/assets/samples';
+  for (const slug of ['skill-creator', 'skill-installer']) {
+    writeTarget(root, slug, {
+      layout: 'official',
+      repository,
+      sourceRef: 'main',
+      skillPath: `${oldRoot}/${slug}`,
+    });
+  }
+  const plan = selectionPlan(slugs.map((slug) => ({ slug, path: `${newRoot}/${slug}` })), repository);
+  plan.scope = { reason: 'explicit_path', path: newRoot };
+  const result = classify(root, plan);
+  assert.equal(result.disposition, 'processable');
+  assert.equal(result.reasonCode, 'selected_targets_include_new_and_updates');
+  assert.deepEqual(result.processingPlan, plan);
+  assert.deepEqual(result.updateTargets, ['skills/skill-creator', 'skills/skill-installer']);
+  assert.equal(result.updateSnapshots.length, 2);
+}));
+
+test('unchanged targets are filtered while updates and new targets continue', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: SOURCE_COMMIT });
+  writeTarget(root, 'beta', { sourceRef: 'main', skillPath: 'legacy/beta' });
+  const plan = selectionPlan([
+    { slug: 'alpha', path: 'skills/alpha' },
+    { slug: 'beta', path: 'skills/beta' },
+    { slug: 'gamma', path: 'skills/gamma' },
+  ]);
+  const result = classify(root, plan);
+  assert.equal(result.reasonCode, 'selected_targets_include_new_and_updates');
+  assert.deepEqual(result.processingPlan.skills, [
+    { slug: 'beta', path: 'skills/beta' },
+    { slug: 'gamma', path: 'skills/gamma' },
+  ]);
+  assert.deepEqual(result.updateTargets, ['skills/example/beta']);
 }));
 
 for (const mismatch of [
   { name: 'repository', options: { repository: 'other/source' }, pattern: /source (?:repository mismatch|URL is not canonical)|source_url is not canonical/ },
-  { name: 'ref', options: { sourceRef: 'release' }, pattern: /immutable commit URL/ },
-  { name: 'path', options: { skillPath: 'skills/other' }, pattern: /source (?:path mismatch|URL is not canonical)|source_url is not canonical/ },
 ]) {
   test(`a published target with a ${mismatch.name} mismatch fails closed`, () => withMarketplace((root) => {
     writeTarget(root, 'alpha', mismatch.options);
@@ -341,14 +383,14 @@ test('slash refs require the canonical percent-encoded source URL', () => withMa
     sourceRef: 'feature/ready',
     sourceUrl: 'https://github.com/example/source/tree/feature%2Fready/skills/alpha/',
   });
-  assert.equal(classify(root, plan, 'feature/ready').disposition, 'all_existing');
+  assert.equal(classify(root, plan).disposition, 'processable');
 
   rmSync(join(root, 'skills', 'example', 'alpha'), { recursive: true, force: true });
   writeTarget(root, 'alpha', {
     sourceRef: 'feature/ready',
     sourceUrl: 'https://github.com/example/source/tree/feature/ready/skills/alpha/',
   });
-  assert.throws(() => classify(root, plan, 'feature/ready'), /source_url is not canonical/);
+  assert.throws(() => classify(root, plan), /source_url (?:does not match source_ref|is not canonical)/);
 }));
 
 test('a symlinked target ancestor fails closed even when the final path is missing', () => withMarketplace((root) => {
@@ -362,7 +404,7 @@ test('a symlinked target ancestor fails closed even when the final path is missi
 }));
 
 test('an unrelated flat official slug does not hide an exact namespaced target', () => withMarketplace((root) => {
-  writeTarget(root, 'alpha');
+  writeTarget(root, 'alpha', { sourceRef: SOURCE_COMMIT });
   writeTarget(root, 'alpha', {
     layout: 'official',
     repository: 'other/source',

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -462,13 +462,18 @@ test('existing-target classification is a pre-CLI gate with a handled rejection 
     /all_selected_targets_already_published/,
   );
   assert.match(reusable, /existing_targets:/);
+  assert.match(reusable, /FULL_SELECTION_PLAN: \$\{\{ steps\.targets\.outputs\.processing_plan \}\}/);
+  assert.doesNotMatch(reusable, /--source-ref/);
   const latePendingGuard = reusable.indexOf('Pending path already exists on main');
   const latePublishedGuard = reusable.indexOf('Frozen update target is missing or unsafe');
   const lateCopy = reusable.indexOf('cp -R "$MERGED_RESULTS/$pending_dir"');
   assert.ok(latePendingGuard > 0 && latePendingGuard < lateCopy);
   assert.ok(latePublishedGuard > latePendingGuard && latePublishedGuard < lateCopy);
   assert.match(reusable, /Unexpected published target collision/);
-  assert.match(reusable, /UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.existing_targets \}\}/);
+  assert.match(reusable, /UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.update_targets \}\}/);
+  assert.match(reusable, /Update target and snapshot sets do not match/);
+  assert.match(reusable, /CURRENT_TREE_HASH=\$\(node "\$GITHUB_WORKSPACE\/scripts\/resolve-approved-submission\.mjs"/);
+  assert.match(reusable, /\[ "\$CURRENT_TREE_HASH" = "\$EXPECTED_TREE_HASH" \]/);
   assert.match(reusable, /previous_tree_hash = \$treeHash/);
   assert.match(reusable, /previous_source_ref = \$sourceRef/);
 });

--- a/scripts/tests/submission-scope-workflows.test.mjs
+++ b/scripts/tests/submission-scope-workflows.test.mjs
@@ -226,6 +226,10 @@ test('submission processing isolates every shard and stages only its frozen plan
   assert.match(reusable, /Enforce shard terminal status/);
   assert.match(reusable, /Frozen update target is missing or unsafe/);
   assert.match(reusable, /Unexpected published target collision/);
+  assert.match(reusable, /UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.update_targets \}\}/);
+  assert.match(reusable, /Update target and snapshot sets do not match/);
+  assert.match(reusable, /FULL_SELECTION_PLAN: \$\{\{ steps\.targets\.outputs\.processing_plan \}\}/);
+  assert.match(reusable, /CURRENT_TREE_HASH=\$\(node "\$GITHUB_WORKSPACE\/scripts\/resolve-approved-submission\.mjs"/);
 });
 
 test('submission staging preserves frozen tracked files hidden by a copied .gitignore', () => withTempDirectory((root) => {
@@ -763,6 +767,8 @@ test('merged approval scope comes only from immutable PR changed files', () => {
   assert.match(approval, /verify_update_parent/);
   assert.match(approval, /--tree-hash-at-commit/);
   assert.match(approval, /\[ "\$parent_tree" = "\$expected_tree" \]/);
+  assert.match(approval, /\.meta\.source_ref == \$sourceRef/);
+  assert.doesNotMatch(approval, /\.meta\.tree_hash == \$treeHash and \.meta\.source_ref == \$sourceRef/);
   assert.match(approval, /Published update target changed before push/);
   assert.match(approval, /git add -A -f -- "\$\{SKILL_PATHS\[@\]\}" "\$\{TARGET_PATHS\[@\]\}"/);
   assert.match(approval, /PUSHED=false/);


### PR DESCRIPTION
## Summary

- treat same-repository source path moves as updates while preserving repository, target, slug, source-type, and canonical URL checks
- process new and updated skills in the same submission; filter unchanged skills from the processing plan
- snapshot the authoritative canonical tree for legacy reports and revalidate it in the fresh clone, approval, and rebase boundaries

## Verification

- `CI=true node --test scripts/tests/submission-existing-targets.test.mjs scripts/tests/resolve-approved-submission.test.mjs scripts/tests/submission-runtime-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs` — 92 passed
- workflow YAML parsing passed
- `git diff --check` passed
- exact replay of submission `9df69099-e92c-4012-8859-cf1459697184` classifies all 6 skills as processable: 2 updates + 4 new