### PR TITLE
Fix source monitor relative reference validation

### DIFF
--- a/scripts/tests/source-monitor-update-safety.test.mjs
+++ b/scripts/tests/source-monitor-update-safety.test.mjs
@@ -94,6 +94,24 @@ test('accepts a coherent source-monitor payload update', () => {
   }
 });
 
+test('accepts a quoted relative source reference with trailing punctuation', () => {
+  const root = fixture();
+  try {
+    const dir = join(root, 'skills', 'owner', 'relative-reference');
+    write(join(dir, 'SKILL.md'), "# Relative\n\n```ts\nsetupFiles: './tests/setup.ts',\n```\n");
+    write(join(dir, 'tests', 'setup.ts'), '// setup\n');
+    bindReport(root, dir, { slug: 'owner-relative-reference' });
+    commit(root);
+
+    write(join(dir, 'tests', 'setup.ts'), '// updated setup\n');
+    bindReport(root, dir, { slug: 'owner-relative-reference' });
+
+    assert.equal(verifySourceMonitorUpdate({ repositoryRoot: root }).changedSkills, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('accepts a coherent flat published skill update', () => {
   const root = fixture();
   try {

--- a/scripts/verify-source-monitor-update.mjs
+++ b/scripts/verify-source-monitor-update.mjs
@@ -60,7 +60,7 @@ function existingRegular(path, label) {
 }
 
 function normalizeReference(raw) {
-  let value = raw.trim().replace(/^['"]|['"]$/gu, '');
+  let value = raw.trim();
   value = value.split('#', 1)[0].split('?', 1)[0];
   try {
     value = decodeURIComponent(value);
@@ -68,6 +68,7 @@ function normalizeReference(raw) {
     return null;
   }
   value = value.replace(/[)\]}>.,;:!?]+$/u, '');
+  value = value.replace(/^['"]|['"]$/gu, '').replace(/^(?:\.\/)+/u, '');
   if (
     value === ''
     || /^(?:https?:|mailto:|data:|#)/iu.test(value)


### PR DESCRIPTION
## Root cause

`normalizeReference` removed quotes before trailing punctuation. A valid code reference such as `setupFiles: './tests/setup.ts',` therefore retained the closing quote after the comma was removed, while its safe `./` prefix also remained non-canonical. Source Monitor run 32458528321 then failed closed with `unsafe source monitor path`.

## Change

- remove trailing punctuation before quote delimiters
- normalize repeated safe `./` prefixes
- retain absolute-path, backslash, control-character, and `..` rejection

## Verification

- `CI=true node --test scripts/tests/source-monitor-update-safety.test.mjs`
- `CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs`

Original failure: https://github.com/aiskillstore/marketplace/actions/runs/32458528321