### PR TITLE
fix(cache): allow bounded withdrawal invalidation

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'warm = verify/fill cache, force = invalidate selected skills first'
+        description: 'warm = verify/fill, force = invalidate then verify, invalidate = remove selected cache entries only'
         required: true
         type: choice
         options:
           - warm
           - force
+          - invalidate
         default: warm
       scope:
         description: 'Warm only an explicit changed or high-traffic Skill set'
@@ -128,8 +129,8 @@ jobs:
             echo "::error::warm_zip must be true or false"
             exit 1
           fi
-          if [ "$MODE" = "force" ] && [ "$WARM_ZIP" = "true" ]; then
-            echo "::error::force mode does not invalidate immutable ZIP artifacts; run ZIP verification separately in warm mode"
+          if [ "$MODE" != "warm" ] && [ "$WARM_ZIP" = "true" ]; then
+            echo "::error::force/invalidate modes do not invalidate immutable ZIP artifacts; run ZIP verification separately in warm mode"
             exit 1
           fi
 
@@ -178,14 +179,17 @@ jobs:
             echo "::error::Warm scope is empty. Supply an explicit changed or high-traffic Skill set."
             exit 1
           fi
-          if [ "$MODE" = "force" ] && [ "$SLUG_COUNT" -gt "$MAX_FORCE_INVALIDATION_SLUGS" ]; then
-            echo "::error::Force invalidation is limited to $MAX_FORCE_INVALIDATION_SLUGS skills per run; resolved $SLUG_COUNT"
+          if [ "$MODE" != "warm" ] && [ "$SLUG_COUNT" -gt "$MAX_FORCE_INVALIDATION_SLUGS" ]; then
+            echo "::error::Invalidation is limited to $MAX_FORCE_INVALIDATION_SLUGS skills per run; resolved $SLUG_COUNT"
             exit 1
           fi
           LOCALE_COUNT=$(grep -c . "$LOCALES_FILE")
-          MINIMUM_REQUESTS=$((2 + SLUG_COUNT * LOCALE_COUNT * 6))
-          if [ "$WARM_ZIP" = "true" ]; then
-            MINIMUM_REQUESTS=$((MINIMUM_REQUESTS + SLUG_COUNT * 3))
+          MINIMUM_REQUESTS=0
+          if [ "$MODE" != "invalidate" ]; then
+            MINIMUM_REQUESTS=$((2 + SLUG_COUNT * LOCALE_COUNT * 6))
+            if [ "$WARM_ZIP" = "true" ]; then
+              MINIMUM_REQUESTS=$((MINIMUM_REQUESTS + SLUG_COUNT * 3))
+            fi
           fi
           if [ "$MINIMUM_REQUESTS" -gt "$REQUEST_BUDGET" ]; then
             echo "::error::Resolved scope needs at least $MINIMUM_REQUESTS requests for complete cache verification, above request_budget=$REQUEST_BUDGET"
@@ -198,7 +202,7 @@ jobs:
           echo "locales=$RESOLVED_LOCALES" >> "$GITHUB_OUTPUT"
 
       - name: Invalidate selected skill caches
-        if: inputs.mode == 'force'
+        if: inputs.mode != 'warm'
         uses: ./.github/actions/invalidate-cache
         with:
           type: skills
@@ -206,11 +210,12 @@ jobs:
           secret: ${{ secrets.CACHE_INVALIDATE_SECRET }}
           batch-size: ${{ env.INVALIDATE_BATCH_SIZE }}
           concurrency: '1'
-          invalidate-artifacts: 'false'
-          invalidate-dependent-packs: 'false'
+          invalidate-artifacts: ${{ inputs.mode == 'invalidate' }}
+          invalidate-dependent-packs: ${{ inputs.mode == 'invalidate' }}
           fail-on-error: 'true'
 
       - name: Warm and verify API, HTML, and optional ZIP caches
+        if: inputs.mode != 'invalidate'
         env:
           SLUGS_FILE: ${{ steps.scope.outputs.slugs_file }}
           REQUEST_BUDGET: ${{ inputs.request_budget }}
@@ -253,7 +258,7 @@ jobs:
           node scripts/warm-skill-cache.mjs "${args[@]}"
 
       - name: Upload warm verification evidence
-        if: always()
+        if: always() && inputs.mode != 'invalidate'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: warm-cache-verification-${{ github.run_id }}

