### PR TITLE
fix(actions): use CLI compatibility parser fix

### DIFF
--- a/.github/workflows/approve-submission.yml
+++ b/.github/workflows/approve-submission.yml
@@ -36,10 +36,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.16.5'
         required: false
         type: string
-        default: '2.15.12'
+        default: '2.16.5'
       max_parallel:
         description: 'Max parallel shards (default: 6)'
         type: string

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -29,10 +29,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.16.5'
         required: false
         type: string
-        default: '2.15.12'
+        default: '2.16.5'
       max_parallel:
         description: 'Max parallel shards (default: 6)'
         type: string
@@ -57,7 +57,7 @@ jobs:
       github_url: ${{ github.event.client_payload.github_url || inputs.github_url }}
       submission_id: ${{ github.event.client_payload.submission_id || github.run_id }}
       model: ${{ inputs.model || '' }}
-      cli_version: ${{ inputs.cli_version || '2.15.12' }}
+      cli_version: ${{ inputs.cli_version || '2.16.5' }}
       max_parallel: ${{ inputs.max_parallel || '6' }}
       is_manual_approval: false
       approved_by: ''

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -25,10 +25,10 @@ on:
         type: string
         default: ''
       cli_version:
-        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.15.12'
+        description: 'Reserved compatibility input; submission processing is pinned to CLI 2.16.5'
         required: false
         type: string
-        default: '2.15.12'
+        default: '2.16.5'
       max_parallel:
         description: 'Maximum parallel shards'
         required: false
@@ -677,11 +677,11 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          # Dependency gate: do not merge before cli-v2.15.12 is released.
-          version: '2.15.12'
+          # Dependency gate: do not merge before cli-v2.16.5 is released.
+          version: '2.16.5'
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.15.12
+          minimum-version: 2.16.5
           require-checksum: true
 
       - name: Process shard ${{ matrix.shard }}

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -19,7 +19,7 @@ const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
 const approvalCaller = readFileSync('.github/workflows/approve-submission.yml', 'utf8');
 const publicationProvenance = readFileSync('.github/workflows/publication-provenance.yml', 'utf8');
 const cliCompatibilityDescription =
-  'Reserved compatibility input; submission processing is pinned to CLI 2.15.12';
+  'Reserved compatibility input; submission processing is pinned to CLI 2.16.5';
 const runtimeFiles = [
   'schemas/skill-report.schema.json',
   'governance/submission-slug-aliases.json',
@@ -270,8 +270,8 @@ test('all submission entrypoints and the aggregation import closure are immutabl
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/aggregate-submission-shards\.mjs"/);
   assert.match(reusable, /node "\$GITHUB_WORKSPACE\/scripts\/classify-submission-targets\.mjs"/);
   assert.match(reusable, /require-checksum: true/);
-  assert.match(reusable, /minimum-version: 2\.15\.12/);
-  assert.match(reusable, /Dependency gate: do not merge before cli-v2\.15\.12 is released/);
+  assert.match(reusable, /minimum-version: 2\.16\.5/);
+  assert.match(reusable, /Dependency gate: do not merge before cli-v2\.16\.5 is released/);
   assert.match(reusable, /trap cleanup_input_plan EXIT/);
   assert.match(reusable, /--slug-aliases-file "\$GITHUB_WORKSPACE\/governance\/submission-slug-aliases\.json"/);
   assert.match(reusable, /--selection-plan "\$INPUT_PLAN"/);
@@ -347,7 +347,7 @@ test('HELM credential is injected only into the Process shard step environment',
   );
 });
 
-test('submission processing compatibility inputs and CLI download are pinned to 2.15.12', () => {
+test('submission processing compatibility inputs and CLI download are pinned to 2.16.5', () => {
   for (const [name, workflow] of [
     ['repository dispatch', caller],
     ['manual approval', approvalCaller],
@@ -359,12 +359,12 @@ test('submission processing compatibility inputs and CLI download are pinned to 
       new RegExp(`description: '${cliCompatibilityDescription.replaceAll('.', '\\.')}'`),
       `${name} compatibility input must describe the fixed CLI dependency`,
     );
-    assert.match(cliInput, /default: '2\.15\.12'/);
+    assert.match(cliInput, /default: '2\.16\.5'/);
   }
 
   const download = extractNamedBlock(reusable, '- name: Download Skillstore CLI');
-  assert.match(download, /version: '2\.15\.12'/);
-  assert.match(download, /minimum-version: 2\.15\.12/);
+  assert.match(download, /version: '2\.16\.5'/);
+  assert.match(download, /minimum-version: 2\.16\.5/);
   assert.doesNotMatch(download, /inputs\.cli_version|version: ['"]?latest/);
 });
 


### PR DESCRIPTION
## Summary
- pin submission processing to released skillstore-cli 2.16.5
- keep manual, dispatch, and reusable workflow inputs consistent
- update the immutable-runtime regression test

## Why
CLI 2.16.5 preserves author-owned compatibility host exclusions. Without this pin update, Marketplace submission processing would continue using 2.15.12 and reproduce #3272.

## Validation
- `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs` (13/13 pass)
- `git diff --check`

Closes #3272