### PR TITLE
Fix same-source pending submission follow-ups

### DIFF
--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -113,6 +113,7 @@ env:
     /scripts/resolve-submission-source.mjs
     /scripts/discover-submission-skills.mjs
     /scripts/classify-submission-targets.mjs
+    /scripts/replace-pending-submission.mjs
     /scripts/process-submission-shard.mjs
     /scripts/submission-selection-plan.mjs
     /scripts/submission-shard-contract.mjs
@@ -213,6 +214,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/classify-submission-targets.mjs"
+            "scripts/replace-pending-submission.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
@@ -657,6 +659,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/classify-submission-targets.mjs"
+            "scripts/replace-pending-submission.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
@@ -860,6 +863,7 @@ jobs:
             "scripts/resolve-submission-source.mjs"
             "scripts/discover-submission-skills.mjs"
             "scripts/classify-submission-targets.mjs"
+            "scripts/replace-pending-submission.mjs"
             "scripts/process-submission-shard.mjs"
             "scripts/submission-selection-plan.mjs"
             "scripts/submission-shard-contract.mjs"
@@ -1055,19 +1059,17 @@ jobs:
                 '[.[] | select(.pendingDir == $pendingDir)] | if length == 1 then .[0] else error("missing pending update snapshot") end' \
                 <<< "$PENDING_UPDATE_SNAPSHOTS")
               EXPECTED_PENDING_TREE_HASH=$(jq -er '.treeHash' <<< "$SNAPSHOT")
+              EXPECTED_PENDING_REPORT_HASH=$(jq -er '.reportHash' <<< "$SNAPSHOT")
+              EXPECTED_PENDING_GIT_TREE_OID=$(jq -er '.gitTreeOid' <<< "$SNAPSHOT")
               EXPECTED_PENDING_SOURCE_REF=$(jq -er '.sourceRef' <<< "$SNAPSHOT")
-              CURRENT_PENDING_REPORT="$WORK_DIR/$pending_dir/skill-report.json"
-              CURRENT_PENDING_TREE_HASH=$(node "$GITHUB_WORKSPACE/scripts/resolve-approved-submission.mjs" \
-                --tree-hash-at-commit \
-                --repo-root "$WORK_DIR" \
-                --commit HEAD \
-                --skill-dir "$pending_dir")
-              jq -e --arg sourceRef "$EXPECTED_PENDING_SOURCE_REF" '.meta.source_ref == $sourceRef' \
-                "$CURRENT_PENDING_REPORT" >/dev/null && [ "$CURRENT_PENDING_TREE_HASH" = "$EXPECTED_PENDING_TREE_HASH" ] || {
-                  echo "::error::Pending update target changed after classification: $pending_dir"
-                  exit 1
-                }
-              rm -rf -- "$WORK_DIR/$pending_dir"
+              node "$GITHUB_WORKSPACE/scripts/replace-pending-submission.mjs" \
+                --repository-root "$WORK_DIR" \
+                --merged-results "$MERGED_RESULTS" \
+                --pending-dir "$pending_dir" \
+                --expected-tree-hash "$EXPECTED_PENDING_TREE_HASH" \
+                --expected-report-hash "$EXPECTED_PENDING_REPORT_HASH" \
+                --expected-git-tree-oid "$EXPECTED_PENDING_GIT_TREE_OID" \
+                --expected-source-ref "$EXPECTED_PENDING_SOURCE_REF"
             else
               test ! -e "$WORK_DIR/$pending_dir" || {
                 echo "::error::Pending path already exists on main: $pending_dir"
@@ -1101,8 +1103,10 @@ jobs:
                 exit 1
               }
             fi
-            mkdir -p "$WORK_DIR/$(dirname "$pending_dir")"
-            cp -R "$MERGED_RESULTS/$pending_dir" "$WORK_DIR/$pending_dir"
+            if ! is_pending_update_target "$pending_dir"; then
+              mkdir -p "$WORK_DIR/$(dirname "$pending_dir")"
+              cp -R "$MERGED_RESULTS/$pending_dir" "$WORK_DIR/$pending_dir"
+            fi
             if is_update_target "$target_dir"; then
               REPORT="$WORK_DIR/$pending_dir/skill-report.json"
               TEMP_REPORT="${REPORT}.tmp"

--- a/.github/workflows/reusable-process-skills.yml
+++ b/.github/workflows/reusable-process-skills.yml
@@ -151,6 +151,8 @@ jobs:
       existing_targets: ${{ steps.targets.outputs.existing_targets }}
       update_targets: ${{ steps.targets.outputs.update_targets }}
       update_snapshots: ${{ steps.targets.outputs.update_snapshots }}
+      pending_update_targets: ${{ steps.targets.outputs.pending_update_targets }}
+      pending_update_snapshots: ${{ steps.targets.outputs.pending_update_snapshots }}
     steps:
       - name: Clear inherited discovery checkout
         run: |
@@ -455,6 +457,8 @@ jobs:
           EXISTING_TARGETS=$(jq -er '.existingTargets | join(",")' <<< "$CLASSIFICATION")
           UPDATE_TARGETS=$(jq -cer '.updateTargets' <<< "$CLASSIFICATION")
           UPDATE_SNAPSHOTS=$(jq -cer '.updateSnapshots // []' <<< "$CLASSIFICATION")
+          PENDING_UPDATE_TARGETS=$(jq -cer '.pendingUpdateTargets // []' <<< "$CLASSIFICATION")
+          PENDING_UPDATE_SNAPSHOTS=$(jq -cer '.pendingUpdateSnapshots // []' <<< "$CLASSIFICATION")
           echo "disposition=$DISPOSITION" >> "$GITHUB_OUTPUT"
           echo "reason_code=$REASON_CODE" >> "$GITHUB_OUTPUT"
           echo "processing_plan=$PROCESSING_PLAN" >> "$GITHUB_OUTPUT"
