### PR TITLE
Recover missed trusted auto-merge events

### DIFF
--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -4,6 +4,9 @@ on:
   workflow_run:
     workflows: ["Validate Marketplace"]
     types: [completed]
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
 
 permissions:
   actions: write
@@ -18,7 +21,7 @@ concurrency:
 
 jobs:
   auto-merge:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -53,4 +56,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RECOVERY_SWEEP: ${{ github.event_name != 'workflow_run' }}
         run: node scripts/auto-merge-trusted-skill-pr.mjs

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -265,26 +265,36 @@ export async function runAutoMerge(api, { workflowRunId }) {
     } catch (error) {
       mutationError = error;
     }
-    let changedHead;
-    try {
-      for (let attempt = 0; attempt < 12; attempt += 1) {
-        const pr = await api.readPr(second.prNumber);
-        if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
-          const commit = await api.readCommit(pr.head.sha);
-          const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
-          if (parentShas.has(second.headSha) && parentShas.has(second.baseSha)) {
-            changedHead = pr.head.sha;
-            break;
-          }
-          throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
-        }
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      let pr;
+      try {
+        pr = await api.readPr(second.prNumber);
+      } catch {
         if (attempt < 11) await api.sleep(5_000);
+        continue;
       }
-    } catch {
-      throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
-    }
-    if (changedHead) {
-      return { outcome: 'UPDATE_CONFIRMED_AWAITING_CI', prNumber: second.prNumber, oldHeadSha: second.headSha, newHeadSha: changedHead, classification: second.classification };
+      if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
+        let commit;
+        try {
+          commit = await api.readCommit(pr.head.sha);
+        } catch {
+          if (attempt < 11) await api.sleep(5_000);
+          continue;
+        }
+        const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
+        const readbackBaseSha = pr.base?.sha;
+        if (parentShas.has(second.headSha) && validSha(readbackBaseSha) && parentShas.has(readbackBaseSha)) {
+          return {
+            outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
+            prNumber: second.prNumber,
+            oldHeadSha: second.headSha,
+            newHeadSha: pr.head.sha,
+            classification: second.classification,
+          };
+        }
+        throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
+      }
+      if (attempt < 11) await api.sleep(5_000);
     }
     if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`update-branch rejected with HTTP ${mutationError.status}`);
     throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
@@ -314,8 +324,46 @@ export async function runAutoMerge(api, { workflowRunId }) {
   throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
 }
 
