### PR TITLE
fix: block unsafe skill auto-merge

### DIFF
--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -263,6 +263,8 @@ export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
       && report.sha === reportFile?.sha
       && report.sha === reportTreeEntry?.sha,
     'skill report is not bound to the exact PR head');
+    block(report?.securityAudit?.is_blocked === false, `${reportPath} is blocked from automatic publication`);
+    block(report?.securityAudit?.safe_to_publish === true, `${reportPath} is not safe for automatic publication`);
   }
 
   block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
@@ -575,8 +577,16 @@ export class GitHubApi {
     const reports = await Promise.all(roots.map(async (root) => {
       const reportPath = `${root}/skill-report.json`;
       const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
-      block(reportBlob?.type === 'file' && validSha(reportBlob.sha), `exact-head skill report is unavailable: ${reportPath}`);
-      return { path: reportPath, sha: reportBlob.sha };
+      block(reportBlob?.type === 'file' && validSha(reportBlob.sha)
+        && reportBlob.encoding === 'base64' && typeof reportBlob.content === 'string',
+      `exact-head skill report is unavailable: ${reportPath}`);
+      let report;
+      try {
+        report = JSON.parse(Buffer.from(reportBlob.content, 'base64').toString('utf8'));
+      } catch {
+        throw new AutoMergeBlockedError(`exact-head skill report is invalid JSON: ${reportPath}`);
+      }
+      return { path: reportPath, sha: reportBlob.sha, securityAudit: report?.security_audit };
     }));
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -79,6 +79,7 @@ function snapshot(overrides = {}) {
     reports: [{
       path: `${ROOT}/skill-report.json`,
       sha: '2'.repeat(40),
+      securityAudit: { is_blocked: false, safe_to_publish: true },
     }],
     basePendingExists: false,
     baseSkillRootsExist: false,
@@ -100,7 +101,11 @@ function sourceMonitorSnapshot(overrides = {}) {
     { path: `${SOURCE_ROOT}/skill-report.json`, type: 'blob', mode: '100644', sha: '4'.repeat(40) },
     { path: `${SOURCE_ROOT}/references/unchanged.md`, type: 'blob', mode: '100644', sha: '5'.repeat(40) },
   ];
-  value.reports = [{ path: `${SOURCE_ROOT}/skill-report.json`, sha: '4'.repeat(40) }];
+  value.reports = [{
+    path: `${SOURCE_ROOT}/skill-report.json`,
+    sha: '4'.repeat(40),
+    securityAudit: { is_blocked: false, safe_to_publish: true },
+  }];
   return structuredClone(Object.assign(value, overrides));
 }
 
@@ -244,8 +249,15 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
-test('does not inspect security-report risk fields as auto-merge gates', () => {
-  assert.equal(validateSnapshot(snapshot()).eligible, true);
+test('fails closed when an exact-head report is blocked or unsafe to publish', () => {
+  for (const [securityAudit, pattern] of [
+    [{ is_blocked: true, safe_to_publish: false }, /blocked from automatic publication/],
+    [{ is_blocked: false, safe_to_publish: false }, /not safe for automatic publication/],
+  ]) {
+    const value = snapshot();
+    value.reports[0].securityAudit = securityAudit;
+    expectBlocked(value, pattern);
+  }
 });
 
 test('qualifies multiple canonical pending Skill roots when every root has a bound report', () => {
@@ -260,7 +272,11 @@ test('qualifies multiple canonical pending Skill roots when every root has a bou
     { path: `${secondRoot}/SKILL.md`, type: 'blob', mode: '100644', sha: '3'.repeat(40) },
     { path: `${secondRoot}/skill-report.json`, type: 'blob', mode: '100644', sha: '4'.repeat(40) },
   );
-  value.reports.push({ path: `${secondRoot}/skill-report.json`, sha: '4'.repeat(40) });
+  value.reports.push({
+    path: `${secondRoot}/skill-report.json`,
+    sha: '4'.repeat(40),
+    securityAudit: { is_blocked: false, safe_to_publish: true },
+  });
   assert.deepEqual(validateSnapshot(value).roots, [ROOT, secondRoot].sort());
 });
 


### PR DESCRIPTION
Summary:
- decode each exact-head bound skill report before automatic merge
- require is_blocked=false and safe_to_publish=true
- fail closed on unavailable or invalid report JSON

Regression test:
CI=true node --test scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs

This closes the gate that allowed PR #3208 to auto-publish solana-mobile-integration-privy while its bound report remained high risk and safe_to_publish=false. Production data rollback is intentionally separate and evidence-gated.