### PR TITLE
fix: correct agy-worker host compatibility metadata

### DIFF
--- a/skills/cagdasyurekli/agy-worker/skill-report.json
+++ b/skills/cagdasyurekli/agy-worker/skill-report.json
@@ -44,9 +44,7 @@
       "verification"
     ],
     "supported_tools": [
-      "claude",
-      "codex",
-      "claude-code"
+      "codex"
     ],
     "risk_factors": [
       "external_commands",


### PR DESCRIPTION
## Summary
- correct the currently published `agy-worker` audit metadata to advertise Codex only
- leave the bound skill artifact and its content/tree hashes unchanged
- rely on the already-merged CLI parser and Marketplace pin fixes for future submissions

## Why
The bound `SKILL.md` explicitly states that Claude and Claude Code hosts are unsupported, but the existing v0.13.0 report was generated before the compatibility parser fix and still advertised all three hosts.

The forward fix is already merged in [skillstore PR #375](https://github.com/aiskillstore/skillstore/pull/375) and [Marketplace PR #3273](https://github.com/aiskillstore/marketplace/pull/3273). This PR backfills the existing published artifact so the live listing can converge immediately after the normal sync pipeline runs.

## Red → Green evidence
- RED: exact metadata assertion failed with `got ["claude","codex","claude-code"]`
- GREEN: exact metadata assertion passes with `["codex"]`
- bound `SKILL.md` compatibility declaration verified
- JSON schema and packaged `content_hash` / `tree_hash` contracts verified
- `CI=true node --test scripts/tests/submission-runtime-workflow.test.mjs` — 13/13 pass
- `git diff --check`

Fixes #3272