@@ -462,6 +466,8 @@ jobs:
           echo "existing_targets=$EXISTING_TARGETS" >> "$GITHUB_OUTPUT"
           echo "update_targets=$UPDATE_TARGETS" >> "$GITHUB_OUTPUT"
           echo "update_snapshots=$UPDATE_SNAPSHOTS" >> "$GITHUB_OUTPUT"
+          echo "pending_update_targets=$PENDING_UPDATE_TARGETS" >> "$GITHUB_OUTPUT"
+          echo "pending_update_snapshots=$PENDING_UPDATE_SNAPSHOTS" >> "$GITHUB_OUTPUT"
           if [ "$DISPOSITION" = "all_existing" ]; then
             echo "::notice title=SUBMISSION_ALREADY_PUBLISHED::All $EXISTING_COUNT selected targets already exist; skipping CLI, AI, shards, artifacts, branch, and PR"
           fi
@@ -901,6 +907,8 @@ jobs:
           SHARD_MATRIX: ${{ needs.discover-and-plan.outputs.matrix }}
           UPDATE_TARGETS: ${{ needs.discover-and-plan.outputs.update_targets }}
           UPDATE_SNAPSHOTS: ${{ needs.discover-and-plan.outputs.update_snapshots }}
+          PENDING_UPDATE_TARGETS: ${{ needs.discover-and-plan.outputs.pending_update_targets }}
+          PENDING_UPDATE_SNAPSHOTS: ${{ needs.discover-and-plan.outputs.pending_update_snapshots }}
         run: |
           set -euo pipefail
 
@@ -1024,13 +1032,48 @@ jobs:
           is_update_target() {
             jq -e --arg targetDir "$1" 'index($targetDir) != null' <<< "$UPDATE_TARGETS" >/dev/null
           }
+          jq -e --argjson targets "$PENDING_UPDATE_TARGETS" '
+            (map(.pendingDir) | sort) == ($targets | sort)
+            and (map(.pendingDir) | unique | length) == length
+            and ($targets | unique | length) == ($targets | length)
+          ' <<< "$PENDING_UPDATE_SNAPSHOTS" >/dev/null || {
+            echo "::error::Pending update target and snapshot sets do not match"
+            exit 1
+          }
+          is_pending_update_target() {
+            jq -e --arg pendingDir "$1" 'index($pendingDir) != null' <<< "$PENDING_UPDATE_TARGETS" >/dev/null
+          }
           for pending_dir in "${SUBMISSION_PATHS[@]}"; do
-            test ! -e "$WORK_DIR/$pending_dir" || {
-              echo "::error::Pending path already exists on main: $pending_dir"
-              exit 1
-            }
             target_dir=$(jq -r --arg pendingDir "$pending_dir" \
               '.skills[] | select(.pendingDir == $pendingDir) | .targetDir' "$APPROVAL_PLAN")
