### PR TITLE
Fix trusted auto-merge recovery and effect reconciliation

### DIFF
--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -12,7 +12,7 @@ permissions:
   checks: read
   contents: write
   pull-requests: write
-  statuses: read
+  statuses: write
 
 concurrency:
   group: trusted-skill-auto-merge-${{ github.repository }}

--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -6,7 +6,6 @@ on:
     types: [completed]
   schedule:
     - cron: "*/5 * * * *"
-  workflow_dispatch:
 
 permissions:
   actions: write
@@ -21,7 +20,7 @@ concurrency:
 
 jobs:
   auto-merge:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request'
+    if: github.event_name == 'schedule' || github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -56,5 +55,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          RECOVERY_SWEEP: ${{ github.event_name != 'workflow_run' }}
+          RECOVERY_SWEEP: ${{ github.event_name == 'schedule' }}
         run: node scripts/auto-merge-trusted-skill-pr.mjs

--- a/.github/workflows/auto-merge-trusted-skill-pr.yml
+++ b/.github/workflows/auto-merge-trusted-skill-pr.yml
@@ -4,6 +4,9 @@ on:
   workflow_run:
     workflows: ["Validate Marketplace"]
     types: [completed]
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
 
 permissions:
   actions: write
@@ -18,7 +21,7 @@ concurrency:
 
 jobs:
   auto-merge:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -53,4 +56,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RECOVERY_SWEEP: ${{ github.event_name != 'workflow_run' }}
         run: node scripts/auto-merge-trusted-skill-pr.mjs

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -1,5 +1,5 @@
 name: On PR Merge - Approve Skill
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Publication {0}', inputs.correlation_id) || format('Publish merged PR #{0}', github.event.pull_request.number) }}
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Publication {0}', inputs.correlation_id) || format('Publish merged PR #{0}', github.event.pull_request.number) }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -18,6 +18,10 @@ permissions:
   pull-requests: read
   statuses: write
 
+concurrency:
+  group: publication-${{ inputs.correlation_id }}
+  cancel-in-progress: false
+
 jobs:
   approve-skill:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
@@ -78,7 +82,8 @@ jobs:
             echo "merged_by=$MERGED_BY"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Record durable publication reservation
+      - name: Verify durable publication dispatch claim
+        id: publication_claim
         env:
           GH_TOKEN: ${{ github.token }}
           CORRELATION_ID: ${{ inputs.correlation_id }}
@@ -86,11 +91,26 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          CONTEXT="agentcrew/publication/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          DIGEST=$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')
+          CLAIM_REF="tags/agentcrew-dispatch-claims/publication/$DIGEST"
+          CONTEXT="agentcrew/publication/$DIGEST"
+          CLAIM=$(gh api "repos/$REPOSITORY/git/ref/$CLAIM_REF")
+          jq -e --arg ref "refs/$CLAIM_REF" --arg merge_sha "$MERGE_COMMIT_SHA" '
+            .ref == $ref and .object.type == "commit" and .object.sha == $merge_sha
+          ' <<< "$CLAIM" >/dev/null || {
+            echo "::error::Durable publication dispatch claim does not bind the exact merge commit"
+            exit 1
+          }
+          STATUSES=$(gh api --paginate "repos/$REPOSITORY/commits/$MERGE_COMMIT_SHA/statuses?per_page=100" | jq -s 'add')
+          if jq -e --arg context "$CONTEXT" 'any(.[]; .context == $context)' <<< "$STATUSES" >/dev/null; then
+            echo "::error::Existing durable publication status refuses duplicate execution"
+            exit 1
+          fi
           gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
             -f state=pending -f context="$CONTEXT" \
             -f description='Correlated publication is running' \
             -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
+          echo "owns_reservation=true" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -422,7 +442,7 @@ jobs:
             -d "$PAYLOAD"
 
       - name: Record durable publication result
-        if: always() && steps.freeze_pr.outputs.merge_commit_sha != ''
+        if: always() && steps.publication_claim.outputs.owns_reservation == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           CORRELATION_ID: ${{ inputs.correlation_id }}

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -39,14 +39,14 @@ jobs:
             exit 1
           }
           PR=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
-          jq -e --arg repository "$REPOSITORY" '
+          jq -e --arg repository "$REPOSITORY" --arg event_name "$EVENT_NAME" '
             .merged == true and
             .base.ref == "main" and
             .user.id == 254047988 and
             .user.login == "ai-skill-store[bot]" and
             .head.repo.full_name == $repository and
             (.head.ref | startswith("submission/")) and
-            any(.labels[]; .name == "pending-review")
+            ($event_name == "workflow_dispatch" or any(.labels[]; .name == "pending-review"))
           ' <<< "$PR" >/dev/null || {
             echo "::error::Merged pending-review PR does not have trusted submission provenance"
             exit 1

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -1,4 +1,5 @@
 name: On PR Merge - Approve Skill
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Publication {0}', inputs.correlation_id) || format('Publish merged PR #{0}', github.event.pull_request.number) }}
 
 on:
   pull_request:
@@ -8,6 +9,10 @@ on:
     inputs:
       pr_number:
         description: Exact merged submission PR to recover
+        required: true
+        type: string
+      correlation_id:
+        description: Exact idempotency correlation bound to the merged PR identity
         required: true
         type: string
 
@@ -24,6 +29,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          CORRELATION_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.correlation_id || '' }}
+          EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -46,12 +53,21 @@ jobs:
           }
 
           MERGE_COMMIT_SHA=$(jq -er '.merge_commit_sha' <<< "$PR")
+          HEAD_SHA=$(jq -er '.head.sha' <<< "$PR")
           PR_URL=$(jq -er '.html_url' <<< "$PR")
           MERGED_BY=$(jq -er '.merged_by.login' <<< "$PR")
           SUBMISSION_ID=$(jq -r '.body // ""' <<< "$PR" \
             | grep -oE 'Submission ID.*`[0-9a-f-]{36}`' \
             | grep -oE '[0-9a-f-]{36}' || true)
           [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            EXPECTED_CORRELATION_ID="submission-pr-${PR_NUMBER}-${HEAD_SHA}-${MERGE_COMMIT_SHA}"
+            [ "$CORRELATION_ID" = "$EXPECTED_CORRELATION_ID" ] || {
+              echo "::error::Publication correlation does not match the authoritative merged PR identity"
+              exit 1
+            }
+          fi
           [ "$PR_URL" = "https://github.com/$REPOSITORY/pull/$PR_NUMBER" ]
           [[ "$MERGED_BY" =~ ^([A-Za-z0-9-]+|github-actions\[bot\])$ ]]
           {

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -2,9 +2,6 @@ name: On PR Merge - Approve Skill
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('Publication {0}', inputs.correlation_id) || format('Publish merged PR #{0}', github.event.pull_request.number) }}
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -16,11 +13,14 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   approve-skill:
-    if: >-
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-      (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pending-review'))
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
@@ -28,8 +28,8 @@ jobs:
         id: freeze_pr
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
-          CORRELATION_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.correlation_id || '' }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
           EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -77,6 +77,20 @@ jobs:
             echo "pr_url=$PR_URL"
             echo "merged_by=$MERGED_BY"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Record durable publication reservation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          CONTEXT="agentcrew/publication/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state=pending -f context="$CONTEXT" \
+            -f description='Correlated publication is running' \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -406,3 +420,24 @@ jobs:
             -H "User-Agent: GitHub-Actions/SkillstoreBot" \
             -H "X-Skillstore-Callback: true" \
             -d "$PAYLOAD"
