### PR TITLE
fix: dispatch publication after auto-merge

### DIFF
--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  actions: read
+  actions: write
   checks: read
   contents: write
   pull-requests: write

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -53,7 +53,7 @@ jobs:
             | grep -oE '[0-9a-f-]{36}' || true)
           [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
           [ "$PR_URL" = "https://github.com/$REPOSITORY/pull/$PR_NUMBER" ]
-          [[ "$MERGED_BY" =~ ^[A-Za-z0-9-]+$ ]]
+          [[ "$MERGED_BY" =~ ^([A-Za-z0-9-]+|github-actions\[bot\])$ ]]
           {
             echo "pr_number=$PR_NUMBER"
             echo "merge_commit_sha=$MERGE_COMMIT_SHA"

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -276,7 +276,12 @@ export async function runAutoMerge(api, { workflowRunId }) {
     throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
   }
   if (mergedReadback(readback, second)) {
-    return { outcome: 'MERGED_CONFIRMED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+    try {
+      await api.dispatchPublication(second.prNumber);
+    } catch {
+      throw new AutoMergeUnknownEffectError(`merge is confirmed but publication recovery dispatch is unknown for PR #${second.prNumber}`);
+    }
+    return { outcome: 'MERGED_AND_PUBLICATION_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
   }
   if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`merge rejected with HTTP ${mutationError.status}`);
   throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
@@ -476,6 +481,13 @@ export class GitHubApi {
 
   async merge(number, headSha, method) {
     return this.request(`/pulls/${number}/merge`, { method: 'PUT', body: { sha: headSha, merge_method: method } });
+  }
+
+  async dispatchPublication(number) {
+    return this.request('/actions/workflows/on-pr-merge.yml/dispatches', {
+      method: 'POST',
+      body: { ref: 'main', inputs: { pr_number: String(number) } },
+    });
   }
 }
 

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -7,7 +7,9 @@ import { parse } from 'yaml';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const WORKFLOW_PATH = resolve(ROOT, '.github/workflows/auto-merge-trusted-skill-pr.yml');
+const PUBLISH_WORKFLOW_PATH = resolve(ROOT, '.github/workflows/on-pr-merge.yml');
 const source = readFileSync(WORKFLOW_PATH, 'utf8');
+const publishSource = readFileSync(PUBLISH_WORKFLOW_PATH, 'utf8');
 const workflow = parse(source);
 const trigger = workflow.on ?? workflow.true;
 
@@ -20,7 +22,7 @@ test('uses only the trusted default-branch validation workflow_run event', () =>
 
 test('uses a literal hosted runner, non-cancelling serialization and exact minimal permissions', () => {
   assert.deepEqual(workflow.permissions, {
-    actions: 'read',
+    actions: 'write',
     checks: 'read',
     contents: 'write',
     'pull-requests': 'write',
@@ -50,4 +52,8 @@ test('checks out only the trusted workflow SHA without credentials and executes 
 
 test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {
   assert.doesNotMatch(source, /--admin|--auto|force-with-lease|git push|pull\/\$\{|workflow_run\.head_repository|workflow_run\.head_branch/);
+});
+
+test('post-merge recovery accepts the exact GitHub Actions bot merger identity', () => {
+  assert.match(publishSource, /github-actions\\\[bot\\\]/);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -180,6 +180,9 @@ function fakeApi(sequence) {
       calls.push(['merge', number, headSha, method]);
       return { merged: true, sha: 'd'.repeat(40), message: 'Pull Request successfully merged' };
     },
+    async dispatchPublication(number) {
+      calls.push(['dispatch-publication', number]);
+    },
   };
 }
 
@@ -209,9 +212,9 @@ test('revalidates immediately before exact-head ordinary merge and confirms auth
   merged.pr.merge_commit_sha = 'd'.repeat(40);
   const api = fakeApi([snapshot(), snapshot(), merged]);
   const result = await runAutoMerge(api, { workflowRunId: 123 });
-  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge']]);
+  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge'], ['dispatch-publication', 42]]);
   assert.deepEqual(result, {
-    outcome: 'MERGED_CONFIRMED',
+    outcome: 'MERGED_AND_PUBLICATION_DISPATCHED',
     prNumber: 42,
     headSha: HEAD,
     mergeCommitSha: 'd'.repeat(40),
@@ -249,6 +252,21 @@ test('an accepted but unconfirmed asynchronous update is UNKNOWN and is never re
   const api = fakeApi([behind, behind, ...Array.from({ length: 12 }, () => behind.pr)]);
   await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
   assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
+});
+
+test('confirmed merge with failed publication dispatch is UNKNOWN and is never repeated', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([snapshot(), snapshot(), merged.pr]);
+  api.dispatchPublication = async (...args) => {
+    api.calls.push(['dispatch-publication', ...args]);
+    throw new TypeError('dispatch response lost');
+  };
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+  assert.equal(api.calls.filter(([kind]) => kind === 'dispatch-publication').length, 1);
 });
 
 test('successful merge followed by readback failure is UNKNOWN and is never repeated', async () => {


### PR DESCRIPTION
## Root cause

The GitHub-native auto-merger correctly merged canary PR #3158 using `GITHUB_TOKEN`, but GitHub suppresses downstream `pull_request: closed` workflow creation for effects made by `GITHUB_TOKEN`. Manual recovery dispatch then exposed a second compatibility issue: `on-pr-merge.yml` rejected the exact merger login `github-actions[bot]` because its audit-only login regex did not allow brackets.

## Fix

- Grant the trusted default-branch auto-merge workflow only the additional `actions: write` permission needed for workflow dispatch.
- After authoritative exact-head merge readback, dispatch existing `on-pr-merge.yml` on `main` with the exact PR number.
- Treat dispatch failure/unknown response as `UNKNOWN_EFFECT`; do not repeat merge or dispatch.
- Allow exact `github-actions[bot]` in the post-merge audit login shape while retaining all existing PR author/provenance gates.

## Evidence

- Red test reproduced rejection of `github-actions[bot]`.
- Focused auto-merge, post-merge scope, action-pin and runner-safety set: 89/89 pass.
- `check-workflow-action-pins`: pass.
- `check-workflow-runner-safety`: pass (40 workflows).
- Live evidence: auto-merge run 32636500752 succeeded and merged #3158 at head `e640a3b5dd86158914e6609682769981c980406c`; no automatic post-merge run appeared; manual recovery run 32636836811 failed exactly at the old merger-login regex.

## Recovery

After this PR lands, rerun `on-pr-merge.yml` once for exact PR #3158, then verify publication path and provider sync. Future automatic merges will dispatch that recovery path themselves.
