### PR TITLE
fix(source-monitor): preserve nested reference paths

### DIFF
--- a/scripts/tests/source-monitor-update-safety.test.mjs
+++ b/scripts/tests/source-monitor-update-safety.test.mjs
@@ -73,8 +73,9 @@ test('accepts a coherent source-monitor payload update', () => {
   const root = fixture();
   try {
     const dir = join(root, 'skills', 'owner', 'coherent');
-    write(join(dir, 'SKILL.md'), '# Coherent\n\nSee [guide](references/guide.md).\n');
+    write(join(dir, 'SKILL.md'), '# Coherent\n\nSee [guide](references/guide.md) and `ooxml/scripts/pack.py`.\n');
     write(join(dir, 'references', 'guide.md'), '# Old\n');
+    write(join(dir, 'ooxml', 'scripts', 'pack.py'), '# pack\n');
     bindReport(root, dir, { slug: 'owner-coherent' });
     commit(root);
 

--- a/scripts/verify-source-monitor-update.mjs
+++ b/scripts/verify-source-monitor-update.mjs
@@ -84,7 +84,7 @@ function referencedPaths(skillText) {
     const value = normalizeReference(match[1]);
     if (value) references.add(value);
   }
-  for (const match of skillText.matchAll(/\b((?:references|scripts|assets|commands|prompts|tests)\/[A-Za-z0-9._~!$&'()+,;=@%/-]+)/gu)) {
+  for (const match of skillText.matchAll(/(?<![A-Za-z0-9._~!$&'()+,;=@%/:-])((?:[A-Za-z0-9._~!$&'()+,;=@%-]+\/)*(?:references|scripts|assets|commands|prompts|tests)\/[A-Za-z0-9._~!$&'()+,;=@%/-]+)/gu)) {
     const value = normalizeReference(match[1]);
     if (value) references.add(value);
   }


### PR DESCRIPTION
Fixes the false fail-closed result in source monitor run 32006409483.

Root cause:
- the bare-reference regex matched scripts/pack.py as a suffix of ooxml/scripts/pack.py
- validation therefore checked a nonexistent shortened path even though the immutable upstream tree contains the full referenced file

Change:
- capture the complete relative path leading to known reference directories
- keep absolute paths, traversal, URLs, missing files, symlinks, and unsafe paths fail-closed
- extend the existing safety regression fixture with the exact nested-path shape

Focused verification:
- CI=true node --test scripts/tests/source-monitor-update-safety.test.mjs scripts/tests/source-monitor-runtime-workflow.test.mjs
- 19/19 passed