+
+      - name: Record durable publication result
+        if: always() && steps.freeze_pr.outputs.merge_commit_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
+          REPOSITORY: ${{ github.repository }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          STATE=failure
+          DESCRIPTION='Correlated publication failed; inspection required'
+          if [ "$JOB_STATUS" = success ]; then
+            STATE=pending
+            DESCRIPTION='Publication completed; awaiting provider sync'
+          fi
+          CONTEXT="agentcrew/publication/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state="$STATE" -f context="$CONTEXT" -f description="$DESCRIPTION" \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -188,27 +188,39 @@ jobs:
 
           mapfile -t EXPECTED_SLUGS < <(tr ', ' '\n\n' <<< "$INPUT_SLUGS" | sed '/^$/d' | LC_ALL=C sort -u)
           mapfile -t CHANGED_FILES < <(gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+          TREE=$(gh api "repos/$REPOSITORY/git/trees/$HEAD_SHA?recursive=1")
+          jq -e '.truncated == false and (.tree | type == "array")' <<< "$TREE" >/dev/null
+          mapfile -t CANDIDATE_ROOTS < <(jq -r '
+            [.tree[] | select(.type == "blob") | .path] as $blobs
+            | $blobs[]
+            | select(endswith("/skill-report.json"))
+            | sub("/skill-report.json$"; "")
+            | select((split("/") | length) == 2 or (split("/") | length) == 3)
+            | select(split("/")[1:] | all(test("^[A-Za-z0-9][A-Za-z0-9._-]*$")))
+            | select(. as $root | $blobs | index($root + "/SKILL.md"))
+          ' <<< "$TREE" | LC_ALL=C sort -u)
           [ "${#EXPECTED_SLUGS[@]}" -gt 0 ] && [ "${#EXPECTED_SLUGS[@]}" -le 25 ]
+          ACTUAL_ROOTS=()
           for file in "${CHANGED_FILES[@]}"; do
-            matched=false
-            for slug in "${EXPECTED_SLUGS[@]}"; do
-              if [[ "$file" == "skills/$slug" || "$file" == "skills/$slug/"* ]]; then matched=true; break; fi
+            matched_root=''
+            for root in "${CANDIDATE_ROOTS[@]}"; do
+              if [[ "$file" == "$root" || "$file" == "$root/"* ]] \
+                && [ "${#root}" -gt "${#matched_root}" ]; then
+                matched_root="$root"
+              fi
             done
-            [ "$matched" = true ] || {
-              echo "::error::Changed file is outside correlated provider sync roots: $file"
+            [ -n "$matched_root" ] || {
+              echo "::error::Changed file is outside an exact canonical provider sync root: $file"
               exit 1
             }
+            ACTUAL_ROOTS+=("${matched_root#skills/}")
           done
-          for slug in "${EXPECTED_SLUGS[@]}"; do
-            found=false
-            for file in "${CHANGED_FILES[@]}"; do
-              if [[ "$file" == "skills/$slug" || "$file" == "skills/$slug/"* ]]; then found=true; break; fi
-            done
-            [ "$found" = true ] || {
-              echo "::error::Correlated provider sync root is not changed by the merged PR: $slug"
+          mapfile -t ACTUAL_SLUGS < <(printf '%s\n' "${ACTUAL_ROOTS[@]}" | LC_ALL=C sort -u)
+          [ "${#ACTUAL_SLUGS[@]}" -eq "${#EXPECTED_SLUGS[@]}" ] \
+            && diff -u <(printf '%s\n' "${EXPECTED_SLUGS[@]}") <(printf '%s\n' "${ACTUAL_SLUGS[@]}") || {
+              echo "::error::Correlated provider sync roots do not exactly match the merged PR"
               exit 1
             }
-          done
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -29,12 +29,21 @@ on:
         type: string
         default: ''
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  statuses: write
+
 concurrency:
   group: sync-supabase
   cancel-in-progress: false
 
 jobs:
   sync:
+    if: >-
+      (github.event_name != 'push' || !contains(github.event.head_commit.message || '', 'AgentCrew-Recovery:')) &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: self-hosted
     timeout-minutes: 240
     outputs:
@@ -152,13 +161,14 @@ jobs:
             echo "::error::A correlated provider sync must be dispatched on main"
             exit 1
           fi
-          if ! [[ "$CORRELATION_ID" =~ ^source-monitor-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$ ]]; then
+          if ! [[ "$CORRELATION_ID" =~ ^source-monitor-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})-([0-9a-f]{64})$ ]]; then
             echo "::error::Invalid provider sync correlation"
             exit 1
           fi
           PR_NUMBER="${BASH_REMATCH[1]}"
           HEAD_SHA="${BASH_REMATCH[2]}"
           CORRELATED_MERGE_SHA="${BASH_REMATCH[3]}"
+          CORRELATED_ROOTS_DIGEST="${BASH_REMATCH[4]}"
           if [ "$MERGE_COMMIT_SHA" != "$CORRELATED_MERGE_SHA" ] || [ -z "$INPUT_SLUGS" ]; then
             echo "::error::A correlated provider sync requires exact merge identity and Skill slugs"
             exit 1
@@ -221,6 +231,28 @@ jobs:
               echo "::error::Correlated provider sync roots do not exactly match the merged PR"
               exit 1
             }
+          ROOTS_CANONICAL=$(IFS=$'\n'; printf '%s' "${ACTUAL_SLUGS[*]}")
+          ROOTS_DIGEST=$(printf '%s' "$ROOTS_CANONICAL" | sha256sum | awk '{print $1}')
+          [ "$ROOTS_DIGEST" = "$CORRELATED_ROOTS_DIGEST" ] \
+            && [ "$CORRELATION_ID" = "source-monitor-pr-${PR_NUMBER}-${HEAD_SHA}-${MERGE_COMMIT_SHA}-${ROOTS_DIGEST}" ] || {
+            echo "::error::Provider sync correlation is not bound to the exact canonical root set"
+            exit 1
+          }
+
+      - name: Record durable provider sync reservation
+        if: inputs.correlation_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          MERGE_COMMIT_SHA: ${{ inputs.merge_commit_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          CONTEXT="agentcrew/provider-sync/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state=pending -f context="$CONTEXT" \
+            -f description='Correlated provider sync is running' \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -915,6 +947,41 @@ jobs:
           name: synced-slugs
           path: synced-slugs.txt
           retention-days: 30
+
+      - name: Record durable correlated sync result
+        if: >-
+          always() &&
+          ((inputs.correlation_id != '' && inputs.merge_commit_sha != '') ||
+           (github.event_name == 'workflow_run' && startsWith(github.event.workflow_run.display_title, 'Publication submission-pr-')))
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_CORRELATION_ID: ${{ inputs.correlation_id }}
+          INPUT_MERGE_COMMIT_SHA: ${{ inputs.merge_commit_sha }}
+          UPSTREAM_TITLE: ${{ github.event.workflow_run.display_title }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          CORRELATION_ID="$INPUT_CORRELATION_ID"
+          MERGE_COMMIT_SHA="$INPUT_MERGE_COMMIT_SHA"
+          CONTEXT_PREFIX='agentcrew/provider-sync'
+          if [ "$EVENT_NAME" = workflow_run ]; then
+            CORRELATION_ID="${UPSTREAM_TITLE#Publication }"
+            [[ "$CORRELATION_ID" =~ ^submission-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$ ]]
+            MERGE_COMMIT_SHA="${BASH_REMATCH[3]}"
+            CONTEXT_PREFIX='agentcrew/publication'
+          fi
+          STATE=failure
+          DESCRIPTION='Correlated provider sync failed; inspection required'
+          if [ "$JOB_STATUS" = success ]; then
+            STATE=success
+            DESCRIPTION='Correlated provider sync completed'
+          fi
+          CONTEXT="$CONTEXT_PREFIX/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state="$STATE" -f context="$CONTEXT" -f description="$DESCRIPTION" \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
 
   # ============================================================
   # CALCULATE QUALITY SCORES

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -73,6 +73,7 @@ jobs:
           /scripts/resolve-manual-skills.mjs
           /scripts/detect-changed-skills.mjs
           /scripts/materialize-changed-skills.mjs
+          /scripts/validate-correlated-sync-roots.mjs
           /scripts/refresh-security-research-stats.sh
           /.github/actions/download-skillstore-cli/
           EOF
@@ -124,6 +125,7 @@ jobs:
             scripts/resolve-manual-skills.mjs \
             scripts/detect-changed-skills.mjs \
             scripts/materialize-changed-skills.mjs \
+            scripts/validate-correlated-sync-roots.mjs \
             scripts/refresh-security-research-stats.sh \
             .github/actions/download-skillstore-cli/action.yml; do
             if git ls-files -v -- "$required_path" | awk '$1 ~ /^S/ { found=1 } END { exit !found }'; then
@@ -143,6 +145,7 @@ jobs:
           done
 
       - name: Validate trusted sync correlation
+        id: trusted-correlation
         env:
           CORRELATION_ID: ${{ inputs.correlation_id }}
           INPUT_SLUGS: ${{ inputs.slugs }}
@@ -155,6 +158,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$CORRELATION_ID" ]; then
+            echo "sync_commit_sha=$CURRENT_MAIN_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$EVENT_NAME" != 'workflow_dispatch' ] || [ "$GIT_REF" != 'refs/heads/main' ]; then
@@ -238,8 +242,14 @@ jobs:
             echo "::error::Provider sync correlation is not bound to the exact canonical root set"
             exit 1
           }
+          node ./scripts/validate-correlated-sync-roots.mjs \
+            --merge "$MERGE_COMMIT_SHA" \
+            --current "$CURRENT_MAIN_SHA" \
+            --slugs "${ACTUAL_SLUGS[*]}"
+          echo "sync_commit_sha=$MERGE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Record durable provider sync reservation
+      - name: Verify durable provider sync dispatch claim
+        id: provider_sync_claim
         if: inputs.correlation_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -248,11 +258,26 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          CONTEXT="agentcrew/provider-sync/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
+          DIGEST=$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')
+          CLAIM_REF="tags/agentcrew-dispatch-claims/provider-sync/$DIGEST"
+          CONTEXT="agentcrew/provider-sync/$DIGEST"
+          CLAIM=$(gh api "repos/$REPOSITORY/git/ref/$CLAIM_REF")
+          jq -e --arg ref "refs/$CLAIM_REF" --arg merge_sha "$MERGE_COMMIT_SHA" '
+            .ref == $ref and .object.type == "commit" and .object.sha == $merge_sha
+          ' <<< "$CLAIM" >/dev/null || {
+            echo "::error::Durable provider sync dispatch claim does not bind the exact merge commit"
+            exit 1
+          }
+          STATUSES=$(gh api --paginate "repos/$REPOSITORY/commits/$MERGE_COMMIT_SHA/statuses?per_page=100" | jq -s 'add')
+          if jq -e --arg context "$CONTEXT" 'any(.[]; .context == $context)' <<< "$STATUSES" >/dev/null; then
+            echo "::error::Existing durable provider sync status refuses duplicate execution"
+            exit 1
+          fi
           gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
             -f state=pending -f context="$CONTEXT" \
             -f description='Correlated provider sync is running' \
             -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
+          echo "owns_reservation=true" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -296,6 +321,7 @@ jobs:
           BASE_SHA: ${{ steps.last_sync.outputs.base_sha }}
           BASE_RUN_CREATED_AT: ${{ steps.last_sync.outputs.base_run_created_at }}
           HEAD_SHA: ${{ github.sha }}
+          SYNC_COMMIT_SHA: ${{ steps.trusted-correlation.outputs.sync_commit_sha }}
           INPUT_SLUGS: ${{ inputs.slugs }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -305,7 +331,7 @@ jobs:
             # Resolve against the immutable workflow commit. A mutable self-hosted
             # checkout may not have a skills/ directory at all.
             CHANGED=$(node ./scripts/resolve-manual-skills.mjs \
-              --commit "$HEAD_SHA" \
+              --commit "$SYNC_COMMIT_SHA" \
               --skills "$INPUT_SLUGS")
             echo "Resolved manual skill paths: $CHANGED"
             echo "mode=manual-slugs" >> $GITHUB_OUTPUT
@@ -435,10 +461,11 @@ jobs:
         if: steps.changes.outputs.skip_sync != 'true'
         env:
           CHANGED_SKILLS: ${{ steps.changes.outputs.changed_skills }}
+          SYNC_COMMIT_SHA: ${{ steps.trusted-correlation.outputs.sync_commit_sha }}
         run: |
           set -euo pipefail
           node ./scripts/materialize-changed-skills.mjs \
-            --commit "$GITHUB_SHA" \
+            --commit "$SYNC_COMMIT_SHA" \
             --skills "$CHANGED_SKILLS"
 
       - name: Sync skills to Supabase
@@ -453,6 +480,7 @@ jobs:
           SECURITY_NOTIFICATIONS_ENABLED: ${{ vars.SECURITY_NOTIFICATIONS_ENABLED || 'false' }}
           PUBLIC_SITE_URL: https://skillstore.io
           AUTOMATION_API_KEY: ${{ secrets.SECURITY_ATTESTATION_AUTOMATION_KEY }}
+          SYNC_COMMIT_SHA: ${{ steps.trusted-correlation.outputs.sync_commit_sha }}
         run: |
           echo "Sync mode: $SYNC_MODE"
           echo "Syncing skills: $CHANGED_SKILLS"
@@ -518,7 +546,7 @@ jobs:
               "$GITHUB_WORKSPACE/skillstore-cli" skill sync \
                 --slugs "$paths" \
                 --concurrency "$concurrency" \
-                --marketplace-commit "$GITHUB_SHA" 2>&1 | tee "$output_file"
+                --marketplace-commit "$SYNC_COMMIT_SHA" 2>&1 | tee "$output_file"
             local rc=${PIPESTATUS[0]}
             # Keep errexit disabled until the caller captures rc. Returning a
             # non-zero status with errexit enabled exits before retry handling.
@@ -558,7 +586,22 @@ jobs:
             exit 1
           fi
 
-          printf '%s\n' "$SYNCED_SLUGS" | tr ',' '\n' | sed '/^$/d' | sort -u > synced-slugs.txt
+          printf '%s\n' "$SYNCED_SLUGS" | tr ',' '\n' | sed '/^$/d' | LC_ALL=C sort -u > synced-slugs.txt
+          : > expected-synced-slugs.txt
+          for skill_path in $CHANGED_SKILLS; do
+            report_path="skills/$skill_path/skill-report.json"
+            test -f "$report_path" && test ! -L "$report_path" || {
+              echo "::error::materialized Skill report is missing or unsafe: $report_path"
+              exit 1
+            }
+            jq -er '.meta.slug | select(type == "string" and test("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"))' \
+              "$report_path" >> expected-synced-slugs.txt
+          done
+          LC_ALL=C sort -u -o expected-synced-slugs.txt expected-synced-slugs.txt
+          diff -u expected-synced-slugs.txt synced-slugs.txt || {
+            echo "::error::skillstore-cli reported a different synced slug set than requested"
+            exit 1
+          }
           SYNCED_COUNT=$(wc -l < synced-slugs.txt | tr -d ' ')
           echo "synced_count=$SYNCED_COUNT" >> "$GITHUB_OUTPUT"
           echo "::notice::Synced $SYNCED_COUNT skill(s); slug payload saved to artifact input"
@@ -951,7 +994,7 @@ jobs:
       - name: Record durable correlated sync result
         if: >-
           always() &&
-          ((inputs.correlation_id != '' && inputs.merge_commit_sha != '') ||
+          ((inputs.correlation_id != '' && inputs.merge_commit_sha != '' && steps.provider_sync_claim.outputs.owns_reservation == 'true') ||
            (github.event_name == 'workflow_run' && startsWith(github.event.workflow_run.display_title, 'Publication submission-pr-')))
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -24,6 +24,10 @@ on:
         description: 'Optional exact idempotency correlation for trusted automation'
         type: string
         default: ''
+      merge_commit_sha:
+        description: 'Exact marker-bound merge commit for correlated source-monitor recovery'
+        type: string
+        default: ''
 
 concurrency:
   group: sync-supabase
@@ -133,8 +137,12 @@ jobs:
         env:
           CORRELATION_ID: ${{ inputs.correlation_id }}
           INPUT_SLUGS: ${{ inputs.slugs }}
+          MERGE_COMMIT_SHA: ${{ inputs.merge_commit_sha }}
           EVENT_NAME: ${{ github.event_name }}
           GIT_REF: ${{ github.ref }}
+          CURRENT_MAIN_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ -z "$CORRELATION_ID" ]; then
@@ -144,14 +152,63 @@ jobs:
             echo "::error::A correlated provider sync must be dispatched on main"
             exit 1
           fi
-          if ! [[ "$CORRELATION_ID" =~ ^source-monitor-pr-[1-9][0-9]*-[0-9a-f]{40}$ ]]; then
+          if ! [[ "$CORRELATION_ID" =~ ^source-monitor-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$ ]]; then
             echo "::error::Invalid provider sync correlation"
             exit 1
           fi
-          if [ -z "$INPUT_SLUGS" ]; then
-            echo "::error::A correlated provider sync requires exact Skill slugs"
+          PR_NUMBER="${BASH_REMATCH[1]}"
+          HEAD_SHA="${BASH_REMATCH[2]}"
+          CORRELATED_MERGE_SHA="${BASH_REMATCH[3]}"
+          if [ "$MERGE_COMMIT_SHA" != "$CORRELATED_MERGE_SHA" ] || [ -z "$INPUT_SLUGS" ]; then
+            echo "::error::A correlated provider sync requires exact merge identity and Skill slugs"
             exit 1
           fi
+
+          PR=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
+          jq -e --arg repository "$REPOSITORY" --arg head_sha "$HEAD_SHA" --arg merge_sha "$MERGE_COMMIT_SHA" '
+            .merged == true and
+            .base.ref == "main" and
+            .user.id == 254047988 and
+            .user.login == "ai-skill-store[bot]" and
+            .head.repo.full_name == $repository and
+            (.head.ref | test("^skill-source-monitor/run-[1-9][0-9]*$")) and
+            .head.sha == $head_sha and
+            .merge_commit_sha == $merge_sha
+          ' <<< "$PR" >/dev/null || {
+            echo "::error::Provider sync correlation does not match the authoritative merged source-monitor PR"
+            exit 1
+          }
+          COMPARE=$(gh api "repos/$REPOSITORY/compare/${MERGE_COMMIT_SHA}...${CURRENT_MAIN_SHA}")
+          jq -e --arg merge_sha "$MERGE_COMMIT_SHA" '
+            .merge_base_commit.sha == $merge_sha and (.status == "ahead" or .status == "identical")
+          ' <<< "$COMPARE" >/dev/null || {
+            echo "::error::Correlated merge is not on the current main lineage"
+            exit 1
+          }
+
+          mapfile -t EXPECTED_SLUGS < <(tr ', ' '\n\n' <<< "$INPUT_SLUGS" | sed '/^$/d' | LC_ALL=C sort -u)
+          mapfile -t CHANGED_FILES < <(gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+          [ "${#EXPECTED_SLUGS[@]}" -gt 0 ] && [ "${#EXPECTED_SLUGS[@]}" -le 25 ]
+          for file in "${CHANGED_FILES[@]}"; do
+            matched=false
+            for slug in "${EXPECTED_SLUGS[@]}"; do
+              if [[ "$file" == "skills/$slug" || "$file" == "skills/$slug/"* ]]; then matched=true; break; fi
+            done
+            [ "$matched" = true ] || {
+              echo "::error::Changed file is outside correlated provider sync roots: $file"
+              exit 1
+            }
+          done
+          for slug in "${EXPECTED_SLUGS[@]}"; do
+            found=false
+            for file in "${CHANGED_FILES[@]}"; do
+              if [[ "$file" == "skills/$slug" || "$file" == "skills/$slug/"* ]]; then found=true; break; fi
+            done
+            [ "$found" = true ] || {
+              echo "::error::Correlated provider sync root is not changed by the merged PR: $slug"
+              exit 1
+            }
+          done
 
       - name: Generate GitHub App Token
         id: app-token

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -358,19 +358,27 @@ function definiteMutationRejection(error) {
   return error instanceof GitHubApiError && [405, 409, 422].includes(error.status);
 }
 
-export async function runAutoMerge(api, { workflowRunId }) {
+export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch = false }) {
   const firstSnapshot = await buildStableSnapshot(api, workflowRunId);
   if (firstSnapshot?.pr?.merged === true && firstSnapshot.pr.state === 'closed' && firstSnapshot.pr.head?.sha === firstSnapshot.workflowRun?.head_sha) {
-    if (SOURCE_MONITOR_REF_RE.test(firstSnapshot.pr.head?.ref ?? '')) {
-      const merged = validateSnapshot(firstSnapshot, { allowMerged: true });
-      try {
-        await api.dispatchProviderSync(merged.prNumber, merged.headSha, merged.roots);
-      } catch {
-        throw new AutoMergeUnknownEffectError(`merge is confirmed but provider sync reconciliation is unknown for PR #${merged.prNumber}`);
-      }
-      return { outcome: 'ALREADY_MERGED_AND_PROVIDER_SYNC_CONFIRMED', prNumber: merged.prNumber, headSha: merged.headSha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha, classification: merged.classification };
+    const merged = validateSnapshot(firstSnapshot, { allowMerged: true });
+    let dispatchResult;
+    try {
+      dispatchResult = merged.postMergeAction === 'provider_sync'
+        ? await api.dispatchProviderSync(merged.prNumber, merged.headSha, merged.roots)
+        : await api.dispatchPublication(merged.prNumber, merged.headSha, firstSnapshot.pr.merge_commit_sha);
+    } catch (error) {
+      if (error instanceof AutoMergeBlockedError || error instanceof AutoMergeUnknownEffectError) throw error;
+      const effect = merged.postMergeAction === 'provider_sync' ? 'provider sync' : 'publication';
+      throw new AutoMergeUnknownEffectError(`merge is confirmed but ${effect} reconciliation is unknown for PR #${merged.prNumber}`);
     }
-    return { outcome: 'ALREADY_MERGED', prNumber: firstSnapshot.pr.number, headSha: firstSnapshot.pr.head.sha, mergeCommitSha: firstSnapshot.pr.merge_commit_sha };
+    return {
+      ...dispatchResult,
+      prNumber: merged.prNumber,
+      headSha: merged.headSha,
+      mergeCommitSha: firstSnapshot.pr.merge_commit_sha,
+      classification: merged.classification,
+    };
   }
   const first = validateSnapshot(firstSnapshot);
   const secondSnapshot = await buildStableSnapshot(api, workflowRunId);
@@ -446,20 +454,29 @@ export async function runAutoMerge(api, { workflowRunId }) {
     throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
   }
   if (mergedReadback(readback, second)) {
-    if (second.postMergeAction === 'provider_sync') {
-      try {
-        await api.dispatchProviderSync(second.prNumber, second.headSha, second.roots);
-      } catch {
-        throw new AutoMergeUnknownEffectError(`merge is confirmed but provider sync dispatch is unknown for PR #${second.prNumber}`);
-      }
-      return { outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+    if (deferPostMergeDispatch) {
+      return {
+        outcome: second.postMergeAction === 'provider_sync'
+          ? 'MERGED_AWAITING_PROVIDER_SYNC_RECONCILIATION'
+          : 'MERGED_AWAITING_PUBLICATION_RECONCILIATION',
+        prNumber: second.prNumber,
+        headSha: second.headSha,
+        mergeCommitSha: readback.merge_commit_sha,
+        classification: second.classification,
+      };
     }
     try {
-      await api.dispatchPublication(second.prNumber);
-    } catch {
-      throw new AutoMergeUnknownEffectError(`merge is confirmed but publication recovery dispatch is unknown for PR #${second.prNumber}`);
+      if (second.postMergeAction === 'provider_sync') {
+        await api.dispatchProviderSync(second.prNumber, second.headSha, second.roots);
+        return { outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+      }
+      await api.dispatchPublication(second.prNumber, second.headSha, readback.merge_commit_sha);
+      return { outcome: 'MERGED_AND_PUBLICATION_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
+    } catch (error) {
+      if (error instanceof AutoMergeBlockedError || error instanceof AutoMergeUnknownEffectError) throw error;
+      const effect = second.postMergeAction === 'provider_sync' ? 'provider sync' : 'publication';
+      throw new AutoMergeUnknownEffectError(`merge is confirmed but ${effect} dispatch is unknown for PR #${second.prNumber}`);
     }
-    return { outcome: 'MERGED_AND_PUBLICATION_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
   }
   if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`merge rejected with HTTP ${mutationError.status}`);
   throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
@@ -469,6 +486,7 @@ export async function runRecoverySweep(api) {
   const candidates = await api.listRecoveryCandidates();
   for (const candidate of candidates) {
     if (candidate.workflowRunId == null) {
+      if (candidate.phase === 'MERGED') continue;
       return {
         outcome: 'WAITING_CI',
         prNumber: candidate.prNumber,
@@ -477,8 +495,11 @@ export async function runRecoverySweep(api) {
       };
     }
     try {
-      const result = await runAutoMerge(api, { workflowRunId: candidate.workflowRunId });
-      if (result.outcome === 'ALREADY_MERGED') continue;
+      const result = await runAutoMerge(api, {
+        workflowRunId: candidate.workflowRunId,
+        deferPostMergeDispatch: true,
+      });
+      if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
       return result;
     } catch (error) {
       if (error instanceof AutoMergeSkippedError) continue;
@@ -503,8 +524,9 @@ function trustedRecoverySeed(pr, repository) {
   const sourceMonitor = SOURCE_MONITOR_REF_RE.test(pr?.head?.ref ?? '')
     && labels.has('skill-source-monitor')
     && !labels.has('pending-review');
-  return pr?.state === 'open'
-    && pr.draft === false
+  const lifecycle = (pr?.state === 'open' && pr.draft === false && pr.merged_at == null)
+    || (pr?.state === 'closed' && pr.draft === false && typeof pr.merged_at === 'string' && validSha(pr.merge_commit_sha));
+  return lifecycle
     && pr.base?.ref === 'main'
     && sameRepository(pr.base?.repo, repository)
     && sameRepository(pr.head?.repo, repository)
@@ -604,14 +626,31 @@ export class GitHubApi {
   async listRecoveryCandidates() {
     const repository = await this.request('');
     block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
-    const pulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
+    const [openPulls, recentClosedPulls] = await Promise.all([
+      this.paginate('/pulls?state=open&base=main&sort=created&direction=asc'),
+      this.request('/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100&page=1'),
+    ]);
+    block(Array.isArray(recentClosedPulls), 'recent merged PR evidence is unavailable');
+    const mergedSeeds = [];
+    for (const pr of recentClosedPulls) {
+      if (!trustedRecoverySeed(pr, repository) || pr.state !== 'closed') continue;
+      const mergeCommit = await this.readCommit(pr.merge_commit_sha);
+      const marker = `Trusted auto-merge PR #${pr.number}\n\nAgentCrew-Recovery: ${pr.number}:${pr.head.sha}`;
+      if (mergeCommit?.commit?.message === marker) mergedSeeds.push(pr);
+    }
+    mergedSeeds.sort((left, right) => String(left.merged_at).localeCompare(String(right.merged_at)) || left.number - right.number);
+    const openSeeds = openPulls.filter((pr) => trustedRecoverySeed(pr, repository) && pr.state === 'open');
     const candidates = [];
-    for (const pr of pulls) {
-      if (!trustedRecoverySeed(pr, repository)) continue;
+    for (const pr of [...mergedSeeds, ...openSeeds]) {
       const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
       const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
       block(runIds.length <= 1, `PR #${pr.number} has ambiguous exact-head validation runs`);
-      candidates.push({ prNumber: pr.number, headSha: pr.head.sha, workflowRunId: runIds[0] ?? null });
+      candidates.push({
+        prNumber: pr.number,
+        headSha: pr.head.sha,
+        workflowRunId: runIds[0] ?? null,
+        phase: pr.state === 'closed' ? 'MERGED' : 'OPEN',
+      });
     }
     return candidates;
   }
@@ -754,14 +793,56 @@ export class GitHubApi {
   }
 
   async merge(number, headSha, method) {
-    return this.request(`/pulls/${number}/merge`, { method: 'PUT', body: { sha: headSha, merge_method: method } });
+    return this.request(`/pulls/${number}/merge`, {
+      method: 'PUT',
+      body: {
+        sha: headSha,
+        merge_method: method,
+        commit_title: `Trusted auto-merge PR #${number}`,
+        commit_message: `AgentCrew-Recovery: ${number}:${headSha}`,
+      },
+    });
   }
 
-  async dispatchPublication(number) {
-    return this.request('/actions/workflows/on-pr-merge.yml/dispatches', {
-      method: 'POST',
-      body: { ref: 'main', inputs: { pr_number: String(number) } },
-    });
+  async findPublicationRun(correlationTitle) {
+    for (let page = 1; page <= 30; page += 1) {
+      const result = await this.request(`/actions/workflows/on-pr-merge.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
+      block(Array.isArray(result?.workflow_runs), 'publication workflow run evidence is invalid');
+      const match = result.workflow_runs.find((run) => run?.display_title === correlationTitle
+        && run?.event === 'workflow_dispatch'
+        && run?.head_branch === 'main'
+        && run?.head_repository?.full_name === this.repository);
+      if (match) return match;
+      if (result.workflow_runs.length < 100) return undefined;
+    }
+    throw new AutoMergeBlockedError('publication workflow run search exceeded the bounded limit');
+  }
+
+  async dispatchPublication(prNumber, headSha, mergeCommitSha) {
+    block(Number.isSafeInteger(prNumber) && prNumber > 0, 'publication PR number is invalid');
+    block(validSha(headSha), 'publication head SHA is invalid');
+    block(validSha(mergeCommitSha), 'publication merge commit SHA is invalid');
+    const correlationId = `submission-pr-${prNumber}-${headSha}-${mergeCommitSha}`;
+    const correlationTitle = `Publication ${correlationId}`;
+    const existing = await this.findPublicationRun(correlationTitle);
+    if (existing) return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing.id };
+
+    let mutationError;
+    try {
+      await this.request('/actions/workflows/on-pr-merge.yml/dispatches', {
+        method: 'POST',
+        body: { ref: 'main', inputs: { pr_number: String(prNumber), correlation_id: correlationId } },
+      });
+    } catch (error) {
+      mutationError = error;
+    }
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      const run = await this.findPublicationRun(correlationTitle);
+      if (run) return { outcome: 'PUBLICATION_DISPATCH_CONFIRMED', workflowRunId: run.id };
+      if (attempt < 11) await this.sleep(5_000);
+    }
+    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`publication dispatch rejected with HTTP ${mutationError.status}`);
+    throw new AutoMergeUnknownEffectError(`publication dispatch effect is unknown for PR #${prNumber}`);
   }
 
   async findProviderSyncRun(correlationTitle) {

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -90,6 +90,27 @@ function rootSetDigest(slugs) {
   return createHash('sha256').update([...new Set(slugs)].sort().join('\n')).digest('hex');
 }
 
+function dispatchClaim(kind, correlationId) {
+  block(['publication', 'provider-sync'].includes(kind), 'dispatch claim kind is invalid');
+  block(typeof correlationId === 'string' && correlationId.length > 0, 'dispatch claim correlation is invalid');
+  const digest = rootSetDigest([correlationId]);
+  const name = `agentcrew-dispatch-claims/${kind}/${digest}`;
+  return { fullRef: `refs/tags/${name}`, apiRef: `tags/${name}` };
+}
+
+export function resolveWorkflowPrNumber(payloadPrs, exactAssociatedPrs) {
+  block(Array.isArray(payloadPrs) && Array.isArray(exactAssociatedPrs), 'workflow PR evidence is invalid');
+  const payloadNumbers = payloadPrs.map((candidate) => candidate?.number);
+  block(payloadNumbers.every((number) => Number.isSafeInteger(number) && number > 0), 'workflow payload PR evidence is invalid');
+  const uniquePayloadNumbers = [...new Set(payloadNumbers)];
+  block(uniquePayloadNumbers.length <= 1, 'workflow run must resolve exactly one PR from the exact head');
+  if (uniquePayloadNumbers.length === 1) return uniquePayloadNumbers[0];
+  const associatedNumbers = [...new Set(exactAssociatedPrs.map((candidate) => candidate?.number))];
+  block(associatedNumbers.length === 1 && Number.isSafeInteger(associatedNumbers[0]) && associatedNumbers[0] > 0,
+    'workflow run must resolve exactly one PR from the exact head');
+  return associatedNumbers[0];
+}
+
 function publishedRootSyntax(root) {
   if (!safePath(root)) return false;
   const parts = root.split('/');
@@ -364,6 +385,13 @@ function definiteMutationRejection(error) {
   return error instanceof GitHubApiError && [405, 409, 422].includes(error.status);
 }
 
+function definiteDispatchRejection(error) {
+  return error instanceof GitHubApiError
+    && error.status >= 400
+    && error.status < 500
+    && ![408, 425, 429].includes(error.status);
+}
+
 export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch = false }) {
   const firstSnapshot = await buildStableSnapshot(api, workflowRunId);
   if (firstSnapshot?.pr?.merged === true && firstSnapshot.pr.state === 'closed' && firstSnapshot.pr.head?.sha === firstSnapshot.workflowRun?.head_sha) {
@@ -490,12 +518,22 @@ export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch 
 
 export async function runRecoverySweep(api) {
   const candidates = await api.listRecoveryCandidates();
+  let deferredResult;
   for (const candidate of candidates) {
     if (candidate.phase === 'MERGED') {
       const result = candidate.postMergeAction === 'provider_sync'
         ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha, candidate.roots)
         : await api.dispatchPublication(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha);
       if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
+      if (result.outcome === 'PUBLICATION_AWAITING_PROVIDER_SYNC') {
+        deferredResult ??= {
+          ...result,
+          prNumber: candidate.prNumber,
+          headSha: candidate.headSha,
+          mergeCommitSha: candidate.mergeCommitSha,
+        };
+        continue;
+      }
       if (result.outcome.endsWith('_FAILED_REQUIRES_INSPECTION')) {
         throw new AutoMergeBlockedError(`${result.outcome} for PR #${candidate.prNumber} (workflow run ${result.workflowRunId ?? 'unavailable'})`);
       }
@@ -529,7 +567,7 @@ export async function runRecoverySweep(api) {
       throw error;
     }
   }
-  return { outcome: 'NO_ELIGIBLE_RECOVERY' };
+  return deferredResult ?? { outcome: 'NO_ELIGIBLE_RECOVERY' };
 }
 
 function encodeContentPath(path) {
@@ -727,10 +765,8 @@ export class GitHubApi {
       && candidate?.base?.ref === 'main'
       && candidate?.base?.repo?.full_name === this.repository
       && candidate?.head?.repo?.full_name === this.repository);
-    const payloadNumbers = (workflowRun.pull_requests ?? []).map((candidate) => candidate.number).filter(Number.isSafeInteger);
-    const candidateNumbers = [...new Set([...exactAssociatedPrs.map((candidate) => candidate.number), ...payloadNumbers])];
-    block(candidateNumbers.length === 1, 'workflow run must resolve exactly one PR from the exact head');
-    const pr = await this.request(`/pulls/${candidateNumbers[0]}`);
+    const candidateNumber = resolveWorkflowPrNumber(workflowRun.pull_requests ?? [], exactAssociatedPrs);
+    const pr = await this.request(`/pulls/${candidateNumber}`);
     const headSha = pr.head?.sha;
     block(validSha(headSha) && headSha === workflowRun.head_sha, 'PR head does not match the workflow run');
     const files = await this.paginate(`/pulls/${pr.number}/files`);
@@ -868,6 +904,66 @@ export class GitHubApi {
     return latestStatusesByContext(statuses).find((status) => status.context === context);
   }
 
+  async readDispatchClaim(kind, correlationId) {
+    const claim = dispatchClaim(kind, correlationId);
+    try {
+      const ref = await this.request(`/git/ref/${claim.apiRef}`);
+      block(ref?.ref === claim.fullRef && ref?.object?.type === 'commit' && validSha(ref.object.sha),
+        'dispatch claim evidence is invalid');
+      return { claim, ref };
+    } catch (error) {
+      if (error instanceof GitHubApiError && error.status === 404) return { claim, ref: undefined };
+      throw error;
+    }
+  }
+
+  async acquireDispatchClaim(kind, correlationId, mergeCommitSha) {
+    const before = await this.readDispatchClaim(kind, correlationId);
+    if (before.ref) {
+      block(before.ref.object.sha === mergeCommitSha, 'dispatch claim is bound to a different merge commit');
+      return false;
+    }
+    let createError;
+    let created;
+    try {
+      created = await this.request('/git/refs', {
+        method: 'POST',
+        body: { ref: before.claim.fullRef, sha: mergeCommitSha },
+      });
+    } catch (error) {
+      createError = error;
+    }
+    if (created) {
+      block(created.ref === before.claim.fullRef
+        && created.object?.type === 'commit'
+        && created.object.sha === mergeCommitSha,
+      'created dispatch claim does not match the exact merge commit');
+      return true;
+    }
+    const after = await this.readDispatchClaim(kind, correlationId);
+    if (after.ref) {
+      block(after.ref.object.sha === mergeCommitSha, 'dispatch claim is bound to a different merge commit');
+      throw new AutoMergeUnknownEffectError('dispatch claim ownership is unknown; refusing workflow dispatch');
+    }
+    if (createError && definiteMutationRejection(createError)) {
+      throw new AutoMergeBlockedError(`dispatch claim rejected with HTTP ${createError.status}`);
+    }
+    throw new AutoMergeUnknownEffectError('dispatch claim effect is unknown; refusing workflow dispatch');
+  }
+
+  async recordTerminalDispatchRejection(commitSha, context, description) {
+    block(validSha(commitSha), 'terminal dispatch rejection commit is invalid');
+    await this.request(`/statuses/${commitSha}`, {
+      method: 'POST',
+      body: {
+        state: 'failure',
+        context,
+        description,
+        target_url: `https://github.com/${this.repository}/actions/runs/${this.currentRunId}`,
+      },
+    });
+  }
+
   async findPublicationRun(correlationTitle) {
     for (let page = 1; page <= 30; page += 1) {
       const result = await this.request(`/actions/workflows/on-pr-merge.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
@@ -903,6 +999,9 @@ export class GitHubApi {
       if (!existing || (existing.status === 'completed' && existing.conclusion !== 'success')) {
         return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion ?? 'missing-run-evidence' };
       }
+      if (existing.status === 'completed' && existing.conclusion === 'success') {
+        return { outcome: 'PUBLICATION_AWAITING_PROVIDER_SYNC', workflowRunId: existing.id };
+      }
       return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
@@ -913,6 +1012,11 @@ export class GitHubApi {
     }
     if (existing) {
       return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
+    }
+
+    const ownsClaim = await this.acquireDispatchClaim('publication', correlationId, mergeCommitSha);
+    if (!ownsClaim) {
+      throw new AutoMergeUnknownEffectError(`publication dispatch is claimed but has no authoritative run or status evidence for PR #${prNumber}`);
     }
 
     let mutationError;
@@ -929,7 +1033,18 @@ export class GitHubApi {
       if (run) return { outcome: 'PUBLICATION_DISPATCH_CONFIRMED', workflowRunId: run.id };
       if (attempt < 11) await this.sleep(5_000);
     }
-    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`publication dispatch rejected with HTTP ${mutationError.status}`);
+    if (mutationError && definiteDispatchRejection(mutationError)) {
+      try {
+        await this.recordTerminalDispatchRejection(
+          mergeCommitSha,
+          effectContext,
+          `Publication dispatch rejected with HTTP ${mutationError.status}`,
+        );
+      } catch {
+        throw new AutoMergeUnknownEffectError(`publication dispatch rejection could not be durably recorded for PR #${prNumber}`);
+      }
+      throw new AutoMergeBlockedError(`publication dispatch rejected with HTTP ${mutationError.status}`);
+    }
     throw new AutoMergeUnknownEffectError(`publication dispatch effect is unknown for PR #${prNumber}`);
   }
 
@@ -986,6 +1101,11 @@ export class GitHubApi {
       return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
     }
 
+    const ownsClaim = await this.acquireDispatchClaim('provider-sync', correlationId, mergeCommitSha);
+    if (!ownsClaim) {
+      throw new AutoMergeUnknownEffectError(`provider sync dispatch is claimed but has no authoritative run or status evidence for PR #${prNumber}`);
+    }
+
     let mutationError;
     try {
       await this.request('/actions/workflows/sync-to-supabase.yml/dispatches', {
@@ -1006,7 +1126,18 @@ export class GitHubApi {
       if (await this.findProviderSyncRun(correlationTitle)) return { outcome: 'PROVIDER_SYNC_DISPATCH_CONFIRMED' };
       if (attempt < 11) await this.sleep(5_000);
     }
-    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`provider sync dispatch rejected with HTTP ${mutationError.status}`);
+    if (mutationError && definiteDispatchRejection(mutationError)) {
+      try {
+        await this.recordTerminalDispatchRejection(
+          mergeCommitSha,
+          effectContext,
+          `Provider sync dispatch rejected with HTTP ${mutationError.status}`,
+        );
+      } catch {
+        throw new AutoMergeUnknownEffectError(`provider sync dispatch rejection could not be durably recorded for PR #${prNumber}`);
+      }
+      throw new AutoMergeBlockedError(`provider sync dispatch rejected with HTTP ${mutationError.status}`);
+    }
     throw new AutoMergeUnknownEffectError(`provider sync dispatch effect is unknown for PR #${prNumber}`);
   }
 }

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -15,6 +15,7 @@ const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const SOURCE_MONITOR_REF_RE = /^skill-source-monitor\/run-[1-9][0-9]*$/u;
 const SUBMISSION_ROUTE = 'submission';
 const SOURCE_MONITOR_ROUTE = 'source_monitor';
+const RECOVERY_MARKER_EPOCH = '2026-08-30T00:00:00Z';
 
 export class AutoMergeBlockedError extends Error {
   constructor(message) {
@@ -485,8 +486,19 @@ export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch 
 export async function runRecoverySweep(api) {
   const candidates = await api.listRecoveryCandidates();
   for (const candidate of candidates) {
+    if (candidate.phase === 'MERGED') {
+      const result = candidate.postMergeAction === 'provider_sync'
+        ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.roots)
+        : await api.dispatchPublication(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha);
+      if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
+      return {
+        ...result,
+        prNumber: candidate.prNumber,
+        headSha: candidate.headSha,
+        mergeCommitSha: candidate.mergeCommitSha,
+      };
+    }
     if (candidate.workflowRunId == null) {
-      if (candidate.phase === 'MERGED') continue;
       return {
         outcome: 'WAITING_CI',
         prNumber: candidate.prNumber,
@@ -626,30 +638,69 @@ export class GitHubApi {
   async listRecoveryCandidates() {
     const repository = await this.request('');
     block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
-    const [openPulls, recentClosedPulls] = await Promise.all([
-      this.paginate('/pulls?state=open&base=main&sort=created&direction=asc'),
-      this.request('/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100&page=1'),
-    ]);
-    block(Array.isArray(recentClosedPulls), 'recent merged PR evidence is unavailable');
-    const mergedSeeds = [];
-    for (const pr of recentClosedPulls) {
+    const openPulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
+    const closedPulls = [];
+    for (let page = 1; page <= 30; page += 1) {
+      const items = await this.request(`/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100&page=${page}`);
+      block(Array.isArray(items), 'merged PR recovery evidence is unavailable');
+      closedPulls.push(...items.filter((pr) => String(pr?.merged_at ?? '') >= RECOVERY_MARKER_EPOCH));
+      const reachedEpoch = items.length < 100
+        || items.every((pr) => String(pr?.updated_at ?? '') < RECOVERY_MARKER_EPOCH);
+      if (reachedEpoch) break;
+      if (page === 30) throw new AutoMergeBlockedError('merged PR recovery search exceeded the bounded marker epoch');
+    }
+
+    const seeds = [];
+    for (const pr of closedPulls) {
       if (!trustedRecoverySeed(pr, repository) || pr.state !== 'closed') continue;
       const mergeCommit = await this.readCommit(pr.merge_commit_sha);
       const marker = `Trusted auto-merge PR #${pr.number}\n\nAgentCrew-Recovery: ${pr.number}:${pr.head.sha}`;
-      if (mergeCommit?.commit?.message === marker) mergedSeeds.push(pr);
+      if (mergeCommit?.commit?.message !== marker) continue;
+      const sourceMonitor = SOURCE_MONITOR_REF_RE.test(pr.head?.ref ?? '');
+      let roots = [];
+      if (sourceMonitor) {
+        const [files, tree] = await Promise.all([
+          this.paginate(`/pulls/${pr.number}/files`),
+          this.request(`/git/trees/${pr.head.sha}?recursive=1`),
+        ]);
+        block(tree?.truncated === false && Array.isArray(tree.tree), `merged source-monitor PR #${pr.number} has no exact tree evidence`);
+        const candidates = publishedRootsFromTree({ entries: tree.tree });
+        roots = [...new Set(files.map((file) => publishedRootForPath(file.filename, candidates)).filter(Boolean))].sort();
+        block(roots.length > 0 && roots.length <= 25, `merged source-monitor PR #${pr.number} has invalid sync roots`);
+      }
+      seeds.push({
+        pr,
+        phase: 'MERGED',
+        mergeCommitSha: pr.merge_commit_sha,
+        postMergeAction: sourceMonitor ? 'provider_sync' : 'publication',
+        roots,
+      });
     }
-    mergedSeeds.sort((left, right) => String(left.merged_at).localeCompare(String(right.merged_at)) || left.number - right.number);
-    const openSeeds = openPulls.filter((pr) => trustedRecoverySeed(pr, repository) && pr.state === 'open');
+    for (const pr of openPulls) {
+      if (trustedRecoverySeed(pr, repository) && pr.state === 'open') seeds.push({ pr, phase: 'OPEN' });
+    }
+    seeds.sort((left, right) => String(left.pr.created_at).localeCompare(String(right.pr.created_at)) || left.pr.number - right.pr.number);
+
     const candidates = [];
-    for (const pr of [...mergedSeeds, ...openSeeds]) {
-      const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
-      const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
-      block(runIds.length <= 1, `PR #${pr.number} has ambiguous exact-head validation runs`);
+    for (const seed of seeds) {
+      const { pr } = seed;
+      let workflowRunId = null;
+      if (seed.phase === 'OPEN') {
+        const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
+        const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
+        block(runIds.length <= 1, `PR #${pr.number} has ambiguous exact-head validation runs`);
+        workflowRunId = runIds[0] ?? null;
+      }
       candidates.push({
         prNumber: pr.number,
         headSha: pr.head.sha,
-        workflowRunId: runIds[0] ?? null,
-        phase: pr.state === 'closed' ? 'MERGED' : 'OPEN',
+        workflowRunId,
+        phase: seed.phase,
+        ...(seed.phase === 'MERGED' ? {
+          mergeCommitSha: seed.mergeCommitSha,
+          postMergeAction: seed.postMergeAction,
+          roots: seed.roots,
+        } : {}),
       });
     }
     return candidates;

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -883,17 +883,11 @@ export class GitHubApi {
       return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing) {
-      let rerunError;
-      try {
-        await this.request(`/actions/runs/${existing.id}/rerun`, { method: 'POST' });
-      } catch (error) {
-        rerunError = error;
-      }
-      if (!rerunError) return { outcome: 'PUBLICATION_RETRY_CONFIRMED', workflowRunId: existing.id };
-      const readback = await this.findPublicationRun(correlationTitle);
-      if (readback && readback.status !== 'completed') return { outcome: 'PUBLICATION_RETRY_CONFIRMED', workflowRunId: readback.id };
-      if (definiteMutationRejection(rerunError)) throw new AutoMergeBlockedError(`publication rerun rejected with HTTP ${rerunError.status}`);
-      throw new AutoMergeUnknownEffectError(`publication rerun effect is unknown for PR #${prNumber}`);
+      return {
+        outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION',
+        workflowRunId: existing.id,
+        conclusion: existing.conclusion,
+      };
     }
 
     let mutationError;
@@ -947,17 +941,11 @@ export class GitHubApi {
       return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing) {
-      let rerunError;
-      try {
-        await this.request(`/actions/runs/${existing.id}/rerun`, { method: 'POST' });
-      } catch (error) {
-        rerunError = error;
-      }
-      if (!rerunError) return { outcome: 'PROVIDER_SYNC_RETRY_CONFIRMED', workflowRunId: existing.id };
-      const readback = await this.findProviderSyncRun(correlationTitle);
-      if (readback && readback.status !== 'completed') return { outcome: 'PROVIDER_SYNC_RETRY_CONFIRMED', workflowRunId: readback.id };
-      if (definiteMutationRejection(rerunError)) throw new AutoMergeBlockedError(`provider sync rerun rejected with HTTP ${rerunError.status}`);
-      throw new AutoMergeUnknownEffectError(`provider sync rerun effect is unknown for PR #${prNumber}`);
+      return {
+        outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION',
+        workflowRunId: existing.id,
+        conclusion: existing.conclusion,
+      };
     }
 
     let mutationError;

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
 const TRUSTED_REPOSITORY = 'aiskillstore/marketplace';
@@ -83,6 +84,10 @@ function rootForPath(path, topLevel = 'pending') {
   if (parts.length < 4 || parts[0] !== topLevel) return null;
   if (!SEGMENT_RE.test(parts[1]) || !SEGMENT_RE.test(parts[2])) return null;
   return parts.slice(0, 3).join('/');
+}
+
+function rootSetDigest(slugs) {
+  return createHash('sha256').update([...new Set(slugs)].sort().join('\n')).digest('hex');
 }
 
 function publishedRootSyntax(root) {
@@ -491,6 +496,9 @@ export async function runRecoverySweep(api) {
         ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha, candidate.roots)
         : await api.dispatchPublication(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha);
       if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
+      if (result.outcome.endsWith('_FAILED_REQUIRES_INSPECTION')) {
+        throw new AutoMergeBlockedError(`${result.outcome} for PR #${candidate.prNumber} (workflow run ${result.workflowRunId ?? 'unavailable'})`);
+      }
       return {
         ...result,
         prNumber: candidate.prNumber,
@@ -855,6 +863,11 @@ export class GitHubApi {
     });
   }
 
+  async readEffectStatus(commitSha, context) {
+    const statuses = await this.paginate(`/commits/${commitSha}/statuses`);
+    return latestStatusesByContext(statuses).find((status) => status.context === context);
+  }
+
   async findPublicationRun(correlationTitle) {
     for (let page = 1; page <= 30; page += 1) {
       const result = await this.request(`/actions/workflows/on-pr-merge.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
@@ -875,7 +888,20 @@ export class GitHubApi {
     block(validSha(mergeCommitSha), 'publication merge commit SHA is invalid');
     const correlationId = `submission-pr-${prNumber}-${headSha}-${mergeCommitSha}`;
     const correlationTitle = `Publication ${correlationId}`;
-    const existing = await this.findPublicationRun(correlationTitle);
+    const effectContext = `agentcrew/publication/${rootSetDigest([correlationId])}`;
+    const [effectStatus, existing] = await Promise.all([
+      this.readEffectStatus(mergeCommitSha, effectContext),
+      this.findPublicationRun(correlationTitle),
+    ]);
+    if (effectStatus?.state === 'success') {
+      return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing?.id };
+    }
+    if (['failure', 'error'].includes(effectStatus?.state)) {
+      return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion };
+    }
+    if (effectStatus?.state === 'pending') {
+      return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing?.id };
+    }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
       return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing.id };
     }
@@ -883,11 +909,7 @@ export class GitHubApi {
       return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing) {
-      return {
-        outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION',
-        workflowRunId: existing.id,
-        conclusion: existing.conclusion,
-      };
+      return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
     }
 
     let mutationError;
@@ -931,9 +953,23 @@ export class GitHubApi {
       block(publishedRootSyntax(root), `invalid provider sync root: ${root}`);
       return root.slice('skills/'.length);
     });
-    const correlationId = `source-monitor-pr-${prNumber}-${headSha}-${mergeCommitSha}`;
+    const rootsDigest = rootSetDigest(slugs);
+    const correlationId = `source-monitor-pr-${prNumber}-${headSha}-${mergeCommitSha}-${rootsDigest}`;
     const correlationTitle = `Provider sync ${correlationId}`;
-    const existing = await this.findProviderSyncRun(correlationTitle);
+    const effectContext = `agentcrew/provider-sync/${rootSetDigest([correlationId])}`;
+    const [effectStatus, existing] = await Promise.all([
+      this.readEffectStatus(mergeCommitSha, effectContext),
+      this.findProviderSyncRun(correlationTitle),
+    ]);
+    if (effectStatus?.state === 'success') {
+      return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED', workflowRunId: existing?.id };
+    }
+    if (['failure', 'error'].includes(effectStatus?.state)) {
+      return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion };
+    }
+    if (effectStatus?.state === 'pending') {
+      return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing?.id };
+    }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
       return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED', workflowRunId: existing.id };
     }
@@ -941,11 +977,7 @@ export class GitHubApi {
       return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing) {
-      return {
-        outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION',
-        workflowRunId: existing.id,
-        conclusion: existing.conclusion,
-      };
+      return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
     }
 
     let mutationError;

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -366,7 +366,7 @@ export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch 
     let dispatchResult;
     try {
       dispatchResult = merged.postMergeAction === 'provider_sync'
-        ? await api.dispatchProviderSync(merged.prNumber, merged.headSha, merged.roots)
+        ? await api.dispatchProviderSync(merged.prNumber, merged.headSha, firstSnapshot.pr.merge_commit_sha, merged.roots)
         : await api.dispatchPublication(merged.prNumber, merged.headSha, firstSnapshot.pr.merge_commit_sha);
     } catch (error) {
       if (error instanceof AutoMergeBlockedError || error instanceof AutoMergeUnknownEffectError) throw error;
@@ -468,7 +468,7 @@ export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch 
     }
     try {
       if (second.postMergeAction === 'provider_sync') {
-        await api.dispatchProviderSync(second.prNumber, second.headSha, second.roots);
+        await api.dispatchProviderSync(second.prNumber, second.headSha, readback.merge_commit_sha, second.roots);
         return { outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED', prNumber: second.prNumber, headSha: second.headSha, mergeCommitSha: readback.merge_commit_sha, classification: second.classification };
       }
       await api.dispatchPublication(second.prNumber, second.headSha, readback.merge_commit_sha);
@@ -488,7 +488,7 @@ export async function runRecoverySweep(api) {
   for (const candidate of candidates) {
     if (candidate.phase === 'MERGED') {
       const result = candidate.postMergeAction === 'provider_sync'
-        ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.roots)
+        ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha, candidate.roots)
         : await api.dispatchPublication(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha);
       if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
       return {
@@ -530,14 +530,14 @@ function encodeContentPath(path) {
 
 function trustedRecoverySeed(pr, repository) {
   const labels = new Set((Array.isArray(pr?.labels) ? pr.labels : []).map((label) => label?.name));
+  const merged = pr?.state === 'closed' && pr.draft === false
+    && typeof pr.merged_at === 'string' && validSha(pr.merge_commit_sha);
   const submission = typeof pr?.head?.ref === 'string'
     && pr.head.ref.startsWith('submission/')
-    && labels.has('pending-review');
+    && (merged || labels.has('pending-review'));
   const sourceMonitor = SOURCE_MONITOR_REF_RE.test(pr?.head?.ref ?? '')
-    && labels.has('skill-source-monitor')
-    && !labels.has('pending-review');
-  const lifecycle = (pr?.state === 'open' && pr.draft === false && pr.merged_at == null)
-    || (pr?.state === 'closed' && pr.draft === false && typeof pr.merged_at === 'string' && validSha(pr.merge_commit_sha));
+    && (merged || (labels.has('skill-source-monitor') && !labels.has('pending-review')));
+  const lifecycle = (pr?.state === 'open' && pr.draft === false && pr.merged_at == null) || merged;
   return lifecycle
     && pr.base?.ref === 'main'
     && sameRepository(pr.base?.repo, repository)
@@ -876,7 +876,25 @@ export class GitHubApi {
     const correlationId = `submission-pr-${prNumber}-${headSha}-${mergeCommitSha}`;
     const correlationTitle = `Publication ${correlationId}`;
     const existing = await this.findPublicationRun(correlationTitle);
-    if (existing) return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing.id };
+    if (existing?.status === 'completed' && existing.conclusion === 'success') {
+      return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing.id };
+    }
+    if (existing && existing.status !== 'completed') {
+      return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
+    }
+    if (existing) {
+      let rerunError;
+      try {
+        await this.request(`/actions/runs/${existing.id}/rerun`, { method: 'POST' });
+      } catch (error) {
+        rerunError = error;
+      }
+      if (!rerunError) return { outcome: 'PUBLICATION_RETRY_CONFIRMED', workflowRunId: existing.id };
+      const readback = await this.findPublicationRun(correlationTitle);
+      if (readback && readback.status !== 'completed') return { outcome: 'PUBLICATION_RETRY_CONFIRMED', workflowRunId: readback.id };
+      if (definiteMutationRejection(rerunError)) throw new AutoMergeBlockedError(`publication rerun rejected with HTTP ${rerunError.status}`);
+      throw new AutoMergeUnknownEffectError(`publication rerun effect is unknown for PR #${prNumber}`);
+    }
 
     let mutationError;
     try {
@@ -901,6 +919,7 @@ export class GitHubApi {
       const result = await this.request(`/actions/workflows/sync-to-supabase.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
       block(Array.isArray(result?.workflow_runs), 'provider sync workflow run evidence is invalid');
       const match = result.workflow_runs.find((run) => run?.display_title === correlationTitle
+        && run?.event === 'workflow_dispatch'
         && run?.head_branch === 'main'
         && run?.head_repository?.full_name === this.repository);
       if (match) return match;
@@ -909,23 +928,50 @@ export class GitHubApi {
     throw new AutoMergeBlockedError('provider sync workflow run search exceeded the bounded limit');
   }
 
-  async dispatchProviderSync(prNumber, headSha, roots) {
+  async dispatchProviderSync(prNumber, headSha, mergeCommitSha, roots) {
     block(Number.isSafeInteger(prNumber) && prNumber > 0, 'provider sync PR number is invalid');
     block(validSha(headSha), 'provider sync head SHA is invalid');
+    block(validSha(mergeCommitSha), 'provider sync merge commit SHA is invalid');
     block(Array.isArray(roots) && roots.length > 0 && roots.length <= 25, 'provider sync roots are required');
     const slugs = roots.map((root) => {
       block(publishedRootSyntax(root), `invalid provider sync root: ${root}`);
       return root.slice('skills/'.length);
     });
-    const correlationId = `source-monitor-pr-${prNumber}-${headSha}`;
+    const correlationId = `source-monitor-pr-${prNumber}-${headSha}-${mergeCommitSha}`;
     const correlationTitle = `Provider sync ${correlationId}`;
-    if (await this.findProviderSyncRun(correlationTitle)) return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED' };
+    const existing = await this.findProviderSyncRun(correlationTitle);
+    if (existing?.status === 'completed' && existing.conclusion === 'success') {
+      return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED', workflowRunId: existing.id };
+    }
+    if (existing && existing.status !== 'completed') {
+      return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing.id };
+    }
+    if (existing) {
+      let rerunError;
+      try {
+        await this.request(`/actions/runs/${existing.id}/rerun`, { method: 'POST' });
+      } catch (error) {
+        rerunError = error;
+      }
+      if (!rerunError) return { outcome: 'PROVIDER_SYNC_RETRY_CONFIRMED', workflowRunId: existing.id };
+      const readback = await this.findProviderSyncRun(correlationTitle);
+      if (readback && readback.status !== 'completed') return { outcome: 'PROVIDER_SYNC_RETRY_CONFIRMED', workflowRunId: readback.id };
+      if (definiteMutationRejection(rerunError)) throw new AutoMergeBlockedError(`provider sync rerun rejected with HTTP ${rerunError.status}`);
+      throw new AutoMergeUnknownEffectError(`provider sync rerun effect is unknown for PR #${prNumber}`);
+    }
 
     let mutationError;
     try {
       await this.request('/actions/workflows/sync-to-supabase.yml/dispatches', {
         method: 'POST',
-        body: { ref: 'main', inputs: { slugs: slugs.join(' '), correlation_id: correlationId } },
+        body: {
+          ref: 'main',
+          inputs: {
+            slugs: slugs.join(' '),
+            correlation_id: correlationId,
+            merge_commit_sha: mergeCommitSha,
+          },
+        },
       });
     } catch (error) {
       mutationError = error;
@@ -947,9 +993,7 @@ async function main() {
     currentRunId: process.env.GITHUB_RUN_ID,
   });
   try {
-    const result = process.env.RECOVERY_SWEEP === 'true'
-      ? await runRecoverySweep(api)
-      : await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
+    const result = await runRecoverySweep(api);
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     if (error instanceof AutoMergeSkippedError) {

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -30,6 +30,13 @@ export class AutoMergeWaitingError extends AutoMergeBlockedError {
   }
 }
 
+export class AutoMergeSkippedError extends AutoMergeBlockedError {
+  constructor(message) {
+    super(message);
+    this.name = 'AutoMergeSkippedError';
+  }
+}
+
 export class AutoMergeUnknownEffectError extends Error {
   constructor(message) {
     super(message);
@@ -48,6 +55,10 @@ class GitHubApiError extends Error {
 
 function block(condition, message) {
   if (!condition) throw new AutoMergeBlockedError(message);
+}
+
+function skip(condition, message) {
+  if (!condition) throw new AutoMergeSkippedError(message);
 }
 
 function validSha(value) {
@@ -109,7 +120,7 @@ function routeForPr(pr) {
     block(SOURCE_MONITOR_REF_RE.test(ref), 'PR head must use trusted source-monitor provenance');
     return SOURCE_MONITOR_ROUTE;
   }
-  throw new AutoMergeBlockedError('PR head must use trusted submission/ or source-monitor provenance');
+  throw new AutoMergeSkippedError('PR head must use trusted submission/ or source-monitor provenance');
 }
 
 export function latestStatusesByContext(statusHistory) {
@@ -169,27 +180,28 @@ export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
   if (allowMerged) {
     block(pr.state === 'closed' && pr.merged === true && validSha(pr.merge_commit_sha), 'PR must be authoritatively merged');
   } else {
-    block(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
+    skip(pr.state === 'open' && pr.draft === false && pr.merged !== true, 'PR must be open and non-draft');
   }
-  block(pr.base?.ref === 'main', 'PR base must be main');
-  block(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
-  block(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
+  skip(pr.base?.ref === 'main', 'PR base must be main');
+  skip(sameRepository(pr.base?.repo, repository) && sameRepository(pr.head?.repo, repository), 'PR head and base must use the same repository');
+  skip(pr.user?.id === TRUSTED_BOT.id && pr.user?.login === TRUSTED_BOT.login && pr.user?.type === TRUSTED_BOT.type, 'PR author is not the trusted App identity');
   const route = routeForPr(pr);
   block(validSha(pr.head?.sha) && validSha(pr.base?.sha), 'PR head and base SHA must be exact');
   block(workflowRun.head_sha === pr.head.sha, 'workflow run must bind the exact PR head');
   const labelNames = new Set((Array.isArray(pr.labels) ? pr.labels : []).map((label) => label?.name));
   if (route === SUBMISSION_ROUTE) {
-    block(labelNames.has('pending-review'), 'PR must have pending-review');
+    skip(labelNames.has('pending-review'), 'PR must have pending-review');
   } else {
-    block(labelNames.has('skill-source-monitor'), 'source-monitor PR must have skill-source-monitor label');
-    block(!labelNames.has('pending-review'), 'source-monitor PR must not have pending-review');
+    skip(labelNames.has('skill-source-monitor'), 'source-monitor PR must have skill-source-monitor label');
+    skip(!labelNames.has('pending-review'), 'source-monitor PR must not have pending-review');
   }
   if (!allowMerged) {
     block(pr.mergeable === true, 'PR is not mergeable');
     block(['clean', 'behind'].includes(pr.mergeable_state), `PR mergeable_state is ${pr.mergeable_state ?? 'unknown'}`);
   }
 
-  block(Array.isArray(files) && files.length > 0, 'PR files are required');
+  block(Array.isArray(files), 'PR files are required');
+  skip(files.length > 0, 'PR files are required');
   block(Number.isSafeInteger(pr.changed_files) && pr.changed_files === files.length, 'PR file pagination/count is incomplete');
   block(tree?.truncated === false && Array.isArray(tree.entries), 'exact-head tree is truncated or missing');
   const seenFiles = new Set();
@@ -197,56 +209,56 @@ export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
   const topLevel = route === SUBMISSION_ROUTE ? 'pending' : 'skills';
   const publishedRootCandidates = route === SOURCE_MONITOR_ROUTE ? publishedRootsFromTree(tree) : [];
   for (const file of files) {
-    block(safePath(file?.filename), 'PR contains an unsafe path');
-    block(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
+    skip(safePath(file?.filename), 'PR contains an unsafe path');
+    skip(!seenFiles.has(file.filename), `duplicate PR file ${file.filename}`);
     seenFiles.add(file.filename);
     if (route === SUBMISSION_ROUTE) {
-      block(file.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file.filename}`);
+      skip(file.status === 'added' && file.previous_filename == null, `every Skill file must be newly added: ${file.filename}`);
     } else {
-      block(['added', 'modified', 'removed', 'changed'].includes(file.status) && file.previous_filename == null,
+      skip(['added', 'modified', 'removed', 'changed'].includes(file.status) && file.previous_filename == null,
         `unsupported source-monitor file status: ${file.status ?? 'missing'}`);
     }
     const root = route === SUBMISSION_ROUTE
       ? rootForPath(file.filename, topLevel)
       : publishedRootForPath(file.filename, publishedRootCandidates);
-    block(root !== null, `PR must change only ${topLevel === 'pending' ? 'pending' : 'published'} Skill roots`);
+    skip(root !== null, `PR must change only ${topLevel === 'pending' ? 'pending' : 'published'} Skill roots`);
     roots.add(root);
   }
-  block(roots.size > 0, `PR must change ${topLevel} Skill roots`);
+  skip(roots.size > 0, `PR must change ${topLevel} Skill roots`);
   const rootList = [...roots].sort();
-  if (route === SOURCE_MONITOR_ROUTE) block(rootList.length <= 25, 'source-monitor PR exceeds the provider sync limit');
+  if (route === SOURCE_MONITOR_ROUTE) skip(rootList.length <= 25, 'source-monitor PR exceeds the provider sync limit');
   for (const root of rootList) {
     const skillFile = files.find((file) => file.filename === `${root}/SKILL.md`);
     const reportFile = files.find((file) => file.filename === `${root}/skill-report.json`);
-    if (route === SUBMISSION_ROUTE) block(skillFile && skillFile.status !== 'removed', 'Skill root is missing SKILL.md');
-    block(reportFile && reportFile.status !== 'removed', 'Skill root is missing skill-report.json');
+    if (route === SUBMISSION_ROUTE) skip(skillFile && skillFile.status !== 'removed', 'Skill root is missing SKILL.md');
+    skip(reportFile && reportFile.status !== 'removed', 'Skill root is missing skill-report.json');
   }
   if (route === SUBMISSION_ROUTE) {
-    block(snapshot.basePendingExists === false, 'pending root already exists on the base');
+    skip(snapshot.basePendingExists === false, 'pending root already exists on the base');
   } else {
-    block(snapshot.baseSkillRootsExist === true, 'source-monitor Skill roots must already exist on the base');
+    skip(snapshot.baseSkillRootsExist === true, 'source-monitor Skill roots must already exist on the base');
   }
 
   const treeByPath = new Map();
   for (const entry of tree.entries) {
     if (typeof entry?.path !== 'string' || !rootList.some((root) => entry.path === root || entry.path.startsWith(`${root}/`))) continue;
     if (entry.type === 'tree') continue;
-    block(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
+    skip(entry.type === 'blob' && ['100644', '100755'].includes(entry.mode), 'Skill tree must contain ordinary blobs only');
     treeByPath.set(entry.path, entry);
   }
   if (route === SUBMISSION_ROUTE) {
-    block(treeByPath.size === seenFiles.size && [...seenFiles].every((path) => treeByPath.has(path)), 'PR files do not equal the exact-head Skill tree');
+    skip(treeByPath.size === seenFiles.size && [...seenFiles].every((path) => treeByPath.has(path)), 'PR files do not equal the exact-head Skill tree');
   } else {
     for (const file of files) {
       const entry = treeByPath.get(file.filename);
       if (file.status === 'removed') {
-        block(entry == null, `removed source-monitor file remains on the exact PR head: ${file.filename}`);
+        skip(entry == null, `removed source-monitor file remains on the exact PR head: ${file.filename}`);
       } else {
         block(entry?.sha === file.sha && validSha(file.sha), `source-monitor file is not bound to the exact PR head: ${file.filename}`);
       }
     }
     for (const root of rootList) {
-      block(treeByPath.has(`${root}/SKILL.md`) && treeByPath.has(`${root}/skill-report.json`), 'source-monitor Skill root is incomplete on the exact PR head');
+      skip(treeByPath.has(`${root}/SKILL.md`) && treeByPath.has(`${root}/skill-report.json`), 'source-monitor Skill root is incomplete on the exact PR head');
     }
   }
 
@@ -265,7 +277,8 @@ export function validateSnapshot(snapshot, { allowMerged = false } = {}) {
     'skill report is not bound to the exact PR head');
   }
 
-  block(Array.isArray(checks) && checks.length > 0, 'exact-head checks are required');
+  block(Array.isArray(checks), 'exact-head checks are required');
+  if (checks.length === 0) throw new AutoMergeWaitingError('exact-head checks are required');
   const checkNames = new Set();
   for (const check of checks) {
     block(check?.app?.id === GITHUB_ACTIONS_APP_ID, `check ${check?.name ?? '<unknown>'} is not from GitHub Actions`);
@@ -387,16 +400,30 @@ export async function runAutoMerge(api, { workflowRunId }) {
           if (attempt < 11) await api.sleep(5_000);
           continue;
         }
-        const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
+        const parentShas = [...new Set((commit?.parents ?? []).map((parent) => parent.sha))];
         const readbackBaseSha = pr.base?.sha;
-        if (parentShas.has(second.headSha) && validSha(readbackBaseSha) && parentShas.has(readbackBaseSha)) {
-          return {
-            outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
-            prNumber: second.prNumber,
-            oldHeadSha: second.headSha,
-            newHeadSha: pr.head.sha,
-            classification: second.classification,
-          };
+        const updateBaseParents = parentShas.filter((sha) => sha !== second.headSha);
+        if (parentShas.length === 2
+          && parentShas.includes(second.headSha)
+          && updateBaseParents.length === 1
+          && validSha(readbackBaseSha)) {
+          let updateBaseIsOnMain;
+          try {
+            updateBaseIsOnMain = updateBaseParents[0] === readbackBaseSha
+              || await api.isCommitAncestor(updateBaseParents[0], readbackBaseSha);
+          } catch {
+            if (attempt < 11) await api.sleep(5_000);
+            continue;
+          }
+          if (updateBaseIsOnMain) {
+            return {
+              outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
+              prNumber: second.prNumber,
+              oldHeadSha: second.headSha,
+              newHeadSha: pr.head.sha,
+              classification: second.classification,
+            };
+          }
         }
         throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
       }
@@ -439,14 +466,25 @@ export async function runAutoMerge(api, { workflowRunId }) {
 }
 
 export async function runRecoverySweep(api) {
-  const workflowRunIds = await api.listRecoveryWorkflowRunIds();
-  for (const workflowRunId of workflowRunIds) {
+  const candidates = await api.listRecoveryCandidates();
+  for (const candidate of candidates) {
+    if (candidate.workflowRunId == null) {
+      return {
+        outcome: 'WAITING_CI',
+        prNumber: candidate.prNumber,
+        headSha: candidate.headSha,
+        reason: 'missing exact-head Validate Marketplace run',
+      };
+    }
     try {
-      const result = await runAutoMerge(api, { workflowRunId });
+      const result = await runAutoMerge(api, { workflowRunId: candidate.workflowRunId });
       if (result.outcome === 'ALREADY_MERGED') continue;
       return result;
     } catch (error) {
-      if (error instanceof AutoMergeBlockedError) continue;
+      if (error instanceof AutoMergeSkippedError) continue;
+      if (error instanceof AutoMergeWaitingError) {
+        return { outcome: 'WAITING_CI', prNumber: candidate.prNumber, workflowRunId: candidate.workflowRunId, reason: error.message };
+      }
       throw error;
     }
   }
@@ -458,6 +496,13 @@ function encodeContentPath(path) {
 }
 
 function trustedRecoverySeed(pr, repository) {
+  const labels = new Set((Array.isArray(pr?.labels) ? pr.labels : []).map((label) => label?.name));
+  const submission = typeof pr?.head?.ref === 'string'
+    && pr.head.ref.startsWith('submission/')
+    && labels.has('pending-review');
+  const sourceMonitor = SOURCE_MONITOR_REF_RE.test(pr?.head?.ref ?? '')
+    && labels.has('skill-source-monitor')
+    && !labels.has('pending-review');
   return pr?.state === 'open'
     && pr.draft === false
     && pr.base?.ref === 'main'
@@ -466,11 +511,8 @@ function trustedRecoverySeed(pr, repository) {
     && pr.user?.id === TRUSTED_BOT.id
     && pr.user?.login === TRUSTED_BOT.login
     && pr.user?.type === TRUSTED_BOT.type
-    && typeof pr.head?.ref === 'string'
-    && pr.head.ref.startsWith('submission/')
     && validSha(pr.head?.sha)
-    && Array.isArray(pr.labels)
-    && pr.labels.some((label) => label?.name === 'pending-review');
+    && (submission || sourceMonitor);
 }
 
 function workflowRunIdFromCheck(check) {
@@ -541,6 +583,14 @@ export class GitHubApi {
     return this.request(`/commits/${sha}`);
   }
 
+  async isCommitAncestor(ancestorSha, descendantSha) {
+    block(validSha(ancestorSha) && validSha(descendantSha), 'commit lineage requires exact SHAs');
+    const comparison = await this.request(`/compare/${ancestorSha}...${descendantSha}`);
+    return comparison?.base_commit?.sha === ancestorSha
+      && comparison?.merge_base_commit?.sha === ancestorSha
+      && ['ahead', 'identical'].includes(comparison?.status);
+  }
+
   async existsAt(path, ref) {
     try {
       await this.request(`/contents/${encodeContentPath(path)}?ref=${encodeURIComponent(ref)}`);
@@ -551,18 +601,19 @@ export class GitHubApi {
     }
   }
 
-  async listRecoveryWorkflowRunIds() {
+  async listRecoveryCandidates() {
     const repository = await this.request('');
     block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
     const pulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
-    const workflowRunIds = [];
+    const candidates = [];
     for (const pr of pulls) {
       if (!trustedRecoverySeed(pr, repository)) continue;
       const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
       const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
-      if (runIds.length === 1) workflowRunIds.push(runIds[0]);
+      block(runIds.length <= 1, `PR #${pr.number} has ambiguous exact-head validation runs`);
+      candidates.push({ prNumber: pr.number, headSha: pr.head.sha, workflowRunId: runIds[0] ?? null });
     }
-    return workflowRunIds;
+    return candidates;
   }
 
   async buildSnapshot(workflowRunId) {
@@ -769,6 +820,10 @@ async function main() {
       : await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
+    if (error instanceof AutoMergeSkippedError) {
+      process.stdout.write(`${JSON.stringify({ outcome: 'SKIPPED', reason: error.message })}\n`);
+      return;
+    }
     if (error instanceof AutoMergeWaitingError) {
       process.stdout.write(`${JSON.stringify({ outcome: 'WAITING_CI', reason: error.message })}\n`);
       return;

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -900,7 +900,10 @@ export class GitHubApi {
       return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion };
     }
     if (effectStatus?.state === 'pending') {
-      return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing?.id };
+      if (!existing || (existing.status === 'completed' && existing.conclusion !== 'success')) {
+        return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion ?? 'missing-run-evidence' };
+      }
+      return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
       return { outcome: 'PUBLICATION_ALREADY_DISPATCHED', workflowRunId: existing.id };
@@ -968,7 +971,10 @@ export class GitHubApi {
       return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion };
     }
     if (effectStatus?.state === 'pending') {
-      return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing?.id };
+      if (!existing || (existing.status === 'completed' && existing.conclusion !== 'success')) {
+        return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion ?? 'missing-run-evidence' };
+      }
+      return { outcome: 'PROVIDER_SYNC_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
       return { outcome: 'PROVIDER_SYNC_ALREADY_DISPATCHED', workflowRunId: existing.id };

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -371,26 +371,36 @@ export async function runAutoMerge(api, { workflowRunId }) {
     } catch (error) {
       mutationError = error;
     }
-    let changedHead;
-    try {
-      for (let attempt = 0; attempt < 12; attempt += 1) {
-        const pr = await api.readPr(second.prNumber);
-        if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
-          const commit = await api.readCommit(pr.head.sha);
-          const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
-          if (parentShas.has(second.headSha) && parentShas.has(second.baseSha)) {
-            changedHead = pr.head.sha;
-            break;
-          }
-          throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
-        }
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      let pr;
+      try {
+        pr = await api.readPr(second.prNumber);
+      } catch {
         if (attempt < 11) await api.sleep(5_000);
+        continue;
       }
-    } catch {
-      throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
-    }
-    if (changedHead) {
-      return { outcome: 'UPDATE_CONFIRMED_AWAITING_CI', prNumber: second.prNumber, oldHeadSha: second.headSha, newHeadSha: changedHead, classification: second.classification };
+      if (validSha(pr?.head?.sha) && pr.head.sha !== second.headSha) {
+        let commit;
+        try {
+          commit = await api.readCommit(pr.head.sha);
+        } catch {
+          if (attempt < 11) await api.sleep(5_000);
+          continue;
+        }
+        const parentShas = new Set((commit?.parents ?? []).map((parent) => parent.sha));
+        const readbackBaseSha = pr.base?.sha;
+        if (parentShas.has(second.headSha) && validSha(readbackBaseSha) && parentShas.has(readbackBaseSha)) {
+          return {
+            outcome: 'UPDATE_CONFIRMED_AWAITING_CI',
+            prNumber: second.prNumber,
+            oldHeadSha: second.headSha,
+            newHeadSha: pr.head.sha,
+            classification: second.classification,
+          };
+        }
+        throw new AutoMergeUnknownEffectError(`update-branch produced an uncorrelated head for PR #${second.prNumber}`);
+      }
+      if (attempt < 11) await api.sleep(5_000);
     }
     if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`update-branch rejected with HTTP ${mutationError.status}`);
     throw new AutoMergeUnknownEffectError(`update-branch effect is unknown for PR #${second.prNumber}`);
@@ -428,8 +438,46 @@ export async function runAutoMerge(api, { workflowRunId }) {
   throw new AutoMergeUnknownEffectError(`merge effect is unknown for PR #${second.prNumber}`);
 }
 
+export async function runRecoverySweep(api) {
+  const workflowRunIds = await api.listRecoveryWorkflowRunIds();
+  for (const workflowRunId of workflowRunIds) {
+    try {
+      const result = await runAutoMerge(api, { workflowRunId });
+      if (result.outcome === 'ALREADY_MERGED') continue;
+      return result;
+    } catch (error) {
+      if (error instanceof AutoMergeBlockedError) continue;
+      throw error;
+    }
+  }
+  return { outcome: 'NO_ELIGIBLE_RECOVERY' };
+}
+
 function encodeContentPath(path) {
   return path.split('/').map(encodeURIComponent).join('/');
+}
+
+function trustedRecoverySeed(pr, repository) {
+  return pr?.state === 'open'
+    && pr.draft === false
+    && pr.base?.ref === 'main'
+    && sameRepository(pr.base?.repo, repository)
+    && sameRepository(pr.head?.repo, repository)
+    && pr.user?.id === TRUSTED_BOT.id
+    && pr.user?.login === TRUSTED_BOT.login
+    && pr.user?.type === TRUSTED_BOT.type
+    && typeof pr.head?.ref === 'string'
+    && pr.head.ref.startsWith('submission/')
+    && validSha(pr.head?.sha)
+    && Array.isArray(pr.labels)
+    && pr.labels.some((label) => label?.name === 'pending-review');
+}
+
+function workflowRunIdFromCheck(check) {
+  if (check?.name !== 'validate' || check?.app?.id !== GITHUB_ACTIONS_APP_ID) return null;
+  const match = /^https:\/\/github\.com\/aiskillstore\/marketplace\/actions\/runs\/(\d+)\/job\/\d+(?:\?.*)?$/u.exec(check.details_url ?? '');
+  const runId = match ? Number(match[1]) : NaN;
+  return Number.isSafeInteger(runId) && runId > 0 ? runId : null;
 }
 
 export class GitHubApi {
@@ -501,6 +549,20 @@ export class GitHubApi {
       if (error instanceof GitHubApiError && error.status === 404) return false;
       throw error;
     }
+  }
+
+  async listRecoveryWorkflowRunIds() {
+    const repository = await this.request('');
+    block(repository?.full_name === TRUSTED_REPOSITORY && Number.isSafeInteger(repository.id), 'trusted repository evidence is unavailable');
+    const pulls = await this.paginate('/pulls?state=open&base=main&sort=created&direction=asc');
+    const workflowRunIds = [];
+    for (const pr of pulls) {
+      if (!trustedRecoverySeed(pr, repository)) continue;
+      const checks = await this.paginate(`/commits/${pr.head.sha}/check-runs?filter=latest`, (value) => value?.check_runs);
+      const runIds = [...new Set(checks.map(workflowRunIdFromCheck).filter(Number.isSafeInteger))];
+      if (runIds.length === 1) workflowRunIds.push(runIds[0]);
+    }
+    return workflowRunIds;
   }
 
   async buildSnapshot(workflowRunId) {
@@ -702,7 +764,9 @@ async function main() {
     currentRunId: process.env.GITHUB_RUN_ID,
   });
   try {
-    const result = await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
+    const result = process.env.RECOVERY_SWEEP === 'true'
+      ? await runRecoverySweep(api)
+      : await runAutoMerge(api, { workflowRunId: Number(process.env.WORKFLOW_RUN_ID) });
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     if (error instanceof AutoMergeWaitingError) {

--- a/scripts/auto-merge-trusted-skill-pr.mjs
+++ b/scripts/auto-merge-trusted-skill-pr.mjs
@@ -90,6 +90,27 @@ function rootSetDigest(slugs) {
   return createHash('sha256').update([...new Set(slugs)].sort().join('\n')).digest('hex');
 }
 
+function dispatchClaim(kind, correlationId) {
+  block(['publication', 'provider-sync'].includes(kind), 'dispatch claim kind is invalid');
+  block(typeof correlationId === 'string' && correlationId.length > 0, 'dispatch claim correlation is invalid');
+  const digest = rootSetDigest([correlationId]);
+  const name = `agentcrew-dispatch-claims/${kind}/${digest}`;
+  return { fullRef: `refs/tags/${name}`, apiRef: `tags/${name}` };
+}
+
+export function resolveWorkflowPrNumber(payloadPrs, exactAssociatedPrs) {
+  block(Array.isArray(payloadPrs) && Array.isArray(exactAssociatedPrs), 'workflow PR evidence is invalid');
+  const payloadNumbers = payloadPrs.map((candidate) => candidate?.number);
+  block(payloadNumbers.every((number) => Number.isSafeInteger(number) && number > 0), 'workflow payload PR evidence is invalid');
+  const uniquePayloadNumbers = [...new Set(payloadNumbers)];
+  block(uniquePayloadNumbers.length <= 1, 'workflow run must resolve exactly one PR from the exact head');
+  if (uniquePayloadNumbers.length === 1) return uniquePayloadNumbers[0];
+  const associatedNumbers = [...new Set(exactAssociatedPrs.map((candidate) => candidate?.number))];
+  block(associatedNumbers.length === 1 && Number.isSafeInteger(associatedNumbers[0]) && associatedNumbers[0] > 0,
+    'workflow run must resolve exactly one PR from the exact head');
+  return associatedNumbers[0];
+}
+
 function publishedRootSyntax(root) {
   if (!safePath(root)) return false;
   const parts = root.split('/');
@@ -490,12 +511,22 @@ export async function runAutoMerge(api, { workflowRunId, deferPostMergeDispatch 
 
 export async function runRecoverySweep(api) {
   const candidates = await api.listRecoveryCandidates();
+  let deferredResult;
   for (const candidate of candidates) {
     if (candidate.phase === 'MERGED') {
       const result = candidate.postMergeAction === 'provider_sync'
         ? await api.dispatchProviderSync(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha, candidate.roots)
         : await api.dispatchPublication(candidate.prNumber, candidate.headSha, candidate.mergeCommitSha);
       if (['PUBLICATION_ALREADY_DISPATCHED', 'PROVIDER_SYNC_ALREADY_DISPATCHED'].includes(result.outcome)) continue;
+      if (result.outcome === 'PUBLICATION_AWAITING_PROVIDER_SYNC') {
+        deferredResult ??= {
+          ...result,
+          prNumber: candidate.prNumber,
+          headSha: candidate.headSha,
+          mergeCommitSha: candidate.mergeCommitSha,
+        };
+        continue;
+      }
       if (result.outcome.endsWith('_FAILED_REQUIRES_INSPECTION')) {
         throw new AutoMergeBlockedError(`${result.outcome} for PR #${candidate.prNumber} (workflow run ${result.workflowRunId ?? 'unavailable'})`);
       }
@@ -529,7 +560,7 @@ export async function runRecoverySweep(api) {
       throw error;
     }
   }
-  return { outcome: 'NO_ELIGIBLE_RECOVERY' };
+  return deferredResult ?? { outcome: 'NO_ELIGIBLE_RECOVERY' };
 }
 
 function encodeContentPath(path) {
@@ -727,10 +758,8 @@ export class GitHubApi {
       && candidate?.base?.ref === 'main'
       && candidate?.base?.repo?.full_name === this.repository
       && candidate?.head?.repo?.full_name === this.repository);
-    const payloadNumbers = (workflowRun.pull_requests ?? []).map((candidate) => candidate.number).filter(Number.isSafeInteger);
-    const candidateNumbers = [...new Set([...exactAssociatedPrs.map((candidate) => candidate.number), ...payloadNumbers])];
-    block(candidateNumbers.length === 1, 'workflow run must resolve exactly one PR from the exact head');
-    const pr = await this.request(`/pulls/${candidateNumbers[0]}`);
+    const candidateNumber = resolveWorkflowPrNumber(workflowRun.pull_requests ?? [], exactAssociatedPrs);
+    const pr = await this.request(`/pulls/${candidateNumber}`);
     const headSha = pr.head?.sha;
     block(validSha(headSha) && headSha === workflowRun.head_sha, 'PR head does not match the workflow run');
     const files = await this.paginate(`/pulls/${pr.number}/files`);
@@ -868,6 +897,66 @@ export class GitHubApi {
     return latestStatusesByContext(statuses).find((status) => status.context === context);
   }
 
+  async readDispatchClaim(kind, correlationId) {
+    const claim = dispatchClaim(kind, correlationId);
+    try {
+      const ref = await this.request(`/git/ref/${claim.apiRef}`);
+      block(ref?.ref === claim.fullRef && ref?.object?.type === 'commit' && validSha(ref.object.sha),
+        'dispatch claim evidence is invalid');
+      return { claim, ref };
+    } catch (error) {
+      if (error instanceof GitHubApiError && error.status === 404) return { claim, ref: undefined };
+      throw error;
+    }
+  }
+
+  async acquireDispatchClaim(kind, correlationId, mergeCommitSha) {
+    const before = await this.readDispatchClaim(kind, correlationId);
+    if (before.ref) {
+      block(before.ref.object.sha === mergeCommitSha, 'dispatch claim is bound to a different merge commit');
+      return false;
+    }
+    let createError;
+    let created;
+    try {
+      created = await this.request('/git/refs', {
+        method: 'POST',
+        body: { ref: before.claim.fullRef, sha: mergeCommitSha },
+      });
+    } catch (error) {
+      createError = error;
+    }
+    if (created) {
+      block(created.ref === before.claim.fullRef
+        && created.object?.type === 'commit'
+        && created.object.sha === mergeCommitSha,
+      'created dispatch claim does not match the exact merge commit');
+      return true;
+    }
+    const after = await this.readDispatchClaim(kind, correlationId);
+    if (after.ref) {
+      block(after.ref.object.sha === mergeCommitSha, 'dispatch claim is bound to a different merge commit');
+      throw new AutoMergeUnknownEffectError('dispatch claim ownership is unknown; refusing workflow dispatch');
+    }
+    if (createError && definiteMutationRejection(createError)) {
+      throw new AutoMergeBlockedError(`dispatch claim rejected with HTTP ${createError.status}`);
+    }
+    throw new AutoMergeUnknownEffectError('dispatch claim effect is unknown; refusing workflow dispatch');
+  }
+
+  async recordTerminalDispatchRejection(commitSha, context, description) {
+    block(validSha(commitSha), 'terminal dispatch rejection commit is invalid');
+    await this.request(`/statuses/${commitSha}`, {
+      method: 'POST',
+      body: {
+        state: 'failure',
+        context,
+        description,
+        target_url: `https://github.com/${this.repository}/actions/runs/${this.currentRunId}`,
+      },
+    });
+  }
+
   async findPublicationRun(correlationTitle) {
     for (let page = 1; page <= 30; page += 1) {
       const result = await this.request(`/actions/workflows/on-pr-merge.yml/runs?event=workflow_dispatch&per_page=100&page=${page}`);
@@ -903,6 +992,9 @@ export class GitHubApi {
       if (!existing || (existing.status === 'completed' && existing.conclusion !== 'success')) {
         return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing?.id, conclusion: existing?.conclusion ?? 'missing-run-evidence' };
       }
+      if (existing.status === 'completed' && existing.conclusion === 'success') {
+        return { outcome: 'PUBLICATION_AWAITING_PROVIDER_SYNC', workflowRunId: existing.id };
+      }
       return { outcome: 'PUBLICATION_IN_PROGRESS', workflowRunId: existing.id };
     }
     if (existing?.status === 'completed' && existing.conclusion === 'success') {
@@ -913,6 +1005,11 @@ export class GitHubApi {
     }
     if (existing) {
       return { outcome: 'PUBLICATION_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
+    }
+
+    const ownsClaim = await this.acquireDispatchClaim('publication', correlationId, mergeCommitSha);
+    if (!ownsClaim) {
+      throw new AutoMergeUnknownEffectError(`publication dispatch is claimed but has no authoritative run or status evidence for PR #${prNumber}`);
     }
 
     let mutationError;
@@ -929,7 +1026,18 @@ export class GitHubApi {
       if (run) return { outcome: 'PUBLICATION_DISPATCH_CONFIRMED', workflowRunId: run.id };
       if (attempt < 11) await this.sleep(5_000);
     }
-    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`publication dispatch rejected with HTTP ${mutationError.status}`);
+    if (mutationError && definiteMutationRejection(mutationError)) {
+      try {
+        await this.recordTerminalDispatchRejection(
+          mergeCommitSha,
+          effectContext,
+          `Publication dispatch rejected with HTTP ${mutationError.status}`,
+        );
+      } catch {
+        throw new AutoMergeUnknownEffectError(`publication dispatch rejection could not be durably recorded for PR #${prNumber}`);
+      }
+      throw new AutoMergeBlockedError(`publication dispatch rejected with HTTP ${mutationError.status}`);
+    }
     throw new AutoMergeUnknownEffectError(`publication dispatch effect is unknown for PR #${prNumber}`);
   }
 
@@ -986,6 +1094,11 @@ export class GitHubApi {
       return { outcome: 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION', workflowRunId: existing.id, conclusion: existing.conclusion };
     }
 
+    const ownsClaim = await this.acquireDispatchClaim('provider-sync', correlationId, mergeCommitSha);
+    if (!ownsClaim) {
+      throw new AutoMergeUnknownEffectError(`provider sync dispatch is claimed but has no authoritative run or status evidence for PR #${prNumber}`);
+    }
+
     let mutationError;
     try {
       await this.request('/actions/workflows/sync-to-supabase.yml/dispatches', {
@@ -1006,7 +1119,18 @@ export class GitHubApi {
       if (await this.findProviderSyncRun(correlationTitle)) return { outcome: 'PROVIDER_SYNC_DISPATCH_CONFIRMED' };
       if (attempt < 11) await this.sleep(5_000);
     }
-    if (mutationError && definiteMutationRejection(mutationError)) throw new AutoMergeBlockedError(`provider sync dispatch rejected with HTTP ${mutationError.status}`);
+    if (mutationError && definiteMutationRejection(mutationError)) {
+      try {
+        await this.recordTerminalDispatchRejection(
+          mergeCommitSha,
+          effectContext,
+          `Provider sync dispatch rejected with HTTP ${mutationError.status}`,
+        );
+      } catch {
+        throw new AutoMergeUnknownEffectError(`provider sync dispatch rejection could not be durably recorded for PR #${prNumber}`);
+      }
+      throw new AutoMergeBlockedError(`provider sync dispatch rejected with HTTP ${mutationError.status}`);
+    }
     throw new AutoMergeUnknownEffectError(`provider sync dispatch effect is unknown for PR #${prNumber}`);
   }
 }

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -13,11 +13,13 @@ const publishSource = readFileSync(PUBLISH_WORKFLOW_PATH, 'utf8');
 const workflow = parse(source);
 const trigger = workflow.on ?? workflow.true;
 
-test('uses only the trusted default-branch validation workflow_run event', () => {
-  assert.deepEqual(Object.keys(trigger), ['workflow_run']);
+test('uses trusted validation events plus bounded default-branch recovery triggers', () => {
+  assert.deepEqual(Object.keys(trigger), ['workflow_run', 'schedule', 'workflow_dispatch']);
   assert.deepEqual(trigger.workflow_run.workflows, ['Validate Marketplace']);
   assert.deepEqual(trigger.workflow_run.types, ['completed']);
-  assert.doesNotMatch(source, /pull_request_target|\bworkflow_dispatch\b/);
+  assert.deepEqual(trigger.schedule, [{ cron: '*/5 * * * *' }]);
+  assert.equal(trigger.workflow_dispatch, null);
+  assert.doesNotMatch(source, /pull_request_target/);
 });
 
 test('uses a literal hosted runner, non-cancelling repository serialization and exact minimal permissions', () => {
@@ -32,6 +34,7 @@ test('uses a literal hosted runner, non-cancelling repository serialization and 
   assert.equal(workflow.concurrency.group, 'trusted-skill-auto-merge-${{ github.repository }}');
   const job = workflow.jobs['auto-merge'];
   assert.equal(job['runs-on'], 'ubuntu-latest');
+  assert.match(job.if, /github\.event_name != 'workflow_run'/);
   assert.match(job.if, /workflow_run\.event == 'pull_request'/);
   assert.ok(Number.parseInt(job['timeout-minutes'], 10) <= 15);
 });
@@ -56,6 +59,7 @@ test('checks out only trusted automation and confines the event-capable App toke
   assert.equal(executor.env.GH_UPDATE_TOKEN, '${{ steps.app-token.outputs.token }}');
   assert.equal(executor.env.GITHUB_RUN_ID, '${{ github.run_id }}');
   assert.equal(executor.env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
+  assert.equal(executor.env.RECOVERY_SWEEP, "${{ github.event_name != 'workflow_run' }}");
 });
 
 test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -65,6 +65,11 @@ test('contains no bypass, force-push, auto-merge or untrusted PR execution path'
   assert.doesNotMatch(source, /--admin|--auto|force-with-lease|git push|pull\/\$\{|workflow_run\.head_repository|workflow_run\.head_branch/);
 });
 
-test('post-merge recovery accepts the exact GitHub Actions bot merger identity', () => {
+test('post-merge recovery accepts the exact GitHub Actions bot merger identity and binds dispatch correlation', () => {
   assert.match(publishSource, /github-actions\\\[bot\\\]/);
+  assert.match(publishSource, /^run-name:.*Publication.*inputs\.correlation_id/m);
+  assert.match(publishSource, /correlation_id:/);
+  assert.match(publishSource, /required: true/);
+  assert.match(publishSource, /EXPECTED_CORRELATION_ID="submission-pr-\$\{PR_NUMBER\}-\$\{HEAD_SHA\}-\$\{MERGE_COMMIT_SHA\}"/);
+  assert.match(publishSource, /\[ "\$CORRELATION_ID" = "\$EXPECTED_CORRELATION_ID" \]/);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -14,11 +14,10 @@ const workflow = parse(source);
 const trigger = workflow.on ?? workflow.true;
 
 test('uses trusted validation events plus bounded default-branch recovery triggers', () => {
-  assert.deepEqual(Object.keys(trigger), ['workflow_run', 'schedule', 'workflow_dispatch']);
+  assert.deepEqual(Object.keys(trigger), ['workflow_run', 'schedule']);
   assert.deepEqual(trigger.workflow_run.workflows, ['Validate Marketplace']);
   assert.deepEqual(trigger.workflow_run.types, ['completed']);
   assert.deepEqual(trigger.schedule, [{ cron: '*/5 * * * *' }]);
-  assert.equal(trigger.workflow_dispatch, null);
   assert.doesNotMatch(source, /pull_request_target/);
 });
 
@@ -34,7 +33,7 @@ test('uses a literal hosted runner, non-cancelling repository serialization and 
   assert.equal(workflow.concurrency.group, 'trusted-skill-auto-merge-${{ github.repository }}');
   const job = workflow.jobs['auto-merge'];
   assert.equal(job['runs-on'], 'ubuntu-latest');
-  assert.match(job.if, /github\.event_name != 'workflow_run'/);
+  assert.match(job.if, /github\.event_name == 'schedule'/);
   assert.match(job.if, /workflow_run\.event == 'pull_request'/);
   assert.ok(Number.parseInt(job['timeout-minutes'], 10) <= 15);
 });
@@ -59,7 +58,7 @@ test('checks out only trusted automation and confines the event-capable App toke
   assert.equal(executor.env.GH_UPDATE_TOKEN, '${{ steps.app-token.outputs.token }}');
   assert.equal(executor.env.GITHUB_RUN_ID, '${{ github.run_id }}');
   assert.equal(executor.env.WORKFLOW_RUN_ID, '${{ github.event.workflow_run.id }}');
-  assert.equal(executor.env.RECOVERY_SWEEP, "${{ github.event_name != 'workflow_run' }}");
+  assert.equal(executor.env.RECOVERY_SWEEP, "${{ github.event_name == 'schedule' }}");
 });
 
 test('contains no bypass, force-push, auto-merge or untrusted PR execution path', () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -66,8 +66,10 @@ test('contains no bypass, force-push, auto-merge or untrusted PR execution path'
 });
 
 test('post-merge recovery accepts the exact GitHub Actions bot merger identity and binds dispatch correlation', () => {
+  const publishWorkflow = parse(publishSource);
   assert.match(publishSource, /github-actions\\\[bot\\\]/);
   assert.match(publishSource, /^run-name:.*Publication.*inputs\.correlation_id/m);
+  assert.match(publishWorkflow['run-name'], /Publish merged PR #\{0\}.*\}\}$/);
   assert.match(publishSource, /correlation_id:/);
   assert.match(publishSource, /required: true/);
   assert.match(publishSource, /EXPECTED_CORRELATION_ID="submission-pr-\$\{PR_NUMBER\}-\$\{HEAD_SHA\}-\$\{MERGE_COMMIT_SHA\}"/);

--- a/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs
@@ -27,7 +27,7 @@ test('uses a literal hosted runner, non-cancelling repository serialization and 
     checks: 'read',
     contents: 'write',
     'pull-requests': 'write',
-    statuses: 'read',
+    statuses: 'write',
   });
   assert.equal(workflow.concurrency['cancel-in-progress'], false);
   assert.equal(workflow.concurrency.group, 'trusted-skill-auto-merge-${{ github.repository }}');
@@ -72,4 +72,17 @@ test('post-merge recovery accepts the exact GitHub Actions bot merger identity a
   assert.match(publishSource, /required: true/);
   assert.match(publishSource, /EXPECTED_CORRELATION_ID="submission-pr-\$\{PR_NUMBER\}-\$\{HEAD_SHA\}-\$\{MERGE_COMMIT_SHA\}"/);
   assert.match(publishSource, /\[ "\$CORRELATION_ID" = "\$EXPECTED_CORRELATION_ID" \]/);
+});
+
+test('publication receiver serializes one correlation and verifies the durable claim before writes', () => {
+  const publishWorkflow = parse(publishSource);
+  assert.equal(publishWorkflow.concurrency.group, 'publication-${{ inputs.correlation_id }}');
+  assert.equal(publishWorkflow.concurrency['cancel-in-progress'], false);
+  const claimGuard = publishSource.indexOf('Verify durable publication dispatch claim');
+  const appToken = publishSource.indexOf('Generate GitHub App Token');
+  assert.ok(claimGuard > 0 && claimGuard < appToken);
+  assert.match(publishSource, /agentcrew-dispatch-claims\/publication/);
+  assert.match(publishSource, /object\.sha == \$merge_sha/);
+  assert.match(publishSource, /Existing durable publication status refuses duplicate execution/);
+  assert.match(publishSource, /steps\.publication_claim\.outputs\.owns_reservation == 'true'/);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -6,6 +6,7 @@ import {
   GitHubApi,
   latestStatusesByContext,
   runAutoMerge,
+  runRecoverySweep,
   validateSnapshot,
 } from '../auto-merge-trusted-skill-pr.mjs';
 
@@ -387,6 +388,36 @@ test('update-branch uses expected exact head through the event-capable update cr
   assert.equal(result.newHeadSha, 'e'.repeat(40));
 });
 
+test('confirms update-branch against the fresh base readback when main advances after pre-effect validation', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = 'c'.repeat(40);
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: changed.pr.base.sha }] });
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.newHeadSha, changed.pr.head.sha);
+});
+
+test('retries a transient new-head commit read and returns confirmed instead of UNKNOWN', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  const api = fakeApi([behind, behind, changed.pr, changed.pr]);
+  let reads = 0;
+  api.readCommit = async (sha) => {
+    reads += 1;
+    if (reads === 1) throw new TypeError('transient commit read failure');
+    return { sha, parents: [{ sha: HEAD }, { sha: BASE }] };
+  };
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(reads, 2);
+});
+
 test('an unrelated concurrent head change cannot confirm update-branch', async () => {
   const behind = snapshot();
   behind.pr.mergeable_state = 'behind';
@@ -593,4 +624,29 @@ test('does not repeat an unknown merge effect and only trusts merged readback', 
   };
   await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
   assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+});
+
+test('recovery sweep skips ineligible historical PRs and performs only the first eligible effect', async () => {
+  const unsafe = snapshot();
+  unsafe.report.securityAudit.riskLevel = 'high';
+  const behind = snapshot();
+  behind.pr.number = 43;
+  behind.workflowRun.pull_requests = [{ number: 43 }];
+  behind.pr.mergeable_state = 'behind';
+  const changed = structuredClone(behind);
+  changed.pr.head.sha = 'e'.repeat(40);
+  const api = fakeApi([unsafe, behind, behind, changed.pr]);
+  api.listRecoveryWorkflowRunIds = async () => [101, 102, 103];
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: BASE }] });
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.prNumber, 43);
+  assert.deepEqual(api.calls, [['update', 43, HEAD]]);
+});
+
+test('recovery sweep is a no-op when no exact-head validation run is recoverable', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryWorkflowRunIds = async () => [];
+  assert.deepEqual(await runRecoverySweep(api), { outcome: 'NO_ELIGIBLE_RECOVERY' });
+  assert.deepEqual(api.calls, []);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -615,6 +615,34 @@ test('publication reconciliation waits on an in-progress run without another eff
   }
 });
 
+test('a terminal failed run overrides a stale durable pending reservation', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  const correlationId = `submission-pr-42-${HEAD}-${MERGE}`;
+  const context = `agentcrew/publication/${createHash('sha256').update(correlationId).digest('hex')}`;
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([{ context, state: 'pending' }]);
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'failure',
+      display_title: `Publication ${correlationId}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_FAILED_REQUIRES_INSPECTION');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('publication reconciliation fails closed on a partial failed run without replaying effects', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -6,6 +6,7 @@ import {
   AutoMergeUnknownEffectError,
   GitHubApi,
   latestStatusesByContext,
+  resolveWorkflowPrNumber,
   runAutoMerge,
   runRecoverySweep,
   validateSnapshot,
@@ -505,14 +506,194 @@ test('source-monitor merge dispatches exact changed Skill roots to provider sync
   });
 });
 
+test('workflow payload selects its exact PR even when another PR shares the head', () => {
+  assert.equal(resolveWorkflowPrNumber(
+    [{ number: 42 }],
+    [{ number: 42 }, { number: 43 }],
+  ), 42);
+  assert.equal(resolveWorkflowPrNumber([], [{ number: 42 }]), 42);
+  assert.throws(() => resolveWorkflowPrNumber([], [{ number: 42 }, { number: 43 }]), /exactly one PR/);
+  assert.throws(() => resolveWorkflowPrNumber([{ number: 42 }, { number: 43 }], [{ number: 42 }]), /exactly one PR/);
+});
+
+test('publication dispatch claim prevents a second POST after an accepted but unobserved dispatch', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/actions/workflows/on-pr-merge.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/on-pr-merge.yml/dispatches') && method === 'POST') {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), AutoMergeUnknownEffectError);
+    const secondStart = observed.length;
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), AutoMergeUnknownEffectError);
+    const posts = observed.filter(({ method }) => method === 'POST');
+    assert.equal(posts.filter(({ url }) => url.endsWith('/git/refs')).length, 1);
+    assert.equal(posts.filter(({ url }) => url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 1);
+    assert.equal(observed.slice(secondStart).filter(({ method }) => method === 'POST').length, 0);
+    assert.equal(claim.sha, MERGE);
+    assert.match(claim.ref, /^refs\/tags\/agentcrew-dispatch-claims\/publication\/[0-9a-f]{64}$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('provider sync dispatch claim prevents a second POST after an accepted but unobserved dispatch', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/actions/workflows/sync-to-supabase.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/provider-sync/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/sync-to-supabase.yml/dispatches') && method === 'POST') {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), AutoMergeUnknownEffectError);
+    const secondStart = observed.length;
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), AutoMergeUnknownEffectError);
+    const posts = observed.filter(({ method }) => method === 'POST');
+    assert.equal(posts.filter(({ url }) => url.endsWith('/git/refs')).length, 1);
+    assert.equal(posts.filter(({ url }) => url.endsWith('/actions/workflows/sync-to-supabase.yml/dispatches')).length, 1);
+    assert.equal(observed.slice(secondStart).filter(({ method }) => method === 'POST').length, 0);
+    assert.equal(claim.sha, MERGE);
+    assert.match(claim.ref, /^refs\/tags\/agentcrew-dispatch-claims\/provider-sync\/[0-9a-f]{64}$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a definite dispatch rejection is durably recorded and is not retried', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  let failureStatus;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes(`/commits/${MERGE}/statuses`)) {
+      return Response.json(failureStatus ? [failureStatus] : []);
+    }
+    if (String(url).endsWith(`/statuses/${MERGE}`) && method === 'POST') {
+      const body = JSON.parse(options.body);
+      failureStatus = { context: body.context, state: body.state };
+      return Response.json({ id: 1, ...failureStatus }, { status: 201 });
+    }
+    if (String(url).includes('/actions/workflows/on-pr-merge.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/on-pr-merge.yml/dispatches') && method === 'POST') {
+      return Response.json({ message: 'rejected' }, { status: 422 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), /rejected with HTTP 422/);
+    assert.equal(failureStatus.state, 'failure');
+    const secondStart = observed.length;
+    const second = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(second.outcome, 'PUBLICATION_FAILED_REQUIRES_INSPECTION');
+    assert.equal(observed.slice(secondStart).filter(({ url, method }) => method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a definite provider dispatch 404 is durably recorded and is not retried', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  let failureStatus;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes(`/commits/${MERGE}/statuses`)) {
+      return Response.json(failureStatus ? [failureStatus] : []);
+    }
+    if (String(url).endsWith(`/statuses/${MERGE}`) && method === 'POST') {
+      const body = JSON.parse(options.body);
+      failureStatus = { context: body.context, state: body.state };
+      return Response.json({ id: 1, ...failureStatus }, { status: 201 });
+    }
+    if (String(url).includes('/actions/workflows/sync-to-supabase.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/provider-sync/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/sync-to-supabase.yml/dispatches') && method === 'POST') {
+      return Response.json({ message: 'workflow unavailable' }, { status: 404 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), /rejected with HTTP 404/);
+    assert.equal(failureStatus.state, 'failure');
+    const secondStart = observed.length;
+    const second = await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]);
+    assert.equal(second.outcome, 'PROVIDER_SYNC_FAILED_REQUIRES_INSPECTION');
+    assert.equal(observed.slice(secondStart).filter(({ url, method }) => method === 'POST' && url.endsWith('/actions/workflows/sync-to-supabase.yml/dispatches')).length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('publication dispatch binds exact merged identity and confirms a correlated workflow run', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
   let dispatched = false;
+  let claim;
   const mergeSha = 'd'.repeat(40);
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
     if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: mergeSha } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && options?.method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: mergeSha } }, { status: 201 });
+    }
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -531,12 +712,13 @@ test('publication dispatch binds exact merged identity and confirms a correlated
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
     const result = await api.dispatchPublication(42, HEAD, mergeSha);
     assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
-    const post = observed.find(({ options }) => options?.method === 'POST');
+    const post = observed.find(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches'));
     assert.deepEqual(JSON.parse(post.options.body), {
       ref: 'main',
       inputs: { pr_number: '42', correlation_id: `submission-pr-42-${HEAD}-${mergeSha}` },
     });
-    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 1);
+    assert.equal(observed.filter(({ url, options }) => options?.method === 'POST' && url.endsWith('/git/refs')).length, 1);
+    assert.equal(observed.filter(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -615,6 +797,34 @@ test('publication reconciliation waits on an in-progress run without another eff
   }
 });
 
+test('a completed publication with pending durable status is awaiting provider sync, not active', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  const correlationId = `submission-pr-42-${HEAD}-${MERGE}`;
+  const context = `agentcrew/publication/${createHash('sha256').update(correlationId).digest('hex')}`;
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([{ context, state: 'pending' }]);
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      display_title: `Publication ${correlationId}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_AWAITING_PROVIDER_SYNC');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('a terminal failed run overrides a stale durable pending reservation', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
@@ -674,9 +884,17 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
   const originalFetch = globalThis.fetch;
   const observed = [];
   let dispatched = false;
+  let claim;
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
     if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/provider-sync/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && options?.method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -699,7 +917,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       currentRunId: 999,
     });
     await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT, 'skills/flat-skill']);
-    const post = observed.find(({ options }) => options?.method === 'POST');
+    const post = observed.find(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/sync-to-supabase.yml/dispatches'));
     assert.ok(post);
     assert.equal(post.url, 'https://api.github.com/repos/aiskillstore/marketplace/actions/workflows/sync-to-supabase.yml/dispatches');
     assert.deepEqual(JSON.parse(post.options.body), {
@@ -973,6 +1191,24 @@ test('recovery sweep stops before later PRs when the oldest trusted seed has no 
     reason: 'missing exact-head Validate Marketplace run',
   });
   assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep skips a completed publication awaiting provider sync and performs one later effect', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, mergeCommitSha: MERGE, phase: 'MERGED', postMergeAction: 'publication', roots: [ROOT] },
+    { prNumber: 43, headSha: HEAD, mergeCommitSha: 'e'.repeat(40), phase: 'MERGED', postMergeAction: 'provider_sync', roots: [SOURCE_ROOT] },
+  ];
+  api.dispatchPublication = async (...args) => {
+    api.calls.push(['dispatch-publication', ...args]);
+    return { outcome: 'PUBLICATION_AWAITING_PROVIDER_SYNC', workflowRunId: 9001 };
+  };
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'PROVIDER_SYNC_DISPATCH_CONFIRMED');
+  assert.deepEqual(api.calls, [
+    ['dispatch-publication', 42, HEAD, MERGE],
+    ['dispatch-provider-sync', 43, HEAD, 'e'.repeat(40), [SOURCE_ROOT]],
+  ]);
 });
 
 test('recovery sweep is a no-op when no trusted open candidate is recoverable', async () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -13,6 +13,7 @@ import {
 const REPO = { id: 9001, full_name: 'aiskillstore/marketplace', default_branch: 'main' };
 const HEAD = 'a'.repeat(40);
 const BASE = 'b'.repeat(40);
+const MERGE = 'd'.repeat(40);
 const ROOT = 'pending/example/skill';
 const SOURCE_ROOT = 'skills/example/skill';
 
@@ -490,7 +491,7 @@ test('source-monitor merge dispatches exact changed Skill roots to provider sync
   const result = await runAutoMerge(api, { workflowRunId: 123 });
   assert.deepEqual(api.calls, [
     ['merge', 42, HEAD, 'merge'],
-    ['dispatch-provider-sync', 42, HEAD, [SOURCE_ROOT]],
+    ['dispatch-provider-sync', 42, HEAD, MERGE, [SOURCE_ROOT]],
   ]);
   assert.deepEqual(result, {
     outcome: 'MERGED_AND_PROVIDER_SYNC_DISPATCHED',
@@ -515,6 +516,8 @@ test('publication dispatch binds exact merged identity and confirms a correlated
     return Response.json({ workflow_runs: dispatched ? [{
       id: 9001,
       event: 'workflow_dispatch',
+      status: 'queued',
+      conclusion: null,
       display_title: `Publication submission-pr-42-${HEAD}-${mergeSha}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
@@ -544,6 +547,8 @@ test('publication reconciliation does not redispatch an existing exact correlati
     return Response.json({ workflow_runs: [{
       id: 9001,
       event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
       display_title: `Publication submission-pr-42-${HEAD}-${mergeSha}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
@@ -554,6 +559,59 @@ test('publication reconciliation does not redispatch an existing exact correlati
     const result = await api.dispatchPublication(42, HEAD, mergeSha);
     assert.equal(result.outcome, 'PUBLICATION_ALREADY_DISPATCHED');
     assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('publication reconciliation waits on an in-progress run without another effect', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      status: 'in_progress',
+      conclusion: null,
+      display_title: `Publication submission-pr-42-${HEAD}-${MERGE}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_IN_PROGRESS');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('publication reconciliation reruns one failed correlated run instead of redispatching', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if ((options?.method ?? 'GET') === 'POST') return new Response(null, { status: 201 });
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'failure',
+      display_title: `Publication submission-pr-42-${HEAD}-${MERGE}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_RETRY_CONFIRMED');
+    const posts = observed.filter(({ options }) => options?.method === 'POST');
+    assert.equal(posts.length, 1);
+    assert.match(posts[0].url, /\/actions\/runs\/9001\/rerun$/);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -570,7 +628,11 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       return new Response(null, { status: 204 });
     }
     return Response.json({ workflow_runs: dispatched ? [{
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      id: 9101,
+      event: 'workflow_dispatch',
+      status: 'queued',
+      conclusion: null,
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] : [] });
@@ -582,7 +644,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       repository: REPO.full_name,
       currentRunId: 999,
     });
-    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT, 'skills/flat-skill']);
+    await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT, 'skills/flat-skill']);
     const post = observed.find(({ options }) => options?.method === 'POST');
     assert.ok(post);
     assert.equal(post.url, 'https://api.github.com/repos/aiskillstore/marketplace/actions/workflows/sync-to-supabase.yml/dispatches');
@@ -590,7 +652,8 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       ref: 'main',
       inputs: {
         slugs: 'example/skill flat-skill',
-        correlation_id: `source-monitor-pr-42-${HEAD}`,
+        correlation_id: `source-monitor-pr-42-${HEAD}-${MERGE}`,
+        merge_commit_sha: MERGE,
       },
     });
     assert.ok(observed.some(({ url, options }) => (options?.method ?? 'GET') === 'GET'
@@ -606,14 +669,18 @@ test('provider sync reconciliation does not redispatch an existing exact correla
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
     return Response.json({ workflow_runs: [{
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      id: 9101,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] });
   };
   try {
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
-    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]);
+    await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]);
     assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
   } finally {
     globalThis.fetch = originalFetch;
@@ -634,14 +701,18 @@ test('provider sync reconciliation finds an exact correlation on a later bounded
       })) });
     }
     return Response.json({ workflow_runs: [{
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}`,
+      id: 9101,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] });
   };
   try {
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
-    await api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]);
+    await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]);
     assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
     assert.ok(observed.some(({ url }) => new URL(url).searchParams.get('page') === '2'));
   } finally {
@@ -662,7 +733,7 @@ test('provider sync reconciliation fails closed after bounded pagination without
   };
   try {
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
-    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, [SOURCE_ROOT]), /bounded limit/);
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), /bounded limit/);
     assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
     assert.equal(observed.length, 30);
   } finally {
@@ -677,7 +748,7 @@ test('a rerun reconciles provider sync for an already merged source-monitor PR',
   merged.pr.merge_commit_sha = 'd'.repeat(40);
   const api = fakeApi([merged]);
   const result = await runAutoMerge(api, { workflowRunId: 123 });
-  assert.deepEqual(api.calls, [['dispatch-provider-sync', 42, HEAD, [SOURCE_ROOT]]]);
+  assert.deepEqual(api.calls, [['dispatch-provider-sync', 42, HEAD, MERGE, [SOURCE_ROOT]]]);
   assert.equal(result.outcome, 'PROVIDER_SYNC_DISPATCH_CONFIRMED');
 });
 

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { test } from 'node:test';
 import {
   AutoMergeBlockedError,
@@ -14,6 +15,8 @@ const REPO = { id: 9001, full_name: 'aiskillstore/marketplace', default_branch: 
 const HEAD = 'a'.repeat(40);
 const BASE = 'b'.repeat(40);
 const MERGE = 'd'.repeat(40);
+const SOURCE_DIGEST = 'ca9a8698b31c5d2f7e83762e1debad971057946329aa47cc81ac2f36d73cb9a9';
+const MULTI_SOURCE_DIGEST = '4c9b6e03bb42455445bb3db770c886b045b29599e57aed5568b783e168d31730';
 const ROOT = 'pending/example/skill';
 const SOURCE_ROOT = 'skills/example/skill';
 
@@ -509,6 +512,7 @@ test('publication dispatch binds exact merged identity and confirms a correlated
   const mergeSha = 'd'.repeat(40);
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -544,6 +548,7 @@ test('publication reconciliation does not redispatch an existing exact correlati
   const mergeSha = 'd'.repeat(40);
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     return Response.json({ workflow_runs: [{
       id: 9001,
       event: 'workflow_dispatch',
@@ -564,11 +569,32 @@ test('publication reconciliation does not redispatch an existing exact correlati
   }
 });
 
+test('durable publication success prevents replay after the Actions run is no longer listed', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  const correlationId = `submission-pr-42-${HEAD}-${MERGE}`;
+  const context = `agentcrew/publication/${createHash('sha256').update(correlationId).digest('hex')}`;
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([{ context, state: 'success' }]);
+    return Response.json({ workflow_runs: [] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_ALREADY_DISPATCHED');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('publication reconciliation waits on an in-progress run without another effect', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     return Response.json({ workflow_runs: [{
       id: 9001,
       event: 'workflow_dispatch',
@@ -594,6 +620,7 @@ test('publication reconciliation fails closed on a partial failed run without re
   const observed = [];
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     if ((options?.method ?? 'GET') === 'POST') return new Response(null, { status: 201 });
     return Response.json({ workflow_runs: [{
       id: 9001,
@@ -621,6 +648,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
   let dispatched = false;
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -630,7 +658,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       event: 'workflow_dispatch',
       status: 'queued',
       conclusion: null,
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}-${MULTI_SOURCE_DIGEST}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] : [] });
@@ -650,7 +678,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       ref: 'main',
       inputs: {
         slugs: 'example/skill flat-skill',
-        correlation_id: `source-monitor-pr-42-${HEAD}-${MERGE}`,
+        correlation_id: `source-monitor-pr-42-${HEAD}-${MERGE}-${MULTI_SOURCE_DIGEST}`,
         merge_commit_sha: MERGE,
       },
     });
@@ -666,12 +694,13 @@ test('provider sync reconciliation does not redispatch an existing exact correla
   const observed = [];
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     return Response.json({ workflow_runs: [{
       id: 9101,
       event: 'workflow_dispatch',
       status: 'completed',
       conclusion: 'success',
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}-${SOURCE_DIGEST}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] });
@@ -690,6 +719,7 @@ test('provider sync reconciliation finds an exact correlation on a later bounded
   const observed = [];
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     const page = Number(new URL(String(url)).searchParams.get('page'));
     if (page === 1) {
       return Response.json({ workflow_runs: Array.from({ length: 100 }, (_, index) => ({
@@ -703,7 +733,7 @@ test('provider sync reconciliation finds an exact correlation on a later bounded
       event: 'workflow_dispatch',
       status: 'completed',
       conclusion: 'success',
-      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}`,
+      display_title: `Provider sync source-monitor-pr-42-${HEAD}-${MERGE}-${SOURCE_DIGEST}`,
       head_branch: 'main',
       head_repository: { full_name: REPO.full_name },
     }] });
@@ -723,6 +753,7 @@ test('provider sync reconciliation fails closed after bounded pagination without
   const observed = [];
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([]);
     return Response.json({ workflow_runs: Array.from({ length: 100 }, (_, index) => ({
       display_title: `unrelated-${index}`,
       head_branch: 'main',
@@ -733,7 +764,7 @@ test('provider sync reconciliation fails closed after bounded pagination without
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
     await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), /bounded limit/);
     assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
-    assert.equal(observed.length, 30);
+    assert.equal(observed.length, 31);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -589,7 +589,7 @@ test('publication reconciliation waits on an in-progress run without another eff
   }
 });
 
-test('publication reconciliation reruns one failed correlated run instead of redispatching', async () => {
+test('publication reconciliation fails closed on a partial failed run without replaying effects', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
   globalThis.fetch = async (url, options) => {
@@ -608,10 +608,8 @@ test('publication reconciliation reruns one failed correlated run instead of red
   try {
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
     const result = await api.dispatchPublication(42, HEAD, MERGE);
-    assert.equal(result.outcome, 'PUBLICATION_RETRY_CONFIRMED');
-    const posts = observed.filter(({ options }) => options?.method === 'POST');
-    assert.equal(posts.length, 1);
-    assert.match(posts[0].url, /\/actions\/runs\/9001\/rerun$/);
+    assert.equal(result.outcome, 'PUBLICATION_FAILED_REQUIRES_INSPECTION');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -742,15 +742,17 @@ test('recovery sweep performs at most one effect when it merges a clean submissi
   assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge']]);
 });
 
-test('recovery sweep reconciles one already merged submission without another merge', async () => {
-  const merged = snapshot();
-  merged.pr.state = 'closed';
-  merged.pr.merged = true;
-  merged.pr.merge_commit_sha = 'd'.repeat(40);
-  const api = fakeApi([merged]);
-  api.listRecoveryCandidates = async () => [
-    { prNumber: 42, headSha: HEAD, workflowRunId: 101, phase: 'MERGED' },
-  ];
+test('recovery sweep reconciles a marker-bound merged submission without historical workflow metadata', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryCandidates = async () => [{
+    prNumber: 42,
+    headSha: HEAD,
+    mergeCommitSha: 'd'.repeat(40),
+    workflowRunId: null,
+    phase: 'MERGED',
+    postMergeAction: 'publication',
+    roots: [ROOT],
+  }];
   const result = await runRecoverySweep(api);
   assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
   assert.deepEqual(api.calls, [['dispatch-publication', 42, HEAD, 'd'.repeat(40)]]);
@@ -833,8 +835,8 @@ test('recovery sweep reports oldest-candidate conflict instead of scanning later
 test('recovery sweep stops before later PRs when the oldest trusted seed has no validation run yet', async () => {
   const api = fakeApi([]);
   api.listRecoveryCandidates = async () => [
-    { prNumber: 42, headSha: HEAD, workflowRunId: null },
-    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+    { prNumber: 42, headSha: HEAD, workflowRunId: null, phase: 'OPEN' },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102, phase: 'OPEN' },
   ];
   assert.deepEqual(await runRecoverySweep(api), {
     outcome: 'WAITING_CI',

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -315,11 +315,13 @@ function fakeApi(sequence) {
       calls.push(['merge', number, headSha, method]);
       return { merged: true, sha: 'd'.repeat(40), message: 'Pull Request successfully merged' };
     },
-    async dispatchPublication(number) {
-      calls.push(['dispatch-publication', number]);
+    async dispatchPublication(...args) {
+      calls.push(['dispatch-publication', ...args]);
+      return { outcome: 'PUBLICATION_DISPATCH_CONFIRMED' };
     },
     async dispatchProviderSync(...args) {
       calls.push(['dispatch-provider-sync', ...args]);
+      return { outcome: 'PROVIDER_SYNC_DISPATCH_CONFIRMED' };
     },
   };
 }
@@ -332,15 +334,15 @@ test('rejects base drift before the effect and performs no mutation', async () =
   assert.deepEqual(api.calls, []);
 });
 
-test('returns a harmless no-op for the duplicate prerequisite event after merge', async () => {
+test('reconciles publication for an already merged trusted submission', async () => {
   const merged = snapshot();
   merged.pr.state = 'closed';
   merged.pr.merged = true;
   merged.pr.merge_commit_sha = 'd'.repeat(40);
   const api = fakeApi([merged]);
   const result = await runAutoMerge(api, { workflowRunId: 123 });
-  assert.equal(result.outcome, 'ALREADY_MERGED');
-  assert.deepEqual(api.calls, []);
+  assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
+  assert.deepEqual(api.calls, [['dispatch-publication', 42, HEAD, 'd'.repeat(40)]]);
 });
 
 test('waits for transient GitHub mergeability before qualifying and updating a behind PR', async () => {
@@ -365,7 +367,7 @@ test('revalidates immediately before exact-head ordinary merge and confirms auth
   merged.pr.merge_commit_sha = 'd'.repeat(40);
   const api = fakeApi([snapshot(), snapshot(), merged]);
   const result = await runAutoMerge(api, { workflowRunId: 123 });
-  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge'], ['dispatch-publication', 42]]);
+  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge'], ['dispatch-publication', 42, HEAD, 'd'.repeat(40)]]);
   assert.deepEqual(result, {
     outcome: 'MERGED_AND_PUBLICATION_DISPATCHED',
     prNumber: 42,
@@ -373,6 +375,17 @@ test('revalidates immediately before exact-head ordinary merge and confirms auth
     mergeCommitSha: 'd'.repeat(40),
     classification: 'NEW_SKILL',
   });
+});
+
+test('scheduled recovery performs only the merge effect and defers publication reconciliation', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([snapshot(), snapshot(), merged]);
+  const result = await runAutoMerge(api, { workflowRunId: 123, deferPostMergeDispatch: true });
+  assert.equal(result.outcome, 'MERGED_AWAITING_PUBLICATION_RECONCILIATION');
+  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge']]);
 });
 
 test('update-branch uses expected exact head through the event-capable update credential and awaits fresh CI', async () => {
@@ -486,6 +499,64 @@ test('source-monitor merge dispatches exact changed Skill roots to provider sync
     mergeCommitSha: 'd'.repeat(40),
     classification: 'SOURCE_MONITOR_UPDATE',
   });
+});
+
+test('publication dispatch binds exact merged identity and confirms a correlated workflow run', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let dispatched = false;
+  const mergeSha = 'd'.repeat(40);
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if ((options?.method ?? 'GET') === 'POST') {
+      dispatched = true;
+      return new Response(null, { status: 204 });
+    }
+    return Response.json({ workflow_runs: dispatched ? [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      display_title: `Publication submission-pr-42-${HEAD}-${mergeSha}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] : [] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, mergeSha);
+    assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
+    const post = observed.find(({ options }) => options?.method === 'POST');
+    assert.deepEqual(JSON.parse(post.options.body), {
+      ref: 'main',
+      inputs: { pr_number: '42', correlation_id: `submission-pr-42-${HEAD}-${mergeSha}` },
+    });
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('publication reconciliation does not redispatch an existing exact correlation', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  const mergeSha = 'd'.repeat(40);
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      display_title: `Publication submission-pr-42-${HEAD}-${mergeSha}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, mergeSha);
+    assert.equal(result.outcome, 'PUBLICATION_ALREADY_DISPATCHED');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('provider sync dispatch binds canonical source-monitor roots and idempotency key to exact manual slugs', async () => {
@@ -607,7 +678,7 @@ test('a rerun reconciles provider sync for an already merged source-monitor PR',
   const api = fakeApi([merged]);
   const result = await runAutoMerge(api, { workflowRunId: 123 });
   assert.deepEqual(api.calls, [['dispatch-provider-sync', 42, HEAD, [SOURCE_ROOT]]]);
-  assert.equal(result.outcome, 'ALREADY_MERGED_AND_PROVIDER_SYNC_CONFIRMED');
+  assert.equal(result.outcome, 'PROVIDER_SYNC_DISPATCH_CONFIRMED');
 });
 
 test('confirmed source-monitor merge with failed provider sync dispatch is UNKNOWN and is never repeated', async () => {
@@ -655,6 +726,34 @@ test('does not repeat an unknown merge effect and only trusts merged readback', 
   };
   await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
   assert.equal(api.calls.filter(([kind]) => kind === 'merge').length, 1);
+});
+
+test('recovery sweep performs at most one effect when it merges a clean submission', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([snapshot(), snapshot(), merged]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101, phase: 'OPEN' },
+  ];
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'MERGED_AWAITING_PUBLICATION_RECONCILIATION');
+  assert.deepEqual(api.calls, [['merge', 42, HEAD, 'merge']]);
+});
+
+test('recovery sweep reconciles one already merged submission without another merge', async () => {
+  const merged = snapshot();
+  merged.pr.state = 'closed';
+  merged.pr.merged = true;
+  merged.pr.merge_commit_sha = 'd'.repeat(40);
+  const api = fakeApi([merged]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101, phase: 'MERGED' },
+  ];
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
+  assert.deepEqual(api.calls, [['dispatch-publication', 42, HEAD, 'd'.repeat(40)]]);
 });
 
 test('recovery sweep skips ineligible historical PRs and performs only the first eligible effect', async () => {

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -80,7 +80,6 @@ function snapshot(overrides = {}) {
     reports: [{
       path: `${ROOT}/skill-report.json`,
       sha: '2'.repeat(40),
-      securityAudit: { is_blocked: false, safe_to_publish: true },
     }],
     basePendingExists: false,
     baseSkillRootsExist: false,
@@ -105,7 +104,6 @@ function sourceMonitorSnapshot(overrides = {}) {
   value.reports = [{
     path: `${SOURCE_ROOT}/skill-report.json`,
     sha: '4'.repeat(40),
-    securityAudit: { is_blocked: false, safe_to_publish: true },
   }];
   return structuredClone(Object.assign(value, overrides));
 }
@@ -278,7 +276,6 @@ test('qualifies multiple canonical pending Skill roots when every root has a bou
   value.reports.push({
     path: `${secondRoot}/skill-report.json`,
     sha: '4'.repeat(40),
-    securityAudit: { is_blocked: false, safe_to_publish: true },
   });
   assert.deepEqual(validateSnapshot(value).roots, [ROOT, secondRoot].sort());
 });
@@ -305,6 +302,9 @@ function fakeApi(sequence) {
     },
     async readCommit(sha) {
       return { sha, parents: [{ sha: HEAD }, { sha: BASE }] };
+    },
+    async isCommitAncestor(ancestorSha, descendantSha) {
+      return ancestorSha === descendantSha;
     },
     async sleep() {},
     async updateBranch(number, headSha) {
@@ -399,6 +399,37 @@ test('confirms update-branch against the fresh base readback when main advances 
   const result = await runAutoMerge(api, { workflowRunId: 123 });
   assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
   assert.equal(result.newHeadSha, changed.pr.head.sha);
+});
+
+test('confirms update when the update base is an ancestor of a twice-advanced main tip', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const updateBase = 'c'.repeat(40);
+  const currentBase = 'd'.repeat(40);
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = currentBase;
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: updateBase }] });
+  api.isCommitAncestor = async (ancestorSha, descendantSha) => ancestorSha === updateBase && descendantSha === currentBase;
+  const result = await runAutoMerge(api, { workflowRunId: 123 });
+  assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
+  assert.equal(result.newHeadSha, changed.pr.head.sha);
+});
+
+test('rejects a new-head second parent that is not on the trusted main lineage', async () => {
+  const behind = snapshot();
+  behind.pr.mergeable_state = 'behind';
+  const unrelated = 'c'.repeat(40);
+  const currentBase = 'd'.repeat(40);
+  const changed = snapshot();
+  changed.pr.head.sha = 'e'.repeat(40);
+  changed.pr.base.sha = currentBase;
+  const api = fakeApi([behind, behind, changed.pr]);
+  api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: unrelated }] });
+  api.isCommitAncestor = async () => false;
+  await assert.rejects(() => runAutoMerge(api, { workflowRunId: 123 }), AutoMergeUnknownEffectError);
+  assert.equal(api.calls.filter(([kind]) => kind === 'update').length, 1);
 });
 
 test('retries a transient new-head commit read and returns confirmed instead of UNKNOWN', async () => {
@@ -628,7 +659,8 @@ test('does not repeat an unknown merge effect and only trusts merged readback', 
 
 test('recovery sweep skips ineligible historical PRs and performs only the first eligible effect', async () => {
   const unsafe = snapshot();
-  unsafe.report.securityAudit.riskLevel = 'high';
+  unsafe.files.push({ filename: 'scripts/injected.mjs', status: 'added', sha: '9'.repeat(40) });
+  unsafe.pr.changed_files = unsafe.files.length;
   const behind = snapshot();
   behind.pr.number = 43;
   behind.workflowRun.pull_requests = [{ number: 43 }];
@@ -636,7 +668,11 @@ test('recovery sweep skips ineligible historical PRs and performs only the first
   const changed = structuredClone(behind);
   changed.pr.head.sha = 'e'.repeat(40);
   const api = fakeApi([unsafe, behind, behind, changed.pr]);
-  api.listRecoveryWorkflowRunIds = async () => [101, 102, 103];
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+    { prNumber: 44, headSha: HEAD, workflowRunId: 103 },
+  ];
   api.readCommit = async (sha) => ({ sha, parents: [{ sha: HEAD }, { sha: BASE }] });
   const result = await runRecoverySweep(api);
   assert.equal(result.outcome, 'UPDATE_CONFIRMED_AWAITING_CI');
@@ -644,9 +680,75 @@ test('recovery sweep skips ineligible historical PRs and performs only the first
   assert.deepEqual(api.calls, [['update', 43, HEAD]]);
 });
 
-test('recovery sweep is a no-op when no exact-head validation run is recoverable', async () => {
+test('recovery sweep stops at the oldest waiting candidate and never updates a later behind PR', async () => {
+  const waiting = snapshot();
+  waiting.checks = waiting.checks.filter((check) => check.name !== 'validate');
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([waiting, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  const result = await runRecoverySweep(api);
+  assert.match(result.reason, /missing required check validate/);
+  assert.equal(result.outcome, 'WAITING_CI');
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep reports oldest-candidate CI failure instead of scanning later PRs', async () => {
+  const failed = snapshot();
+  failed.checks.find((check) => check.name === 'validate').conclusion = 'failure';
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([failed, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  await assert.rejects(() => runRecoverySweep(api), /check validate concluded failure/);
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep reports oldest-candidate conflict instead of scanning later PRs', async () => {
+  const conflicted = snapshot();
+  conflicted.pr.mergeable = false;
+  conflicted.pr.mergeable_state = 'dirty';
+  const later = snapshot();
+  later.pr.number = 43;
+  later.workflowRun.pull_requests = [{ number: 43 }];
+  later.pr.mergeable_state = 'behind';
+  const api = fakeApi([conflicted, later, later]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: 101 },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  await assert.rejects(() => runRecoverySweep(api), /PR is not mergeable/);
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep stops before later PRs when the oldest trusted seed has no validation run yet', async () => {
   const api = fakeApi([]);
-  api.listRecoveryWorkflowRunIds = async () => [];
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, workflowRunId: null },
+    { prNumber: 43, headSha: HEAD, workflowRunId: 102 },
+  ];
+  assert.deepEqual(await runRecoverySweep(api), {
+    outcome: 'WAITING_CI',
+    prNumber: 42,
+    headSha: HEAD,
+    reason: 'missing exact-head Validate Marketplace run',
+  });
+  assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep is a no-op when no trusted open candidate is recoverable', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryCandidates = async () => [];
   assert.deepEqual(await runRecoverySweep(api), { outcome: 'NO_ELIGIBLE_RECOVERY' });
   assert.deepEqual(api.calls, []);
 });

--- a/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
+++ b/scripts/tests/auto-merge-trusted-skill-pr.test.mjs
@@ -6,6 +6,7 @@ import {
   AutoMergeUnknownEffectError,
   GitHubApi,
   latestStatusesByContext,
+  resolveWorkflowPrNumber,
   runAutoMerge,
   runRecoverySweep,
   validateSnapshot,
@@ -505,14 +506,151 @@ test('source-monitor merge dispatches exact changed Skill roots to provider sync
   });
 });
 
+test('workflow payload selects its exact PR even when another PR shares the head', () => {
+  assert.equal(resolveWorkflowPrNumber(
+    [{ number: 42 }],
+    [{ number: 42 }, { number: 43 }],
+  ), 42);
+  assert.equal(resolveWorkflowPrNumber([], [{ number: 42 }]), 42);
+  assert.throws(() => resolveWorkflowPrNumber([], [{ number: 42 }, { number: 43 }]), /exactly one PR/);
+  assert.throws(() => resolveWorkflowPrNumber([{ number: 42 }, { number: 43 }], [{ number: 42 }]), /exactly one PR/);
+});
+
+test('publication dispatch claim prevents a second POST after an accepted but unobserved dispatch', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/actions/workflows/on-pr-merge.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/on-pr-merge.yml/dispatches') && method === 'POST') {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), AutoMergeUnknownEffectError);
+    const secondStart = observed.length;
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), AutoMergeUnknownEffectError);
+    const posts = observed.filter(({ method }) => method === 'POST');
+    assert.equal(posts.filter(({ url }) => url.endsWith('/git/refs')).length, 1);
+    assert.equal(posts.filter(({ url }) => url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 1);
+    assert.equal(observed.slice(secondStart).filter(({ method }) => method === 'POST').length, 0);
+    assert.equal(claim.sha, MERGE);
+    assert.match(claim.ref, /^refs\/tags\/agentcrew-dispatch-claims\/publication\/[0-9a-f]{64}$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('provider sync dispatch claim prevents a second POST after an accepted but unobserved dispatch', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/actions/workflows/sync-to-supabase.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/provider-sync/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/sync-to-supabase.yml/dispatches') && method === 'POST') {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), AutoMergeUnknownEffectError);
+    const secondStart = observed.length;
+    await assert.rejects(() => api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT]), AutoMergeUnknownEffectError);
+    const posts = observed.filter(({ method }) => method === 'POST');
+    assert.equal(posts.filter(({ url }) => url.endsWith('/git/refs')).length, 1);
+    assert.equal(posts.filter(({ url }) => url.endsWith('/actions/workflows/sync-to-supabase.yml/dispatches')).length, 1);
+    assert.equal(observed.slice(secondStart).filter(({ method }) => method === 'POST').length, 0);
+    assert.equal(claim.sha, MERGE);
+    assert.match(claim.ref, /^refs\/tags\/agentcrew-dispatch-claims\/provider-sync\/[0-9a-f]{64}$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a definite dispatch rejection is durably recorded and is not retried', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  let claim;
+  let failureStatus;
+  globalThis.fetch = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    observed.push({ url: String(url), method, body: options.body });
+    if (String(url).includes(`/commits/${MERGE}/statuses`)) {
+      return Response.json(failureStatus ? [failureStatus] : []);
+    }
+    if (String(url).endsWith(`/statuses/${MERGE}`) && method === 'POST') {
+      const body = JSON.parse(options.body);
+      failureStatus = { context: body.context, state: body.state };
+      return Response.json({ id: 1, ...failureStatus }, { status: 201 });
+    }
+    if (String(url).includes('/actions/workflows/on-pr-merge.yml/runs')) return Response.json({ workflow_runs: [] });
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
+    if (String(url).endsWith('/actions/workflows/on-pr-merge.yml/dispatches') && method === 'POST') {
+      return Response.json({ message: 'rejected' }, { status: 422 });
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    api.sleep = async () => {};
+    await assert.rejects(() => api.dispatchPublication(42, HEAD, MERGE), /rejected with HTTP 422/);
+    assert.equal(failureStatus.state, 'failure');
+    const secondStart = observed.length;
+    const second = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(second.outcome, 'PUBLICATION_FAILED_REQUIRES_INSPECTION');
+    assert.equal(observed.slice(secondStart).filter(({ url, method }) => method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('publication dispatch binds exact merged identity and confirms a correlated workflow run', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
   let dispatched = false;
+  let claim;
   const mergeSha = 'd'.repeat(40);
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
     if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/publication/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: mergeSha } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && options?.method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: mergeSha } }, { status: 201 });
+    }
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -531,12 +669,13 @@ test('publication dispatch binds exact merged identity and confirms a correlated
     const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
     const result = await api.dispatchPublication(42, HEAD, mergeSha);
     assert.equal(result.outcome, 'PUBLICATION_DISPATCH_CONFIRMED');
-    const post = observed.find(({ options }) => options?.method === 'POST');
+    const post = observed.find(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches'));
     assert.deepEqual(JSON.parse(post.options.body), {
       ref: 'main',
       inputs: { pr_number: '42', correlation_id: `submission-pr-42-${HEAD}-${mergeSha}` },
     });
-    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 1);
+    assert.equal(observed.filter(({ url, options }) => options?.method === 'POST' && url.endsWith('/git/refs')).length, 1);
+    assert.equal(observed.filter(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/on-pr-merge.yml/dispatches')).length, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -615,6 +754,34 @@ test('publication reconciliation waits on an in-progress run without another eff
   }
 });
 
+test('a completed publication with pending durable status is awaiting provider sync, not active', async () => {
+  const originalFetch = globalThis.fetch;
+  const observed = [];
+  const correlationId = `submission-pr-42-${HEAD}-${MERGE}`;
+  const context = `agentcrew/publication/${createHash('sha256').update(correlationId).digest('hex')}`;
+  globalThis.fetch = async (url, options) => {
+    observed.push({ url: String(url), options });
+    if (String(url).includes('/statuses')) return Response.json([{ context, state: 'pending' }]);
+    return Response.json({ workflow_runs: [{
+      id: 9001,
+      event: 'workflow_dispatch',
+      status: 'completed',
+      conclusion: 'success',
+      display_title: `Publication ${correlationId}`,
+      head_branch: 'main',
+      head_repository: { full_name: REPO.full_name },
+    }] });
+  };
+  try {
+    const api = new GitHubApi({ token: 'test-token', updateToken: 'test-update-token', repository: REPO.full_name, currentRunId: 999 });
+    const result = await api.dispatchPublication(42, HEAD, MERGE);
+    assert.equal(result.outcome, 'PUBLICATION_AWAITING_PROVIDER_SYNC');
+    assert.equal(observed.filter(({ options }) => options?.method === 'POST').length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('a terminal failed run overrides a stale durable pending reservation', async () => {
   const originalFetch = globalThis.fetch;
   const observed = [];
@@ -674,9 +841,17 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
   const originalFetch = globalThis.fetch;
   const observed = [];
   let dispatched = false;
+  let claim;
   globalThis.fetch = async (url, options) => {
     observed.push({ url: String(url), options });
     if (String(url).includes('/statuses')) return Response.json([]);
+    if (String(url).includes('/git/ref/tags/agentcrew-dispatch-claims/provider-sync/')) {
+      return claim ? Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }) : Response.json({}, { status: 404 });
+    }
+    if (String(url).endsWith('/git/refs') && options?.method === 'POST') {
+      claim = JSON.parse(options.body);
+      return Response.json({ ref: claim.ref, object: { type: 'commit', sha: MERGE } }, { status: 201 });
+    }
     if ((options?.method ?? 'GET') === 'POST') {
       dispatched = true;
       return new Response(null, { status: 204 });
@@ -699,7 +874,7 @@ test('provider sync dispatch binds canonical source-monitor roots and idempotenc
       currentRunId: 999,
     });
     await api.dispatchProviderSync(42, HEAD, MERGE, [SOURCE_ROOT, 'skills/flat-skill']);
-    const post = observed.find(({ options }) => options?.method === 'POST');
+    const post = observed.find(({ url, options }) => options?.method === 'POST' && url.endsWith('/actions/workflows/sync-to-supabase.yml/dispatches'));
     assert.ok(post);
     assert.equal(post.url, 'https://api.github.com/repos/aiskillstore/marketplace/actions/workflows/sync-to-supabase.yml/dispatches');
     assert.deepEqual(JSON.parse(post.options.body), {
@@ -973,6 +1148,24 @@ test('recovery sweep stops before later PRs when the oldest trusted seed has no 
     reason: 'missing exact-head Validate Marketplace run',
   });
   assert.deepEqual(api.calls, []);
+});
+
+test('recovery sweep skips a completed publication awaiting provider sync and performs one later effect', async () => {
+  const api = fakeApi([]);
+  api.listRecoveryCandidates = async () => [
+    { prNumber: 42, headSha: HEAD, mergeCommitSha: MERGE, phase: 'MERGED', postMergeAction: 'publication', roots: [ROOT] },
+    { prNumber: 43, headSha: HEAD, mergeCommitSha: 'e'.repeat(40), phase: 'MERGED', postMergeAction: 'provider_sync', roots: [SOURCE_ROOT] },
+  ];
+  api.dispatchPublication = async (...args) => {
+    api.calls.push(['dispatch-publication', ...args]);
+    return { outcome: 'PUBLICATION_AWAITING_PROVIDER_SYNC', workflowRunId: 9001 };
+  };
+  const result = await runRecoverySweep(api);
+  assert.equal(result.outcome, 'PROVIDER_SYNC_DISPATCH_CONFIRMED');
+  assert.deepEqual(api.calls, [
+    ['dispatch-publication', 42, HEAD, MERGE],
+    ['dispatch-provider-sync', 43, HEAD, 'e'.repeat(40), [SOURCE_ROOT]],
+  ]);
 });
 
 test('recovery sweep is a no-op when no trusted open candidate is recoverable', async () => {

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -163,7 +163,10 @@ test('manual slug sync carries an optional exact correlation without requiring a
   const lastSync = section(workflow, '      - name: Find last successful sync commit', '      - name: Detect changed skills');
   assert.match(lastSync, /if: inputs\.slugs == ''/);
   const correlation = section(workflow, '      - name: Validate trusted sync correlation', '      - name: Generate GitHub App Token');
-  assert.match(correlation, /\^source-monitor-pr-\[1-9\]\[0-9\]\*-\[0-9a-f\]\{40\}\$/);
+  assert.match(correlation, /\^source-monitor-pr-\(\[1-9\]\[0-9\]\*\)-\(\[0-9a-f\]\{40\}\)-\(\[0-9a-f\]\{40\}\)\$/);
+  assert.match(correlation, /MERGE_COMMIT_SHA/);
+  assert.match(correlation, /Provider sync correlation does not match the authoritative merged source-monitor PR/);
+  assert.match(correlation, /Correlated merge is not on the current main lineage/);
   assert.match(correlation, /"\$EVENT_NAME" != 'workflow_dispatch'/);
   assert.match(correlation, /"\$GIT_REF" != 'refs\/heads\/main'/);
   const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildShardPlan } from '../plan-cache-invalidation.mjs';
@@ -11,6 +12,7 @@ const REPO_ROOT = resolve(TEST_DIR, '..', '..');
 const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'sync-to-supabase.yml');
 const TEST_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'test-recalculate-scores.yml');
 const AGGREGATE = join(REPO_ROOT, 'scripts', 'check-cache-invalidation-aggregate.sh');
+const CORRELATED_ROOT_GUARD = join(REPO_ROOT, 'scripts', 'validate-correlated-sync-roots.mjs');
 
 function section(workflow, start, end) {
   const startIndex = workflow.indexOf(start);
@@ -129,7 +131,7 @@ test('incremental detection resolves both sides from pinned Git trees', () => {
   assert.match(detectJob, /INPUT_SLUGS: \$\{\{ inputs\.slugs \}\}/);
   assert.match(detectJob, /HEAD_SHA: \$\{\{ github\.sha \}\}/);
   assert.doesNotMatch(detectJob.slice(detectJob.indexOf('run: |')), /\$\{\{\s*inputs\./);
-  assert.match(detectJob, /--commit "\$HEAD_SHA"/);
+  assert.match(detectJob, /--commit "\$SYNC_COMMIT_SHA"/);
   assert.match(detectJob, /--base "\$BASE_SHA"/);
   assert.match(detectJob, /--head "\$HEAD_SHA"/);
   assert.doesNotMatch(detectJob, /get_skill_slug|\[ -f "skills\/\$first/);
@@ -154,6 +156,50 @@ test('incremental detection subtracts only verified successful manual recovery a
   assert.match(detect, /--recoveries "\$RECOVERIES_FILE"/);
   assert.match(detect, /MAX_RECOVERY_RUNS=100/);
   assert.match(workflow, /retention-days: 30/);
+});
+
+test('correlated provider sync verifies exact root versions and uses the correlated merge commit', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const correlation = section(workflow, '      - name: Validate trusted sync correlation', '      - name: Generate GitHub App Token');
+  const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
+  const materialize = section(workflow, '      - name: Materialize changed skills', '      - name: Sync skills to Supabase');
+  const sync = section(workflow, '      - name: Sync skills to Supabase', '      - name: Reconcile durable security change events');
+  assert.match(correlation, /id: trusted-correlation/);
+  assert.match(correlation, /validate-correlated-sync-roots\.mjs/);
+  assert.match(correlation, /sync_commit_sha=\$MERGE_COMMIT_SHA/);
+  assert.match(detect, /SYNC_COMMIT_SHA: \$\{\{ steps\.trusted-correlation\.outputs\.sync_commit_sha \}\}/);
+  assert.match(detect, /--commit "\$SYNC_COMMIT_SHA"/);
+  assert.match(materialize, /--commit "\$SYNC_COMMIT_SHA"/);
+  assert.match(sync, /--marketplace-commit "\$SYNC_COMMIT_SHA"/);
+  assert.match(sync, /\.meta\.slug/);
+  assert.match(sync, /materialized Skill report is missing or unsafe/);
+  assert.match(sync, /diff -u expected-synced-slugs\.txt synced-slugs\.txt/);
+
+  const tmp = mkdtempSync(join(tmpdir(), 'marketplace-correlated-roots-'));
+  try {
+    const git = (...args) => spawnSync('git', args, { cwd: tmp, encoding: 'utf8' });
+    assert.equal(git('init').status, 0);
+    assert.equal(git('config', 'user.email', 'test@example.com').status, 0);
+    assert.equal(git('config', 'user.name', 'Test').status, 0);
+    assert.equal(spawnSync('/bin/mkdir', ['-p', join(tmp, 'skills/example/skill'), join(tmp, 'skills/other/skill')]).status, 0);
+    assert.equal(spawnSync('/bin/sh', ['-c', "printf 'v1\\n' > skills/example/skill/SKILL.md; printf '{}\\n' > skills/example/skill/skill-report.json; printf 'o1\\n' > skills/other/skill/SKILL.md"], { cwd: tmp }).status, 0);
+    assert.equal(git('add', '.').status, 0);
+    assert.equal(git('commit', '-m', 'merge').status, 0);
+    const mergeSha = git('rev-parse', 'HEAD').stdout.trim();
+    assert.equal(spawnSync('/bin/sh', ['-c', "printf 'o2\\n' > skills/other/skill/SKILL.md"], { cwd: tmp }).status, 0);
+    assert.equal(git('commit', '-am', 'unrelated').status, 0);
+    const unrelatedSha = git('rev-parse', 'HEAD').stdout.trim();
+    const unchanged = spawnSync(process.execPath, [CORRELATED_ROOT_GUARD, '--merge', mergeSha, '--current', unrelatedSha, '--slugs', 'example/skill'], { cwd: tmp, encoding: 'utf8' });
+    assert.equal(unchanged.status, 0, `${unchanged.stdout}\n${unchanged.stderr}`);
+    assert.equal(spawnSync('/bin/sh', ['-c', "printf 'v2\\n' > skills/example/skill/SKILL.md"], { cwd: tmp }).status, 0);
+    assert.equal(git('commit', '-am', 'same root changed').status, 0);
+    const changedSha = git('rev-parse', 'HEAD').stdout.trim();
+    const changed = spawnSync(process.execPath, [CORRELATED_ROOT_GUARD, '--merge', mergeSha, '--current', changedSha, '--slugs', 'example/skill'], { cwd: tmp, encoding: 'utf8' });
+    assert.notEqual(changed.status, 0);
+    assert.match(`${changed.stdout}\n${changed.stderr}`, /changed after the marker-bound merge/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('manual slug sync carries an optional exact correlation without requiring an incremental baseline', () => {
@@ -230,11 +276,12 @@ test('sync materializes only the detected paths from the exact workflow commit',
   );
   assert.match(materialize, /CHANGED_SKILLS: \$\{\{ steps\.changes\.outputs\.changed_skills \}\}/);
   assert.match(materialize, /node \.\/scripts\/materialize-changed-skills\.mjs/);
-  assert.match(materialize, /--commit "\$GITHUB_SHA"/);
+  assert.match(materialize, /SYNC_COMMIT_SHA: \$\{\{ steps\.trusted-correlation\.outputs\.sync_commit_sha \}\}/);
+  assert.match(materialize, /--commit "\$SYNC_COMMIT_SHA"/);
   assert.match(materialize, /--skills "\$CHANGED_SKILLS"/);
   assert.doesNotMatch(materialize, /checkout\s+\.\s*$|sparse-checkout disable|git clean/mi);
   assert.match(sync, /skill sync[\s\S]*--slugs "\$paths"/);
-  assert.match(sync, /--marketplace-commit "\$GITHUB_SHA"/);
+  assert.match(sync, /--marketplace-commit "\$SYNC_COMMIT_SHA"/);
 });
 
 test('sync writes are single-concurrency, single-attempt, and wall-clock bounded', () => {

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -163,10 +163,11 @@ test('manual slug sync carries an optional exact correlation without requiring a
   const lastSync = section(workflow, '      - name: Find last successful sync commit', '      - name: Detect changed skills');
   assert.match(lastSync, /if: inputs\.slugs == ''/);
   const correlation = section(workflow, '      - name: Validate trusted sync correlation', '      - name: Generate GitHub App Token');
-  assert.match(correlation, /\^source-monitor-pr-\(\[1-9\]\[0-9\]\*\)-\(\[0-9a-f\]\{40\}\)-\(\[0-9a-f\]\{40\}\)\$/);
+  assert.match(correlation, /\^source-monitor-pr-\(\[1-9\]\[0-9\]\*\)-\(\[0-9a-f\]\{40\}\)-\(\[0-9a-f\]\{40\}\)-\(\[0-9a-f\]\{64\}\)\$/);
   assert.match(correlation, /MERGE_COMMIT_SHA/);
   assert.match(correlation, /Provider sync correlation does not match the authoritative merged source-monitor PR/);
   assert.match(correlation, /Correlated merge is not on the current main lineage/);
+  assert.match(correlation, /Provider sync correlation is not bound to the exact canonical root set/);
   assert.match(correlation, /"\$EVENT_NAME" != 'workflow_dispatch'/);
   assert.match(correlation, /"\$GIT_REF" != 'refs\/heads\/main'/);
   const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');

--- a/scripts/validate-correlated-sync-roots.mjs
+++ b/scripts/validate-correlated-sync-roots.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+
+const SHA_RE = /^[0-9a-f]{40}$/u;
+const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) throw new Error('expected --merge, --current and --slugs');
+    values.set(key.slice(2), value);
+  }
+  const merge = values.get('merge');
+  const current = values.get('current');
+  const slugs = (values.get('slugs') ?? '').split(/[\s,]+/u).filter(Boolean);
+  if (!SHA_RE.test(merge ?? '') || !SHA_RE.test(current ?? '') || slugs.length === 0 || slugs.length > 25) {
+    throw new Error('invalid correlated sync root arguments');
+  }
+  const uniqueSlugs = [...new Set(slugs)].sort();
+  if (uniqueSlugs.length !== slugs.length || uniqueSlugs.some((slug) => {
+    const segments = slug.split('/');
+    return ![1, 2].includes(segments.length) || segments.some((segment) => !SEGMENT_RE.test(segment));
+  })) throw new Error('invalid canonical correlated sync slugs');
+  return { merge, current, slugs: uniqueSlugs };
+}
+
+function gitObject(commit, path) {
+  return execFileSync('git', ['rev-parse', '--verify', `${commit}:${path}`], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+try {
+  const { merge, current, slugs } = parseArgs(process.argv.slice(2));
+  for (const slug of slugs) {
+    const root = `skills/${slug}`;
+    const mergeObject = gitObject(merge, root);
+    const currentObject = gitObject(current, root);
+    const mergeType = execFileSync('git', ['cat-file', '-t', mergeObject], { encoding: 'utf8' }).trim();
+    const currentType = execFileSync('git', ['cat-file', '-t', currentObject], { encoding: 'utf8' }).trim();
+    if (mergeType !== 'tree' || currentType !== 'tree') throw new Error(`correlated provider sync root is not a tree: ${root}`);
+    if (mergeObject !== currentObject) throw new Error(`correlated provider sync root changed after the marker-bound merge: ${root}`);
+  }
+  process.stdout.write(`${merge}\n`);
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}


### PR DESCRIPTION
## Goal
Recover trusted submission and source-monitor PRs when burst concurrency cancels or loses `workflow_run` events, while preserving strict serial ordering and exact effect reconciliation.

## Changes
- run both validation events and a five-minute schedule through one globally oldest-first arbiter
- recover `BEHIND` PRs through exact-head `update-branch`, await fresh CI, then merge only `CLEAN / MERGEABLE`
- perform at most one external mutation per arbiter execution
- mark executor merges with an immutable recovery marker and reconcile post-merge effects on later executions
- bind publication to PR/head/merge identity and provider sync to PR/head/merge plus canonical-root digest
- persist pending/success/failure effect state as commit statuses so deleted Actions run history cannot cause replay
- keep failed/partial effects fail-closed for inspection rather than blindly replaying
- keep security-report risk fields outside automatic routing
- remove direct submission publication on `pull_request.closed`; correlated publication uses fixed `main` workflow dispatch only

## Evidence
- `CI=true node --test scripts/tests/auto-merge-trusted-skill-pr.test.mjs scripts/tests/cache-invalidation-workflow.test.mjs scripts/tests/auto-merge-trusted-skill-pr-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs` — 107 passed
- `node scripts/check-workflow-action-pins.mjs` — passed
- `git diff --check` — passed
- independent read-only final review at pre-rebase equivalent head: READY, no P0/P1 findings

## Authority / deployment
This PR does not merge or deploy itself. The scheduled production recovery and durable status ledger become active only after an authorized merge to `main`.

## Canary
After merge, observe the scheduled arbiter update the oldest eligible PR only, await its fresh exact-head CI, merge it in a later execution, then reconcile publication/provider sync in subsequent serialized executions.