### PR TITLE
fix(actions): use source monitor CLI 2.16.6

### DIFF
--- a/.github/workflows/monitor-skill-sources.yml
+++ b/.github/workflows/monitor-skill-sources.yml
@@ -237,10 +237,10 @@ jobs:
       - name: Download Skillstore CLI
         uses: ./.github/actions/download-skillstore-cli
         with:
-          version: 2.16.1
+          version: 2.16.6
           token: ${{ steps.app-token.outputs.token }}
           cache-dir: /home/runner/_work/_cache/skillstore-cli
-          minimum-version: 2.16.1
+          minimum-version: 2.16.6
           require-checksum: true
 
       - name: Prepare git workspace

--- a/scripts/tests/recalculate-scores.test.mjs
+++ b/scripts/tests/recalculate-scores.test.mjs
@@ -529,7 +529,7 @@ test('download action invalidates stale local CLI cache entries', () => {
 
 test('source monitor pins its audited CLI contract and falls back when checkout-cache support is unavailable', () => {
 	const workflow = readFileSync(MONITOR_WORKFLOW, 'utf8');
-	assert.match(workflow, /version: 2\.16\.1/, 'source monitor must download the audited CLI contract version');
+	assert.match(workflow, /version: 2\.16\.6/, 'source monitor must download the audited CLI contract version');
 	assert.doesNotMatch(workflow, /cli_version:/, 'source monitor must not expose a fixed CLI version input');
 	assert.doesNotMatch(workflow, /inputs\.cli_version/, 'source monitor must not consume a fixed CLI version input');
 	assert.match(workflow, /MONITOR_HELP=/, 'workflow must feature-probe monitor-upstream once before building the command');

--- a/scripts/tests/source-monitor-runtime-workflow.test.mjs
+++ b/scripts/tests/source-monitor-runtime-workflow.test.mjs
@@ -228,8 +228,8 @@ test('source monitor binds checkout and artifacts to immutable runtime evidence'
   assert.match(checkout, /\/skills\/\*\*\/skill-report\.json/);
   assert.match(checkout, /checkout --detach --force "\$EXPECTED_SHA"/);
   assert.doesNotMatch(checkout, /actions\/checkout/);
-  assert.match(workflow, /version: 2\.16\.1/);
-  assert.match(workflow, /minimum-version: 2\.16\.1/);
+  assert.match(workflow, /version: 2\.16\.6/);
+  assert.match(workflow, /minimum-version: 2\.16\.6/);
   assert.match(workflow, /require-checksum: true/);
   assert.match(workflow, /\$\{\{ runner\.temp \}\}\/source-monitor-diagnostics-\$\{\{ github\.run_id \}\}\//);
   assert.match(workflow, /name: Upload monitor evidence\n\s+if: always\(\)/);


### PR DESCRIPTION
## Summary
- pin Source Monitor to Skillstore CLI 2.16.6
- require the same minimum version so missing local-path candidates are isolated before Marketplace replacement
- update the workflow contract assertion

## Verification
- CI=true node --test scripts/tests/source-monitor-runtime-workflow.test.mjs scripts/tests/workflow-action-pin-policy.test.mjs (32/32 passed)

This keeps existing strict validation, hashes, snapshots, and fail-closed gates unchanged.