+export async function runRecoverySweep(api) {
+  const workflowRunIds = await api.listRecoveryWorkflowRunIds();
+  for (const workflowRunId of workflowRunIds) {
+    try {
+      const result = await runAutoMerge(api, { workflowRunId });
+      if (result.outcome === 'ALREADY_MERGED') continue;
+      return result;
+    } catch (error) {
+      if (error instanceof AutoMergeBlockedError) continue;
+      throw error;
+    }
+  }
+  return { outcome: 'NO_ELIGIBLE_RECOVERY' };
+}
+
 function encodeContentPath(path) {
   return path.split('/').map(encodeURIComponent).join('/');
+}
+
+function trustedRecoverySeed(pr, repository) {
+  return pr?.state === 'open'
+    && pr.draft === false
+    && pr.base?.ref === 'main'
+    && sameRepository(pr.base?.repo, repository)
+    && sameRepository(pr.head?.repo, repository)
+    && pr.user?.id === TRUSTED_BOT.id
+    && pr.user?.login === TRUSTED_BOT.login
+    && pr.user?.type === TRUSTED_BOT.type
+    && typeof pr.head?.ref === 'string'
+    && pr.head.ref.startsWith('submission/')
+    && validSha(pr.head?.sha)
+    && Array.isArray(pr.labels)
+    && pr.labels.some((label) => label?.name === 'pending-review');
+}
+
+function workflowRunIdFromCheck(check) {
+  if (check?.name !== 'validate' || check?.app?.id !== GITHUB_ACTIONS_APP_ID) return null;
+  const match = /^https:\/\/github\.com\/aiskillstore\/marketplace\/actions\/runs\/(\d+)\/job\/\d+(?:\?.*)?$/u.exec(check.details_url ?? '');
+  const runId = match ? Number(match[1]) : NaN;
+  return Number.isSafeInteger(runId) && runId > 0 ? runId : null;
 }
 
 export class GitHubApi {
@@ -387,6 +435,20 @@ export class GitHubApi {
       if (error instanceof GitHubApiError && error.status === 404) return false;
       throw error;
     }
+  }
+
+  async listRecoveryWorkflowRunIds() {
+    const repository = await this.request('');
+    block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
+    const pulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
+    const workflowRunIds = [];
+    for (const pr of pulls) {
+      if (!trustedRecoverySeed(pr, repository)) continue;
+      const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
+      const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
+      if (runIds.length === 1) workflowRunIds.push(runIds[0]);
+    }
+    return workflowRunIds;
   }
 
   async buildSnapshot(workflowRunId) {
@@ -551,7 +613,9 @@ async function main() {
     currentRunId: process.env.GITHUB_RUN_ID,
   });
   try {
-    const result = await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
+    const result = process.env.RECOVERY_SWEEP === 'true'
+      ? await runRecoverySweep(api)
+      : await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     if (error instanceof AutoMergeWaitingError) {

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -27,6 +27,13 @@ export class AutoMergeWaitingError extends AutoMergeBlockedError {
   }
 }
 
+export class AutoMergeSkippedError extends AutoMergeBlockedError {
+  constructor(message) {
+    super(message);
+    this.name = 'AutoMergeSkippedError';
+  }
+}
+
 export class AutoMergeUnknownEffectError extends Error {
   constructor(message) {
     super(message);
@@ -45,6 +52,10 @@ class GitHubApiError extends Error {
 
 function block(condition, message) {
   if (!condition) throw new AutoMergeBlockedError(message);
+}
+
+function skip(condition, message) {
+  if (!condition) throw new AutoMergeSkippedError(message);
 }
 
 function validSha(value) {
@@ -124,35 +135,36 @@ export function validateSnapshot(snapshot) {
   block(Array.isArray(workflowRun.pull_requests) && workflowRun.pull_requests.length === 1, 'workflow run must bind exactly one PR');
 
   block(pr?.number === workflowRun.pull_requests[0]?.number, 'workflow run PR number does not match');
-  block(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
-  block(pr.base?.ref === 'main', 'PR base must be main');
-  block(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
-  block(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
-  block(typeof pr.head?.ref === 'string' && pr.head.ref.startsWith('submission/'), 'PR head must use trusted submission/ provenance');
+  skip(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
+  skip(pr.base?.ref === 'main', 'PR base must be main');
+  skip(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
+  skip(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
+  skip(typeof pr.head?.ref === 'string' && pr.head.ref.startsWith('submission/'), 'PR head must use trusted submission/ provenance');
   block(validSha(pr.head?.sha) && validSha(pr.base?.sha), 'PR head and base SHA must be exact');
   block(workflowRun.head_sha === pr.head.sha, 'workflow run must bind the exact PR head');
-  block(Array.isArray(pr.labels) && pr.labels.some((label) => label?.name === 'pending-review'), 'PR must have pending-review');
+  skip(Array.isArray(pr.labels) && pr.labels.some((label) => label?.name === 'pending-review'), 'PR must have pending-review');
   block(pr.mergeable === true, 'PR is not mergeable');
   block(['clean', 'behind'].includes(pr.mergeable_state), `PR mergeable_state is ${pr.mergeable_state ?? 'unknown'}`);
 
-  block(Array.isArray(files) && files.length > 0, 'PR files are required');
+  block(Array.isArray(files), 'PR files are required');
+  skip(files.length > 0, 'PR files are required');
   block(Number.isSafeInteger(pr.changed_files) && pr.changed_files === files.length, 'PR file pagination/count is incomplete');
   const seenFiles = new Set();
   const roots = new Set();
   for (const file of files) {
-    block(file?.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file?.filename ?? '<unknown>'}`);
-    block(safePath(file.filename), 'PR contains an unsafe path');
-    block(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
+    skip(file?.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file?.filename ?? '<unknown>'}`);
+    skip(safePath(file.filename), 'PR contains an unsafe path');
+    skip(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
     seenFiles.add(file.filename);
     const root = rootForPath(file.filename);
-    block(root !== null, 'PR must change only one pending Skill root');
+    skip(root !== null, 'PR must change only one pending Skill root');
     roots.add(root);
   }
-  block(roots.size === 1, 'PR must change only one pending Skill root');
+  skip(roots.size === 1, 'PR must change only one pending Skill root');
   const [root] = roots;
-  block(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
-  block(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
-  block(snapshot.basePendingExists === false, 'pending root already exists on the base');
+  skip(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
+  skip(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
+  skip(snapshot.basePendingExists === false, 'pending root already exists on the base');
 
   block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
   const treeFiles = new Set();
@@ -160,10 +172,10 @@ export function validateSnapshot(snapshot) {
     if (typeof entry?.path !== 'string' || (entry.path !== root && !entry.path.startsWith(`${root}/`))) continue;
     if (entry.path === root && entry.type === 'tree') continue;
     if (entry.type === 'tree') continue;
-    block(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
+    skip(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
     treeFiles.add(entry.path);
   }
-  block(treeFiles.size === seenFiles.size && [...seenFiles].every((path) => treeFiles.has(path)), 'PR files do not equal the exact-head Skill tree');
+  skip(treeFiles.size === seenFiles.size && [...seenFiles].every((path) => treeFiles.has(path)), 'PR files do not equal the exact-head Skill tree');
 
   const reportPath = `${root}/skill-report.json`;
   const reportFile = files.find((file) => file.filename === reportPath);
@@ -174,11 +186,12 @@ export function validateSnapshot(snapshot) {
     && report.sha === reportFile?.sha
     && report.sha === reportTreeEntry?.sha,
   'security report is not bound to the exact PR head');
-  block(report.securityAudit?.isBlocked === false, 'security report blocks publication');
-  block(report.securityAudit?.safeToPublish === true, 'unsafe Skill requires manual review');
-  block(['safe', 'low', 'medium'].includes(report.securityAudit?.riskLevel), 'high-risk Skill requires manual review');
+  skip(report.securityAudit?.isBlocked === false, 'security report blocks publication');
+  skip(report.securityAudit?.safeToPublish === true, 'unsafe Skill requires manual review');
+  skip(['safe', 'low', 'medium'].includes(report.securityAudit?.riskLevel), 'high-risk Skill requires manual review');
 
-  block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
+  block(Array.isArray(checks), 'exact-head checks are required');
+  if (checks.length === 0) throw new AutoMergeWaitingError('exact-head checks are required');
   const checkNames = new Set();
   for (const check of checks) {
     block(check?.app?.id === GITHUB_ACTIONS_APP_ID, `check ${check?.name ?? '<unknown>'} is not from GitHub Actions`);
@@ -281,16 +294,30 @@ export async function runAutoMerge(api, { workflowRunId }) {
           if (attempt < 11) await api.sleep(5_000);
           continue;
         }
-        const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
+        const parentShas = [...new Set((commit?.parents ?? []).map((parent) => parent.sha))];
         const readbackBaseSha = pr.base?.sha;
-        if (parentShas.has(second.headSha) && validSha(readbackBaseSha) && parentShas.has(readbackBaseSha)) {
-          return {
-            outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
-            prNumber: second.prNumber,
-            oldHeadSha: second.headSha,
-            newHeadSha: pr.head.sha,
-            classification: second.classification,
-          };
+        const updateBaseParents = parentShas.filter((sha) => sha !== second.headSha);
+        if (parentShas.length === 2
+          && parentShas.includes(second.headSha)
+          && updateBaseParents.length === 1
+          && validSha(readbackBaseSha)) {
+          let updateBaseIsOnMain;
+          try {
+            updateBaseIsOnMain = updateBaseParents[0] === readbackBaseSha
+              || await api.isCommitAncestor(updateBaseParents[0], readbackBaseSha);
+          } catch {
+            if (attempt < 11) await api.sleep(5_000);
+            continue;
+          }
+          if (updateBaseIsOnMain) {
+            return {
+              outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
+              prNumber: second.prNumber,
+              oldHeadSha: second.headSha,
+              newHeadSha: pr.head.sha,
+              classification: second.classification,
+            };
+          }
         }
         throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
       }
@@ -325,14 +352,25 @@ export async function runAutoMerge(api, { workflowRunId }) {
 }
 
 export async function runRecoverySweep(api) {
-  const workflowRunIds = await api.listRecoveryWorkflowRunIds();
-  for (const workflowRunId of workflowRunIds) {
+  const candidates = await api.listRecoveryCandidates();
+  for (const candidate of candidates) {
+    if (candidate.workflowRunId == null) {
+      return {
+        outcome: 'WAITING_CI',
+        prNumber: candidate.prNumber,
+        headSha: candidate.headSha,
+        reason: 'missing exact-head Validate Marketplace run',
+      };
+    }
     try {
-      const result = await runAutoMerge(api, { workflowRunId });
+      const result = await runAutoMerge(api, { workflowRunId: candidate.workflowRunId });
       if (result.outcome === 'ALREADY_MERGED') continue;
       return result;
     } catch (error) {
-      if (error instanceof AutoMergeBlockedError) continue;
+      if (error instanceof AutoMergeSkippedError) continue;
+      if (error instanceof AutoMergeWaitingError) {
+        return { outcome: 'WAITING_CI', prNumber: candidate.prNumber, workflowRunId: candidate.workflowRunId, reason: error.message };
+      }
       throw error;
     }
   }
@@ -427,6 +465,14 @@ export class GitHubApi {
     return this.request(`/commits/${sha}`);
   }
 
+  async isCommitAncestor(ancestorSha, descendantSha) {
+    block(validSha(ancestorSha) && validSha(descendantSha), 'commit lineage requires exact SHAs');
+    const comparison = await this.request(`/compare/${ancestorSha}...${descendantSha}`);
+    return comparison?.base_commit?.sha === ancestorSha
+      && comparison?.merge_base_commit?.sha === ancestorSha
+      && ['ahead', 'identical'].includes(comparison?.status);
+  }
+
   async existsAt(path, ref) {
     try {
       await this.request(`/contents/${encodeContentPath(path)}?ref=${encodeURIComponent(ref)}`);
@@ -437,18 +483,19 @@ export class GitHubApi {
     }
   }
 
-  async listRecoveryWorkflowRunIds() {
+  async listRecoveryCandidates() {
     const repository = await this.request('');
     block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
     const pulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
-    const workflowRunIds = [];
+    const candidates = [];
     for (const pr of pulls) {
       if (!trustedRecoverySeed(pr, repository)) continue;
       const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
       const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
-      if (runIds.length === 1) workflowRunIds.push(runIds[0]);
+      block(runIds.length <= 1, `PR #${pr.number} has ambiguous exact-head validation runs`);
+      candidates.push({ prNumber: pr.number, headSha: pr.head.sha, workflowRunId: runIds[0] ?? null });
     }
-    return workflowRunIds;
+    return candidates;
   }
 
   async buildSnapshot(workflowRunId) {
@@ -618,6 +665,10 @@ async function main() {
       : await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
+    if (error instanceof AutoMergeSkippedError) {
+      process.stdout.write(`${JSON.stringify({ outcome: 'SKIPPED', reason: error.message })}\n`);
+      return;
+    }
     if (error instanceof AutoMergeWaitingError) {
       process.stdout.write(`${JSON.stringify({ outcome: 'WAITING_CI', reason: error.message })}\n`);
       return;

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -13,11 +13,13 @@ const publishSource = readFileSync(PUBLISH_WORKFLOW_PATH, 'utf8');
 const workflow = parse(source);
 const trigger = workflow.on ?? workflow.true;
 
-test('uses only the trusted default-branch validation workflow_run event', () => {
-  assert.deepEqual(Object.keys(trigger), ['workflow_run']);
+test('uses trusted validation events plus bounded default-branch recovery triggers', () => {
+  assert.deepEqual(Object.keys(trigger), ['workflow_run', 'schedule', 'workflow_dispatch']);
   assert.deepEqual(trigger.workflow_run.workflows, ['Validate Marketplace']);
   assert.deepEqual(trigger.workflow_run.types, ['completed']);
-  assert.doesNotMatch(source, /pull_request_target|\bworkflow_dispatch\b/);
+  assert.deepEqual(trigger.schedule, [{ cron: '*/5 * * * *' }]);
+  assert.equal(trigger.workflow_dispatch, null);
+  assert.doesNotMatch(source, /pull_request_target/);
 });
 
 test('uses a literal hosted runner, non-cancelling repository serialization and exact minimal permissions', () => {
@@ -32,6 +34,7 @@ test('uses a literal hosted runner, non-cancelling repository serialization and 
   assert.equal(workflow.concurrency.group, 'trusted-skill-auto-merge-${{ github.repository }}');
   const job = workflow.jobs['auto-merge'];
   assert.equal(job['runs-on'], 'ubuntu-latest');
+  assert.match(job.if, /github\.event_name != 'workflow_run'/);
   assert.match(job.if, /workflow_run\.event == 'pull_request'/);
   assert.ok(Number.parseInt(job['timeout-minutes'], 10) <= 15);
 });
@@ -56,6 +59,7 @@ test('checks out only trusted automation and confines the event-capable App toke
   assert.equal(executor.env.GH_UPDATE_TOKEN, '${{ steps.app-token.outputs.token }}');
   assert.equal(executor.env.GITHUB_RUN_ID, '${{ github.run_id }}');
   assert.equal(executor.env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
+  assert.equal(executor.env.RECOVERY_SWEEP, "${{ github.event_name != 'workflow_run' }}");
 });
 
 test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -187,6 +187,9 @@ function fakeApi(sequence) {
     async readCommit(sha) {
       return { sha, parents: [{ sha: HEAD }, { sha: BASE }] };
     },
+    async isCommitAncestor(ancestorSha, descendantSha) {
+      return ancestorSha === descendantSha;
+    },
     async sleep() {},
     async updateBranch(number, headSha) {
       calls.push(['update', number, headSha]);
@@ -279,6 +282,37 @@ test('confirms update-branch against the fresh base readback when main advances 
   assert.equal(result.newHeadSha, changed.pr.head.sha);
 });
 
+test('confirms update when the update base is an ancestor of a twice-advanced main tip', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const updateBase = 'c'.repeat(40);
+  const currentBase = 'd'.repeat(40);
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = currentBase;
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: updateBase }] });
+  api.isCommitAncestor = async (ancestorSha, descendantSha) => ancestorSha === updateBase && descendantSha === currentBase;
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.newHeadSha, changed.pr.head.sha);
+});
+
+test('rejects a new-head second parent that is not on the trusted main lineage', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const unrelated = 'c'.repeat(40);
+  const currentBase = 'd'.repeat(40);
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = currentBase;
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: unrelated }] });
+  api.isCommitAncestor = async () => false;
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
+});
+
 test('retries a transient new-head commit read and returns confirmed instead of UNKNOWN', async () => {
   const behind = snapshot();
   behind.pr.mergeable_state = 'behind';
@@ -356,7 +390,11 @@ test('recovery sweep skips ineligible historical PRs and performs only the first
   const changed = structuredClone(behind);
   changed.pr.head.sha = 'e'.repeat(40);
   const api = fakeApi([unsafe, behind, behind, changed.pr]);
-  api.listRecoveryWorkflowRunIds = async () => [101, 102, 103];
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+    { prNumber: 44, headSha: HEAD, workflowRunId: 103 },
+  ];
   api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: BASE }] });
   const result = await runRecoverySweep(api);
   assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
@@ -364,9 +402,75 @@ test('recovery sweep skips ineligible historical PRs and performs only the first
   assert.deepEqual(api.calls, [['update', 43, HEAD]]);
 });
 
-test('recovery sweep is a no-op when no exact-head validation run is recoverable', async () => {
+test('recovery sweep stops at the oldest waiting candidate and never updates a later behind PR', async () => {
+  const waiting = snapshot();
+  waiting.checks = waiting.checks.filter((check) => check.name !== 'validate');
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([waiting, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  const result = await runRecoverySweep(api);
+  assert.match(result.reason, /missing required check validate/);
+  assert.equal(result.outcome, 'WAITING_CI');
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep reports oldest-candidate CI failure instead of scanning later PRs', async () => {
+  const failed = snapshot();
+  failed.checks.find((check) => check.name === 'validate').conclusion = 'failure';
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([failed, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  await assert.rejects(() => runRecoverySweep(api), /check validate concluded failure/);
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep reports oldest-candidate conflict instead of scanning later PRs', async () => {
+  const conflicted = snapshot();
+  conflicted.pr.mergeable = false;
+  conflicted.pr.mergeable_state = 'dirty';
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([conflicted, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  await assert.rejects(() => runRecoverySweep(api), /PR is not mergeable/);
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep stops before later PRs when the oldest trusted seed has no validation run yet', async () => {
   const api = fakeApi([]);
-  api.listRecoveryWorkflowRunIds = async () => [];
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: null },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  assert.deepEqual(await runRecoverySweep(api), {
+    outcome: 'WAITING_CI',
+    prNumber: 42,
+    headSha: HEAD,
+    reason: 'missing exact-head Validate Marketplace run',
+  });
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep is a no-op when no trusted open candidate is recoverable', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryCandidates = async () => [];
   assert.deepEqual(await runRecoverySweep(api), { outcome: 'NO_ELIGIBLE_RECOVERY' });
   assert.deepEqual(api.calls, []);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -5,6 +5,7 @@ import {
   AutoMergeUnknownEffectError,
   latestStatusesByContext,
   runAutoMerge,
+  runRecoverySweep,
   validateSnapshot,
 } from '../auto-merge-trusted-skill-pr.mjs';
 
@@ -265,6 +266,36 @@ test('update-branch uses expected exact head through the event-capable update cr
   assert.equal(result.newHeadSha, 'e'.repeat(40));
 });
 
+test('confirms update-branch against the fresh base readback when main advances after pre-effect validation', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = 'c'.repeat(40);
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: changed.pr.base.sha }] });
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.newHeadSha, changed.pr.head.sha);
+});
+
+test('retries a transient new-head commit read and returns confirmed instead of UNKNOWN', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  const api = fakeApi([behind, behind, changed.pr, changed.pr]);
+  let reads = 0;
+  api.readCommit = async (sha) => {
+    reads += 1;
+    if (reads === 1) throw new TypeError('transient commit read failure');
+    return { sha, parents: [{ sha: HEAD }, { sha: BASE }] };
+  };
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(reads, 2);
+});
+
 test('an unrelated concurrent head change cannot confirm update-branch', async () => {
   const behind = snapshot();
   behind.pr.mergeable_state = 'behind';
@@ -313,4 +344,29 @@ test('does not repeat an unknown merge effect and only trusts merged readback', 
   };
   await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
   assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+});
+
+test('recovery sweep skips ineligible historical PRs and performs only the first eligible effect', async () => {
+  const unsafe = snapshot();
+  unsafe.report.securityAudit.riskLevel = 'high';
+  const behind = snapshot();
+  behind.pr.number = 43;
+  behind.workflowRun.pull_requests = [{ number: 43 }];
+  behind.pr.mergeable_state = 'behind';
+  const changed = structuredClone(behind);
+  changed.pr.head.sha = 'e'.repeat(40);
+  const api = fakeApi([unsafe, behind, behind, changed.pr]);
+  api.listRecoveryWorkflowRunIds = async () => [101, 102, 103];
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: BASE }] });
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.prNumber, 43);
+  assert.deepEqual(api.calls, [['update', 43, HEAD]]);
+});
+
+test('recovery sweep is a no-op when no exact-head validation run is recoverable', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryWorkflowRunIds = async () => [];
+  assert.deepEqual(await runRecoverySweep(api), { outcome: 'NO_ELIGIBLE_RECOVERY' });
+  assert.deepEqual(api.calls, []);
 });


### PR DESCRIPTION
## Goal
Make trusted Skill auto-merge recover historical open PRs whose validation event was missed, and avoid false UNKNOWN failures after authoritative rebase/update readback.

## Root cause
- The executor consumed only new `workflow_run` events, so failures that ended before the executor fix were never replayed.
- Update readback correlated the new merge commit to a mutable base tip and aborted on transient commit-read errors.
- Recovery initially treated waiting and hard failures as skippable, which could violate strict oldest-candidate ordering.

## Changes
- Add a default-branch scheduled/manual recovery trigger. Every recovery run scans open PRs in creation order, applies immutable bot/repository/provenance/label seeds, then reuses the full exact-head snapshot gates.
- Distinguish `SKIPPED`, `WAITING_CI`, hard `BLOCKED`, and `UNKNOWN_EFFECT` outcomes. Only permanent ineligibility advances scanning; the oldest waiting candidate stops with zero effects, while CI failure/conflict/config or deterministic mutation rejection fails visibly.
- Perform at most one eligible external effect per sweep, preserving repository-wide serialization.
- Confirm update-branch by requiring a two-parent new commit containing the old exact head and a second parent on trusted main lineage (equal to or ancestor of current main). Retry transient PR/commit/lineage read failures within the existing bounded window.

## Acceptance criteria
- A related new head returns `UPDATE_CONFIRMED_AWAITING_CI`, including when main advances twice before readback.
- A second parent outside main lineage remains `UNKNOWN_EFFECT`.
- `[A waiting, B behind]` produces zero effects and stops on A.
- A CI failure or conflict on A fails visibly and does not process B.
- Historical eligible open PRs are scanned serially; ineligible/high-risk candidates are `SKIPPED`.
- One recovery sweep performs no more than one update/merge effect.
- Existing identity, single-root, report, exact-head CI, protected-main and no-bypass gates remain authoritative.

## Evidence
- Red tests reproduced both Ada P1 findings before implementation.
- `CI=true node --test scripts/tests/workflow-action-pin-policy.test.mjs scripts/tests/workflow-runner-safety.test.mjs scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs` — 61/61 passed.
- `node scripts/check-workflow-action-pins.mjs` — passed.
- `node scripts/check-workflow-runner-safety.mjs` — passed (40 workflows).
- `git diff --check` — passed.

## Scope / residual risk
This PR covers open-PR update/merge recovery only. Durable reconciliation of a hypothetical confirmed merge followed by a lost publication dispatch is unchanged and remains outside this PR; the existing publication workflow/readback remains authoritative.