### PR TITLE
Simplify trusted auto-merge to CI gates

### DIFF
--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -174,9 +174,6 @@ export function validateSnapshot(snapshot) {
     && report.sha === reportFile?.sha
     && report.sha === reportTreeEntry?.sha,
   'security report is not bound to the exact PR head');
-  block(report.securityAudit?.isBlocked === false, 'security report blocks publication');
-  block(report.securityAudit?.safeToPublish === true, 'unsafe Skill requires manual review');
-  block(['safe', 'low', 'medium'].includes(report.securityAudit?.riskLevel), 'high-risk Skill requires manual review');
 
   block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
   const checkNames = new Set();
@@ -458,14 +455,7 @@ export class GitHubApi {
     const published = `skills/${root.slice('pending/'.length)}`;
     const reportPath = `${root}/skill-report.json`;
     const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
-    block(reportBlob?.type === 'file' && reportBlob.encoding === 'base64' && validSha(reportBlob.sha)
-      && typeof reportBlob.content === 'string', 'exact-head security report is unavailable');
-    let reportJson;
-    try {
-      reportJson = JSON.parse(Buffer.from(reportBlob.content, 'base64').toString('utf8'));
-    } catch {
-      throw new AutoMergeBlockedError('exact-head security report is not valid JSON');
-    }
+    block(reportBlob?.type === 'file' && validSha(reportBlob.sha), 'exact-head skill report is unavailable');
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');
     const [basePendingExists, publishedTargetExists] = await Promise.all([
@@ -512,11 +502,6 @@ export class GitHubApi {
       report: {
         path: reportPath,
         sha: reportBlob.sha,
-        securityAudit: {
-          riskLevel: reportJson?.security_audit?.risk_level,
-          isBlocked: reportJson?.security_audit?.is_blocked,
-          safeToPublish: reportJson?.security_audit?.safe_to_publish,
-        },
       },
       basePendingExists,
       publishedTargetExists,

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -159,14 +159,20 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
-test('leaves blocked, unsafe, and high-risk Skills for manual review', () => {
+test('does not use security-report risk fields as auto-merge gates', () => {
   const cases = [
-    [() => { const v = snapshot(); v.report.securityAudit.isBlocked = true; return v; }, /blocks publication/],
-    [() => { const v = snapshot(); v.report.securityAudit.safeToPublish = false; return v; }, /requires manual review/],
-    [() => { const v = snapshot(); v.report.securityAudit.riskLevel = 'high'; return v; }, /high-risk/],
-    [() => { const v = snapshot(); v.report.sha = '3'.repeat(40); return v; }, /exact PR head/],
+    () => { const v = snapshot(); v.report.securityAudit.isBlocked = true; return v; },
+    () => { const v = snapshot(); v.report.securityAudit.safeToPublish = false; return v; },
+    () => { const v = snapshot(); v.report.securityAudit.riskLevel = 'critical'; return v; },
+    () => { const v = snapshot(); v.report.securityAudit = {}; return v; },
   ];
-  for (const [build, pattern] of cases) expectBlocked(build(), pattern);
+  for (const build of cases) assert.equal(validateSnapshot(build()).eligible, true);
+});
+
+test('still requires the report file to be bound to the exact head', () => {
+  const value = snapshot();
+  value.report.sha = '3'.repeat(40);
+  expectBlocked(value, /exact PR head/);
 });
 
 function fakeApi(sequence) {


### PR DESCRIPTION
## Goal
Align trusted auto-merge with the current policy: do not inspect report risk levels and do not reject a trusted submission merely because it contains multiple canonical Skill roots.

## Changes
- Remove all reads and gates for `risk_level`, `safe_to_publish`, `is_blocked`, and critical/high findings.
- Allow one or more canonical `pending/<publisher>/<skill>/**` roots.
- Require every root to contain `SKILL.md` and an exact-head SHA-bound `skill-report.json`.
- Keep trusted App identity, same-repository `submission/*`, `pending-review`, pending-only paths, exact-head CI, protected-main, mergeability, and effect revalidation unchanged.

## Evidence
- Red tests reproduced the deprecated risk gate and single-root rejection.
- `CI=true node --test scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs scripts/tests/workflow-action-pin-policy.test.mjs scripts/tests/workflow-runner-safety.test.mjs`: 53/53 passed.
- workflow action pin policy: passed.
- workflow runner safety: passed (40 workflows).
- `git diff --check`: passed.

## Rollout
Not deployed until merged into `main`; validate the next trusted submission after deployment.