### PR TITLE
fix(submissions): normalize GitHub repository identity case

### DIFF
--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -193,7 +193,7 @@ function assertSourceIdentity(report, { repository }, reportPath) {
 
   const segments = decodedSegments(sourceUrl);
   const [owner, repo, kind, actualRef, ...actualPathSegments] = segments;
-  if (`${owner ?? ''}/${repo ?? ''}` !== repository || kind !== 'tree') {
+  if (`${owner ?? ''}/${repo ?? ''}`.toLowerCase() !== repository || kind !== 'tree') {
     sourceMismatch(`published target source repository mismatch at ${reportPath}: expected ${repository}`);
   }
   if (actualRef === undefined) {
@@ -206,7 +206,7 @@ function assertSourceIdentity(report, { repository }, reportPath) {
     fail(`published target source_url does not match source_ref at ${reportPath}`);
   }
   const sourcePath = actualPathSegments.join('/');
-  const canonicalPath = `/${repository}/tree/${encodeURIComponent(reportRef)}${sourcePath === ''
+  const canonicalPath = `/${owner}/${repo}/tree/${encodeURIComponent(reportRef)}${sourcePath === ''
     ? ''
     : `/${actualPathSegments.map((segment) => encodeURIComponent(segment)).join('/')}`}`;
   const parsedPath = new URL(sourceUrl).pathname;

--- a/scripts/resolve-submission-source.mjs
+++ b/scripts/resolve-submission-source.mjs
@@ -86,8 +86,8 @@ export function parseGitHubRepository(githubUrl) {
   const rawSegments = parsed.pathname.split('/').filter(Boolean);
   if (rawSegments.length < 2) fail(`GitHub URL must include owner and repository: ${githubUrl}`);
   const segments = rawSegments.map(decodePathSegment);
-  const owner = segments[0];
-  const repo = segments[1].replace(/\.git$/i, '');
+  const owner = segments[0].toLowerCase();
+  const repo = segments[1].replace(/\.git$/i, '').toLowerCase();
   if (!/^[A-Za-z0-9_-]+$/.test(owner) || !/^[A-Za-z0-9._-]+$/.test(repo) || repo === '') {
     fail(`invalid GitHub owner or repository: ${owner}/${repo}`);
   }

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -179,6 +179,15 @@ test('a same-repository source path move is processed as an update', () => withM
   assert.deepEqual(result.processingPlan, plan);
 }));
 
+test('legacy GitHub owner and repository casing preserves the same source identity', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', {
+    sourceRef: SOURCE_COMMIT,
+    sourceUrl: `https://github.com/Example/Source/tree/${SOURCE_COMMIT}/skills/alpha/`,
+  });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.disposition, 'all_existing');
+}));
+
 test('an update snapshots the authoritative tree when legacy report metadata is stale', () => withMarketplace((root) => {
   writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
   writeFileSync(join(root, 'skills/example/alpha/SKILL.md'), '---\nname: alpha\n---\nchanged\n');
@@ -350,7 +359,6 @@ for (const sourceUrl of [
   'https://github.com/example/source/tree/main/skills%2Falpha',
   'https://github.com/example/source/tree/main/skills/%2e/alpha',
   'https://github.com/example/source/tree/main/skills/%0Aalpha',
-  'https://github.com/Example/source/tree/main/skills/alpha/',
 ]) {
   test(`noncanonical published source URL fails closed: ${sourceUrl}`, () => withMarketplace((root) => {
     writeTarget(root, 'alpha', { sourceUrl });

--- a/scripts/tests/submission-source-resolution.test.mjs
+++ b/scripts/tests/submission-source-resolution.test.mjs
@@ -109,6 +109,18 @@ test('repository URLs use the exact default head and unsafe encoded paths are re
   }), /unsafe path segment/);
 });
 
+test('repository identity is normalized to lowercase without changing ref or skill path', () => {
+  const result = resolveSubmissionSource({
+    githubUrl: 'https://github.com/Side-Products/Faceless-Skill/tree/main/skills/demo',
+    defaultRef: 'main',
+    refsText: refs([MAIN_SHA, 'refs/heads/main']),
+  });
+  assert.equal(result.owner, 'side-products');
+  assert.equal(result.repo, 'faceless-skill');
+  assert.equal(result.skillPath, 'skills/demo');
+  assert.equal(result.normalizedUrl, 'https://github.com/side-products/faceless-skill/tree/main/skills/demo');
+});
+
 test('root SKILL.md blob keeps the explicit root sentinel and cannot be overridden by a manifest', () => {
   const result = resolveSubmissionSource({
     githubUrl: 'https://github.com/example/repo/blob/main/SKILL.md',


### PR DESCRIPTION
## Summary
- normalize GitHub owner/repository identity to lowercase before building submission plans
- accept legacy report owner/repository casing only for the same case-insensitive GitHub identity
- preserve exact ref, path, URL encoding, tree and hash validation

## Failure evidence
- run 32312256630 rejected `Side-Products/faceless-skill` after the resolver emitted mixed-case identity
- runs 32239576927 and 32239790715 rejected lowercase `ariesyb/zentao-ai-agent` against its legacy mixed-case report URL

## Tests
- `CI=true node --test scripts/tests/submission-source-resolution.test.mjs scripts/tests/submission-existing-targets.test.mjs`
- `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs`
- real `zentao-task-planner` plan now classifies as a processable same-repository update

## Safety boundary
Only GitHub owner/repository casing is folded. Ref/path identity, percent encoding, report schema, tree snapshots, symlink checks, audit and publication gates remain fail-closed.