### PR TITLE
Fix trusted auto-merge rebase continuation

### DIFF
--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -13,7 +13,7 @@ permissions:
   statuses: read
 
 concurrency:
-  group: trusted-skill-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.head_sha }}
+  group: trusted-skill-auto-merge-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
@@ -33,9 +33,23 @@ jobs:
         with:
           node-version: 22
 
+      # GITHUB_TOKEN update-branch events do not trigger a fresh pull_request CI run.
+      # This event-capable App token is confined by the helper to update-branch only;
+      # merges and publication dispatches continue to use the non-bypass GITHUB_TOKEN.
+      - name: Generate event-capable update-branch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: marketplace
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Qualify, update, or merge the exact trusted Skill PR
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_UPDATE_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -230,17 +230,31 @@ function mergedReadback(pr, plan) {
   return pr?.merged === true && pr.state === 'closed' && pr.head?.sha === plan.headSha && validSha(pr.merge_commit_sha);
 }
 
+function mergeabilityIsComputing(pr) {
+  return pr?.merged !== true && (pr?.mergeable == null || pr?.mergeable_state === 'unknown');
+}
+
+async function buildStableSnapshot(api, workflowRunId) {
+  let snapshot;
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    snapshot = await api.buildSnapshot(workflowRunId);
+    if (!mergeabilityIsComputing(snapshot?.pr)) return snapshot;
+    if (attempt < 5) await api.sleep(5_000);
+  }
+  return snapshot;
+}
+
 function definiteMutationRejection(error) {
   return error instanceof GitHubApiError && [405, 409, 422].includes(error.status);
 }
 
 export async function runAutoMerge(api, { workflowRunId }) {
-  const firstSnapshot = await api.buildSnapshot(workflowRunId);
+  const firstSnapshot = await buildStableSnapshot(api, workflowRunId);
   if (firstSnapshot?.pr?.merged === true && firstSnapshot.pr.state === 'closed' && firstSnapshot.pr.head?.sha === firstSnapshot.workflowRun?.head_sha) {
     return { outcome: 'ALREADY_MERGED', prNumber: firstSnapshot.pr.number, headSha: firstSnapshot.pr.head.sha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha };
   }
   const first = validateSnapshot(firstSnapshot);
-  const secondSnapshot = await api.buildSnapshot(workflowRunId);
+  const secondSnapshot = await buildStableSnapshot(api, workflowRunId);
   const second = validateSnapshot(secondSnapshot);
   block(samePlan(first, second), 'candidate changed during pre-effect revalidation');
 
@@ -305,24 +319,26 @@ function encodeContentPath(path) {
 }
 
 export class GitHubApi {
-  constructor({ token, repository, currentRunId }) {
+  constructor({ token, updateToken, repository, currentRunId }) {
     block(typeof token === 'string' && token.length > 0, 'GH_TOKEN is required');
+    block(typeof updateToken === 'string' && updateToken.length > 0, 'GH_UPDATE_TOKEN is required');
     block(repository === TRUSTED_REPOSITORY, `GITHUB_REPOSITORY must be ${TRUSTED_REPOSITORY}`);
     block(Number.isSafeInteger(Number(currentRunId)) && Number(currentRunId) > 0, 'GITHUB_RUN_ID is invalid');
     this.token = token;
+    this.updateToken = updateToken;
     this.repository = repository;
     this.currentRunId = Number(currentRunId);
     this.baseUrl = `https://api.github.com/repos/${repository}`;
   }
 
-  async request(path, { method = 'GET', body } = {}) {
+  async request(path, { method = 'GET', body, token = this.token } = {}) {
     let response;
     try {
       response = await fetch(`${this.baseUrl}${path}`, {
         method,
         headers: {
           Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${this.token}`,
+          Authorization: `Bearer ${token}`,
           'X-GitHub-Api-Version': '2022-11-28',
           'User-Agent': 'skillstore-trusted-auto-merge',
         },
@@ -508,7 +524,11 @@ export class GitHubApi {
   }
 
   async updateBranch(number, headSha) {
-    return this.request(`/pulls/${number}/update-branch`, { method: 'PUT', body: { expected_head_sha: headSha } });
+    return this.request(`/pulls/${number}/update-branch`, {
+      method: 'PUT',
+      body: { expected_head_sha: headSha },
+      token: this.updateToken,
+    });
   }
 
   async merge(number, headSha, method) {
@@ -524,7 +544,12 @@ export class GitHubApi {
 }
 
 async function main() {
-  const api = new GitHubApi({ token: process.env.GH_TOKEN, repository: process.env.GITHUB_REPOSITORY, currentRunId: process.env.GITHUB_RUN_ID });
+  const api = new GitHubApi({
+    token: process.env.GH_TOKEN,
+    updateToken: process.env.GH_UPDATE_TOKEN,
+    repository: process.env.GITHUB_REPOSITORY,
+    currentRunId: process.env.GITHUB_RUN_ID,
+  });
   try {
     const result = await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
     process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -20,7 +20,7 @@ test('uses only the trusted default-branch validation workflow_run event', () =>
   assert.doesNotMatch(source, /pull_request_target|\bworkflow_dispatch\b/);
 });
 
-test('uses a literal hosted runner, non-cancelling serialization and exact minimal permissions', () => {
+test('uses a literal hosted runner, non-cancelling repository serialization and exact minimal permissions', () => {
   assert.deepEqual(workflow.permissions, {
     actions: 'write',
     checks: 'read',
@@ -29,25 +29,33 @@ test('uses a literal hosted runner, non-cancelling serialization and exact minim
     statuses: 'read',
   });
   assert.equal(workflow.concurrency['cancel-in-progress'], false);
-  assert.match(workflow.concurrency.group, /workflow_run\.head_sha/);
+  assert.equal(workflow.concurrency.group, 'trusted-skill-auto-merge-${{ github.repository }}');
   const job = workflow.jobs['auto-merge'];
   assert.equal(job['runs-on'], 'ubuntu-latest');
   assert.match(job.if, /workflow_run\.event == 'pull_request'/);
   assert.ok(Number.parseInt(job['timeout-minutes'], 10) <= 15);
 });
 
-test('checks out only the trusted workflow SHA without credentials and executes the bounded helper', () => {
+test('checks out only trusted automation and confines the event-capable App token to update-branch', () => {
   const steps = workflow.jobs['auto-merge'].steps;
   const checkout = steps.find((step) => step.uses?.startsWith('actions/checkout@'));
   assert.match(checkout.uses, /^actions\/checkout@[0-9a-f]{40}$/);
   assert.equal(checkout.with.ref, '${{ github.sha }}');
   assert.equal(checkout.with['persist-credentials'], false);
   assert.ok(steps.every((step) => !String(step.with?.ref ?? '').includes('workflow_run.head_sha')));
-  const run = steps.find((step) => step.run)?.run ?? '';
-  assert.match(run, /^node scripts\/auto-merge-trusted-skill-pr\.mjs$/m);
-  assert.equal(steps.find((step) => step.run).env.GH_TOKEN, '${{ github.token }}');
-  assert.equal(steps.find((step) => step.run).env.GITHUB_RUN_ID, '${{ github.run_id }}');
-  assert.equal(steps.find((step) => step.run).env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
+  const appToken = steps.find((step) => step.id === 'app-token');
+  assert.match(appToken.uses, /^actions\/create-github-app-token@[0-9a-f]{40}$/);
+  assert.equal(appToken.with['client-id'], '${{ vars.APP_CLIENT_ID }}');
+  assert.equal(appToken.with['private-key'], '${{ secrets.APP_PRIVATE_KEY }}');
+  assert.equal(appToken.with.repositories, 'marketplace');
+  assert.equal(appToken.with['permission-contents'], 'write');
+  assert.equal(appToken.with['permission-pull-requests'], 'write');
+  const executor = steps.find((step) => step.run);
+  assert.match(executor.run, /^node scripts\/auto-merge-trusted-skill-pr\.mjs$/m);
+  assert.equal(executor.env.GH_TOKEN, '${{ github.token }}');
+  assert.equal(executor.env.GH_UPDATE_TOKEN, '${{ steps.app-token.outputs.token }}');
+  assert.equal(executor.env.GITHUB_RUN_ID, '${{ github.run_id }}');
+  assert.equal(executor.env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
 });
 
 test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -220,6 +220,21 @@ test('returns a harmless no-op for the duplicate prerequisite event after merge'
   assert.deepEqual(api.calls, []);
 });
 
+test('waits for transient GitHub mergeability before qualifying and updating a behind PR', async () => {
+  const computing = snapshot();
+  computing.pr.mergeable = null;
+  computing.pr.mergeable_state = 'unknown';
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.workflowRun.head_sha = 'e'.repeat(40);
+  const api = fakeApi([computing, behind, behind, changed]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.deepEqual(api.calls, [['update', 42, HEAD]]);
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+});
+
 test('revalidates immediately before exact-head ordinary merge and confirms authoritative readback', async () => {
   const merged = snapshot();
   merged.pr.state = 'closed';
@@ -237,7 +252,7 @@ test('revalidates immediately before exact-head ordinary merge and confirms auth
   });
 });
 
-test('update-branch uses expected exact head and stops for a fresh CI run', async () => {
+test('update-branch uses expected exact head through the event-capable update credential and awaits fresh CI', async () => {
   const behind = snapshot();
   behind.pr.mergeable_state = 'behind';
   const changed = snapshot();


### PR DESCRIPTION
## Goal
Keep trusted Skill PR auto-merge progressing when PRs are behind, instead of stalling after update-branch or transient mergeability computation.

## Root cause
- Executor concurrency was keyed by head SHA, so multiple PR executors raced within one repository.
- GitHub mergeability may temporarily be `null/unknown`, but executor failed immediately.
- `update-branch` used `GITHUB_TOKEN`; GitHub suppresses follow-on `pull_request` workflow runs for events created by that token, so the new head could have no CI and no next executor run.

## Changes
- Serialize trusted auto-merge repository-wide.
- Retry only transient mergeability computation for up to 25 seconds.
- Use an event-capable App token only for exact-head `update-branch`, allowing fresh PR CI and a new executor run.
- Continue using the non-bypass `GITHUB_TOKEN` for merge and publication dispatch.

## Acceptance criteria
- A `BEHIND` eligible PR is updated against its exact old head.
- The update emits a fresh PR CI run; executor stops only that old-head run and continues automatically from the new-head workflow completion.
- Concurrent PR executors cannot race repository-wide.
- Transient `mergeable=null/unknown` is given a bounded wait; conflicts and other hard failures still fail closed.
- No force-push, `--admin`, auto-merge, or untrusted-head execution path is introduced.

## Evidence
- `CI=true node --test scripts/tests/workflow-action-pin-policy.test.mjs scripts/tests/workflow-runner-safety.test.mjs scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs` — 51/51 passed.
- `node scripts/check-workflow-action-pins.mjs` — passed.
- `node scripts/check-workflow-runner-safety.mjs` — passed (40 workflows).
- `git diff --check` — passed.

## Risk / rollout
The App token is present only in the trusted default-branch executor and is passed only to `updateBranch`; merge and publication continue to use `GITHUB_TOKEN`. Existing stuck PRs require one ordered recovery after this PR is merged.