### PR TITLE
Fix owner-qualified pending submission authors

### DIFF
--- a/scripts/classify-submission-targets.mjs
+++ b/scripts/classify-submission-targets.mjs
@@ -238,9 +238,10 @@ function validateCandidate(candidate, identity, targetLabel = 'published target'
     if (report.meta.source_type !== 'community') {
       fail(`namespaced published target must be community at ${reportPath}`);
     }
-    if (typeof report?.skill?.author !== 'string'
-      || report.skill.author.toLowerCase() !== identity.owner.toLowerCase()) {
-      fail(`published target author mismatch at ${reportPath}: expected ${identity.owner}`);
+    const author = report?.skill?.author?.toLowerCase();
+    const owner = identity.owner.toLowerCase();
+    if (typeof author !== 'string' || (author !== owner && !author.endsWith(`(${owner})`))) {
+      fail(`${targetLabel} author mismatch at ${reportPath}: expected ${identity.owner}`);
     }
   } else if (report.meta.source_type !== 'official') {
     fail(`flat published target must be official at ${reportPath}`);

--- a/scripts/tests/submission-existing-targets.test.mjs
+++ b/scripts/tests/submission-existing-targets.test.mjs
@@ -53,6 +53,7 @@ function writeTarget(root, slug, {
   malformed = false,
   targetOwner = 'example',
   skillName = slug,
+  author = null,
   sourceUrl = null,
   schemaValid = true,
 } = {}) {
@@ -80,7 +81,7 @@ function writeTarget(root, slug, {
       },
       skill: {
         name: skillName,
-        author: layout === 'community' ? targetOwner : owner,
+        author: author ?? (layout === 'community' ? targetOwner : owner),
         description: 'fixture',
         supported_tools: ['codex'],
       },
@@ -372,6 +373,29 @@ test('same-source pending follow-up is processable and binds the prior snapshot'
     gitTreeOid: calculatePendingGitTreeOidAtCommit(root, 'HEAD', 'pending/example/alpha'),
     sourceRef: previousRef,
   }]);
+}));
+
+test('same-source pending follow-up accepts a display author with the repository owner handle', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', {
+    rootDirectory: 'pending',
+    sourceRef: '2'.repeat(40),
+    author: 'Example Person (example)',
+  });
+  commitMarketplace(root);
+  const result = classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }]));
+  assert.equal(result.reasonCode, 'all_selected_targets_are_pending_updates');
+}));
+
+test('pending display author without the repository owner handle remains fail-closed', () => withMarketplace((root) => {
+  writeTarget(root, 'alpha', {
+    rootDirectory: 'pending',
+    sourceRef: '2'.repeat(40),
+    author: 'Unrelated Author',
+  });
+  assert.throws(
+    () => classify(root, selectionPlan([{ slug: 'alpha', path: 'skills/alpha' }])),
+    /pending target author mismatch/,
+  );
 }));
 
 test('same-source pending commit is an idempotent no-op', () => withMarketplace((root) => {


### PR DESCRIPTION
## Summary
- accept community author display names only when they retain the exact repository owner handle as a trailing `(owner)`
- keep unrelated author values fail-closed
- cover the production `axelfreeman/marketing-mindset` pending follow-up shape

## Root cause
PR #3332 correctly made same-source pending revisions processable, but reused the published-target author equality check. The existing frozen report preserves the upstream author `Axel Freeman (axelfreeman)`, so the exact production case still failed before replacement despite canonical source repository, ref, path, tree, report, and Git tree identity.

## Verification
- `CI=true node --test scripts/tests/submission-existing-targets.test.mjs` (33/33)
- focused five-submission classifier probe: all five return `processable / all_selected_targets_are_pending_updates`
- full pending-follow-up regression set before the final assertion-only test: 102/102 passed
- `git diff --check`

## Safety boundary
Canonical GitHub source URL, repository identity, immutable source ref, path, report schema, content/tree hashes, full Git tree OID, symlink/type checks, and cross-repository/published collision gates remain unchanged. A display author without the exact trailing repository owner handle is still rejected.