### PR TITLE
fix: remove deprecated risk gates from trusted auto-merge

### DIFF
--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -263,8 +263,6 @@ export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
       && report.sha === reportFile?.sha
       && report.sha === reportTreeEntry?.sha,
     'skill report is not bound to the exact PR head');
-    block(report?.securityAudit?.is_blocked === false, `${reportPath} is blocked from automatic publication`);
-    block(report?.securityAudit?.safe_to_publish === true, `${reportPath} is not safe for automatic publication`);
   }
 
   block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
@@ -577,16 +575,9 @@ export class GitHubApi {
     const reports = await Promise.all(roots.map(async (root) => {
       const reportPath = `${root}/skill-report.json`;
       const reportBlob = await this.request(`/contents/${encodeContentPath(reportPath)}?ref=${encodeURIComponent(headSha)}`);
-      block(reportBlob?.type === 'file' && validSha(reportBlob.sha)
-        && reportBlob.encoding === 'base64' && typeof reportBlob.content === 'string',
-      `exact-head skill report is unavailable: ${reportPath}`);
-      let report;
-      try {
-        report = JSON.parse(Buffer.from(reportBlob.content, 'base64').toString('utf8'));
-      } catch {
-        throw new AutoMergeBlockedError(`exact-head skill report is invalid JSON: ${reportPath}`);
-      }
-      return { path: reportPath, sha: reportBlob.sha, securityAudit: report?.security_audit };
+      block(reportBlob?.type === 'file' && validSha(reportBlob.sha),
+        `exact-head skill report is unavailable: ${reportPath}`);
+      return { path: reportPath, sha: reportBlob.sha };
     }));
     const baseSha = pr.base?.sha;
     block(validSha(baseSha), 'PR base SHA is invalid');

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -249,14 +249,16 @@ test('fails closed on incomplete files, unsafe tree entries, truncation and ambi
   for (const [build, pattern] of cases) expectBlocked(build(), pattern);
 });
 
-test('fails closed when an exact-head report is blocked or unsafe to publish', () => {
-  for (const [securityAudit, pattern] of [
-    [{ is_blocked: true, safe_to_publish: false }, /blocked from automatic publication/],
-    [{ is_blocked: false, safe_to_publish: false }, /not safe for automatic publication/],
+test('does not use security-report risk fields as automatic merge gates', () => {
+  for (const securityAudit of [
+    { is_blocked: true, safe_to_publish: false, risk_level: 'critical' },
+    { is_blocked: false, safe_to_publish: false, risk_level: 'medium' },
+    {},
+    undefined,
   ]) {
     const value = snapshot();
     value.reports[0].securityAudit = securityAudit;
-    expectBlocked(value, pattern);
+    assert.equal(validateSnapshot(value).eligible, true);
   }
 });
 


### PR DESCRIPTION
## Summary
- stop treating security-report `is_blocked`, `safe_to_publish`, and `risk_level` as trusted auto-merge gates
- retain exact-head report file/SHA binding and all required CI/status checks
- remove report-content parsing from the executor path because it is not a routing input

## Evidence
- `CI=true node --test scripts/tests/auto-merge-trusted-skill-pr.test.mjs` (29 passed)
- `CI=true node --test scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs` (5 passed)
- `git diff --check` passed

## Scope
This PR changes only the default-branch executor script and its tests. It does not merge or deploy itself.