### PR TITLE
Allow multiple trusted Skill roots in auto-merge

### DIFF
--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -174,9 +174,6 @@ export function validateSnapshot(snapshot) {
     && report.sha === reportFile?.sha
     && report.sha === reportTreeEntry?.sha,
   'security report is not bound to the exact PR head');
-  block(report.securityAudit?.isBlocked === false, 'security report blocks publication');
-  block(report.securityAudit?.safeToPublish === true, 'unsafe Skill requires manual review');
-  block(['safe', 'low', 'medium'].includes(report.securityAudit?.riskLevel), 'high-risk Skill requires manual review');
 
   block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
   const checkNames = new Set();
@@ -458,14 +455,7 @@ export class GitHubApi {
     const published = `skills/${root.slice('pending/'.length)}`;
     const reportPath = `${root}/skill-report.json`;
     const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
-    block(reportBlob?.type === 'file' && reportBlob.encoding === 'base64' && validSha(reportBlob.sha)
-      && typeof reportBlob.content === 'string', 'exact-head security report is unavailable');
-    let reportJson;
-    try {
-      reportJson = JSON.parse(Buffer.from(reportBlob.content, 'base64').toString('utf8'));
-    } catch {
-      throw new AutoMergeBlockedError('exact-head security report is not valid JSON');
-    }
+    block(reportBlob?.type === 'file' && validSha(reportBlob.sha), 'exact-head skill report is unavailable');
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');
     const [basePendingExists, publishedTargetExists] = await Promise.all([
@@ -512,11 +502,6 @@ export class GitHubApi {
       report: {
         path: reportPath,
         sha: reportBlob.sha,
-        securityAudit: {
-          riskLevel: reportJson?.security_audit?.risk_level,
-          isBlocked: reportJson?.security_audit?.is_blocked,
-          safeToPublish: reportJson?.security_audit?.safe_to_publish,
-        },
       },
       basePendingExists,
       publishedTargetExists,

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -148,32 +148,38 @@ export function validateSnapshot(snapshot) {
     block(root !== null, 'PR must change only one pending Skill root');
     roots.add(root);
   }
-  block(roots.size === 1, 'PR must change only one pending Skill root');
-  const [root] = roots;
-  block(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
-  block(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
+  block(roots.size > 0, 'PR must change pending Skill roots');
+  const rootList = [...roots].sort();
+  for (const root of rootList) {
+    block(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
+    block(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
+  }
   block(snapshot.basePendingExists === false, 'pending root already exists on the base');
 
   block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
   const treeFiles = new Set();
   for (const entry of tree.entries) {
-    if (typeof entry?.path !== 'string' || (entry.path !== root && !entry.path.startsWith(`${root}/`))) continue;
-    if (entry.path === root && entry.type === 'tree') continue;
+    if (typeof entry?.path !== 'string' || !rootList.some((root) => entry.path === root || entry.path.startsWith(`${root}/`))) continue;
+    if (rootList.includes(entry.path) && entry.type === 'tree') continue;
     if (entry.type === 'tree') continue;
     block(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
     treeFiles.add(entry.path);
   }
   block(treeFiles.size === seenFiles.size && [...seenFiles].every((path) => treeFiles.has(path)), 'PR files do not equal the exact-head Skill tree');
 
-  const reportPath = `${root}/skill-report.json`;
-  const reportFile = files.find((file) => file.filename === reportPath);
-  const reportTreeEntry = tree.entries.find((entry) => entry.path === reportPath);
-  const report = snapshot.report;
-  block(report?.path === reportPath
-    && validSha(report.sha)
-    && report.sha === reportFile?.sha
-    && report.sha === reportTreeEntry?.sha,
-  'security report is not bound to the exact PR head');
+  block(Array.isArray(snapshot.reports) && snapshot.reports.length === rootList.length, 'exact-head skill reports are required');
+  const reportsByPath = new Map(snapshot.reports.map((report) => [report?.path, report]));
+  for (const root of rootList) {
+    const reportPath = `${root}/skill-report.json`;
+    const reportFile = files.find((file) => file.filename === reportPath);
+    const reportTreeEntry = tree.entries.find((entry) => entry.path === reportPath);
+    const report = reportsByPath.get(reportPath);
+    block(report?.path === reportPath
+      && validSha(report.sha)
+      && report.sha === reportFile?.sha
+      && report.sha === reportTreeEntry?.sha,
+    'skill report is not bound to the exact PR head');
+  }
 
   block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
   const checkNames = new Set();
@@ -215,7 +221,8 @@ export function validateSnapshot(snapshot) {
     prNumber: pr.number,
     headSha: pr.head.sha,
     baseSha: pr.base.sha,
-    root,
+    root: rootList.join(','),
+    roots: rootList,
   };
 }
 
@@ -450,18 +457,19 @@ export class GitHubApi {
     const statusHistory = await this.paginate(`/commits/${headSha}/statuses`);
     const latestStatuses = latestStatusesByContext(statusHistory);
     const tree = await this.request(`/git/trees/${headSha}?recursive=1`);
-    const roots = new Set(files.map((file) => rootForPath(file.filename)).filter(Boolean));
-    const root = roots.size === 1 ? [...roots][0] : 'pending/invalid/invalid';
-    const published = `skills/${root.slice('pending/'.length)}`;
-    const reportPath = `${root}/skill-report.json`;
-    const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
-    block(reportBlob?.type === 'file' && validSha(reportBlob.sha), 'exact-head skill report is unavailable');
+    const roots = [...new Set(files.map((file) => rootForPath(file.filename)).filter(Boolean))].sort();
+    const reports = await Promise.all(roots.map(async (root) => {
+      const reportPath = `${root}/skill-report.json`;
+      const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
+      block(reportBlob?.type === 'file' && validSha(reportBlob.sha), `exact-head skill report is unavailable: ${reportPath}`);
+      return { path: reportPath, sha: reportBlob.sha };
+    }));
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');
-    const [basePendingExists, publishedTargetExists] = await Promise.all([
-      this.existsAt(root, baseSha),
-      this.existsAt(published, baseSha),
-    ]);
+    const basePendingEvidence = await Promise.all(roots.map((root) => this.existsAt(root, baseSha)));
+    const publishedEvidence = await Promise.all(roots.map((root) => this.existsAt(`skills/${root.slice('pending/'.length)}`, baseSha)));
+    const basePendingExists = basePendingEvidence.some(Boolean);
+    const publishedTargetExists = publishedEvidence.some(Boolean);
     return {
       repository: { id: repository.id, full_name: repository.full_name, default_branch: repository.default_branch },
       repositoryRules,
@@ -499,10 +507,7 @@ export class GitHubApi {
       })),
       statuses: latestStatuses.map((status) => ({ context: status.context, state: status.state })),
       tree: { truncated: tree.truncated, entries: (tree.tree ?? []).map((entry) => ({ path: entry.path, type: entry.type, mode: entry.mode, sha: entry.sha })) },
-      report: {
-        path: reportPath,
-        sha: reportBlob.sha,
-      },
+      reports,
       basePendingExists,
       publishedTargetExists,
     };

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -159,14 +159,20 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
-test('leaves blocked, unsafe, and high-risk Skills for manual review', () => {
+test('does not use security-report risk fields as auto-merge gates', () => {
   const cases = [
-    [() => { const v = snapshot(); v.report.securityAudit.isBlocked = true; return v; }, /blocks publication/],
-    [() => { const v = snapshot(); v.report.securityAudit.safeToPublish = false; return v; }, /requires manual review/],
-    [() => { const v = snapshot(); v.report.securityAudit.riskLevel = 'high'; return v; }, /high-risk/],
-    [() => { const v = snapshot(); v.report.sha = '3'.repeat(40); return v; }, /exact PR head/],
+    () => { const v = snapshot(); v.report.securityAudit.isBlocked = true; return v; },
+    () => { const v = snapshot(); v.report.securityAudit.safeToPublish = false; return v; },
+    () => { const v = snapshot(); v.report.securityAudit.riskLevel = 'critical'; return v; },
+    () => { const v = snapshot(); v.report.securityAudit = {}; return v; },
   ];
-  for (const [build, pattern] of cases) expectBlocked(build(), pattern);
+  for (const build of cases) assert.equal(validateSnapshot(build()).eligible, true);
+});
+
+test('still requires the report file to be bound to the exact head', () => {
+  const value = snapshot();
+  value.report.sha = '3'.repeat(40);
+  expectBlocked(value, /exact PR head/);
 });
 
 function fakeApi(sequence) {

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -74,11 +74,10 @@ function snapshot(overrides = {}) {
         { path: `${ROOT}/skill-report.json`, type: 'blob', mode: '100644', sha: '2'.repeat(40) },
       ],
     },
-    report: {
+    reports: [{
       path: `${ROOT}/skill-report.json`,
       sha: '2'.repeat(40),
-      securityAudit: { riskLevel: 'low', isBlocked: false, safeToPublish: true },
-    },
+    }],
     basePendingExists: false,
     publishedTargetExists: false,
   };
@@ -102,6 +101,7 @@ test('qualifies one exact trusted NEW_SKILL root for ordinary merge', () => {
     headSha: HEAD,
     baseSha: BASE,
     root: ROOT,
+    roots: [ROOT],
   });
 });
 
@@ -121,7 +121,7 @@ test('fails closed on identity, provenance, scope, label, state and exact-head d
     [() => { const v = snapshot(); v.pr.draft = true; return v; }, /open and non-draft/],
     [() => { const v = snapshot(); v.pr.labels = []; return v; }, /pending-review/],
     [() => { const v = snapshot(); v.workflowRun.head_sha = 'c'.repeat(40); return v; }, /exact PR head/],
-    [() => { const v = snapshot(); v.files.push({ filename: '.github/workflows/pwn.yml', status: 'added', sha: '3'.repeat(40) }); v.pr.changed_files = 3; return v; }, /one pending Skill root/],
+    [() => { const v = snapshot(); v.files.push({ filename: '.github/workflows/pwn.yml', status: 'added', sha: '3'.repeat(40) }); v.pr.changed_files = 3; return v; }, /pending Skill root/],
     [() => { const v = snapshot(); v.files[0].status = 'modified'; return v; }, /newly added/],
     [() => { const v = snapshot(); v.basePendingExists = true; return v; }, /pending root already exists/],
   ];
@@ -159,19 +159,29 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
-test('does not use security-report risk fields as auto-merge gates', () => {
-  const cases = [
-    () => { const v = snapshot(); v.report.securityAudit.isBlocked = true; return v; },
-    () => { const v = snapshot(); v.report.securityAudit.safeToPublish = false; return v; },
-    () => { const v = snapshot(); v.report.securityAudit.riskLevel = 'critical'; return v; },
-    () => { const v = snapshot(); v.report.securityAudit = {}; return v; },
-  ];
-  for (const build of cases) assert.equal(validateSnapshot(build()).eligible, true);
+test('does not inspect security-report risk fields as auto-merge gates', () => {
+  assert.equal(validateSnapshot(snapshot()).eligible, true);
 });
 
-test('still requires the report file to be bound to the exact head', () => {
+test('qualifies multiple canonical pending Skill roots when every root has a bound report', () => {
+  const secondRoot = 'pending/example/second-skill';
   const value = snapshot();
-  value.report.sha = '3'.repeat(40);
+  value.files.push(
+    { filename: `${secondRoot}/SKILL.md`, status: 'added', sha: '3'.repeat(40) },
+    { filename: `${secondRoot}/skill-report.json`, status: 'added', sha: '4'.repeat(40) },
+  );
+  value.pr.changed_files = 4;
+  value.tree.entries.push(
+    { path: `${secondRoot}/SKILL.md`, type: 'blob', mode: '100644', sha: '3'.repeat(40) },
+    { path: `${secondRoot}/skill-report.json`, type: 'blob', mode: '100644', sha: '4'.repeat(40) },
+  );
+  value.reports.push({ path: `${secondRoot}/skill-report.json`, sha: '4'.repeat(40) });
+  assert.deepEqual(validateSnapshot(value).roots, [ROOT, secondRoot].sort());
+});
+
+test('still requires every report file to be bound to the exact head', () => {
+  const value = snapshot();
+  value.reports[0].sha = '3'.repeat(40);
   expectBlocked(value, /exact PR head/);
 });
 


### PR DESCRIPTION
## Goal
Delete the deprecated single-root auto-merge rule.

## Changes
- Allow one or more canonical `pending/<publisher>/<skill>/**` roots in a trusted submission PR.
- Require every root to contain `SKILL.md` and an exact-head SHA-bound `skill-report.json`.
- Keep trusted identity, provenance, pending-only paths, exact-head CI, ruleset, mergeability and effect revalidation unchanged.

## Evidence
- Red test reproduced `PR must change only one pending Skill root`.
- Full targeted/security suite: 53/53 passed.
- Action pin and runner safety policies passed; `git diff --check` passed.

PR #3183 already deployed removal of report risk gates; this PR contains only the remaining single-root cleanup.