### PR TITLE
feat: auto-merge trusted Skill PRs

### DIFF
--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -1,0 +1,42 @@
+name: Auto Merge Trusted Skill PR
+
+on:
+  workflow_run:
+    workflows: ["Validate Marketplace"]
+    types: [completed]
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: trusted-skill-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout trusted default-branch automation
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Qualify, update, or merge the exact trusted Skill PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: node scripts/auto-merge-trusted-skill-pr.mjs

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -15,6 +15,7 @@ on:
       - "package-lock.json"
       - "scripts/check-workflow-action-pins.mjs"
       - "scripts/check-workflow-runner-safety.mjs"
+      - "scripts/auto-merge-trusted-skill-pr.mjs"
       - "scripts/resolve-approved-submission.mjs"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
@@ -40,6 +41,7 @@ on:
       - "package-lock.json"
       - "scripts/check-workflow-action-pins.mjs"
       - "scripts/check-workflow-runner-safety.mjs"
+      - "scripts/auto-merge-trusted-skill-pr.mjs"
       - "scripts/resolve-approved-submission.mjs"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/resolve-manual-skills.mjs"
@@ -192,6 +194,8 @@ jobs:
           CI: "true"
         run: |
           node --test \
+            scripts/tests/auto-merge-trusted-skill-pr.test.mjs \
+            scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs \
             scripts/tests/resolve-approved-submission.test.mjs \
             scripts/tests/submission-existing-targets.test.mjs \
             scripts/tests/submission-source-resolution.test.mjs \

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -101,6 +101,9 @@ export function validateSnapshot(snapshot) {
   block(Array.isArray(snapshot.repositoryRules), 'repository ruleset evidence is required');
   const publicationBoundary = snapshot.repositoryRules.find((ruleset) =>
     ruleset?.enforcement === 'active'
+    && ruleset?.target === 'branch'
+    && Array.isArray(ruleset?.conditions?.ref_name?.exclude)
+    && ruleset.conditions.ref_name.exclude.length === 0
     && ruleset?.conditions?.ref_name?.include?.includes('refs/heads/main')
     && ruleset?.rules?.some((rule) => rule.type === 'pull_request')
     && ruleset?.rules?.some((rule) =>
@@ -174,13 +177,16 @@ export function validateSnapshot(snapshot) {
     if (!checkNames.has(required)) throw new AutoMergeWaitingError(`missing required check ${required}`);
     const check = checks.find((candidate) => candidate.name === required);
     const expected = TRUSTED_WORKFLOWS[required];
-    block(check?.workflow?.id === expected.id
+    block(Number.isSafeInteger(check?.id)
+      && Number.isSafeInteger(check?.workflow?.run_id)
+      && check.workflow.id === expected.id
       && check.workflow.name === expected.name
       && check.workflow.path === expected.path
       && check.workflow.event === 'pull_request'
       && check.workflow.head_sha === pr.head.sha
       && check.workflow.status === 'completed'
-      && check.workflow.conclusion === 'success',
+      && check.workflow.conclusion === 'success'
+      && (required === 'publication-admission' || check.workflow.run_id === workflowRun.id),
     `check ${required} is not bound to the trusted workflow run`);
   }
   block(Array.isArray(statuses), 'exact-head statuses are required');
@@ -372,21 +378,29 @@ export class GitHubApi {
     const currentRun = await this.request(`/actions/runs/${this.currentRunId}`);
     const rawChecks = (await this.paginate(`/commits/${headSha}/check-runs?filter=latest`, (value) => value?.check_runs))
       .filter((check) => check.check_suite?.id !== currentRun.check_suite_id && !(check.name === 'auto-merge' && check.app?.id === GITHUB_ACTIONS_APP_ID));
-    const trustedCheckRunIds = new Map();
+    const trustedCheckRefs = new Map();
     for (const check of rawChecks) {
       if (!REQUIRED_CHECKS.includes(check.name)) continue;
-      const match = /^https:\/\/github\.com\/aiskillstore\/marketplace\/actions\/runs\/(\d+)\/job\/\d+(?:\?.*)?$/u.exec(check.details_url ?? '');
+      const match = /^https:\/\/github\.com\/aiskillstore\/marketplace\/actions\/runs\/(\d+)\/job\/(\d+)(?:\?.*)?$/u.exec(check.details_url ?? '');
       block(match, `check ${check.name} has no trusted workflow-run URL`);
-      trustedCheckRunIds.set(check.name, Number(match[1]));
+      trustedCheckRefs.set(check.name, { runId: Number(match[1]), jobId: Number(match[2]), checkId: check.id });
     }
-    const uniqueRunIds = [...new Set(trustedCheckRunIds.values())];
+    const uniqueRunIds = [...new Set([...trustedCheckRefs.values()].map((ref) => ref.runId))];
+    const uniqueJobIds = [...new Set([...trustedCheckRefs.values()].map((ref) => ref.jobId))];
     const trustedRuns = new Map(await Promise.all(uniqueRunIds.map(async (runId) => [runId, await this.request(`/actions/runs/${runId}`)])));
+    const trustedJobs = new Map(await Promise.all(uniqueJobIds.map(async (jobId) => [jobId, await this.request(`/actions/jobs/${jobId}`)])));
+    for (const ref of trustedCheckRefs.values()) {
+      const job = trustedJobs.get(ref.jobId);
+      block(job?.run_id === ref.runId
+        && job?.check_run_url === `https://api.github.com/repos/${this.repository}/check-runs/${ref.checkId}`,
+      'required check is not bound to its GitHub Actions job');
+    }
     const uniqueWorkflowIds = [...new Set([...trustedRuns.values()].map((run) => run.workflow_id))];
     const trustedWorkflowDefinitions = new Map(await Promise.all(uniqueWorkflowIds.map(async (workflowId) => [workflowId, await this.request(`/actions/workflows/${workflowId}`)])));
     const checks = rawChecks.map((check) => {
-      const runId = trustedCheckRunIds.get(check.name);
-      if (!runId) return check;
-      const run = trustedRuns.get(runId);
+      const ref = trustedCheckRefs.get(check.name);
+      if (!ref) return check;
+      const run = trustedRuns.get(ref.runId);
       const definition = trustedWorkflowDefinitions.get(run.workflow_id);
       return {
         ...check,
@@ -442,6 +456,7 @@ export class GitHubApi {
       },
       files: files.map((file) => ({ filename: file.filename, status: file.status, sha: file.sha, ...(file.previous_filename ? { previous_filename: file.previous_filename } : {}) })),
       checks: checks.map((check) => ({
+        id: check.id,
         name: check.name,
         status: check.status,
         conclusion: check.conclusion,

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -4,7 +4,12 @@ import { pathToFileURL } from 'node:url';
 const TRUSTED_REPOSITORY = 'aiskillstore/marketplace';
 const TRUSTED_BOT = Object.freeze({ id: 254047988, login: 'ai-skill-store[bot]', type: 'Bot' });
 const GITHUB_ACTIONS_APP_ID = 15368;
-const REQUIRED_CHECKS = Object.freeze(['publication-admission', 'action-pin-policy', 'validate']);
+const TRUSTED_WORKFLOWS = Object.freeze({
+  'publication-admission': { id: 330383167, name: 'Publication Provenance', path: '.github/workflows/publication-provenance.yml' },
+  'action-pin-policy': { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml' },
+  validate: { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml' },
+});
+const REQUIRED_CHECKS = Object.freeze(Object.keys(TRUSTED_WORKFLOWS));
 const SHA_RE = /^[0-9a-f]{40}$/;
 const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
@@ -63,6 +68,19 @@ function rootForPath(path) {
   if (parts.length < 4 || parts[0] !== 'pending') return null;
   if (!SEGMENT_RE.test(parts[1]) || !SEGMENT_RE.test(parts[2])) return null;
   return parts.slice(0, 3).join('/');
+}
+
+export function latestStatusesByContext(statusHistory) {
+  block(Array.isArray(statusHistory), 'status history must be an array');
+  const latest = [];
+  const seen = new Set();
+  for (const status of statusHistory) {
+    block(typeof status?.context === 'string' && status.context.length > 0, 'status context is required');
+    if (seen.has(status.context)) continue;
+    seen.add(status.context);
+    latest.push(status);
+  }
+  return latest;
 }
 
 function checkTerminal(check) {
@@ -154,6 +172,16 @@ export function validateSnapshot(snapshot) {
   }
   for (const required of REQUIRED_CHECKS) {
     if (!checkNames.has(required)) throw new AutoMergeWaitingError(`missing required check ${required}`);
+    const check = checks.find((candidate) => candidate.name === required);
+    const expected = TRUSTED_WORKFLOWS[required];
+    block(check?.workflow?.id === expected.id
+      && check.workflow.name === expected.name
+      && check.workflow.path === expected.path
+      && check.workflow.event === 'pull_request'
+      && check.workflow.head_sha === pr.head.sha
+      && check.workflow.status === 'completed'
+      && check.workflow.conclusion === 'success',
+    `check ${required} is not bound to the trusted workflow run`);
   }
   block(Array.isArray(statuses), 'exact-head statuses are required');
   const statusNames = new Set();
@@ -209,8 +237,13 @@ export async function runAutoMerge(api, { workflowRunId }) {
       for (let attempt = 0; attempt < 12; attempt += 1) {
         const pr = await api.readPr(second.prNumber);
         if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
-          changedHead = pr.head.sha;
-          break;
+          const commit = await api.readCommit(pr.head.sha);
+          const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
+          if (parentShas.has(second.headSha) && parentShas.has(second.baseSha)) {
+            changedHead = pr.head.sha;
+            break;
+          }
+          throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
         }
         if (attempt < 11) await api.sleep(5_000);
       }
@@ -302,6 +335,10 @@ export class GitHubApi {
     return this.request(`/pulls/${number}`);
   }
 
+  async readCommit(sha) {
+    return this.request(`/commits/${sha}`);
+  }
+
   async existsAt(path, ref) {
     try {
       await this.request(`/contents/${encodeContentPath(path)}?ref=${encodeURIComponent(ref)}`);
@@ -333,9 +370,40 @@ export class GitHubApi {
     block(validSha(headSha) && headSha === workflowRun.head_sha, 'PR head does not match the workflow run');
     const files = await this.paginate(`/pulls/${pr.number}/files`);
     const currentRun = await this.request(`/actions/runs/${this.currentRunId}`);
-    const checks = (await this.paginate(`/commits/${headSha}/check-runs?filter=latest`, (value) => value?.check_runs))
+    const rawChecks = (await this.paginate(`/commits/${headSha}/check-runs?filter=latest`, (value) => value?.check_runs))
       .filter((check) => check.check_suite?.id !== currentRun.check_suite_id && !(check.name === 'auto-merge' && check.app?.id === GITHUB_ACTIONS_APP_ID));
-    const statuses = await this.paginate(`/commits/${headSha}/statuses`);
+    const trustedCheckRunIds = new Map();
+    for (const check of rawChecks) {
+      if (!REQUIRED_CHECKS.includes(check.name)) continue;
+      const match = /^https:\/\/github\.com\/aiskillstore\/marketplace\/actions\/runs\/(\d+)\/job\/\d+(?:\?.*)?$/u.exec(check.details_url ?? '');
+      block(match, `check ${check.name} has no trusted workflow-run URL`);
+      trustedCheckRunIds.set(check.name, Number(match[1]));
+    }
+    const uniqueRunIds = [...new Set(trustedCheckRunIds.values())];
+    const trustedRuns = new Map(await Promise.all(uniqueRunIds.map(async (runId) => [runId, await this.request(`/actions/runs/${runId}`)])));
+    const uniqueWorkflowIds = [...new Set([...trustedRuns.values()].map((run) => run.workflow_id))];
+    const trustedWorkflowDefinitions = new Map(await Promise.all(uniqueWorkflowIds.map(async (workflowId) => [workflowId, await this.request(`/actions/workflows/${workflowId}`)])));
+    const checks = rawChecks.map((check) => {
+      const runId = trustedCheckRunIds.get(check.name);
+      if (!runId) return check;
+      const run = trustedRuns.get(runId);
+      const definition = trustedWorkflowDefinitions.get(run.workflow_id);
+      return {
+        ...check,
+        workflow: {
+          run_id: run.id,
+          id: run.workflow_id,
+          name: run.name,
+          path: definition.path,
+          event: run.event,
+          head_sha: run.head_sha,
+          status: run.status,
+          conclusion: run.conclusion,
+        },
+      };
+    });
+    const statusHistory = await this.paginate(`/commits/${headSha}/statuses`);
+    const latestStatuses = latestStatusesByContext(statusHistory);
     const tree = await this.request(`/git/trees/${headSha}?recursive=1`);
     const roots = new Set(files.map((file) => rootForPath(file.filename)).filter(Boolean));
     const root = roots.size === 1 ? [...roots][0] : 'pending/invalid/invalid';
@@ -373,8 +441,14 @@ export class GitHubApi {
         head: { ref: pr.head?.ref, sha: pr.head?.sha, repo: { id: pr.head?.repo?.id, full_name: pr.head?.repo?.full_name } },
       },
       files: files.map((file) => ({ filename: file.filename, status: file.status, sha: file.sha, ...(file.previous_filename ? { previous_filename: file.previous_filename } : {}) })),
-      checks: checks.map((check) => ({ name: check.name, status: check.status, conclusion: check.conclusion, app: { id: check.app?.id } })),
-      statuses: statuses.map((status) => ({ context: status.context, state: status.state })),
+      checks: checks.map((check) => ({
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        app: { id: check.app?.id },
+        ...(check.workflow ? { workflow: check.workflow } : {}),
+      })),
+      statuses: latestStatuses.map((status) => ({ context: status.context, state: status.state })),
       tree: { truncated: tree.truncated, entries: (tree.tree ?? []).map((entry) => ({ path: entry.path, type: entry.type, mode: entry.mode, sha: entry.sha })) },
       basePendingExists,
       publishedTargetExists,

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+const TRUSTED_REPOSITORY = 'aiskillstore/marketplace';
+const TRUSTED_BOT = Object.freeze({ id: 254047988, login: 'ai-skill-store[bot]', type: 'Bot' });
+const GITHUB_ACTIONS_APP_ID = 15368;
+const REQUIRED_CHECKS = Object.freeze(['publication-admission', 'action-pin-policy', 'validate']);
+const SHA_RE = /^[0-9a-f]{40}$/;
+const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export class AutoMergeBlockedError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AutoMergeBlockedError';
+  }
+}
+
+export class AutoMergeWaitingError extends AutoMergeBlockedError {
+  constructor(message) {
+    super(message);
+    this.name = 'AutoMergeWaitingError';
+  }
+}
+
+export class AutoMergeUnknownEffectError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AutoMergeUnknownEffectError';
+  }
+}
+
+class GitHubApiError extends Error {
+  constructor(message, status, body) {
+    super(message);
+    this.name = 'GitHubApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function block(condition, message) {
+  if (!condition) throw new AutoMergeBlockedError(message);
+}
+
+function validSha(value) {
+  return typeof value === 'string' && SHA_RE.test(value);
+}
+
+function sameRepository(candidate, repository) {
+  return candidate?.id === repository.id && candidate?.full_name === repository.full_name;
+}
+
+function safePath(path) {
+  if (typeof path !== 'string' || path.length === 0 || path.startsWith('/') || path.includes('\\')) return false;
+  if (/[\u0000-\u001f\u007f]/u.test(path)) return false;
+  const parts = path.split('/');
+  return parts.every((part) => part.length > 0 && part !== '.' && part !== '..');
+}
+
+function rootForPath(path) {
+  if (!safePath(path)) return null;
+  const parts = path.split('/');
+  if (parts.length < 4 || parts[0] !== 'pending') return null;
+  if (!SEGMENT_RE.test(parts[1]) || !SEGMENT_RE.test(parts[2])) return null;
+  return parts.slice(0, 3).join('/');
+}
+
+function checkTerminal(check) {
+  const name = check?.name;
+  block(typeof name === 'string' && name.length > 0, 'observed check has no name');
+  if (check.status !== 'completed' || check.conclusion == null) {
+    throw new AutoMergeWaitingError(`check ${name} is ${check.status ?? 'missing'}`);
+  }
+  block(check.conclusion === 'success', `check ${name} concluded ${check.conclusion}`);
+}
+
+export function validateSnapshot(snapshot) {
+  block(snapshot && typeof snapshot === 'object', 'snapshot must be an object');
+  const { repository, workflowRun, pr, files, checks, statuses, tree } = snapshot;
+  block(repository?.full_name === TRUSTED_REPOSITORY, `repository must be ${TRUSTED_REPOSITORY}`);
+  block(Number.isSafeInteger(repository.id), 'repository id is required');
+  block(repository.default_branch === 'main', 'default branch must be main');
+  block(Array.isArray(snapshot.repositoryRules), 'repository ruleset evidence is required');
+  const publicationBoundary = snapshot.repositoryRules.find((ruleset) =>
+    ruleset?.enforcement === 'active'
+    && ruleset?.conditions?.ref_name?.include?.includes('refs/heads/main')
+    && ruleset?.rules?.some((rule) => rule.type === 'pull_request')
+    && ruleset?.rules?.some((rule) =>
+      rule.type === 'required_status_checks'
+      && rule.parameters?.strict_required_status_checks_policy === true
+      && rule.parameters?.required_status_checks?.some((check) =>
+        check.context === 'publication-admission' && check.integration_id === GITHUB_ACTIONS_APP_ID)))
+  ;
+  block(publicationBoundary, 'strict protected-main publication ruleset is missing');
+  block(!(publicationBoundary.bypass_actors ?? []).some((actor) =>
+    actor.actor_type === 'Integration' && actor.actor_id === GITHUB_ACTIONS_APP_ID),
+  'GitHub Actions must not bypass the protected-main ruleset');
+
+  block(workflowRun?.event === 'pull_request', 'trigger must be a pull_request workflow run');
+  block(workflowRun?.name === 'Validate Marketplace', 'unexpected workflow run');
+  block(workflowRun?.status === 'completed', 'workflow run is not completed');
+  block(workflowRun?.conclusion === 'success', `workflow run concluded ${workflowRun?.conclusion ?? 'unknown'}`);
+  block(Array.isArray(workflowRun.pull_requests) && workflowRun.pull_requests.length === 1, 'workflow run must bind exactly one PR');
+
+  block(pr?.number === workflowRun.pull_requests[0]?.number, 'workflow run PR number does not match');
+  block(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
+  block(pr.base?.ref === 'main', 'PR base must be main');
+  block(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
+  block(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
+  block(typeof pr.head?.ref === 'string' && pr.head.ref.startsWith('submission/'), 'PR head must use trusted submission/ provenance');
+  block(validSha(pr.head?.sha) && validSha(pr.base?.sha), 'PR head and base SHA must be exact');
+  block(workflowRun.head_sha === pr.head.sha, 'workflow run must bind the exact PR head');
+  block(Array.isArray(pr.labels) && pr.labels.some((label) => label?.name === 'pending-review'), 'PR must have pending-review');
+  block(pr.mergeable === true, 'PR is not mergeable');
+  block(['clean', 'behind'].includes(pr.mergeable_state), `PR mergeable_state is ${pr.mergeable_state ?? 'unknown'}`);
+
+  block(Array.isArray(files) && files.length > 0, 'PR files are required');
+  block(Number.isSafeInteger(pr.changed_files) && pr.changed_files === files.length, 'PR file pagination/count is incomplete');
+  const seenFiles = new Set();
+  const roots = new Set();
+  for (const file of files) {
+    block(file?.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file?.filename ?? '<unknown>'}`);
+    block(safePath(file.filename), 'PR contains an unsafe path');
+    block(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
+    seenFiles.add(file.filename);
+    const root = rootForPath(file.filename);
+    block(root !== null, 'PR must change only one pending Skill root');
+    roots.add(root);
+  }
+  block(roots.size === 1, 'PR must change only one pending Skill root');
+  const [root] = roots;
+  block(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
+  block(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
+  block(snapshot.basePendingExists === false, 'pending root already exists on the base');
+
+  block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
+  const treeFiles = new Set();
+  for (const entry of tree.entries) {
+    if (typeof entry?.path !== 'string' || (entry.path !== root && !entry.path.startsWith(`${root}/`))) continue;
+    if (entry.path === root && entry.type === 'tree') continue;
+    if (entry.type === 'tree') continue;
+    block(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
+    treeFiles.add(entry.path);
+  }
+  block(treeFiles.size === seenFiles.size && [...seenFiles].every((path) => treeFiles.has(path)), 'PR files do not equal the exact-head Skill tree');
+
+  block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
+  const checkNames = new Set();
+  for (const check of checks) {
+    block(check?.app?.id === GITHUB_ACTIONS_APP_ID, `check ${check?.name ?? '<unknown>'} is not from GitHub Actions`);
+    block(!checkNames.has(check?.name), `duplicate check ${check?.name ?? '<unknown>'}`);
+    checkNames.add(check.name);
+    checkTerminal(check);
+  }
+  for (const required of REQUIRED_CHECKS) {
+    if (!checkNames.has(required)) throw new AutoMergeWaitingError(`missing required check ${required}`);
+  }
+  block(Array.isArray(statuses), 'exact-head statuses are required');
+  const statusNames = new Set();
+  for (const status of statuses) {
+    block(typeof status?.context === 'string' && !statusNames.has(status.context), `duplicate status ${status?.context ?? '<unknown>'}`);
+    statusNames.add(status.context);
+    if (status.state === 'pending') throw new AutoMergeWaitingError(`status ${status.context} is pending`);
+    block(status.state === 'success', `status ${status.context} is ${status.state ?? 'unknown'}`);
+  }
+
+  return {
+    eligible: true,
+    action: pr.mergeable_state === 'behind' ? 'update_branch' : 'merge',
+    classification: snapshot.publishedTargetExists === true ? 'UPDATE_SKILL' : 'NEW_SKILL',
+    prNumber: pr.number,
+    headSha: pr.head.sha,
+    baseSha: pr.base.sha,
+    root,
+  };
+}
+
+function samePlan(first, second) {
+  return first.prNumber === second.prNumber && first.headSha === second.headSha && first.baseSha === second.baseSha && first.root === second.root && first.classification === second.classification && first.action === second.action;
+}
+
+function mergedReadback(pr, plan) {
+  return pr?.merged === true && pr.state === 'closed' && pr.head?.sha === plan.headSha && validSha(pr.merge_commit_sha);
+}
+
+function definiteMutationRejection(error) {
+  return error instanceof GitHubApiError && [405, 409, 422].includes(error.status);
+}
+
+export async function runAutoMerge(api, { workflowRunId }) {
+  const firstSnapshot = await api.buildSnapshot(workflowRunId);
+  if (firstSnapshot?.pr?.merged === true && firstSnapshot.pr.state === 'closed' && firstSnapshot.pr.head?.sha === firstSnapshot.workflowRun?.head_sha) {
+    return { outcome: 'ALREADY_MERGED', prNumber: firstSnapshot.pr.number, headSha: firstSnapshot.pr.head.sha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha };
+  }
+  const first = validateSnapshot(firstSnapshot);
+  const secondSnapshot = await api.buildSnapshot(workflowRunId);
+  const second = validateSnapshot(secondSnapshot);
+  block(samePlan(first, second), 'candidate changed during pre-effect revalidation');
+
+  if (second.action === 'update_branch') {
+    let mutationError;
+    try {
+      await api.updateBranch(second.prNumber, second.headSha);
+    } catch (error) {
+      mutationError = error;
+    }
+    let changedHead;
+    try {
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const pr = await api.readPr(second.prNumber);
+        if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
+          changedHead = pr.head.sha;
+          break;
+        }
+        if (attempt < 11) await api.sleep(5_000);
+      }
+    } catch {
+      throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
+    }
+    if (changedHead) {
+      return { outcome: 'UPDATE_CONFIRMED_AWAITING_CI', prNumber: second.prNumber, oldHeadSha: second.headSha, newHeadSha: changedHead, classification: second.classification };
+    }
+    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`update-branch rejected with HTTP ${mutationError.status}`);
+    throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
+  }
+
+  let mutationError;
+  try {
+    await api.merge(second.prNumber, second.headSha, 'merge');
+  } catch (error) {
+    mutationError = error;
+  }
+  let readback;
+  try {
+    readback = await api.readPr(second.prNumber);
+  } catch {
+    throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
+  }
+  if (mergedReadback(readback, second)) {
+    return { outcome: 'MERGED_CONFIRMED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+  }
+  if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`merge rejected with HTTP ${mutationError.status}`);
+  throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
+}
+
+function encodeContentPath(path) {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+export class GitHubApi {
+  constructor({ token, repository, currentRunId }) {
+    block(typeof token === 'string' && token.length > 0, 'GH_TOKEN is required');
+    block(repository === TRUSTED_REPOSITORY, `GITHUB_REPOSITORY must be ${TRUSTED_REPOSITORY}`);
+    block(Number.isSafeInteger(Number(currentRunId)) && Number(currentRunId) > 0, 'GITHUB_RUN_ID is invalid');
+    this.token = token;
+    this.repository = repository;
+    this.currentRunId = Number(currentRunId);
+    this.baseUrl = `https://api.github.com/repos/${repository}`;
+  }
+
+  async request(path, { method = 'GET', body } = {}) {
+    let response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${this.token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'skillstore-trusted-auto-merge',
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(20_000),
+      });
+    } catch (error) {
+      throw error;
+    }
+    const text = await response.text();
+    const parsed = text.length === 0 ? null : JSON.parse(text);
+    if (!response.ok) throw new GitHubApiError(`GitHub API ${method} ${path} returned ${response.status}`, response.status, parsed);
+    return parsed;
+  }
+
+  async paginate(path, extract = (value) => value) {
+    const all = [];
+    for (let page = 1; page <= 30; page += 1) {
+      const separator = path.includes('?') ? '&' : '?';
+      const value = await this.request(`${path}${separator}per_page=100&page=${page}`);
+      const items = extract(value);
+      block(Array.isArray(items), `paginated GitHub response is invalid for ${path}`);
+      all.push(...items);
+      if (items.length < 100) return all;
+    }
+    throw new AutoMergeBlockedError(`GitHub pagination exceeded the bounded limit for ${path}`);
+  }
+
+  async sleep(milliseconds) {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
+  async readPr(number) {
+    return this.request(`/pulls/${number}`);
+  }
+
+  async existsAt(path, ref) {
+    try {
+      await this.request(`/contents/${encodeContentPath(path)}?ref=${encodeURIComponent(ref)}`);
+      return true;
+    } catch (error) {
+      if (error instanceof GitHubApiError && error.status === 404) return false;
+      throw error;
+    }
+  }
+
+  async buildSnapshot(workflowRunId) {
+    block(Number.isSafeInteger(Number(workflowRunId)) && Number(workflowRunId) > 0, 'WORKFLOW_RUN_ID is invalid');
+    const repository = await this.request('');
+    const rulesetSummaries = await this.paginate('/rulesets');
+    const repositoryRules = await Promise.all(rulesetSummaries.map((ruleset) => this.request(`/rulesets/${ruleset.id}`)));
+    const workflowRun = await this.request(`/actions/runs/${Number(workflowRunId)}`);
+    block(workflowRun.event === 'pull_request' && validSha(workflowRun.head_sha), 'workflow run is not bound to an exact pull_request head');
+    const associatedPrs = await this.paginate(`/commits/${workflowRun.head_sha}/pulls`);
+    const exactAssociatedPrs = associatedPrs.filter((candidate) =>
+      candidate?.head?.sha === workflowRun.head_sha
+      && candidate?.base?.ref === 'main'
+      && candidate?.base?.repo?.full_name === this.repository
+      && candidate?.head?.repo?.full_name === this.repository);
+    const payloadNumbers = (workflowRun.pull_requests ?? []).map((candidate) => candidate.number).filter(Number.isSafeInteger);
+    const candidateNumbers = [...new Set([...exactAssociatedPrs.map((candidate) => candidate.number), ...payloadNumbers])];
+    block(candidateNumbers.length === 1, 'workflow run must resolve exactly one PR from the exact head');
+    const pr = await this.request(`/pulls/${candidateNumbers[0]}`);
+    const headSha = pr.head?.sha;
+    block(validSha(headSha) && headSha === workflowRun.head_sha, 'PR head does not match the workflow run');
+    const files = await this.paginate(`/pulls/${pr.number}/files`);
+    const currentRun = await this.request(`/actions/runs/${this.currentRunId}`);
+    const checks = (await this.paginate(`/commits/${headSha}/check-runs?filter=latest`, (value) => value?.check_runs))
+      .filter((check) => check.check_suite?.id !== currentRun.check_suite_id && !(check.name === 'auto-merge' && check.app?.id === GITHUB_ACTIONS_APP_ID));
+    const statuses = await this.paginate(`/commits/${headSha}/statuses`);
+    const tree = await this.request(`/git/trees/${headSha}?recursive=1`);
+    const roots = new Set(files.map((file) => rootForPath(file.filename)).filter(Boolean));
+    const root = roots.size === 1 ? [...roots][0] : 'pending/invalid/invalid';
+    const published = `skills/${root.slice('pending/'.length)}`;
+    const baseSha = pr.base?.sha;
+    block(validSha(baseSha), 'PR base SHA is invalid');
+    const [basePendingExists, publishedTargetExists] = await Promise.all([
+      this.existsAt(root, baseSha),
+      this.existsAt(published, baseSha),
+    ]);
+    return {
+      repository: { id: repository.id, full_name: repository.full_name, default_branch: repository.default_branch },
+      repositoryRules,
+      workflowRun: {
+        id: workflowRun.id,
+        name: workflowRun.name,
+        event: workflowRun.event,
+        status: workflowRun.status,
+        conclusion: workflowRun.conclusion,
+        head_sha: workflowRun.head_sha,
+        pull_requests: [{ number: pr.number }],
+      },
+      pr: {
+        number: pr.number,
+        state: pr.state,
+        draft: pr.draft,
+        merged: pr.merged,
+        merge_commit_sha: pr.merge_commit_sha,
+        changed_files: pr.changed_files,
+        mergeable: pr.mergeable,
+        mergeable_state: pr.mergeable_state,
+        user: { id: pr.user?.id, login: pr.user?.login, type: pr.user?.type },
+        labels: (pr.labels ?? []).map((label) => ({ name: label.name })),
+        base: { ref: pr.base?.ref, sha: pr.base?.sha, repo: { id: pr.base?.repo?.id, full_name: pr.base?.repo?.full_name } },
+        head: { ref: pr.head?.ref, sha: pr.head?.sha, repo: { id: pr.head?.repo?.id, full_name: pr.head?.repo?.full_name } },
+      },
+      files: files.map((file) => ({ filename: file.filename, status: file.status, sha: file.sha, ...(file.previous_filename ? { previous_filename: file.previous_filename } : {}) })),
+      checks: checks.map((check) => ({ name: check.name, status: check.status, conclusion: check.conclusion, app: { id: check.app?.id } })),
+      statuses: statuses.map((status) => ({ context: status.context, state: status.state })),
+      tree: { truncated: tree.truncated, entries: (tree.tree ?? []).map((entry) => ({ path: entry.path, type: entry.type, mode: entry.mode, sha: entry.sha })) },
+      basePendingExists,
+      publishedTargetExists,
+    };
+  }
+
+  async updateBranch(number, headSha) {
+    return this.request(`/pulls/${number}/update-branch`, { method: 'PUT', body: { expected_head_sha: headSha } });
+  }
+
+  async merge(number, headSha, method) {
+    return this.request(`/pulls/${number}/merge`, { method: 'PUT', body: { sha: headSha, merge_method: method } });
+  }
+}
+
+async function main() {
+  const api = new GitHubApi({ token: process.env.GH_TOKEN, repository: process.env.GITHUB_REPOSITORY, currentRunId: process.env.GITHUB_RUN_ID });
+  try {
+    const result = await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    if (error instanceof AutoMergeWaitingError) {
+      process.stdout.write(`${JSON.stringify({ outcome: 'WAITING_CI', reason: error.message })}\n`);
+      return;
+    }
+    const kind = error instanceof AutoMergeUnknownEffectError ? 'UNKNOWN_EFFECT' : 'BLOCKED';
+    process.stderr.write(`::error title=Trusted Skill auto-merge ${kind}::${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (import.meta.url === invokedPath) await main();

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOW_PATH = resolve(ROOT, '.github/workflows/auto-merge-trusted-skill-pr.yml');
+const source = readFileSync(WORKFLOW_PATH, 'utf8');
+const workflow = parse(source);
+const trigger = workflow.on ?? workflow.true;
+
+test('uses only the trusted default-branch validation workflow_run event', () => {
+  assert.deepEqual(Object.keys(trigger), ['workflow_run']);
+  assert.deepEqual(trigger.workflow_run.workflows, ['Validate Marketplace']);
+  assert.deepEqual(trigger.workflow_run.types, ['completed']);
+  assert.doesNotMatch(source, /pull_request_target|\bworkflow_dispatch\b/);
+});
+
+test('uses a literal hosted runner, non-cancelling serialization and exact minimal permissions', () => {
+  assert.deepEqual(workflow.permissions, {
+    actions: 'read',
+    checks: 'read',
+    contents: 'write',
+    'pull-requests': 'write',
+    statuses: 'read',
+  });
+  assert.equal(workflow.concurrency['cancel-in-progress'], false);
+  assert.match(workflow.concurrency.group, /workflow_run\.head_sha/);
+  const job = workflow.jobs['auto-merge'];
+  assert.equal(job['runs-on'], 'ubuntu-latest');
+  assert.match(job.if, /workflow_run\.event == 'pull_request'/);
+  assert.ok(Number.parseInt(job['timeout-minutes'], 10) <= 15);
+});
+
+test('checks out only the trusted workflow SHA without credentials and executes the bounded helper', () => {
+  const steps = workflow.jobs['auto-merge'].steps;
+  const checkout = steps.find((step) => step.uses?.startsWith('actions/checkout@'));
+  assert.match(checkout.uses, /^actions\/checkout@[0-9a-f]{40}$/);
+  assert.equal(checkout.with.ref, '${{ github.sha }}');
+  assert.equal(checkout.with['persist-credentials'], false);
+  assert.ok(steps.every((step) => !String(step.with?.ref ?? '').includes('workflow_run.head_sha')));
+  const run = steps.find((step) => step.run)?.run ?? '';
+  assert.match(run, /^node scripts\/auto-merge-trusted-skill-pr\.mjs$/m);
+  assert.equal(steps.find((step) => step.run).env.GH_TOKEN, '${{ github.token }}');
+  assert.equal(steps.find((step) => step.run).env.GITHUB_RUN_ID, '${{ github.run_id }}');
+  assert.equal(steps.find((step) => step.run).env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
+});
+
+test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {
+  assert.doesNotMatch(source, /--admin|--auto|force-with-lease|git push|pull\/\$\{|workflow_run\.head_repository|workflow_run\.head_branch/);
+});

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  AutoMergeBlockedError,
+  AutoMergeUnknownEffectError,
+  runAutoMerge,
+  validateSnapshot,
+} from '../auto-merge-trusted-skill-pr.mjs';
+
+const REPO = { id: 9001, full_name: 'aiskillstore/marketplace', default_branch: 'main' };
+const HEAD = 'a'.repeat(40);
+const BASE = 'b'.repeat(40);
+const ROOT = 'pending/example/skill';
+
+function snapshot(overrides = {}) {
+  const value = {
+    repository: REPO,
+    repositoryRules: [{
+      enforcement: 'active',
+      bypass_actors: [{ actor_id: 2628292, actor_type: 'Integration', bypass_mode: 'always' }],
+      conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
+      rules: [
+        { type: 'pull_request', parameters: { allowed_merge_methods: ['merge'] } },
+        { type: 'required_status_checks', parameters: { strict_required_status_checks_policy: true, required_status_checks: [{ context: 'publication-admission', integration_id: 15368 }] } },
+      ],
+    }],
+    workflowRun: {
+      id: 123,
+      name: 'Validate Marketplace',
+      event: 'pull_request',
+      status: 'completed',
+      conclusion: 'success',
+      head_sha: HEAD,
+      pull_requests: [{ number: 42 }],
+    },
+    pr: {
+      number: 42,
+      state: 'open',
+      draft: false,
+      merged: false,
+      changed_files: 2,
+      mergeable: true,
+      mergeable_state: 'clean',
+      user: { id: 254047988, login: 'ai-skill-store[bot]', type: 'Bot' },
+      labels: [{ name: 'pending-review' }],
+      base: { ref: 'main', sha: BASE, repo: { ...REPO } },
+      head: { ref: 'submission/example-42', sha: HEAD, repo: { ...REPO } },
+    },
+    files: [
+      { filename: `${ROOT}/SKILL.md`, status: 'added', sha: '1'.repeat(40) },
+      { filename: `${ROOT}/skill-report.json`, status: 'added', sha: '2'.repeat(40) },
+    ],
+    checks: [
+      { name: 'publication-admission', status: 'completed', conclusion: 'success', app: { id: 15368 } },
+      { name: 'action-pin-policy', status: 'completed', conclusion: 'success', app: { id: 15368 } },
+      { name: 'validate', status: 'completed', conclusion: 'success', app: { id: 15368 } },
+    ],
+    statuses: [],
+    tree: {
+      truncated: false,
+      entries: [
+        { path: `${ROOT}/SKILL.md`, type: 'blob', mode: '100644', sha: '1'.repeat(40) },
+        { path: `${ROOT}/skill-report.json`, type: 'blob', mode: '100644', sha: '2'.repeat(40) },
+      ],
+    },
+    basePendingExists: false,
+    publishedTargetExists: false,
+  };
+  return structuredClone(Object.assign(value, overrides));
+}
+
+function expectBlocked(value, pattern) {
+  assert.throws(() => validateSnapshot(value), (error) => {
+    assert.ok(error instanceof AutoMergeBlockedError);
+    assert.match(error.message, pattern);
+    return true;
+  });
+}
+
+test('qualifies one exact trusted NEW_SKILL root for ordinary merge', () => {
+  assert.deepEqual(validateSnapshot(snapshot()), {
+    eligible: true,
+    action: 'merge',
+    classification: 'NEW_SKILL',
+    prNumber: 42,
+    headSha: HEAD,
+    baseSha: BASE,
+    root: ROOT,
+  });
+});
+
+test('qualifies UPDATE_SKILL and requests only standard update-branch when behind', () => {
+  const value = snapshot({ publishedTargetExists: true });
+  value.pr.mergeable_state = 'behind';
+  assert.equal(validateSnapshot(value).classification, 'UPDATE_SKILL');
+  assert.equal(validateSnapshot(value).action, 'update_branch');
+});
+
+test('fails closed on identity, provenance, scope, label, state and exact-head drift', () => {
+  const cases = [
+    [() => { const v = snapshot(); v.pr.user.id = 7; return v; }, /trusted App identity/],
+    [() => { const v = snapshot(); v.pr.user.login = 'ai-skill-store'; return v; }, /trusted App identity/],
+    [() => { const v = snapshot(); v.pr.head.repo.id = 7; return v; }, /same repository/],
+    [() => { const v = snapshot(); v.pr.head.ref = 'skill-source-monitor/x'; return v; }, /submission\//],
+    [() => { const v = snapshot(); v.pr.draft = true; return v; }, /open and non-draft/],
+    [() => { const v = snapshot(); v.pr.labels = []; return v; }, /pending-review/],
+    [() => { const v = snapshot(); v.workflowRun.head_sha = 'c'.repeat(40); return v; }, /exact PR head/],
+    [() => { const v = snapshot(); v.files.push({ filename: '.github/workflows/pwn.yml', status: 'added', sha: '3'.repeat(40) }); v.pr.changed_files = 3; return v; }, /one pending Skill root/],
+    [() => { const v = snapshot(); v.files[0].status = 'modified'; return v; }, /newly added/],
+    [() => { const v = snapshot(); v.basePendingExists = true; return v; }, /pending root already exists/],
+  ];
+  for (const [build, pattern] of cases) expectBlocked(build(), pattern);
+});
+
+test('fails closed on incomplete files, unsafe tree entries, truncation and ambiguous checks', () => {
+  const cases = [
+    [() => { const v = snapshot(); v.files.pop(); v.tree.entries.pop(); v.pr.changed_files = 1; return v; }, /skill-report\.json/],
+    [() => { const v = snapshot(); v.tree.entries[0].mode = '120000'; return v; }, /ordinary blobs/],
+    [() => { const v = snapshot(); v.tree.truncated = true; return v; }, /truncated/],
+    [() => { const v = snapshot(); v.checks[2].conclusion = 'failure'; return v; }, /check validate.*failure/],
+    [() => { const v = snapshot(); v.checks.push({ ...v.checks[2] }); return v; }, /duplicate check/],
+    [() => { const v = snapshot(); v.checks.pop(); return v; }, /missing required check validate/],
+    [() => { const v = snapshot(); v.statuses = [{ context: 'legacy', state: 'pending' }]; return v; }, /status legacy.*pending/],
+    [() => { const v = snapshot(); v.checks[0].app.id = 999; return v; }, /not from GitHub Actions/],
+    [() => { const v = snapshot(); v.repositoryRules[0].bypass_actors.push({ actor_id: 15368, actor_type: 'Integration' }); return v; }, /must not bypass/],
+    [() => { const v = snapshot(); v.repositoryRules[0].rules[1].parameters.strict_required_status_checks_policy = false; return v; }, /strict protected-main/],
+  ];
+  for (const [build, pattern] of cases) expectBlocked(build(), pattern);
+});
+
+function fakeApi(sequence) {
+  const calls = [];
+  return {
+    calls,
+    async buildSnapshot() {
+      const next = sequence.shift();
+      if (next instanceof Error) throw next;
+      return structuredClone(next);
+    },
+    async readPr() {
+      const next = sequence.shift();
+      if (next instanceof Error) throw next;
+      return structuredClone(next?.pr ?? next);
+    },
+    async sleep() {},
+    async updateBranch(number, headSha) {
+      calls.push(['update', number, headSha]);
+      return { message: 'Updating pull request branch.' };
+    },
+    async merge(number, headSha, method) {
+      calls.push(['merge', number, headSha, method]);
+      return { merged: true, sha: 'd'.repeat(40), message: 'Pull Request successfully merged' };
+    },
+  };
+}
+
+test('rejects base drift before the effect and performs no mutation', async () => {
+  const changedBase = snapshot();
+  changedBase.pr.base.sha = 'c'.repeat(40);
+  const api = fakeApi([snapshot(), changedBase]);
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), /candidate changed/);
+  assert.deepEqual(api.calls, []);
+});
+
+test('returns a harmless no-op for the duplicate prerequisite event after merge', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([merged]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'ALREADY_MERGED');
+  assert.deepEqual(api.calls, []);
+});
+
+test('revalidates immediately before exact-head ordinary merge and confirms authoritative readback', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([snapshot(), snapshot(), merged]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge']]);
+  assert.deepEqual(result, {
+    outcome: 'MERGED_CONFIRMED',
+    prNumber: 42,
+    headSha: HEAD,
+    mergeCommitSha: 'd'.repeat(40),
+    classification: 'NEW_SKILL',
+  });
+});
+
+test('update-branch uses expected exact head and stops for a fresh CI run', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.workflowRun.head_sha = 'e'.repeat(40);
+  const api = fakeApi([behind, behind, changed]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.deepEqual(api.calls, [['update', 42, HEAD]]);
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.newHeadSha, 'e'.repeat(40));
+});
+
+test('an accepted but unconfirmed asynchronous update is UNKNOWN and is never repeated', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const api = fakeApi([behind, behind, ...Array.from({ length: 12 }, () => behind.pr)]);
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
+});
+
+test('successful merge followed by readback failure is UNKNOWN and is never repeated', async () => {
+  const api = fakeApi([snapshot(), snapshot(), new TypeError('readback lost')]);
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+});
+
+test('does not repeat an unknown merge effect and only trusts merged readback', async () => {
+  const api = fakeApi([snapshot(), snapshot(), snapshot().pr]);
+  api.merge = async (...args) => {
+    api.calls.push(['merge', ...args]);
+    throw new TypeError('network lost');
+  };
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+});

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -18,6 +18,7 @@ function snapshot(overrides = {}) {
     repository: REPO,
     repositoryRules: [{
       enforcement: 'active',
+      target: 'branch',
       bypass_actors: [{ actor_id: 2628292, actor_type: 'Integration', bypass_mode: 'always' }],
       conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
       rules: [
@@ -53,16 +54,16 @@ function snapshot(overrides = {}) {
     ],
     checks: [
       {
-        name: 'publication-admission', status: 'completed', conclusion: 'success', app: { id: 15368 },
-        workflow: { id: 330383167, name: 'Publication Provenance', path: '.github/workflows/publication-provenance.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+        id: 1001, name: 'publication-admission', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { run_id: 200, id: 330383167, name: 'Publication Provenance', path: '.github/workflows/publication-provenance.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
       },
       {
-        name: 'action-pin-policy', status: 'completed', conclusion: 'success', app: { id: 15368 },
-        workflow: { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+        id: 1002, name: 'action-pin-policy', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { run_id: 123, id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
       },
       {
-        name: 'validate', status: 'completed', conclusion: 'success', app: { id: 15368 },
-        workflow: { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+        id: 1003, name: 'validate', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { run_id: 123, id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
       },
     ],
     statuses: [],
@@ -144,6 +145,9 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
     [() => { const v = snapshot(); v.statuses = [{ context: 'legacy', state: 'pending' }]; return v; }, /status legacy.*pending/],
     [() => { const v = snapshot(); v.checks[0].app.id = 999; return v; }, /not from GitHub Actions/],
     [() => { const v = snapshot(); v.checks[2].workflow.id = 999; return v; }, /not bound to the trusted workflow/],
+    [() => { const v = snapshot(); v.checks[2].workflow.run_id = 999; return v; }, /not bound to the trusted workflow/],
+    [() => { const v = snapshot(); v.repositoryRules[0].target = 'tag'; return v; }, /strict protected-main/],
+    [() => { const v = snapshot(); v.repositoryRules[0].conditions.ref_name.exclude = ['refs/heads/main']; return v; }, /strict protected-main/],
     [() => { const v = snapshot(); v.repositoryRules[0].bypass_actors.push({ actor_id: 15368, actor_type: 'Integration' }); return v; }, /must not bypass/],
     [() => { const v = snapshot(); v.repositoryRules[0].rules[1].parameters.strict_required_status_checks_policy = false; return v; }, /strict protected-main/],
   ];

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import {
   AutoMergeBlockedError,
   AutoMergeUnknownEffectError,
+  latestStatusesByContext,
   runAutoMerge,
   validateSnapshot,
 } from '../auto-merge-trusted-skill-pr.mjs';
@@ -51,9 +52,18 @@ function snapshot(overrides = {}) {
       { filename: `${ROOT}/skill-report.json`, status: 'added', sha: '2'.repeat(40) },
     ],
     checks: [
-      { name: 'publication-admission', status: 'completed', conclusion: 'success', app: { id: 15368 } },
-      { name: 'action-pin-policy', status: 'completed', conclusion: 'success', app: { id: 15368 } },
-      { name: 'validate', status: 'completed', conclusion: 'success', app: { id: 15368 } },
+      {
+        name: 'publication-admission', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { id: 330383167, name: 'Publication Provenance', path: '.github/workflows/publication-provenance.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+      },
+      {
+        name: 'action-pin-policy', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+      },
+      {
+        name: 'validate', status: 'completed', conclusion: 'success', app: { id: 15368 },
+        workflow: { id: 219313535, name: 'Validate Marketplace', path: '.github/workflows/validate-marketplace.yml', event: 'pull_request', head_sha: HEAD, status: 'completed', conclusion: 'success' },
+      },
     ],
     statuses: [],
     tree: {
@@ -112,6 +122,17 @@ test('fails closed on identity, provenance, scope, label, state and exact-head d
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
+test('uses only the newest commit status per context across retry history', () => {
+  assert.deepEqual(latestStatusesByContext([
+    { id: 3, context: 'legacy', state: 'success' },
+    { id: 2, context: 'other', state: 'success' },
+    { id: 1, context: 'legacy', state: 'failure' },
+  ]), [
+    { id: 3, context: 'legacy', state: 'success' },
+    { id: 2, context: 'other', state: 'success' },
+  ]);
+});
+
 test('fails closed on incomplete files, unsafe tree entries, truncation and ambiguous checks', () => {
   const cases = [
     [() => { const v = snapshot(); v.files.pop(); v.tree.entries.pop(); v.pr.changed_files = 1; return v; }, /skill-report\.json/],
@@ -122,6 +143,7 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
     [() => { const v = snapshot(); v.checks.pop(); return v; }, /missing required check validate/],
     [() => { const v = snapshot(); v.statuses = [{ context: 'legacy', state: 'pending' }]; return v; }, /status legacy.*pending/],
     [() => { const v = snapshot(); v.checks[0].app.id = 999; return v; }, /not from GitHub Actions/],
+    [() => { const v = snapshot(); v.checks[2].workflow.id = 999; return v; }, /not bound to the trusted workflow/],
     [() => { const v = snapshot(); v.repositoryRules[0].bypass_actors.push({ actor_id: 15368, actor_type: 'Integration' }); return v; }, /must not bypass/],
     [() => { const v = snapshot(); v.repositoryRules[0].rules[1].parameters.strict_required_status_checks_policy = false; return v; }, /strict protected-main/],
   ];
@@ -141,6 +163,9 @@ function fakeApi(sequence) {
       const next = sequence.shift();
       if (next instanceof Error) throw next;
       return structuredClone(next?.pr ?? next);
+    },
+    async readCommit(sha) {
+      return { sha, parents: [{ sha: HEAD }, { sha: BASE }] };
     },
     async sleep() {},
     async updateBranch(number, headSha) {
@@ -201,6 +226,17 @@ test('update-branch uses expected exact head and stops for a fresh CI run', asyn
   assert.deepEqual(api.calls, [['update', 42, HEAD]]);
   assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
   assert.equal(result.newHeadSha, 'e'.repeat(40));
+});
+
+test('an unrelated concurrent head change cannot confirm update-branch', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: 'f'.repeat(40) }] });
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
 });
 
 test('an accepted but unconfirmed asynchronous update is UNKNOWN and is never repeated', async () => {


### PR DESCRIPTION
## Goal

Automatically merge trusted AI SkillStore App NEW_SKILL / UPDATE_SKILL PRs after the existing exact-head publication gates pass, without per-PR CEO review.

## Acceptance criteria

- Only `aiskillstore/marketplace`, trusted App id/login/type, same-repository `submission/*`, open non-draft, exact `pending-review`.
- Only one newly added canonical `pending/<publisher>/<skill>/**` root with `SKILL.md` and `skill-report.json`; no mixed scope or pre-existing pending root.
- Exact head requires GitHub Actions `publication-admission`, `action-pin-policy`, and `validate` success plus all other observed checks/statuses successful.
- Protected `main` must retain strict required-status policy; GitHub Actions must not be a ruleset bypass actor.
- `BEHIND` uses only standard update-branch bound to the old exact head, then stops for fresh CI on the new head.
- `CLEAN/MERGEABLE` uses ordinary exact-head merge; no admin/auto/force-push/check bypass.
- Unknown update/merge effects are never replayed.
- Trusted default-branch runtime only; no PR-head checkout or execution in the write-capable workflow.

## Evidence

- `CI=true node --test` affected security/call-chain set: 110/110 pass.
- Exact Validate submission scope contract: 172/172 pass.
- `node scripts/check-workflow-action-pins.mjs`: pass.
- `node scripts/check-workflow-runner-safety.mjs`: pass (40 workflows).
- Live read-only historical run canary resolved PR #3154 as `ALREADY_MERGED` at exact head `9b1a4907512eeb393caf9136a8fc73a5e3d7684a` and merge commit `094042f254ad64f222acf4fb57b1673204f219d8`.

## Risk / rollout

The new workflow cannot run until merged to the default branch. First real eligible PR is the live canary. Rollback is disabling/removing the new workflow; existing manual and post-merge publication paths remain unchanged.