+            if is_pending_update_target "$pending_dir"; then
+              test -d "$WORK_DIR/$pending_dir" && test ! -L "$WORK_DIR/$pending_dir" || {
+                echo "::error::Frozen pending update target is missing or unsafe: $pending_dir"
+                exit 1
+              }
+              SNAPSHOT=$(jq -cer --arg pendingDir "$pending_dir" \
+                '[.[] | select(.pendingDir == $pendingDir)] | if length == 1 then .[0] else error("missing pending update snapshot") end' \
+                <<< "$PENDING_UPDATE_SNAPSHOTS")
+              EXPECTED_PENDING_TREE_HASH=$(jq -er '.treeHash' <<< "$SNAPSHOT")
+              EXPECTED_PENDING_SOURCE_REF=$(jq -er '.sourceRef' <<< "$SNAPSHOT")
+              CURRENT_PENDING_REPORT="$WORK_DIR/$pending_dir/skill-report.json"
+              CURRENT_PENDING_TREE_HASH=$(node "$GITHUB_WORKSPACE/scripts/resolve-approved-submission.mjs" \
+                --tree-hash-at-commit \
+                --repo-root "$WORK_DIR" \
+                --commit HEAD \
+                --skill-dir "$pending_dir")
+              jq -e --arg sourceRef "$EXPECTED_PENDING_SOURCE_REF" '.meta.source_ref == $sourceRef' \
+                "$CURRENT_PENDING_REPORT" >/dev/null && [ "$CURRENT_PENDING_TREE_HASH" = "$EXPECTED_PENDING_TREE_HASH" ] || {
+                  echo "::error::Pending update target changed after classification: $pending_dir"
+                  exit 1
+                }
+              rm -rf -- "$WORK_DIR/$pending_dir"
+            else
+              test ! -e "$WORK_DIR/$pending_dir" || {
+                echo "::error::Pending path already exists on main: $pending_dir"
+                exit 1
+              }
+            fi
             if is_update_target "$target_dir"; then
               test -d "$WORK_DIR/$target_dir" && test ! -L "$WORK_DIR/$target_dir" || {
                 echo "::error::Frozen update target is missing or unsafe: $target_dir"

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -199,6 +199,7 @@ jobs:
             scripts/tests/trusted-auto-merge-executor-retired.test.mjs \
             scripts/tests/publication-receiver-workflow.test.mjs \
             scripts/tests/resolve-approved-submission.test.mjs \
+            scripts/tests/replace-pending-submission.test.mjs \
             scripts/tests/submission-existing-targets.test.mjs \
             scripts/tests/submission-source-resolution.test.mjs \
             scripts/tests/submission-runtime-workflow.test.mjs \

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -184,7 +184,7 @@ function sourceMismatch(message) {
   throw new SourceIdentityMismatchError(message);
 }
 
-function assertSourceIdentity(report, { repository }, reportPath) {
+function assertSourceIdentity(report, { repository }, reportPath, targetLabel = 'published target') {
   const sourceUrl = report?.meta?.source_url;
   const reportRef = report?.meta?.source_ref;
   if (typeof sourceUrl !== 'string' || typeof reportRef !== 'string' || reportRef === '') {
@@ -194,7 +194,7 @@ function assertSourceIdentity(report, { repository }, reportPath) {
   const segments = decodedSegments(sourceUrl);
   const [owner, repo, kind, actualRef, ...actualPathSegments] = segments;
   if (`${owner ?? ''}/${repo ?? ''}`.toLowerCase() !== repository || kind !== 'tree') {
-    sourceMismatch(`published target source repository mismatch at ${reportPath}: expected ${repository}`);
+    sourceMismatch(`${targetLabel} source repository mismatch at ${reportPath}: expected ${repository}`);
   }
   if (actualRef === undefined) {
     fail(`published target source_url has no source ref at ${reportPath}`);
@@ -216,7 +216,7 @@ function assertSourceIdentity(report, { repository }, reportPath) {
   return { sourcePath, sourceRef: reportRef };
 }
 
-function validateCandidate(candidate, identity) {
+function validateCandidate(candidate, identity, targetLabel = 'published target') {
   assertSafeTree(candidate.directory, 'published skill target');
   assertRegularFile(join(candidate.directory, 'SKILL.md'), 'published SKILL.md');
   const reportPath = join(candidate.directory, 'skill-report.json');
@@ -244,7 +244,7 @@ function validateCandidate(candidate, identity) {
     fail(`flat published target must be official at ${reportPath}`);
   }
 
-  const sourceIdentity = assertSourceIdentity(report, identity, reportPath);
+  const sourceIdentity = assertSourceIdentity(report, identity, reportPath, targetLabel);
   return {
     directory: candidate.directory,
     relativePath: candidate.relativePath,
@@ -281,6 +281,9 @@ export function classifySubmissionTargets({
   const sameRevisionTargets = [];
   const updateTargets = [];
   const updateSnapshots = [];
+  const pendingUpdateTargets = [];
+  const pendingUpdateSnapshots = [];
+  const pendingSameRevisionTargets = [];
   const processingSkills = [];
   const newTargets = [];
 
@@ -289,7 +292,6 @@ export function classifySubmissionTargets({
     if (alias && alias.baseSlug !== skill.slug) {
       fail(`slug alias does not match planned slug for ${skill.path}: expected ${alias.baseSlug}`);
     }
-    assertNoPendingCollision(root, owner, skill.slug);
     const identity = {
       repository: plan.repository,
       sourceRef,
@@ -298,6 +300,24 @@ export function classifySubmissionTargets({
       slug: skill.slug,
       expectedName: alias?.expectedName ?? skill.slug,
     };
+    // Only the canonical community pending path can be superseded. Flat pending
+    // paths remain reserved for official submissions and must not be repurposed.
+    const pendingPath = `pending/${owner}/${skill.slug}`;
+    const flatPendingPath = `pending/${skill.slug}`;
+    const pendingState = pathState(root, pendingPath, 'pending target');
+    const flatPendingState = pathState(root, flatPendingPath, 'pending target');
+    if (expectedLayout !== 'community' || flatPendingState !== null) {
+      assertNoPendingCollision(root, owner, skill.slug);
+    }
+    let pendingTarget = null;
+    if (pendingState !== null) {
+      pendingTarget = validateCandidate({
+        layout: 'community',
+        relativePath: pendingPath,
+        directory: join(root, 'pending', owner, skill.slug),
+      }, identity, 'pending target');
+    }
+
     const candidates = [
       {
         layout: 'community',
@@ -338,6 +358,9 @@ export function classifySubmissionTargets({
     if (expectedTarget !== null && alternateExact !== null) {
       fail(`ambiguous published target identity for ${skill.slug}: ${expectedTarget.relativePath}, ${alternateExact.relativePath}`);
     }
+    if (pendingTarget !== null && (expectedTarget !== null || alternateExact !== null)) {
+      fail(`pending target collision with published target for ${skill.slug}: ${pendingTarget.relativePath}`);
+    }
     if (expectedTarget === null && alternateExact !== null) {
       fail(`published target identity for ${skill.slug} exists at unexpected path: ${alternateExact.relativePath}`);
     }
@@ -357,6 +380,22 @@ export function classifySubmissionTargets({
       }
       continue;
     }
+    if (pendingTarget !== null) {
+      existingTargets.push(pendingTarget.relativePath);
+      if (pendingTarget.sourceRef === sourceRef && pendingTarget.sourcePath === skill.path) {
+        sameRevisionTargets.push(pendingTarget.relativePath);
+        pendingSameRevisionTargets.push(pendingTarget.relativePath);
+      } else {
+        pendingUpdateTargets.push(pendingTarget.relativePath);
+        processingSkills.push(skill);
+        pendingUpdateSnapshots.push({
+          pendingDir: pendingTarget.relativePath,
+          treeHash: calculateCanonicalTreeHash(root, pendingTarget.relativePath),
+          sourceRef: pendingTarget.sourceRef,
+        });
+      }
+      continue;
+    }
     newTargets.push(expectedCandidate.relativePath);
     processingSkills.push(skill);
   }
@@ -365,10 +404,17 @@ export function classifySubmissionTargets({
     ? 'all_existing'
     : 'processable';
   let reasonCode = 'no_selected_targets_already_published';
-  if (disposition === 'all_existing') reasonCode = 'all_selected_targets_already_published';
+  if (disposition === 'all_existing') {
+    reasonCode = pendingSameRevisionTargets.length > 0
+      ? 'all_selected_targets_already_processed'
+      : 'all_selected_targets_already_published';
+  }
   else if (updateTargets.length === plan.skills.length) reasonCode = 'all_selected_targets_are_updates';
+  else if (pendingUpdateTargets.length === plan.skills.length) reasonCode = 'all_selected_targets_are_pending_updates';
   else if (updateTargets.length > 0 && newTargets.length > 0) reasonCode = 'selected_targets_include_new_and_updates';
+  else if (pendingUpdateTargets.length > 0 && newTargets.length > 0) reasonCode = 'selected_targets_include_new_and_pending_updates';
   else if (updateTargets.length > 0) reasonCode = 'selected_targets_include_updates';
+  else if (pendingUpdateTargets.length > 0) reasonCode = 'selected_targets_include_pending_updates';
   else if (newTargets.length < plan.skills.length) reasonCode = 'selected_targets_include_new';
   const result = {
     schemaVersion: 1,
@@ -381,6 +427,8 @@ export function classifySubmissionTargets({
     updateTargets: updateTargets.sort((left, right) => left.localeCompare(right, 'en')),
   };
   if (updateSnapshots.length > 0) result.updateSnapshots = updateSnapshots;
+  if (pendingUpdateTargets.length > 0) result.pendingUpdateTargets = pendingUpdateTargets;
+  if (pendingUpdateSnapshots.length > 0) result.pendingUpdateSnapshots = pendingUpdateSnapshots;
   return result;
 }
 

--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import {
   lstatSync,
   readFileSync,
@@ -9,10 +10,11 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { validateSlugAliasRegistry } from './discover-submission-skills.mjs';
 import { calculateCanonicalTreeHash } from './resolve-approved-submission.mjs';
+import { calculatePendingGitTreeOidAtCommit } from './replace-pending-submission.mjs';
 import { parseSelectionPlan, validateSelectionPlan } from './submission-selection-plan.mjs';
 
 const SOURCE_TYPES = new Set(['community', 'official']);
-// Must stay aligned with the exact CLI 2.15.7 trust allowlist pinned by the workflow.
+// Must stay aligned with the exact CLI 2.16.5 trust allowlist pinned by the workflow.
 const OFFICIAL_REPOSITORIES = new Set([
   'aiskillstore/marketplace',
   'anthropics/skills',
@@ -391,6 +393,10 @@ export function classifySubmissionTargets({
         pendingUpdateSnapshots.push({
           pendingDir: pendingTarget.relativePath,
           treeHash: calculateCanonicalTreeHash(root, pendingTarget.relativePath),
+          reportHash: createHash('sha256')
+            .update(readFileSync(join(pendingTarget.directory, 'skill-report.json')))
+            .digest('hex'),
+          gitTreeOid: calculatePendingGitTreeOidAtCommit(root, 'HEAD', pendingTarget.relativePath),
           sourceRef: pendingTarget.sourceRef,
         });
       }

--- a/scripts/replace-pending-submission.mjs
+++ b/scripts/replace-pending-submission.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { basename, dirname, join, posix, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { calculateCanonicalTreeHash } from './resolve-approved-submission.mjs';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) fail(`missing required option ${name}`);
+  if (index === args.length - 1 || args[index + 1].startsWith('--')) fail(`missing value for ${name}`);
+  return args[index + 1];
+}
+
+function normalizePendingDir(value) {
+  if (typeof value !== 'string' || value === '' || value.includes('\\')
+    || posix.normalize(value) !== value) {
+    fail(`invalid pending directory: ${JSON.stringify(value)}`);
+  }
+  const segments = value.split('/');
+  if (segments.length !== 3 || segments[0] !== 'pending'
+    || segments.some((segment) => segment === '' || segment === '.' || segment === '..'
+      || /[\u0000-\u001f\u007f]/u.test(segment))) {
+    fail(`pending directory must be a canonical community path: ${value}`);
+  }
+  return value;
+}
+
+function git(repositoryRoot, args) {
+  const result = spawnSync('git', ['-C', repositoryRoot, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+export function calculatePendingGitTreeOidAtCommit(repositoryRoot, commit, pendingDir) {
+  const normalizedPendingDir = normalizePendingDir(pendingDir);
+  const resolvedCommit = git(repositoryRoot, ['rev-parse', '--verify', `${commit}^{commit}`]);
+  if (!/^[a-f0-9]{40,64}$/.test(resolvedCommit)) fail(`invalid resolved commit: ${resolvedCommit}`);
+  const treeOid = git(repositoryRoot, [
+    'rev-parse', '--verify', `${resolvedCommit}:${normalizedPendingDir}`,
+  ]);
+  if (!/^[a-f0-9]{40,64}$/.test(treeOid)
+    || git(repositoryRoot, ['cat-file', '-t', treeOid]) !== 'tree') {
+    fail(`committed pending path is not a Git tree: ${normalizedPendingDir}`);
+  }
+  return treeOid;
+}
+
+function assertDirectory(path, label) {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') fail(`${label} is missing: ${path}`);
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    fail(`${label} must be a non-symlink directory: ${path}`);
+  }
+}
+
+function assertRegularFile(path, label) {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') fail(`${label} is missing: ${path}`);
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    fail(`${label} must be a non-symlink regular file: ${path}`);
+  }
+}
+
+function resolveSafeDirectory(rootPath, relativePath, label) {
+  const root = resolve(rootPath);
+  assertDirectory(root, `${label} root`);
+  let current = root;
+  for (const segment of relativePath.split('/')) {
+    current = join(current, segment);
+    assertDirectory(current, label);
+  }
+  return current;
+}
+
+function assertSafeTree(directory, label) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink() || (!stat.isDirectory() && !stat.isFile())) {
+      fail(`${label} contains an unsupported file type: ${path}`);
+    }
+    if (stat.isDirectory()) assertSafeTree(path, label);
+  }
+}
+
+function fileSha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function readSourceRef(reportPath, label) {
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  } catch (error) {
+    fail(`${label} is malformed JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (typeof report?.meta?.source_ref !== 'string' || report.meta.source_ref === '') {
+    fail(`${label} is missing meta.source_ref`);
+  }
+  return report.meta.source_ref;
+}
+
+export function replacePendingSubmission({
+  repositoryRoot,
+  mergedResults,
+  pendingDir,
+  expectedTreeHash,
+  expectedReportHash,
+  expectedGitTreeOid,
+  expectedSourceRef,
+}) {
+  const normalizedPendingDir = normalizePendingDir(pendingDir);
+  for (const [value, label] of [
+    [expectedTreeHash, 'expected tree hash'],
+    [expectedReportHash, 'expected report hash'],
+  ]) {
+    if (typeof value !== 'string' || !/^[a-f0-9]{64}$/.test(value)) fail(`${label} is invalid`);
+  }
+  if (typeof expectedGitTreeOid !== 'string' || !/^[a-f0-9]{40,64}$/.test(expectedGitTreeOid)) {
+    fail('expected Git tree OID is invalid');
+  }
+  if (typeof expectedSourceRef !== 'string' || expectedSourceRef === '') {
+    fail('expected source ref must be a non-empty string');
+  }
+
+  const destination = resolveSafeDirectory(repositoryRoot, normalizedPendingDir, 'pending update target');
+  const destinationReport = join(destination, 'skill-report.json');
+  assertRegularFile(destinationReport, 'pending update report');
+  assertSafeTree(destination, 'pending update target');
+
+  if (calculatePendingGitTreeOidAtCommit(repositoryRoot, 'HEAD', normalizedPendingDir) !== expectedGitTreeOid) {
+    fail(`pending update Git tree changed after classification: ${normalizedPendingDir}`);
+  }
+  if (calculateCanonicalTreeHash(repositoryRoot, normalizedPendingDir) !== expectedTreeHash) {
+    fail(`pending update target changed after classification: ${normalizedPendingDir}`);
+  }
+  if (fileSha256(destinationReport) !== expectedReportHash) {
+    fail(`pending update report changed after classification: ${normalizedPendingDir}`);
+  }
+  if (readSourceRef(destinationReport, 'pending update report') !== expectedSourceRef) {
+    fail(`pending update source ref changed after classification: ${normalizedPendingDir}`);
+  }
+
+  const replacementSource = resolveSafeDirectory(mergedResults, normalizedPendingDir, 'replacement pending target');
+  const replacementReport = join(replacementSource, 'skill-report.json');
+  assertRegularFile(replacementReport, 'replacement pending report');
+  assertSafeTree(replacementSource, 'replacement pending target');
+
+  const destinationParent = dirname(destination);
+  const temporaryRoot = mkdtempSync(join(destinationParent, `.${basename(destination)}-replacement-`));
+  const replacement = join(temporaryRoot, 'replacement');
+  const previous = join(temporaryRoot, 'previous');
+  let previousMoved = false;
+  let replacementMoved = false;
+  try {
+    // The artifact directory is runner-private, but still revalidate the copied root
+    // so a source-root symlink can never become the canonical pending directory.
+    cpSync(replacementSource, replacement, { recursive: true, errorOnExist: true });
+    assertDirectory(replacement, 'copied replacement pending target');
+    assertRegularFile(join(replacement, 'skill-report.json'), 'copied replacement pending report');
+    assertSafeTree(replacement, 'copied replacement pending target');
+    assertDirectory(replacement, 'copied replacement pending target');
+    renameSync(destination, previous);
+    previousMoved = true;
+    try {
+      renameSync(replacement, destination);
+      replacementMoved = true;
+    } catch (error) {
+      renameSync(previous, destination);
+      previousMoved = false;
+      throw error;
+    }
+  } finally {
+    if (previousMoved && !replacementMoved) {
+      renameSync(previous, destination);
+      previousMoved = false;
+    }
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  replacePendingSubmission({
+    repositoryRoot: option(args, '--repository-root'),
+    mergedResults: option(args, '--merged-results'),
+    pendingDir: option(args, '--pending-dir'),
+    expectedTreeHash: option(args, '--expected-tree-hash'),
+    expectedReportHash: option(args, '--expected-report-hash'),
+    expectedGitTreeOid: option(args, '--expected-git-tree-oid'),
+    expectedSourceRef: option(args, '--expected-source-ref'),
+  });
+  process.stdout.write('Replaced frozen pending submission\n');
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::Pending replacement failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/replace-pending-submission.test.mjs
+++ b/scripts/tests/replace-pending-submission.test.mjs
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
+import {
+  calculatePendingGitTreeOidAtCommit,
+  replacePendingSubmission,
+} from '../replace-pending-submission.mjs';
+
+function write(root, path, contents) {
+  const fullPath = join(root, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function writePending(root, content, sourceRef, risk = 'safe') {
+  write(root, 'pending/example/alpha/SKILL.md', content);
+  write(root, 'pending/example/alpha/skill-report.json', `${JSON.stringify({
+    meta: { source_ref: sourceRef },
+    security_audit: { risk_level: risk },
+  })}\n`);
+}
+
+function git(root, ...args) {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function commitAll(root, message) {
+  git(root, 'add', '-A');
+  git(root, 'commit', '-qm', message);
+}
+
+function initializeRepository(root) {
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  commitAll(root, 'initial pending');
+}
+
+function snapshot(root) {
+  const report = readFileSync(join(root, 'pending/example/alpha/skill-report.json'));
+  return {
+    treeHash: calculateCanonicalTreeHash(root, 'pending/example/alpha'),
+    reportHash: createHash('sha256').update(report).digest('hex'),
+    gitTreeOid: calculatePendingGitTreeOidAtCommit(root, 'HEAD', 'pending/example/alpha'),
+  };
+}
+
+function withFixture(run) {
+  const root = mkdtempSync(join(tmpdir(), 'replace-pending-'));
+  const repositoryRoot = join(root, 'repository');
+  const mergedResults = join(root, 'merged');
+  mkdirSync(repositoryRoot, { recursive: true });
+  mkdirSync(mergedResults, { recursive: true });
+  try {
+    return run({ repositoryRoot, mergedResults });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('replaces a canonical pending target only when the complete frozen snapshot matches', () => withFixture(({
+  repositoryRoot,
+  mergedResults,
+}) => {
+  const previousRef = '1'.repeat(40);
+  writePending(repositoryRoot, '# Previous\n', previousRef);
+  writePending(mergedResults, '# Replacement\n', '2'.repeat(40), 'medium');
+  initializeRepository(repositoryRoot);
+  const frozen = snapshot(repositoryRoot);
+
+  replacePendingSubmission({
+    repositoryRoot,
+    mergedResults,
+    pendingDir: 'pending/example/alpha',
+    expectedTreeHash: frozen.treeHash,
+    expectedReportHash: frozen.reportHash,
+    expectedGitTreeOid: frozen.gitTreeOid,
+    expectedSourceRef: previousRef,
+  });
+
+  assert.equal(
+    readFileSync(join(repositoryRoot, 'pending/example/alpha/SKILL.md'), 'utf8'),
+    '# Replacement\n',
+  );
+  assert.equal(
+    JSON.parse(readFileSync(join(repositoryRoot, 'pending/example/alpha/skill-report.json'), 'utf8'))
+      .security_audit.risk_level,
+    'medium',
+  );
+}));
+
+test('refuses a report-only concurrent change without replacing it', () => withFixture(({
+  repositoryRoot,
+  mergedResults,
+}) => {
+  const previousRef = '1'.repeat(40);
+  writePending(repositoryRoot, '# Previous\n', previousRef);
+  writePending(mergedResults, '# Replacement\n', '2'.repeat(40));
+  initializeRepository(repositoryRoot);
+  const frozen = snapshot(repositoryRoot);
+  writePending(repositoryRoot, '# Previous\n', previousRef, 'critical');
+
+  assert.throws(() => replacePendingSubmission({
+    repositoryRoot,
+    mergedResults,
+    pendingDir: 'pending/example/alpha',
+    expectedTreeHash: frozen.treeHash,
+    expectedReportHash: frozen.reportHash,
+    expectedGitTreeOid: frozen.gitTreeOid,
+    expectedSourceRef: previousRef,
+  }), /report changed after classification/);
+  assert.equal(
+    JSON.parse(readFileSync(join(repositoryRoot, 'pending/example/alpha/skill-report.json'), 'utf8'))
+      .security_audit.risk_level,
+    'critical',
+  );
+}));
+
+test('refuses an unsafe report file type without replacing it', () => withFixture(({
+  repositoryRoot,
+  mergedResults,
+}) => {
+  const previousRef = '1'.repeat(40);
+  writePending(repositoryRoot, '# Previous\n', previousRef);
+  writePending(mergedResults, '# Replacement\n', '2'.repeat(40));
+  initializeRepository(repositoryRoot);
+  const frozen = snapshot(repositoryRoot);
+  const reportPath = join(repositoryRoot, 'pending/example/alpha/skill-report.json');
+  rmSync(reportPath);
+  symlinkSync('SKILL.md', reportPath);
+
+  assert.throws(() => replacePendingSubmission({
+    repositoryRoot,
+    mergedResults,
+    pendingDir: 'pending/example/alpha',
+    expectedTreeHash: frozen.treeHash,
+    expectedReportHash: frozen.reportHash,
+    expectedGitTreeOid: frozen.gitTreeOid,
+    expectedSourceRef: previousRef,
+  }), /report must be a non-symlink regular file/);
+  assert.equal(readFileSync(reportPath, 'utf8'), '# Previous\n');
+}));
+
+test('refuses a tracked excluded-name change before whole-directory replacement', () => withFixture(({
+  repositoryRoot,
+  mergedResults,
+}) => {
+  const previousRef = '1'.repeat(40);
+  writePending(repositoryRoot, '# Previous\n', previousRef);
+  writePending(mergedResults, '# Replacement\n', '2'.repeat(40));
+  initializeRepository(repositoryRoot);
+  const frozen = snapshot(repositoryRoot);
+  write(repositoryRoot, 'pending/example/alpha/concurrent.tmp', 'review state\n');
+  commitAll(repositoryRoot, 'concurrent excluded-name state');
+  assert.equal(calculateCanonicalTreeHash(repositoryRoot, 'pending/example/alpha'), frozen.treeHash);
+
+  assert.throws(() => replacePendingSubmission({
+    repositoryRoot,
+    mergedResults,
+    pendingDir: 'pending/example/alpha',
+    expectedTreeHash: frozen.treeHash,
+    expectedReportHash: frozen.reportHash,
+    expectedGitTreeOid: frozen.gitTreeOid,
+    expectedSourceRef: previousRef,
+  }), /Git tree changed after classification/);
+  assert.equal(
+    readFileSync(join(repositoryRoot, 'pending/example/alpha/concurrent.tmp'), 'utf8'),
+    'review state\n',
+  );
+}));
+
+test('refuses a tracked report mode-only change before whole-directory replacement', () => withFixture(({
+  repositoryRoot,
+  mergedResults,
+}) => {
+  const previousRef = '1'.repeat(40);
+  writePending(repositoryRoot, '# Previous\n', previousRef);
+  writePending(mergedResults, '# Replacement\n', '2'.repeat(40));
+  initializeRepository(repositoryRoot);
+  const frozen = snapshot(repositoryRoot);
+  const reportPath = join(repositoryRoot, 'pending/example/alpha/skill-report.json');
+  chmodSync(reportPath, 0o755);
+  commitAll(repositoryRoot, 'concurrent report mode');
+  assert.equal(createHash('sha256').update(readFileSync(reportPath)).digest('hex'), frozen.reportHash);
+
+  assert.throws(() => replacePendingSubmission({
+    repositoryRoot,
+    mergedResults,
+    pendingDir: 'pending/example/alpha',
+    expectedTreeHash: frozen.treeHash,
+    expectedReportHash: frozen.reportHash,
+    expectedGitTreeOid: frozen.gitTreeOid,
+    expectedSourceRef: previousRef,
+  }), /Git tree changed after classification/);
+  assert.notEqual(lstatSync(reportPath).mode & 0o111, 0);
+}));

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -42,6 +42,7 @@ function selectionPlan(
 
 function writeTarget(root, slug, {
   layout = 'community',
+  rootDirectory = 'skills',
   repository = 'example/source',
   sourceRef = 'main',
   skillPath = `skills/${slug}`,
@@ -51,7 +52,9 @@ function writeTarget(root, slug, {
   sourceUrl = null,
   schemaValid = true,
 } = {}) {
-  const relative = layout === 'community' ? `skills/${targetOwner}/${slug}` : `skills/${slug}`;
+  const relative = layout === 'community'
+    ? `${rootDirectory}/${targetOwner}/${slug}`
+    : `${rootDirectory}/${slug}`;
   const directory = join(root, ...relative.split('/'));
   mkdirSync(directory, { recursive: true });
   writeFileSync(join(directory, 'SKILL.md'), `---\nname: ${skillName}\n---\n`);
@@ -326,6 +329,54 @@ test('pending paths, including dangling symlinks, fail before target classificat
   assert.throws(
     () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
     /pending target (?:collision|contains a symlink)/,
+  );
+}));
+
+test('same-source pending follow-up is processable and binds the prior snapshot', () => withMarketplace((root) => {
+  const previousRef = '2'.repeat(40);
+  writeTarget(root, 'alpha', {
+    rootDirectory: 'pending',
+    sourceRef: previousRef,
+  });
+  const plan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]);
+  const result = classify(root, plan);
+  assert.equal(result.disposition, 'processable');
+  assert.equal(result.reasonCode, 'all_selected_targets_are_pending_updates');
+  assert.deepEqual(result.processingPlan, plan);
+  assert.deepEqual(result.pendingUpdateTargets, ['pending/example/alpha']);
+  assert.deepEqual(result.pendingUpdateSnapshots, [{
+    pendingDir: 'pending/example/alpha',
+    treeHash: calculateCanonicalTreeHash(root, 'pending/example/alpha'),
+    sourceRef: previousRef,
+  }]);
+}));
+
+test('same-source pending commit is an idempotent no-op', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { rootDirectory: 'pending', sourceRef: SOURCE_COMMIT });
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.disposition, 'all_existing');
+  assert.equal(result.reasonCode, 'all_selected_targets_already_processed');
+  assert.deepEqual(result.processingPlan.skills, []);
+}));
+
+test('pending identity mismatch remains fail-closed instead of becoming an update', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', {
+    rootDirectory: 'pending',
+    repository: 'other/source',
+    sourceRef: '2'.repeat(40),
+  });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /pending target source repository mismatch/,
+  );
+}));
+
+test('a pending follow-up cannot coexist with a published target', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', { sourceRef: '2'.repeat(40) });
+  writeTarget(root, 'alpha', { rootDirectory: 'pending', sourceRef: '3'.repeat(40) });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /pending target collision with published target/,
   );
 }));
 

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -1,16 +1,20 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { test } from 'node:test';
 import { classifySubmissionTargets } from '../classify-submission-targets.mjs';
 import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
+import { calculatePendingGitTreeOidAtCommit } from '../replace-pending-submission.mjs';
 
 const SOURCE_COMMIT = '1'.repeat(40);
 
@@ -108,6 +112,20 @@ function writeTarget(root, slug, {
     writeFileSync(join(directory, 'skill-report.json'), `${JSON.stringify(report)}\n`);
   }
   return directory;
+}
+
+function git(root, ...args) {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function commitMarketplace(root) {
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-qm', 'fixture');
 }
 
 function classify(root, plan = selectionPlan()) {
@@ -338,6 +356,7 @@ test('same-source pending follow-up is processable and binds the prior snapshot'
     rootDirectory: 'pending',
     sourceRef: previousRef,
   });
+  commitMarketplace(root);
   const plan = selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]);
   const result = classify(root, plan);
   assert.equal(result.disposition, 'processable');
@@ -347,6 +366,10 @@ test('same-source pending follow-up is processable and binds the prior snapshot'
   assert.deepEqual(result.pendingUpdateSnapshots, [{
     pendingDir: 'pending/example/alpha',
     treeHash: calculateCanonicalTreeHash(root, 'pending/example/alpha'),
+    reportHash: createHash('sha256')
+      .update(readFileSync(join(root, 'pending/example/alpha/skill-report.json')))
+      .digest('hex'),
+    gitTreeOid: calculatePendingGitTreeOidAtCommit(root, 'HEAD', 'pending/example/alpha'),
     sourceRef: previousRef,
   }]);
 }));

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -476,4 +476,10 @@ test('existing-target classification is a pre-CLI gate with a handled rejection 
   assert.match(reusable, /\[ "\$CURRENT_TREE_HASH" = "\$EXPECTED_TREE_HASH" \]/);
   assert.match(reusable, /previous_tree_hash = \$treeHash/);
   assert.match(reusable, /previous_source_ref = \$sourceRef/);
+  assert.match(reusable, /pending_update_targets:/);
+  assert.match(reusable, /pending_update_snapshots:/);
+  assert.match(reusable, /PENDING_UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.pending_update_targets \}\}/);
+  assert.match(reusable, /Pending update target and snapshot sets do not match/);
+  assert.match(reusable, /Frozen pending update target is missing or unsafe/);
+  assert.match(reusable, /Pending update target changed after classification/);
 });

--- a/scripts/tests/submission-runtime-workflow.test.mjs
+++ b/scripts/tests/submission-runtime-workflow.test.mjs
@@ -17,6 +17,7 @@ import { test } from 'node:test';
 const reusable = readFileSync('.github/workflows/reusable-process-skills.yml', 'utf8');
 const caller = readFileSync('.github/workflows/process-submission.yml', 'utf8');
 const approvalCaller = readFileSync('.github/workflows/approve-submission.yml', 'utf8');
+const validationWorkflow = readFileSync('.github/workflows/validate-marketplace.yml', 'utf8');
 const publicationProvenance = readFileSync('.github/workflows/publication-provenance.yml', 'utf8');
 const cliCompatibilityDescription =
   'Reserved compatibility input; submission processing is pinned to CLI 2.16.5';
@@ -28,6 +29,7 @@ const runtimeFiles = [
   'scripts/resolve-submission-source.mjs',
   'scripts/discover-submission-skills.mjs',
   'scripts/classify-submission-targets.mjs',
+  'scripts/replace-pending-submission.mjs',
   'scripts/process-submission-shard.mjs',
   'scripts/submission-selection-plan.mjs',
   'scripts/submission-shard-contract.mjs',
@@ -118,6 +120,7 @@ function createFixture() {
     'scripts/resolve-submission-source.mjs': 'export const source = true;\n',
     'scripts/discover-submission-skills.mjs': 'export const discover = true;\n',
     'scripts/classify-submission-targets.mjs': 'export const classify = true;\n',
+    'scripts/replace-pending-submission.mjs': 'export const replace = true;\n',
     'scripts/process-submission-shard.mjs': 'export const process = true;\n',
     'scripts/submission-selection-plan.mjs': 'export const selectionPlan = true;\n',
     'scripts/submission-shard-contract.mjs': 'export const contract = true;\n',
@@ -481,5 +484,9 @@ test('existing-target classification is a pre-CLI gate with a handled rejection 
   assert.match(reusable, /PENDING_UPDATE_TARGETS: \$\{\{ needs\.discover-and-plan\.outputs\.pending_update_targets \}\}/);
   assert.match(reusable, /Pending update target and snapshot sets do not match/);
   assert.match(reusable, /Frozen pending update target is missing or unsafe/);
-  assert.match(reusable, /Pending update target changed after classification/);
+  assert.match(reusable, /scripts\/replace-pending-submission\.mjs/);
+  assert.match(reusable, /--expected-report-hash "\$EXPECTED_PENDING_REPORT_HASH"/);
+  assert.match(reusable, /--expected-git-tree-oid "\$EXPECTED_PENDING_GIT_TREE_OID"/);
+  assert.doesNotMatch(reusable, /--skill-dir "\$pending_dir"/);
+  assert.match(validationWorkflow, /scripts\/tests\/replace-pending-submission\.test\.mjs/);
 });


### PR DESCRIPTION
## Goal

Allow a same-source community submission to supersede its existing canonical `pending/<owner>/<slug>` entry instead of failing as a pending collision.

Closes #3324.

## Acceptance criteria

- Same-repository pending follow-ups at a new immutable source revision are processable.
- An identical pending source revision is an idempotent no-op.
- Cross-repository, alternate-layout, official flat, and published/pending collisions remain fail-closed.
- Aggregation freezes and revalidates the complete tracked pending subtree before replacement.
- Report-only, file-type, excluded-name, and Git mode drift cannot be silently overwritten.

## Implementation

- Add pending-update classification and immutable snapshots.
- Bind `HEAD:<pendingDir>` Git tree OID in addition to canonical content and report hashes.
- Add a tested replacement helper with path/type checks and rollback-capable staged replacement.
- Include the new runtime helper and regression suite in immutable workflow/CI manifests.

## Verification

```text
CI=true node --test \
  scripts/tests/submission-existing-targets.test.mjs \
  scripts/tests/replace-pending-submission.test.mjs \
  scripts/tests/submission-runtime-workflow.test.mjs \
  scripts/tests/submission-scope-workflows.test.mjs \
  scripts/tests/resolve-approved-submission.test.mjs
# 101/101 PASS

ruby YAML parsing for reusable-process-skills.yml and validate-marketplace.yml
# PASS

git diff --check
# PASS
```

## Risk and boundaries

- Replacement is limited to canonical community pending paths.
- The complete Git subtree OID detects tracked path/blob/mode drift before any mutation.
- No merge, deployment, or production workflow replay is included in this PR.
- Remote CI and runtime workflow behavior remain pending independent verification.