--- a/scripts/tests/warm-skill-cache.test.mjs
+++ b/scripts/tests/warm-skill-cache.test.mjs
@@ -1152,7 +1152,10 @@ test('workflow checks out scripts, requires bounded skill scope, and has no reti
   assert.match(workflow, /CACHE_VERSION_HEADER: x-kv-version/);
   assert.match(workflow, /Warm scope is empty/);
   assert.match(workflow, /Resolved scope needs at least \$MINIMUM_REQUESTS requests/);
-  assert.match(workflow, /batch-size: \$\{\{ env\.INVALIDATE_BATCH_SIZE \}\}[\s\S]*concurrency: '1'[\s\S]*invalidate-artifacts: 'false'[\s\S]*invalidate-dependent-packs: 'false'/);
+  assert.match(workflow, /- invalidate/);
+  assert.match(workflow, /Invalidate selected skill caches\n\s+if: inputs\.mode != 'warm'/);
+  assert.match(workflow, /Warm and verify API, HTML, and optional ZIP caches\n\s+if: inputs\.mode != 'invalidate'/);
+  assert.match(workflow, /batch-size: \$\{\{ env\.INVALIDATE_BATCH_SIZE \}\}[\s\S]*concurrency: '1'[\s\S]*invalidate-artifacts: \$\{\{ inputs\.mode == 'invalidate' \}\}[\s\S]*invalidate-dependent-packs: \$\{\{ inputs\.mode == 'invalidate' \}\}/);
   assert.match(workflow, /node scripts\/warm-skill-cache\.mjs/);
   assert.doesNotMatch(workflow, /Warm workflows cache|Warm releases cache|type=skills/);
   assert.doesNotMatch(invalidateAction, /packs\/workflows/);
@@ -1203,7 +1206,7 @@ test('workflow rejects oversized and underbudget force invalidation before the i
       INPUT_SLUGS: Array.from({ length: 26 }, (_, index) => `skill-${index + 1}`).join('\n'),
     });
     assert.equal(oversized.status, 1);
-    assert.match(`${oversized.stdout}\n${oversized.stderr}`, /Force invalidation is limited to 25 skills per run; resolved 26/);
+    assert.match(`${oversized.stdout}\n${oversized.stderr}`, /Invalidation is limited to 25 skills per run; resolved 26/);
 
     const underbudget = runScope({
       INPUT_SLUGS: Array.from({ length: 22 }, (_, index) => `skill-${index + 1}`).join('\n'),
@@ -1215,6 +1218,13 @@ test('workflow rejects oversized and underbudget force invalidation before the i
       INPUT_SLUGS: Array.from({ length: 21 }, (_, index) => `skill-${index + 1}`).join('\n'),
     });
     assert.equal(exactBudget.status, 0, `${exactBudget.stdout}\n${exactBudget.stderr}`);
+
+    const invalidateOnly = runScope({
+      MODE: 'invalidate',
+      INPUT_SLUGS: Array.from({ length: 25 }, (_, index) => `skill-${index + 1}`).join('\n'),
+      REQUEST_BUDGET: '1',
+    });
+    assert.equal(invalidateOnly.status, 0, `${invalidateOnly.stdout}\n${invalidateOnly.stderr}`);
 
     const expandedByteBudget = runScope({ BYTE_BUDGET: '33554432' });
     assert.equal(expandedByteBudget.status, 0, `${expandedByteBudget.stdout}\n${expandedByteBudget.stderr}`);
@@ -1228,7 +1238,7 @@ test('workflow rejects oversized and underbudget force invalidation before the i
 
     const forceZip = runScope({ WARM_ZIP: 'true' });
     assert.equal(forceZip.status, 1);
-    assert.match(`${forceZip.stdout}\n${forceZip.stderr}`, /force mode does not invalidate immutable ZIP artifacts/);
+    assert.match(`${forceZip.stdout}\n${forceZip.stderr}`, /force\/invalidate modes do not invalidate immutable ZIP artifacts/);
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add an explicit invalidate-only mode to the existing bounded cache workflow
- keep force semantics unchanged while removing exact API/page, artifact, and dependent Pack cache entries for withdrawn Skills
- skip warm verification because a withdrawn Skill must become unavailable

## Safety
- exact slug scope remains required and invalidation remains capped at 25 Skills
- existing cache secret, response-contract validation, list-generation bump, and fail-on-error behavior are reused
- no Skillstore product code or global public-eligibility mode changes

## Tests
- `CI=true node --test scripts/tests/workflow-action-pin-policy.test.mjs scripts/tests/warm-skill-cache.test.mjs` (64/64)