### PR TITLE
Auto-merge trusted source monitor updates

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -1,4 +1,5 @@
 name: Sync to Supabase (Incremental)
+run-name: ${{ github.event_name == 'workflow_dispatch' && inputs.correlation_id != '' && format('Provider sync {0}', inputs.correlation_id) || 'Sync to Supabase (Incremental)' }}
 
 on:
   push:
@@ -19,6 +20,10 @@ on:
         description: 'Skip cache warming after sync'
         type: boolean
         default: false
+      correlation_id:
+        description: 'Optional exact idempotency correlation for trusted automation'
+        type: string
+        default: ''
 
 concurrency:
   group: sync-supabase
@@ -124,6 +129,30 @@ jobs:
             fi
           done
 
+      - name: Validate trusted sync correlation
+        env:
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          INPUT_SLUGS: ${{ inputs.slugs }}
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CORRELATION_ID" ]; then
+            exit 0
+          fi
+          if [ "$EVENT_NAME" != 'workflow_dispatch' ] || [ "$GIT_REF" != 'refs/heads/main' ]; then
+            echo "::error::A correlated provider sync must be dispatched on main"
+            exit 1
+          fi
+          if ! [[ "$CORRELATION_ID" =~ ^source-monitor-pr-[1-9][0-9]*-[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid provider sync correlation"
+            exit 1
+          fi
+          if [ -z "$INPUT_SLUGS" ]; then
+            echo "::error::A correlated provider sync requires exact Skill slugs"
+            exit 1
+          fi
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -133,6 +162,7 @@ jobs:
           repositories: marketplace,skillstore
 
       - name: Find last successful sync commit
+        if: inputs.slugs == ''
         id: last_sync
         env:
           GH_TOKEN: ${{ github.token }}
@@ -169,8 +199,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          echo "Comparing HEAD against: $BASE_SHA"
-          
           if [ -n "$INPUT_SLUGS" ]; then
             echo "Specific slugs requested: $INPUT_SLUGS"
             # Resolve against the immutable workflow commit. A mutable self-hosted
@@ -181,6 +209,7 @@ jobs:
             echo "Resolved manual skill paths: $CHANGED"
             echo "mode=manual-slugs" >> $GITHUB_OUTPUT
           else
+            echo "Comparing HEAD against: $BASE_SHA"
             # Resolve both the diff and the published-skill inventory from pinned
             # Git trees. A self-hosted runner checkout may be sparse or mutable;
             # it must never turn a real commit diff into an empty sync plan. A
@@ -657,7 +686,7 @@ jobs:
 
       - name: Resolve published submissions
         id: published_submissions
-        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0'
+        if: steps.changes.outputs.skip_sync != 'true' && steps.sync.outputs.synced_count != '0' && !startsWith(inputs.correlation_id, 'source-monitor-pr-')
         env:
           BASE_SHA: ${{ steps.last_sync.outputs.base_sha }}
           SYNC_MODE: ${{ steps.changes.outputs.mode }}

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -12,6 +12,9 @@ const TRUSTED_WORKFLOWS = Object.freeze({
 const REQUIRED_CHECKS = Object.freeze(Object.keys(TRUSTED_WORKFLOWS));
 const SHA_RE = /^[0-9a-f]{40}$/;
 const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SOURCE_MONITOR_REF_RE = /^skill-source-monitor\/run-[1-9][0-9]*$/u;
+const SUBMISSION_ROUTE = 'submission';
+const SOURCE_MONITOR_ROUTE = 'source_monitor';
 
 export class AutoMergeBlockedError extends Error {
   constructor(message) {
@@ -62,12 +65,51 @@ function safePath(path) {
   return parts.every((part) => part.length > 0 && part !== '.' && part !== '..');
 }
 
-function rootForPath(path) {
+function rootForPath(path, topLevel = 'pending') {
   if (!safePath(path)) return null;
   const parts = path.split('/');
-  if (parts.length < 4 || parts[0] !== 'pending') return null;
+  if (parts.length < 4 || parts[0] !== topLevel) return null;
   if (!SEGMENT_RE.test(parts[1]) || !SEGMENT_RE.test(parts[2])) return null;
   return parts.slice(0, 3).join('/');
+}
+
+function publishedRootSyntax(root) {
+  if (!safePath(root)) return false;
+  const parts = root.split('/');
+  return parts[0] === 'skills'
+    && [2, 3].includes(parts.length)
+    && parts.slice(1).every((part) => SEGMENT_RE.test(part));
+}
+
+function publishedRootsFromTree(tree) {
+  const blobs = new Set((tree?.entries ?? [])
+    .filter((entry) => entry?.type === 'blob' && typeof entry.path === 'string')
+    .map((entry) => entry.path));
+  const roots = new Set();
+  for (const path of blobs) {
+    if (!path.endsWith('/skill-report.json')) continue;
+    const root = path.slice(0, -'/skill-report.json'.length);
+    if (publishedRootSyntax(root) && blobs.has(`${root}/SKILL.md`)) roots.add(root);
+  }
+  return [...roots].sort();
+}
+
+function publishedRootForPath(path, candidates) {
+  if (!safePath(path) || !Array.isArray(candidates)) return null;
+  const matches = candidates
+    .filter((root) => path === root || path.startsWith(`${root}/`))
+    .sort((first, second) => second.length - first.length);
+  return matches[0] ?? null;
+}
+
+function routeForPr(pr) {
+  const ref = pr?.head?.ref;
+  if (typeof ref === 'string' && ref.startsWith('submission/')) return SUBMISSION_ROUTE;
+  if (typeof ref === 'string' && ref.startsWith('skill-source-monitor/')) {
+    block(SOURCE_MONITOR_REF_RE.test(ref), 'PR head must use trusted source-monitor provenance');
+    return SOURCE_MONITOR_ROUTE;
+  }
+  throw new AutoMergeBlockedError('PR head must use trusted submission/ or source-monitor provenance');
 }
 
 export function latestStatusesByContext(statusHistory) {
@@ -92,7 +134,7 @@ function checkTerminal(check) {
   block(check.conclusion === 'success', `check ${name} concluded ${check.conclusion}`);
 }
 
-export function validateSnapshot(snapshot) {
+export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
   block(snapshot && typeof snapshot === 'object', 'snapshot must be an object');
   const { repository, workflowRun, pr, files, checks, statuses, tree } = snapshot;
   block(repository?.full_name === TRUSTED_REPOSITORY, `repository must be ${TRUSTED_REPOSITORY}`);
@@ -124,57 +166,99 @@ export function validateSnapshot(snapshot) {
   block(Array.isArray(workflowRun.pull_requests) && workflowRun.pull_requests.length === 1, 'workflow run must bind exactly one PR');
 
   block(pr?.number === workflowRun.pull_requests[0]?.number, 'workflow run PR number does not match');
-  block(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
+  if (allowMerged) {
+    block(pr.state === 'closed' && pr.merged === true && validSha(pr.merge_commit_sha), 'PR must be authoritatively merged');
+  } else {
+    block(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
+  }
   block(pr.base?.ref === 'main', 'PR base must be main');
   block(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
   block(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
-  block(typeof pr.head?.ref === 'string' && pr.head.ref.startsWith('submission/'), 'PR head must use trusted submission/ provenance');
+  const route = routeForPr(pr);
   block(validSha(pr.head?.sha) && validSha(pr.base?.sha), 'PR head and base SHA must be exact');
   block(workflowRun.head_sha === pr.head.sha, 'workflow run must bind the exact PR head');
-  block(Array.isArray(pr.labels) && pr.labels.some((label) => label?.name === 'pending-review'), 'PR must have pending-review');
-  block(pr.mergeable === true, 'PR is not mergeable');
-  block(['clean', 'behind'].includes(pr.mergeable_state), `PR mergeable_state is ${pr.mergeable_state ?? 'unknown'}`);
+  const labelNames = new Set((Array.isArray(pr.labels) ? pr.labels : []).map((label) => label?.name));
+  if (route === SUBMISSION_ROUTE) {
+    block(labelNames.has('pending-review'), 'PR must have pending-review');
+  } else {
+    block(labelNames.has('skill-source-monitor'), 'source-monitor PR must have skill-source-monitor label');
+    block(!labelNames.has('pending-review'), 'source-monitor PR must not have pending-review');
+  }
+  if (!allowMerged) {
+    block(pr.mergeable === true, 'PR is not mergeable');
+    block(['clean', 'behind'].includes(pr.mergeable_state), `PR mergeable_state is ${pr.mergeable_state ?? 'unknown'}`);
+  }
 
   block(Array.isArray(files) && files.length > 0, 'PR files are required');
   block(Number.isSafeInteger(pr.changed_files) && pr.changed_files === files.length, 'PR file pagination/count is incomplete');
+  block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
   const seenFiles = new Set();
   const roots = new Set();
+  const topLevel = route === SUBMISSION_ROUTE ? 'pending' : 'skills';
+  const publishedRootCandidates = route === SOURCE_MONITOR_ROUTE ? publishedRootsFromTree(tree) : [];
   for (const file of files) {
-    block(file?.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file?.filename ?? '<unknown>'}`);
-    block(safePath(file.filename), 'PR contains an unsafe path');
+    block(safePath(file?.filename), 'PR contains an unsafe path');
     block(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
     seenFiles.add(file.filename);
-    const root = rootForPath(file.filename);
-    block(root !== null, 'PR must change only one pending Skill root');
+    if (route === SUBMISSION_ROUTE) {
+      block(file.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file.filename}`);
+    } else {
+      block(['added', 'modified', 'removed', 'changed'].includes(file.status) && file.previous_filename == null,
+        `unsupported source-monitor file status: ${file.status ?? 'missing'}`);
+    }
+    const root = route === SUBMISSION_ROUTE
+      ? rootForPath(file.filename, topLevel)
+      : publishedRootForPath(file.filename, publishedRootCandidates);
+    block(root !== null, `PR must change only ${topLevel === 'pending' ? 'pending' : 'published'} Skill roots`);
     roots.add(root);
   }
-  block(roots.size > 0, 'PR must change pending Skill roots');
+  block(roots.size > 0, `PR must change ${topLevel} Skill roots`);
   const rootList = [...roots].sort();
+  if (route === SOURCE_MONITOR_ROUTE) block(rootList.length <= 25, 'source-monitor PR exceeds the provider sync limit');
   for (const root of rootList) {
-    block(seenFiles.has(`${root}/SKILL.md`), 'Skill root is missing SKILL.md');
-    block(seenFiles.has(`${root}/skill-report.json`), 'Skill root is missing skill-report.json');
+    const skillFile = files.find((file) => file.filename === `${root}/SKILL.md`);
+    const reportFile = files.find((file) => file.filename === `${root}/skill-report.json`);
+    if (route === SUBMISSION_ROUTE) block(skillFile && skillFile.status !== 'removed', 'Skill root is missing SKILL.md');
+    block(reportFile && reportFile.status !== 'removed', 'Skill root is missing skill-report.json');
   }
-  block(snapshot.basePendingExists === false, 'pending root already exists on the base');
+  if (route === SUBMISSION_ROUTE) {
+    block(snapshot.basePendingExists === false, 'pending root already exists on the base');
+  } else {
+    block(snapshot.baseSkillRootsExist === true, 'source-monitor Skill roots must already exist on the base');
+  }
 
-  block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
-  const treeFiles = new Set();
+  const treeByPath = new Map();
   for (const entry of tree.entries) {
     if (typeof entry?.path !== 'string' || !rootList.some((root) => entry.path === root || entry.path.startsWith(`${root}/`))) continue;
-    if (rootList.includes(entry.path) && entry.type === 'tree') continue;
     if (entry.type === 'tree') continue;
     block(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
-    treeFiles.add(entry.path);
+    treeByPath.set(entry.path, entry);
   }
-  block(treeFiles.size === seenFiles.size && [...seenFiles].every((path) => treeFiles.has(path)), 'PR files do not equal the exact-head Skill tree');
+  if (route === SUBMISSION_ROUTE) {
+    block(treeByPath.size === seenFiles.size && [...seenFiles].every((path) => treeByPath.has(path)), 'PR files do not equal the exact-head Skill tree');
+  } else {
+    for (const file of files) {
+      const entry = treeByPath.get(file.filename);
+      if (file.status === 'removed') {
+        block(entry == null, `removed source-monitor file remains on the exact PR head: ${file.filename}`);
+      } else {
+        block(entry?.sha === file.sha && validSha(file.sha), `source-monitor file is not bound to the exact PR head: ${file.filename}`);
+      }
+    }
+    for (const root of rootList) {
+      block(treeByPath.has(`${root}/SKILL.md`) && treeByPath.has(`${root}/skill-report.json`), 'source-monitor Skill root is incomplete on the exact PR head');
+    }
+  }
 
   block(Array.isArray(snapshot.reports) && snapshot.reports.length === rootList.length, 'exact-head skill reports are required');
   const reportsByPath = new Map(snapshot.reports.map((report) => [report?.path, report]));
   for (const root of rootList) {
     const reportPath = `${root}/skill-report.json`;
     const reportFile = files.find((file) => file.filename === reportPath);
-    const reportTreeEntry = tree.entries.find((entry) => entry.path === reportPath);
+    const reportTreeEntry = treeByPath.get(reportPath);
     const report = reportsByPath.get(reportPath);
-    block(report?.path === reportPath
+    block(reportFile?.status !== 'removed'
+      && report?.path === reportPath
       && validSha(report.sha)
       && report.sha === reportFile?.sha
       && report.sha === reportTreeEntry?.sha,
@@ -217,7 +301,10 @@ export function validateSnapshot(snapshot) {
   return {
     eligible: true,
     action: pr.mergeable_state === 'behind' ? 'update_branch' : 'merge',
-    classification: snapshot.publishedTargetExists === true ? 'UPDATE_SKILL' : 'NEW_SKILL',
+    classification: route === SOURCE_MONITOR_ROUTE
+      ? 'SOURCE_MONITOR_UPDATE'
+      : (snapshot.publishedTargetExists === true ? 'UPDATE_SKILL' : 'NEW_SKILL'),
+    postMergeAction: route === SOURCE_MONITOR_ROUTE ? 'provider_sync' : 'publication',
     prNumber: pr.number,
     headSha: pr.head.sha,
     baseSha: pr.base.sha,
@@ -227,7 +314,13 @@ export function validateSnapshot(snapshot) {
 }
 
 function samePlan(first, second) {
-  return first.prNumber === second.prNumber && first.headSha === second.headSha && first.baseSha === second.baseSha && first.root === second.root && first.classification === second.classification && first.action === second.action;
+  return first.prNumber === second.prNumber
+    && first.headSha === second.headSha
+    && first.baseSha === second.baseSha
+    && first.root === second.root
+    && first.classification === second.classification
+    && first.postMergeAction === second.postMergeAction
+    && first.action === second.action;
 }
 
 function mergedReadback(pr, plan) {
@@ -255,6 +348,15 @@ function definiteMutationRejection(error) {
 export async function runAutoMerge(api, { workflowRunId }) {
   const firstSnapshot = await buildStableSnapshot(api, workflowRunId);
   if (firstSnapshot?.pr?.merged === true && firstSnapshot.pr.state === 'closed' && firstSnapshot.pr.head?.sha === firstSnapshot.workflowRun?.head_sha) {
+    if (SOURCE_MONITOR_REF_RE.test(firstSnapshot.pr.head?.ref ?? '')) {
+      const merged = validateSnapshot(firstSnapshot, { allowMerged: true });
+      try {
+        await api.dispatchProviderSync(merged.prNumber, merged.headSha, merged.roots);
+      } catch {
+        throw new AutoMergeUnknownEffectError(`merge is confirmed but provider sync reconciliation is unknown for PR #${merged.prNumber}`);
+      }
+      return { outcome: 'ALREADY_MERGED_AND_PROVIDER_SYNC_CONFIRMED', prNumber: merged.prNumber, headSha: merged.headSha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha, classification: merged.classification };
+    }
     return { outcome: 'ALREADY_MERGED', prNumber: firstSnapshot.pr.number, headSha: firstSnapshot.pr.head.sha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha };
   }
   const first = validateSnapshot(firstSnapshot);
@@ -307,6 +409,14 @@ export async function runAutoMerge(api, { workflowRunId }) {
     throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
   }
   if (mergedReadback(readback, second)) {
+    if (second.postMergeAction === 'provider_sync') {
+      try {
+        await api.dispatchProviderSync(second.prNumber, second.headSha, second.roots);
+      } catch {
+        throw new AutoMergeUnknownEffectError(`merge is confirmed but provider sync dispatch is unknown for PR #${second.prNumber}`);
+      }
+      return { outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+    }
     try {
       await api.dispatchPublication(second.prNumber);
     } catch {
@@ -457,7 +567,11 @@ export class GitHubApi {
     const statusHistory = await this.paginate(`/commits/${headSha}/statuses`);
     const latestStatuses = latestStatusesByContext(statusHistory);
     const tree = await this.request(`/git/trees/${headSha}?recursive=1`);
-    const roots = [...new Set(files.map((file) => rootForPath(file.filename)).filter(Boolean))].sort();
+    const topLevel = SOURCE_MONITOR_REF_RE.test(pr.head?.ref ?? '') ? 'skills' : 'pending';
+    const publishedRootCandidates = topLevel === 'skills' ? publishedRootsFromTree({ entries: tree.tree ?? [] }) : [];
+    const roots = [...new Set(files.map((file) => topLevel === 'pending'
+      ? rootForPath(file.filename, topLevel)
+      : publishedRootForPath(file.filename, publishedRootCandidates)).filter(Boolean))].sort();
     const reports = await Promise.all(roots.map(async (root) => {
       const reportPath = `${root}/skill-report.json`;
       const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
@@ -466,9 +580,12 @@ export class GitHubApi {
     }));
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');
-    const basePendingEvidence = await Promise.all(roots.map((root) => this.existsAt(root, baseSha)));
-    const publishedEvidence = await Promise.all(roots.map((root) => this.existsAt(`skills/${root.slice('pending/'.length)}`, baseSha)));
-    const basePendingExists = basePendingEvidence.some(Boolean);
+    const baseRootEvidence = await Promise.all(roots.map((root) => this.existsAt(root, baseSha)));
+    const publishedEvidence = topLevel === 'pending'
+      ? await Promise.all(roots.map((root) => this.existsAt(`skills/${root.slice('pending/'.length)}`, baseSha)))
+      : baseRootEvidence;
+    const basePendingExists = topLevel === 'pending' && baseRootEvidence.some(Boolean);
+    const baseSkillRootsExist = topLevel === 'skills' && roots.length > 0 && baseRootEvidence.every(Boolean);
     const publishedTargetExists = publishedEvidence.some(Boolean);
     return {
       repository: { id: repository.id, full_name: repository.full_name, default_branch: repository.default_branch },
@@ -509,6 +626,7 @@ export class GitHubApi {
       tree: { truncated: tree.truncated, entries: (tree.tree ?? []).map((entry) => ({ path: entry.path, type: entry.type, mode: entry.mode, sha: entry.sha })) },
       reports,
       basePendingExists,
+      baseSkillRootsExist,
       publishedTargetExists,
     };
   }
@@ -530,6 +648,48 @@ export class GitHubApi {
       method: 'POST',
       body: { ref: 'main', inputs: { pr_number: String(number) } },
     });
+  }
+
+  async findProviderSyncRun(correlationTitle) {
+    for (let page = 1; page <= 30; page += 1) {
+      const result = await this.request(`/actions/workflows/sync-to-supabase.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
+      block(Array.isArray(result?.workflow_runs), 'provider sync workflow run evidence is invalid');
+      const match = result.workflow_runs.find((run) => run?.display_title === correlationTitle
+        && run?.head_branch === 'main'
+        && run?.head_repository?.full_name === this.repository);
+      if (match) return match;
+      if (result.workflow_runs.length < 100) return undefined;
+    }
+    throw new AutoMergeBlockedError('provider sync workflow run search exceeded the bounded limit');
+  }
+
+  async dispatchProviderSync(prNumber, headSha, roots) {
+    block(Number.isSafeInteger(prNumber) && prNumber > 0, 'provider sync PR number is invalid');
+    block(validSha(headSha), 'provider sync head SHA is invalid');
+    block(Array.isArray(roots) && roots.length > 0 && roots.length <= 25, 'provider sync roots are required');
+    const slugs = roots.map((root) => {
+      block(publishedRootSyntax(root), `invalid provider sync root: ${root}`);
+      return root.slice('skills/'.length);
+    });
+    const correlationId = `source-monitor-pr-${prNumber}-${headSha}`;
+    const correlationTitle = `Provider sync ${correlationId}`;
+    if (await this.findProviderSyncRun(correlationTitle)) return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED' };
+
+    let mutationError;
+    try {
+      await this.request('/actions/workflows/sync-to-supabase.yml/dispatches', {
+        method: 'POST',
+        body: { ref: 'main', inputs: { slugs: slugs.join(' '), correlation_id: correlationId } },
+      });
+    } catch (error) {
+      mutationError = error;
+    }
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      if (await this.findProviderSyncRun(correlationTitle)) return { outcome: 'PROVIDER_SYNC_DISPATCH_CONFIRMED' };
+      if (attempt < 11) await this.sleep(5_000);
+    }
+    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`provider sync dispatch rejected with HTTP ${mutationError.status}`);
+    throw new AutoMergeUnknownEffectError(`provider sync dispatch effect is unknown for PR #${prNumber}`);
   }
 }
 

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import {
   AutoMergeBlockedError,
   AutoMergeUnknownEffectError,
+  GitHubApi,
   latestStatusesByContext,
   runAutoMerge,
   validateSnapshot,
@@ -12,6 +13,7 @@ const REPO = { id: 9001, full_name: 'aiskillstore/marketplace', default_branch: 
 const HEAD = 'a'.repeat(40);
 const BASE = 'b'.repeat(40);
 const ROOT = 'pending/example/skill';
+const SOURCE_ROOT = 'skills/example/skill';
 
 function snapshot(overrides = {}) {
   const value = {
@@ -79,8 +81,26 @@ function snapshot(overrides = {}) {
       sha: '2'.repeat(40),
     }],
     basePendingExists: false,
+    baseSkillRootsExist: false,
     publishedTargetExists: false,
   };
+  return structuredClone(Object.assign(value, overrides));
+}
+
+function sourceMonitorSnapshot(overrides = {}) {
+  const value = snapshot({ baseSkillRootsExist: true, publishedTargetExists: true });
+  value.pr.head.ref = 'skill-source-monitor/run-32942863771';
+  value.pr.labels = [{ name: 'skill-source-monitor' }];
+  value.files = [
+    { filename: `${SOURCE_ROOT}/SKILL.md`, status: 'modified', sha: '3'.repeat(40) },
+    { filename: `${SOURCE_ROOT}/skill-report.json`, status: 'modified', sha: '4'.repeat(40) },
+  ];
+  value.tree.entries = [
+    { path: `${SOURCE_ROOT}/SKILL.md`, type: 'blob', mode: '100644', sha: '3'.repeat(40) },
+    { path: `${SOURCE_ROOT}/skill-report.json`, type: 'blob', mode: '100644', sha: '4'.repeat(40) },
+    { path: `${SOURCE_ROOT}/references/unchanged.md`, type: 'blob', mode: '100644', sha: '5'.repeat(40) },
+  ];
+  value.reports = [{ path: `${SOURCE_ROOT}/skill-report.json`, sha: '4'.repeat(40) }];
   return structuredClone(Object.assign(value, overrides));
 }
 
@@ -97,6 +117,7 @@ test('qualifies one exact trusted NEW_SKILL root for ordinary merge', () => {
     eligible: true,
     action: 'merge',
     classification: 'NEW_SKILL',
+    postMergeAction: 'publication',
     prNumber: 42,
     headSha: HEAD,
     baseSha: BASE,
@@ -112,12 +133,76 @@ test('qualifies UPDATE_SKILL and requests only standard update-branch when behin
   assert.equal(validateSnapshot(value).action, 'update_branch');
 });
 
+test('qualifies an exact trusted source-monitor update and routes its post-merge sync', () => {
+  assert.deepEqual(validateSnapshot(sourceMonitorSnapshot()), {
+    eligible: true,
+    action: 'merge',
+    classification: 'SOURCE_MONITOR_UPDATE',
+    postMergeAction: 'provider_sync',
+    prNumber: 42,
+    headSha: HEAD,
+    baseSha: BASE,
+    root: SOURCE_ROOT,
+    roots: [SOURCE_ROOT],
+  });
+});
+
+test('source-monitor accepts a canonical flat published Skill root', () => {
+  const value = sourceMonitorSnapshot();
+  const flatRoot = 'skills/flat-skill';
+  const rewrite = (path) => path.replace(SOURCE_ROOT, flatRoot);
+  value.files = value.files.map((file) => ({ ...file, filename: rewrite(file.filename) }));
+  value.tree.entries = value.tree.entries.map((entry) => ({ ...entry, path: rewrite(entry.path) }));
+  value.reports = value.reports.map((report) => ({ ...report, path: rewrite(report.path) }));
+  assert.deepEqual(validateSnapshot(value).roots, [flatRoot]);
+});
+
+test('source-monitor accepts auxiliary-only changes when exact-head SKILL.md and changed report remain bound', () => {
+  const value = sourceMonitorSnapshot();
+  value.files = value.files.filter((file) => file.filename !== `${SOURCE_ROOT}/SKILL.md`);
+  value.pr.changed_files = value.files.length;
+  assert.equal(validateSnapshot(value).classification, 'SOURCE_MONITOR_UPDATE');
+});
+
+test('source-monitor route fails closed on branch, label, published scope and exact-head binding', () => {
+  const cases = [
+    [() => { const v = sourceMonitorSnapshot(); v.pr.head.ref = 'skill-source-monitor/manual'; return v; }, /trusted source-monitor provenance/],
+    [() => { const v = sourceMonitorSnapshot(); v.pr.labels = [{ name: 'pending-review' }]; return v; }, /skill-source-monitor label/],
+    [() => { const v = sourceMonitorSnapshot(); v.pr.labels.push({ name: 'pending-review' }); return v; }, /must not have pending-review/],
+    [() => { const v = sourceMonitorSnapshot(); v.files.push({ filename: 'scripts/injected.mjs', status: 'modified', sha: '6'.repeat(40) }); v.pr.changed_files = 3; return v; }, /published Skill root/],
+    [() => { const v = sourceMonitorSnapshot(); v.files[0].status = 'renamed'; v.files[0].previous_filename = 'skills/example/old/SKILL.md'; return v; }, /unsupported source-monitor file status/],
+    [() => { const v = sourceMonitorSnapshot(); v.files[1].status = 'removed'; return v; }, /skill-report\.json/],
+    [() => { const v = sourceMonitorSnapshot(); v.baseSkillRootsExist = false; return v; }, /must already exist on the base/],
+    [() => { const v = sourceMonitorSnapshot(); v.files[0].sha = '6'.repeat(40); return v; }, /exact PR head/],
+    [() => {
+      const v = sourceMonitorSnapshot();
+      for (let index = 2; index <= 26; index += 1) {
+        const root = `skills/example/skill-${index}`;
+        const skillSha = index.toString(16).padStart(40, '0');
+        const reportSha = (index + 100).toString(16).padStart(40, '0');
+        v.files.push(
+          { filename: `${root}/SKILL.md`, status: 'modified', sha: skillSha },
+          { filename: `${root}/skill-report.json`, status: 'modified', sha: reportSha },
+        );
+        v.tree.entries.push(
+          { path: `${root}/SKILL.md`, type: 'blob', mode: '100644', sha: skillSha },
+          { path: `${root}/skill-report.json`, type: 'blob', mode: '100644', sha: reportSha },
+        );
+        v.reports.push({ path: `${root}/skill-report.json`, sha: reportSha });
+      }
+      v.pr.changed_files = v.files.length;
+      return v;
+    }, /provider sync limit/],
+  ];
+  for (const [build, pattern] of cases) expectBlocked(build(), pattern);
+});
+
 test('fails closed on identity, provenance, scope, label, state and exact-head drift', () => {
   const cases = [
     [() => { const v = snapshot(); v.pr.user.id = 7; return v; }, /trusted App identity/],
     [() => { const v = snapshot(); v.pr.user.login = 'ai-skill-store'; return v; }, /trusted App identity/],
     [() => { const v = snapshot(); v.pr.head.repo.id = 7; return v; }, /same repository/],
-    [() => { const v = snapshot(); v.pr.head.ref = 'skill-source-monitor/x'; return v; }, /submission\//],
+    [() => { const v = snapshot(); v.pr.head.ref = 'feature/x'; return v; }, /submission\/ or source-monitor/],
     [() => { const v = snapshot(); v.pr.draft = true; return v; }, /open and non-draft/],
     [() => { const v = snapshot(); v.pr.labels = []; return v; }, /pending-review/],
     [() => { const v = snapshot(); v.workflowRun.head_sha = 'c'.repeat(40); return v; }, /exact PR head/],
@@ -214,6 +299,9 @@ function fakeApi(sequence) {
     async dispatchPublication(number) {
       calls.push(['dispatch-publication', number]);
     },
+    async dispatchProviderSync(...args) {
+      calls.push(['dispatch-provider-sync', ...args]);
+    },
   };
 }
 
@@ -298,6 +386,164 @@ test('an accepted but unconfirmed asynchronous update is UNKNOWN and is never re
   const api = fakeApi([behind, behind, ...Array.from({ length: 12 }, () => behind.pr)]);
   await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
   assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
+});
+
+test('source-monitor merge dispatches exact changed Skill roots to provider sync without publication recovery', async () => {
+  const merged = sourceMonitorSnapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([sourceMonitorSnapshot(), sourceMonitorSnapshot(), merged.pr]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.deepEqual(api.calls, [
+    ['merge', 42, HEAD, 'merge'],
+    ['dispatch-provider-sync', 42, HEAD, [SOURCE_ROOT]],
+  ]);
+  assert.deepEqual(result, {
+    outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED',
+    prNumber: 42,
+    headSha: HEAD,
+    mergeCommitSha: 'd'.repeat(40),
+    classification: 'SOURCE_MONITOR_UPDATE',
+  });
+});
+
+test('provider sync dispatch binds canonical source-monitor roots and idempotency key to exact manual slugs', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let dispatched = false;
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if ((options?.method ?? 'GET') === 'POST') {
+      dispatched = true;
+      return new Response(null, { status: 204 });
+    }
+    return Response.json({ workflow_runs: dispatched ? [{
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] : [] });
+  };
+  try {
+    const api = new GitHubApi({
+      token: 'test-token',
+      updateToken: 'test-update-token',
+      repository: REPO.full_name,
+      currentRunId: 999,
+    });
+    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT, 'skills/flat-skill']);
+    const post = observed.find(({ options }) => options?.method === 'POST');
+    assert.ok(post);
+    assert.equal(post.url, 'https://api.github.com/repos/aiskillstore/marketplace/actions/workflows/sync-to-supabase.yml/dispatches');
+    assert.deepEqual(JSON.parse(post.options.body), {
+      ref: 'main',
+      inputs: {
+        slugs: 'example/skill flat-skill',
+        correlation_id: `source-monitor-pr-42-${HEAD}`,
+      },
+    });
+    assert.ok(observed.some(({ url, options }) => (options?.method ?? 'GET') === 'GET'
+      && url.includes('/actions/workflows/sync-to-supabase.yml/runs?event=workflow_dispatch')));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('provider sync reconciliation does not redispatch an existing exact correlation', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    return Response.json({ workflow_runs: [{
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]);
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('provider sync reconciliation finds an exact correlation on a later bounded page', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    const page = Number(new URL(String(url)).searchParams.get('page'));
+    if (page === 1) {
+      return Response.json({ workflow_runs: Array.from({ length: 100 }, (_, index) => ({
+        display_title: `unrelated-${index}`,
+        head_branch: 'main',
+        head_repository: { full_name: REPO.full_name },
+      })) });
+    }
+    return Response.json({ workflow_runs: [{
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]);
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+    assert.ok(observed.some(({ url }) => new URL(url).searchParams.get('page') === '2'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('provider sync reconciliation fails closed after bounded pagination without redispatch', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    return Response.json({ workflow_runs: Array.from({ length: 100 }, (_, index) => ({
+      display_title: `unrelated-${index}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    })) });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]), /bounded limit/);
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+    assert.equal(observed.length, 30);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a rerun reconciles provider sync for an already merged source-monitor PR', async () => {
+  const merged = sourceMonitorSnapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([merged]);
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.deepEqual(api.calls, [['dispatch-provider-sync', 42, HEAD, [SOURCE_ROOT]]]);
+  assert.equal(result.outcome, 'ALREADY_MERGED_AND_PROVIDER_SYNC_CONFIRMED');
+});
+
+test('confirmed source-monitor merge with failed provider sync dispatch is UNKNOWN and is never repeated', async () => {
+  const merged = sourceMonitorSnapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([sourceMonitorSnapshot(), sourceMonitorSnapshot(), merged.pr]);
+  api.dispatchProviderSync = async (...args) => {
+    api.calls.push(['dispatch-provider-sync', ...args]);
+    throw new TypeError('dispatch response lost');
+  };
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+  assert.equal(api.calls.filter(([kind]) => kind === 'dispatch-provider-sync').length, 1);
+  assert.equal(api.calls.filter(([kind]) => kind === 'dispatch-publication').length, 0);
 });
 
 test('confirmed merge with failed publication dispatch is UNKNOWN and is never repeated', async () => {

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -140,6 +140,7 @@ test('incremental detection subtracts only verified successful manual recovery a
   const lastSync = section(workflow, '      - name: Find last successful sync commit', '      - name: Detect changed skills');
   const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
 
+  assert.match(lastSync, /if: inputs\.slugs == ''/);
   assert.match(lastSync, /status=success&event=push/);
   assert.doesNotMatch(lastSync, /status=success&event=workflow_dispatch/);
   assert.match(lastSync, /set -euo pipefail/);
@@ -153,6 +154,23 @@ test('incremental detection subtracts only verified successful manual recovery a
   assert.match(detect, /--recoveries "\$RECOVERIES_FILE"/);
   assert.match(detect, /MAX_RECOVERY_RUNS=100/);
   assert.match(workflow, /retention-days: 30/);
+});
+
+test('manual slug sync carries an optional exact correlation without requiring an incremental baseline', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  assert.match(workflow, /correlation_id:/);
+  assert.match(workflow, /format\('Provider sync \{0\}', inputs\.correlation_id\)/);
+  const lastSync = section(workflow, '      - name: Find last successful sync commit', '      - name: Detect changed skills');
+  assert.match(lastSync, /if: inputs\.slugs == ''/);
+  const correlation = section(workflow, '      - name: Validate trusted sync correlation', '      - name: Generate GitHub App Token');
+  assert.match(correlation, /\^source-monitor-pr-\[1-9\]\[0-9\]\*-\[0-9a-f\]\{40\}\$/);
+  assert.match(correlation, /"\$EVENT_NAME" != 'workflow_dispatch'/);
+  assert.match(correlation, /"\$GIT_REF" != 'refs\/heads\/main'/);
+  const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+  assert.match(detect, /if \[ -n "\$INPUT_SLUGS" \]/);
+  assert.ok(detect.indexOf('Specific slugs requested') < detect.indexOf('Comparing HEAD against'));
+  const callbacks = section(workflow, '      - name: Resolve published submissions', '      - name: Upload synced slugs artifact');
+  assert.match(callbacks, /!startsWith\(inputs\.correlation_id, 'source-monitor-pr-'\)/);
 });
 
 test('manual recovery resolves its original submission and fails closed on callback errors', () => {


### PR DESCRIPTION
## Goal
Allow trusted `ai-skill-store[bot]` source-monitor PRs to follow the existing exact-head auto-merge state machine and sync the exact changed published Skills after merge.

## Why
`skill-source-monitor/run-*` PRs already pass publication provenance and validation, but the production executor only admitted `submission/*`, leaving source updates open indefinitely.

## Acceptance criteria
- Admit only the fixed trusted App identity on exact `skill-source-monitor/run-<id>` branches with `skill-source-monitor` and without `pending-review`.
- Allow only existing canonical `skills/**` roots (namespaced or flat), require exact-head `SKILL.md` and a changed, SHA-bound `skill-report.json`, and cap at 25 roots.
- Preserve exact-head required checks, protected-main rules, serial `BEHIND → update-branch → new-head CI → CLEAN → normal merge` behavior.
- Dispatch exact provider-sync slugs after confirmed merge, with bounded idempotent correlation and already-merged reconciliation.
- Do not replay submission publication callbacks for correlated source-monitor syncs; manual exact-slug sync does not require an incremental push baseline.
- Preserve current trusted submission behavior.

## Evidence
- `CI=true node --test scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs` — 48/48 passed on head `02cad664578f5231cbd299d96f291b9297656114`.
- Affected source/submission/workflow suite — 96/96 passed before final main integration; focused suite rerun after integration is green.
- `CI=true node scripts/check-workflow-action-pins.mjs` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Risk / rollback
This changes a production merge and sync boundary. It fails closed on identity, provenance, label, scope, tree/report binding, root count, CI, ruleset, mergeability, and unknown effects. Rollback is reverting this PR; no schema migration or new dependency.

## Merge boundary
Do not merge until exact-head CI is green and Ada independently accepts the delivery.
