### PR TITLE
Fix report-only publication recovery

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -61,6 +61,7 @@ jobs:
           }
 
           MERGE_COMMIT_SHA=$(jq -er '.merge_commit_sha' <<< "$PR")
+          BASE_COMMIT_SHA=$(jq -er '.base.sha' <<< "$PR")
           HEAD_SHA=$(jq -er '.head.sha' <<< "$PR")
           PR_URL=$(jq -er '.html_url' <<< "$PR")
           MERGED_BY=$(jq -er '.merged_by.login' <<< "$PR")
@@ -68,6 +69,7 @@ jobs:
             | grep -oE 'Submission ID.*`[0-9a-f-]{36}`' \
             | grep -oE '[0-9a-f-]{36}' || true)
           [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$BASE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           if [ "$EVENT_NAME" = workflow_dispatch ]; then
             EXPECTED_CORRELATION_ID="submission-pr-${PR_NUMBER}-${HEAD_SHA}-${MERGE_COMMIT_SHA}"
@@ -80,6 +82,7 @@ jobs:
           [[ "$MERGED_BY" =~ ^([A-Za-z0-9-]+|github-actions\[bot\])$ ]]
           {
             echo "pr_number=$PR_NUMBER"
+            echo "base_commit_sha=$BASE_COMMIT_SHA"
             echo "merge_commit_sha=$MERGE_COMMIT_SHA"
             echo "submission_id=$SUBMISSION_ID"
             echo "pr_url=$PR_URL"
@@ -123,15 +126,31 @@ jobs:
             echo "::error::Existing durable publication attempt status refuses duplicate execution"
             exit 1
           fi
-          CORRELATION_STATE=$(jq -r --arg context "$CONTEXT" '[.[] | select(.context == $context)][0].state // ""' <<< "$STATUSES")
-          if [ "$CORRELATION_STATE" = success ]; then
-            echo "::error::Authoritative publication success refuses retry"
-            exit 1
-          fi
-          if [ "$CORRELATION_STATE" = pending ]; then
-            echo "::error::Existing in-flight publication refuses unknown-effect replay"
-            exit 1
-          fi
+          CORRELATION_STATUS=$(jq -c --arg context "$CONTEXT" '[.[] | select(.context == $context)] | if length == 0 then {} else max_by(.created_at) end' <<< "$STATUSES")
+          CORRELATION_STATE=$(jq -r '.state // ""' <<< "$CORRELATION_STATUS")
+          case "$CORRELATION_STATE" in
+            '') ;;
+            success)
+              echo "::error::Authoritative publication success refuses retry"
+              exit 1
+              ;;
+            pending)
+              echo "::error::Existing in-flight publication refuses unknown-effect replay"
+              exit 1
+              ;;
+            failure|error)
+              FAILURE_AT_MS=$(jq -er '(.created_at | fromdateiso8601) * 1000 | floor' <<< "$CORRELATION_STATUS")
+              OUTBOX_ATTEMPT_MS="${OUTBOX_ATTEMPT%%-*}"
+              if (( 10#$OUTBOX_ATTEMPT_MS <= FAILURE_AT_MS )); then
+                echo "::error::Recovery outbox attempt must be created after the latest terminal failure"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unknown durable publication state refuses recovery"
+              exit 1
+              ;;
+          esac
           gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
             -f state=pending -f context="$ATTEMPT_CONTEXT" \
             -f description='Exact publication attempt is running' \
@@ -162,6 +181,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.base_commit_sha }}
           MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
           CORRELATION_ID: ${{ inputs.correlation_id }}
           PR_NUMBER: ${{ steps.freeze_pr.outputs.pr_number }}
@@ -286,10 +306,17 @@ jobs:
             }
 
           cd "$WORK_DIR"
+          [[ "$BASE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] && [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Merged PR has no exact base and merge commit identity"
+            exit 1
+          }
+          git fetch --no-tags --depth=1 origin "$BASE_COMMIT_SHA" "$MERGE_COMMIT_SHA"
           node scripts/resolve-approved-submission.mjs \
             --repo-root "$WORK_DIR" \
             --files "$PR_FILES" \
-            --output "$APPROVAL_PLAN"
+            --output "$APPROVAL_PLAN" \
+            --report-only-base-commit "$BASE_COMMIT_SHA" \
+            --report-only-merge-commit "$MERGE_COMMIT_SHA"
 
           mapfile -t SKILL_PATHS < <(jq -r '.skills[].pendingDir' "$APPROVAL_PLAN")
           mapfile -t TARGET_PATHS < <(jq -r '.skills[].targetDir' "$APPROVAL_PLAN")
@@ -300,11 +327,6 @@ jobs:
           test "${#SKILL_PATHS[@]}" -eq "${#TARGET_PATHS[@]}"
           echo "Frozen pending skills: ${SKILL_PATHS[*]}"
 
-          [[ "$MERGE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::Merged PR has no exact merge commit identity"
-            exit 1
-          }
-          git fetch --no-tags --depth=1 origin "$MERGE_COMMIT_SHA"
           for PENDING_DIR in "${SKILL_PATHS[@]}"; do
             git diff --quiet "$MERGE_COMMIT_SHA" HEAD -- "$PENDING_DIR" || {
               echo "::error::Pending skill changed after the reviewed merge: $PENDING_DIR"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -12,6 +12,10 @@ on:
         description: Exact idempotency correlation bound to the merged PR identity
         required: true
         type: string
+      outbox_attempt:
+        description: Exact immutable outbox attempt suffix (<13-digit timestamp>-<positive sequence>)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -87,35 +91,59 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CORRELATION_ID: ${{ inputs.correlation_id }}
+          OUTBOX_ATTEMPT: ${{ inputs.outbox_attempt }}
           MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          [[ "$OUTBOX_ATTEMPT" =~ ^[0-9]{13}-[1-9][0-9]*$ ]] || {
+            echo "::error::Publication recovery requires one exact canonical outbox attempt"
+            exit 1
+          }
           DIGEST=$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')
           OUTBOX_PREFIX="tags/agentcrew-dispatch-outbox/publication/$DIGEST/"
+          EXACT_OUTBOX_REF="refs/${OUTBOX_PREFIX}${OUTBOX_ATTEMPT}"
           CONTEXT="agentcrew/publication/$DIGEST"
+          ATTEMPT_CONTEXT="agentcrew/publication-attempt/$DIGEST/$OUTBOX_ATTEMPT"
           OUTBOX=$(gh api "repos/$REPOSITORY/git/matching-refs/$OUTBOX_PREFIX")
-          jq -e --arg prefix "refs/$OUTBOX_PREFIX" --arg merge_sha "$MERGE_COMMIT_SHA" '
+          jq -e --arg prefix "refs/$OUTBOX_PREFIX" --arg exact_ref "$EXACT_OUTBOX_REF" --arg merge_sha "$MERGE_COMMIT_SHA" '
             length > 0 and length <= 8 and
+            any(.[]; .ref == $exact_ref) and
             all(.[];
               (.ref | startswith($prefix)) and
               ((.ref | ltrimstr($prefix)) | test("^[0-9]{13}-[1-9][0-9]*$")) and
               .object.type == "commit" and
               .object.sha == $merge_sha)
           ' <<< "$OUTBOX" >/dev/null || {
-            echo "::error::Durable publication dispatch outbox does not bind the exact merge commit"
+            echo "::error::Durable publication dispatch outbox does not bind the exact merge commit and attempt"
             exit 1
           }
           STATUSES=$(gh api --paginate "repos/$REPOSITORY/commits/$MERGE_COMMIT_SHA/statuses?per_page=100" | jq -s 'add')
-          if jq -e --arg context "$CONTEXT" 'any(.[]; .context == $context)' <<< "$STATUSES" >/dev/null; then
-            echo "::error::Existing durable publication status refuses duplicate execution"
+          if jq -e --arg context "$ATTEMPT_CONTEXT" 'any(.[]; .context == $context)' <<< "$STATUSES" >/dev/null; then
+            echo "::error::Existing durable publication attempt status refuses duplicate execution"
             exit 1
           fi
+          CORRELATION_STATE=$(jq -r --arg context "$CONTEXT" '[.[] | select(.context == $context)][0].state // ""' <<< "$STATUSES")
+          if [ "$CORRELATION_STATE" = success ]; then
+            echo "::error::Authoritative publication success refuses retry"
+            exit 1
+          fi
+          if [ "$CORRELATION_STATE" = pending ]; then
+            echo "::error::Existing in-flight publication refuses unknown-effect replay"
+            exit 1
+          fi
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state=pending -f context="$ATTEMPT_CONTEXT" \
+            -f description='Exact publication attempt is running' \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
           gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
             -f state=pending -f context="$CONTEXT" \
             -f description='Correlated publication is running' \
             -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
-          echo "owns_reservation=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "owns_reservation=true"
+            echo "attempt_context=$ATTEMPT_CONTEXT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App Token
         id: app-token
@@ -161,12 +189,12 @@ jobs:
 
           mapfile -t MATERIALIZE_PENDING_PATHS < <(
             awk -F/ '
-              $1 == "pending" && $NF == "SKILL.md" && NF == 3 { print $1 "/" $2 }
-              $1 == "pending" && $NF == "SKILL.md" && NF == 4 { print $1 "/" $2 "/" $3 }
+              $1 == "pending" && ($NF == "SKILL.md" || $NF == "skill-report.json") && NF == 3 { print $1 "/" $2 }
+              $1 == "pending" && ($NF == "SKILL.md" || $NF == "skill-report.json") && NF == 4 { print $1 "/" $2 "/" $3 }
             ' "$PR_FILES" | LC_ALL=C sort -u
           )
           test "${#MATERIALIZE_PENDING_PATHS[@]}" -gt 0 || {
-            echo "::error::Merged PR contains no canonical pending SKILL.md"
+            echo "::error::Merged PR contains no canonical pending publication identity file"
             exit 1
           }
           MATERIALIZE_TARGET_PATHS=()
@@ -461,6 +489,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CORRELATION_ID: ${{ inputs.correlation_id }}
+          ATTEMPT_CONTEXT: ${{ steps.publication_claim.outputs.attempt_context }}
           MERGE_COMMIT_SHA: ${{ steps.freeze_pr.outputs.merge_commit_sha }}
           PROVIDER_SYNC_REQUIRED: ${{ steps.publish.outputs.provider_sync_required }}
           REPOSITORY: ${{ github.repository }}
@@ -470,11 +499,19 @@ jobs:
           CONTEXT="agentcrew/publication/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
           if [ "$JOB_STATUS" != success ]; then
             gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+              -f state=failure -f context="$ATTEMPT_CONTEXT" \
+              -f description='Exact publication attempt failed' \
+              -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
+            gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
               -f state=failure -f context="$CONTEXT" \
               -f description='Correlated publication failed; inspection required' \
               -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
             exit 0
           fi
+          gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
+            -f state=success -f context="$ATTEMPT_CONTEXT" \
+            -f description='Exact publication attempt completed' \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/${{ github.run_id }}"
           if [ "$PROVIDER_SYNC_REQUIRED" != true ]; then
             gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
               -f state=success -f context="$CONTEXT" \

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -212,11 +212,12 @@ function listRegularFiles(repositoryRoot, directory) {
   return files.sort();
 }
 
-function rootFromSkillFile(path) {
+function rootFromPublicationIdentityFile(path) {
   const segments = path.split('/');
-  if (segments.at(-1) !== 'SKILL.md' || segments[0] !== 'pending') return null;
+  const basename = segments.at(-1);
+  if ((basename !== 'SKILL.md' && basename !== 'skill-report.json') || segments[0] !== 'pending') return null;
   if (segments.length !== 3 && segments.length !== 4) {
-    fail(`pending SKILL.md must be pending/<skill>/SKILL.md or pending/<owner>/<skill>/SKILL.md: ${path}`);
+    fail(`pending publication identity must be pending/<skill>/{SKILL.md,skill-report.json} or pending/<owner>/<skill>/{SKILL.md,skill-report.json}: ${path}`);
   }
   for (const [index, segment] of segments.slice(1, -1).entries()) {
     validateSegment(segment, `pending path segment ${index + 1}`);
@@ -227,11 +228,15 @@ function rootFromSkillFile(path) {
 export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
   const root = realpathSync(repositoryRoot);
   const normalizedFiles = [...new Set(changedFiles.map(normalizeFrozenPath).filter(Boolean))].sort();
-  const pendingFiles = normalizedFiles.filter((path) => path === 'pending' || path.startsWith('pending/'));
+  const nonPendingFiles = normalizedFiles.filter((path) => path !== 'pending' && !path.startsWith('pending/'));
+  if (nonPendingFiles.length > 0) {
+    fail(`submission contains file(s) outside pending: ${nonPendingFiles.slice(0, 5).join(', ')}`);
+  }
+  const pendingFiles = normalizedFiles;
   if (pendingFiles.length === 0) fail('submission contains no pending files');
 
-  const pendingRoots = [...new Set(pendingFiles.map(rootFromSkillFile).filter(Boolean))].sort();
-  if (pendingRoots.length === 0) fail('submission contains no canonical pending SKILL.md');
+  const pendingRoots = [...new Set(pendingFiles.map(rootFromPublicationIdentityFile).filter(Boolean))].sort();
+  if (pendingRoots.length === 0) fail('submission contains no canonical pending publication identity file');
 
   for (const path of pendingFiles) {
     const absolutePath = resolve(root, ...path.split('/'));
@@ -244,13 +249,25 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
   }
 
   for (const path of pendingFiles) {
-    if (!pendingRoots.some((pendingRoot) => path === pendingRoot || path.startsWith(`${pendingRoot}/`))) {
+    if (!pendingRoots.some((pendingRoot) => path.startsWith(`${pendingRoot}/`))) {
       fail(`pending file is outside the frozen skill set: ${path}`);
     }
   }
 
   const frozenFileSet = new Set(pendingFiles);
+  const publicationModeByRoot = new Map();
   for (const pendingRoot of pendingRoots) {
+    const changedInRoot = pendingFiles.filter((path) => path.startsWith(`${pendingRoot}/`));
+    const skillPath = `${pendingRoot}/SKILL.md`;
+    const reportPath = `${pendingRoot}/skill-report.json`;
+    if (!frozenFileSet.has(skillPath)) {
+      if (changedInRoot.length !== 1 || changedInRoot[0] !== reportPath) {
+        fail(`${pendingRoot} report-only publication may change only skill-report.json`);
+      }
+      publicationModeByRoot.set(pendingRoot, 'report-only');
+      continue;
+    }
+    publicationModeByRoot.set(pendingRoot, 'full');
     const unfrozen = listRegularFiles(root, pendingRoot).filter((path) => !frozenFileSet.has(path));
     if (unfrozen.length > 0) {
       fail(`${pendingRoot} contains file(s) outside the frozen PR/artifact set: ${unfrozen.slice(0, 5).join(', ')}`);
@@ -348,6 +365,7 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
       duplicate,
       treeHash: actualTreeHash,
       pendingDir,
+      publicationMode: publicationModeByRoot.get(pendingDir),
       reportSlug: report.meta.slug,
       sourceType,
       targetDir,

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -147,6 +147,51 @@ function gitBuffer(repositoryRoot, args) {
   return result.stdout;
 }
 
+function gitPathBytes(repositoryRoot, commit, path) {
+  return gitBuffer(repositoryRoot, ['show', `${commit}:${path}`]);
+}
+
+function verifyReportOnlyReaudit({ repositoryRoot, pendingDir, baseCommit, mergeCommit, report }) {
+  if (!/^[0-9a-f]{40}$/.test(baseCommit ?? '') || !/^[0-9a-f]{40}$/.test(mergeCommit ?? '')) {
+    fail(`${pendingDir} report-only publication requires exact prior and merged commit identities`);
+  }
+
+  const mergeLine = gitBuffer(repositoryRoot, ['rev-list', '--parents', '-n', '1', mergeCommit])
+    .toString('utf8').trim().split(/\s+/);
+  if (mergeLine.length !== 3 || mergeLine[0] !== mergeCommit || mergeLine[1] !== baseCommit) {
+    fail(`${pendingDir} report-only publication base is not the exact first parent of the merge commit`);
+  }
+
+  const skillPath = `${pendingDir}/SKILL.md`;
+  const reportPath = `${pendingDir}/skill-report.json`;
+  const priorSkill = gitPathBytes(repositoryRoot, baseCommit, skillPath);
+  const mergedSkill = gitPathBytes(repositoryRoot, mergeCommit, skillPath);
+  const currentSkill = readFileSync(resolve(repositoryRoot, ...skillPath.split('/')));
+  if (!priorSkill.equals(mergedSkill) || !priorSkill.equals(currentSkill)) {
+    fail(`${pendingDir} prior pending SKILL.md content changed`);
+  }
+
+  const mergedReport = gitPathBytes(repositoryRoot, mergeCommit, reportPath);
+  const currentReport = readFileSync(resolve(repositoryRoot, ...reportPath.split('/')));
+  if (!mergedReport.equals(currentReport)) {
+    fail(`${pendingDir} current pending report does not match the exact merged commit`);
+  }
+
+  const priorReport = JSON.parse(gitPathBytes(repositoryRoot, baseCommit, reportPath).toString('utf8'));
+  const priorIdentity = sourceIdentity(priorReport, `${pendingDir}/prior skill-report.json`);
+  const currentIdentity = sourceIdentity(report, `${pendingDir}/skill-report.json`);
+  if (currentIdentity.repository !== priorIdentity.repository || currentIdentity.path !== priorIdentity.path
+    || report.meta.source_type !== priorReport?.meta?.source_type
+    || report.meta.slug !== priorReport?.meta?.slug
+    || report.meta.content_hash !== priorReport?.meta?.content_hash
+    || report.meta.tree_hash !== priorReport?.meta?.tree_hash) {
+    fail(`${pendingDir} source provenance does not match the trusted prior pending report`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(currentIdentity.ref) || currentIdentity.ref === priorIdentity.ref) {
+    fail(`${pendingDir} report-only re-audit must reference a new immutable source commit`);
+  }
+}
+
 export function calculateCanonicalTreeHashAtCommit(repositoryRoot, commit, skillDirectory) {
   const normalizedDirectory = normalizeFrozenPath(skillDirectory);
   if (!normalizedDirectory?.startsWith('skills/')) fail('committed skill directory must be under skills/');
@@ -225,7 +270,12 @@ function rootFromPublicationIdentityFile(path) {
   return segments.slice(0, -1).join('/');
 }
 
-export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
+export function resolveApprovedSubmission({
+  repositoryRoot,
+  changedFiles,
+  reportOnlyBaseCommit = null,
+  reportOnlyMergeCommit = null,
+}) {
   const root = realpathSync(repositoryRoot);
   const normalizedFiles = [...new Set(changedFiles.map(normalizeFrozenPath).filter(Boolean))].sort();
   const nonPendingFiles = normalizedFiles.filter((path) => path !== 'pending' && !path.startsWith('pending/'));
@@ -288,6 +338,15 @@ export function resolveApprovedSubmission({ repositoryRoot, changedFiles }) {
     }
 
     const report = readJson(reportPath, `${pendingDir}/skill-report.json`);
+    if (publicationModeByRoot.get(pendingDir) === 'report-only') {
+      verifyReportOnlyReaudit({
+        repositoryRoot: root,
+        pendingDir,
+        baseCommit: reportOnlyBaseCommit,
+        mergeCommit: reportOnlyMergeCommit,
+        report,
+      });
+    }
     if (report?.meta?.source_type !== sourceType) {
       fail(`${pendingDir} source_type does not match its pending path shape`);
     }
@@ -399,8 +458,15 @@ function main() {
   const repositoryRoot = readOption(args, '--repo-root');
   const filesPath = readOption(args, '--files');
   const outputPath = readOption(args, '--output');
+  const reportOnlyBaseCommit = readOption(args, '--report-only-base-commit', { required: false });
+  const reportOnlyMergeCommit = readOption(args, '--report-only-merge-commit', { required: false });
   const changedFiles = readFileSync(filesPath, 'utf8').split(/\r?\n/).filter(Boolean);
-  const plan = resolveApprovedSubmission({ repositoryRoot, changedFiles });
+  const plan = resolveApprovedSubmission({
+    repositoryRoot,
+    changedFiles,
+    reportOnlyBaseCommit,
+    reportOnlyMergeCommit,
+  });
   writeFileSync(outputPath, `${JSON.stringify(plan, null, 2)}\n`, { mode: 0o600 });
   process.stdout.write(`Resolved ${plan.skills.length} frozen pending skill(s)\n`);
 }

--- a/scripts/resolve-approved-submission.mjs
+++ b/scripts/resolve-approved-submission.mjs
@@ -156,9 +156,12 @@ function verifyReportOnlyReaudit({ repositoryRoot, pendingDir, baseCommit, merge
     fail(`${pendingDir} report-only publication requires exact prior and merged commit identities`);
   }
 
-  const mergeLine = gitBuffer(repositoryRoot, ['rev-list', '--parents', '-n', '1', mergeCommit])
-    .toString('utf8').trim().split(/\s+/);
-  if (mergeLine.length !== 3 || mergeLine[0] !== mergeCommit || mergeLine[1] !== baseCommit) {
+  const mergeParents = gitBuffer(repositoryRoot, ['cat-file', '-p', mergeCommit])
+    .toString('utf8')
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('parent '))
+    .map((line) => line.slice('parent '.length));
+  if (mergeParents.length !== 2 || mergeParents[0] !== baseCommit) {
     fail(`${pendingDir} report-only publication base is not the exact first parent of the merge commit`);
   }
 

--- a/scripts/tests/publication-receiver-workflow.test.mjs
+++ b/scripts/tests/publication-receiver-workflow.test.mjs
@@ -29,17 +29,26 @@ test('publication receiver serializes one correlation and verifies the exact dur
   assert.match(source, /EXACT_OUTBOX_REF=.*OUTBOX_ATTEMPT/);
   assert.match(source, /ATTEMPT_CONTEXT="agentcrew\/publication-attempt\/\$DIGEST\/\$OUTBOX_ATTEMPT"/);
   assert.match(source, /Existing durable publication attempt status refuses duplicate execution/);
-  assert.match(source, /if \[ "\$CORRELATION_STATE" = success \]/);
+  assert.match(source, /case "\$CORRELATION_STATE" in/);
   assert.match(source, /Authoritative publication success refuses retry/);
-  assert.match(source, /if \[ "\$CORRELATION_STATE" = pending \]/);
   assert.match(source, /Existing in-flight publication refuses unknown-effect replay/);
+  assert.match(source, /failure\|error\)/);
+  assert.match(source, /10#\$OUTBOX_ATTEMPT_MS <= FAILURE_AT_MS/);
+  assert.match(source, /Recovery outbox attempt must be created after the latest terminal failure/);
+  assert.match(source, /Unknown durable publication state refuses recovery/);
   assert.match(source, /-f state=failure -f context="\$ATTEMPT_CONTEXT"/);
   assert.match(source, /-f state=success -f context="\$ATTEMPT_CONTEXT"/);
   assert.match(source, /steps\.publication_claim\.outputs\.owns_reservation == 'true'/);
   assert.match(source, /Idempotency-Key: publication-resolved-/);
 });
 
-test('publication receiver materializes report-only roots without scanning shared pending', () => {
+test('publication receiver materializes report-only roots only after exact prior-content and provenance verification', () => {
+  assert.match(source, /BASE_COMMIT_SHA=\$\(jq -er '\.base\.sha'/);
+  const fetchCommits = source.indexOf('git fetch --no-tags --depth=1 origin "$BASE_COMMIT_SHA" "$MERGE_COMMIT_SHA"');
+  const resolvePlan = source.indexOf('node scripts/resolve-approved-submission.mjs');
+  assert.ok(fetchCommits > 0 && fetchCommits < resolvePlan);
+  assert.match(source, /--report-only-base-commit "\$BASE_COMMIT_SHA"/);
+  assert.match(source, /--report-only-merge-commit "\$MERGE_COMMIT_SHA"/);
   assert.match(source, /\$NF == "SKILL\.md" \|\| \$NF == "skill-report\.json"/);
   assert.match(source, /Merged PR contains no canonical pending publication identity file/);
   assert.match(source, /git diff --quiet "\$MERGE_COMMIT_SHA" HEAD -- "\$PENDING_DIR"/);

--- a/scripts/tests/publication-receiver-workflow.test.mjs
+++ b/scripts/tests/publication-receiver-workflow.test.mjs
@@ -16,16 +16,32 @@ test('post-merge publication accepts the exact bot merger and binds dispatch cor
   assert.match(source, /\[ "\$CORRELATION_ID" = "\$EXPECTED_CORRELATION_ID" \]/);
 });
 
-test('publication receiver serializes one correlation and verifies the durable outbox before writes', () => {
+test('publication receiver serializes one correlation and verifies the exact durable outbox attempt before writes', () => {
   assert.equal(workflow.concurrency.group, 'publication-${{ inputs.correlation_id }}');
   assert.equal(workflow.concurrency['cancel-in-progress'], false);
+  assert.equal(workflow.on.workflow_dispatch.inputs.outbox_attempt.required, true);
   const outboxGuard = source.indexOf('Verify durable publication dispatch outbox');
   const appToken = source.indexOf('Generate GitHub App Token');
   assert.ok(outboxGuard > 0 && outboxGuard < appToken);
   assert.match(source, /agentcrew-dispatch-outbox\/publication/);
   assert.match(source, /length > 0 and length <= 8/);
   assert.match(source, /object\.sha == \$merge_sha/);
-  assert.match(source, /Existing durable publication status refuses duplicate execution/);
+  assert.match(source, /EXACT_OUTBOX_REF=.*OUTBOX_ATTEMPT/);
+  assert.match(source, /ATTEMPT_CONTEXT="agentcrew\/publication-attempt\/\$DIGEST\/\$OUTBOX_ATTEMPT"/);
+  assert.match(source, /Existing durable publication attempt status refuses duplicate execution/);
+  assert.match(source, /if \[ "\$CORRELATION_STATE" = success \]/);
+  assert.match(source, /Authoritative publication success refuses retry/);
+  assert.match(source, /if \[ "\$CORRELATION_STATE" = pending \]/);
+  assert.match(source, /Existing in-flight publication refuses unknown-effect replay/);
+  assert.match(source, /-f state=failure -f context="\$ATTEMPT_CONTEXT"/);
+  assert.match(source, /-f state=success -f context="\$ATTEMPT_CONTEXT"/);
   assert.match(source, /steps\.publication_claim\.outputs\.owns_reservation == 'true'/);
   assert.match(source, /Idempotency-Key: publication-resolved-/);
+});
+
+test('publication receiver materializes report-only roots without scanning shared pending', () => {
+  assert.match(source, /\$NF == "SKILL\.md" \|\| \$NF == "skill-report\.json"/);
+  assert.match(source, /Merged PR contains no canonical pending publication identity file/);
+  assert.match(source, /git diff --quiet "\$MERGE_COMMIT_SHA" HEAD -- "\$PENDING_DIR"/);
+  assert.doesNotMatch(source, /find pending/);
 });

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -108,6 +108,80 @@ test('supports an official flat pending skill', () => withRepository((root) => {
   assert.equal(plan.skills[0].targetDir, 'skills/official-skill');
 }));
 
+test('resolves a report-only community re-audit without scanning unrelated pending roots', () => withRepository((root) => {
+  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
+  addSkill(root, 'pending/other/unrelated', { slug: 'other-unrelated' });
+
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: ['pending/owner/skill/skill-report.json'],
+  });
+
+  assert.deepEqual(plan.skills.map(({ pendingDir, targetDir, publicationMode }) => ({
+    pendingDir,
+    targetDir,
+    publicationMode,
+  })), [{
+    pendingDir: 'pending/owner/skill',
+    targetDir: 'skills/owner/skill',
+    publicationMode: 'report-only',
+  }]);
+}));
+
+test('resolves a report-only official re-audit', () => withRepository((root) => {
+  addSkill(root, 'pending/official-skill', { slug: 'official-skill', sourceType: 'official' });
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: ['pending/official-skill/skill-report.json'],
+  });
+  assert.equal(plan.skills[0].targetDir, 'skills/official-skill');
+  assert.equal(plan.skills[0].publicationMode, 'report-only');
+}));
+
+test('report-only re-audit rejects additional changed payload files', () => withRepository((root) => {
+  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: [
+        'pending/owner/skill/skill-report.json',
+        'pending/owner/skill/references/note.md',
+      ],
+    }),
+    /report-only.*only.*skill-report\.json/,
+  );
+  write(root, 'README.md', '# Unrelated\n');
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/skill-report.json', 'README.md'],
+    }),
+    /outside pending/,
+  );
+}));
+
+test('report-only re-audit requires a regular SKILL.md bound by report hashes', () => withRepository((root) => {
+  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
+  rmSync(join(root, 'pending/owner/skill/SKILL.md'));
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/skill-report.json'],
+    }),
+    /SKILL\.md is missing/,
+  );
+
+  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
+  write(root, 'pending/owner/skill/SKILL.md', '# Drifted\n');
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: ['pending/owner/skill/skill-report.json'],
+    }),
+    /content_hash does not match/,
+  );
+}));
+
 test('authorizes a reviewed same-repository update when the source path moves', () => withRepository((root) => {
   const oldCommit = '1'.repeat(40);
   const newCommit = '2'.repeat(40);

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -186,6 +186,40 @@ test('report-only CLI accepts the exact workflow commit arguments', () => withRe
   assert.equal(JSON.parse(readFileSync(outputPath, 'utf8')).skills[0].publicationMode, 'report-only');
 }));
 
+test('report-only CLI verifies merge parents after workflow-shaped depth-1 fetches', () => withRepository((root) => {
+  const pendingDir = 'pending/owner/skill';
+  addSkill(root, pendingDir, { slug: 'owner-skill', sourceRef: '1'.repeat(40) });
+  const { baseCommit, mergeCommit } = commitReportOnlyHistory(root, pendingDir);
+  write(root, 'README.md', '# Current main\n');
+  git(root, 'add', 'README.md');
+  git(root, 'commit', '-qm', 'advance main after merge');
+
+  const shallowRoot = mkdtempSync(join(tmpdir(), 'approved-submission-shallow-'));
+  try {
+    const clone = join(shallowRoot, 'clone');
+    const cloneResult = spawnSync('git', ['clone', '--depth=1', `file://${root}`, clone], { encoding: 'utf8' });
+    assert.equal(cloneResult.status, 0, cloneResult.stderr);
+    git(clone, 'fetch', '--no-tags', '--depth=1', 'origin', baseCommit, mergeCommit);
+    assert.equal(git(clone, 'rev-list', '--parents', '-n', '1', mergeCommit), mergeCommit);
+
+    const filesPath = join(shallowRoot, 'pr-files.txt');
+    const outputPath = join(shallowRoot, 'approval-plan.json');
+    writeFileSync(filesPath, `${pendingDir}/skill-report.json\n`);
+    const result = spawnSync(process.execPath, [
+      join(process.cwd(), 'scripts/resolve-approved-submission.mjs'),
+      '--repo-root', clone,
+      '--files', filesPath,
+      '--output', outputPath,
+      '--report-only-base-commit', baseCommit,
+      '--report-only-merge-commit', mergeCommit,
+    ], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(readFileSync(outputPath, 'utf8')).skills[0].publicationMode, 'report-only');
+  } finally {
+    rmSync(shallowRoot, { recursive: true, force: true });
+  }
+}));
+
 test('report-only re-audit is admitted only when the exact prior pending content and provenance are unchanged', () => withRepository((root) => {
   const pendingDir = 'pending/owner/skill';
   const oldRef = '1'.repeat(40);

--- a/scripts/tests/resolve-approved-submission.test.mjs
+++ b/scripts/tests/resolve-approved-submission.test.mjs
@@ -63,6 +63,27 @@ function git(root, ...args) {
   return result.stdout.trim();
 }
 
+function commitReportOnlyHistory(root, pendingDir, { oldRef = '1'.repeat(40), newRef = '2'.repeat(40) } = {}) {
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'add', '.');
+  git(root, 'commit', '-qm', 'prior pending submission');
+  const baseBranch = git(root, 'branch', '--show-current');
+  const baseCommit = git(root, 'rev-parse', 'HEAD');
+  git(root, 'checkout', '-qb', 'report-only-reaudit');
+  const reportPath = join(root, pendingDir, 'skill-report.json');
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  report.meta.source_ref = newRef;
+  report.meta.source_url = report.meta.source_url.replace(oldRef, newRef);
+  writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+  git(root, 'add', reportPath);
+  git(root, 'commit', '-qm', 're-audit report');
+  git(root, 'checkout', '-q', baseBranch);
+  git(root, 'merge', '--no-ff', '-qm', 'merge re-audit report', 'report-only-reaudit');
+  return { baseCommit, mergeCommit: git(root, 'rev-parse', 'HEAD'), report, reportPath };
+}
+
 test('calculates a canonical skill hash from immutable Git blobs', () => withRepository((root) => {
   addSkill(root, 'skills/owner/skill', { slug: 'owner-skill', withReference: true });
   git(root, 'init', '-q');
@@ -109,12 +130,16 @@ test('supports an official flat pending skill', () => withRepository((root) => {
 }));
 
 test('resolves a report-only community re-audit without scanning unrelated pending roots', () => withRepository((root) => {
-  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
+  const pendingDir = 'pending/owner/skill';
+  addSkill(root, pendingDir, { slug: 'owner-skill', sourceRef: '1'.repeat(40), withReference: true });
   addSkill(root, 'pending/other/unrelated', { slug: 'other-unrelated' });
+  const { baseCommit, mergeCommit } = commitReportOnlyHistory(root, pendingDir);
 
   const plan = resolveApprovedSubmission({
     repositoryRoot: root,
-    changedFiles: ['pending/owner/skill/skill-report.json'],
+    changedFiles: [`${pendingDir}/skill-report.json`],
+    reportOnlyBaseCommit: baseCommit,
+    reportOnlyMergeCommit: mergeCommit,
   });
 
   assert.deepEqual(plan.skills.map(({ pendingDir, targetDir, publicationMode }) => ({
@@ -129,13 +154,101 @@ test('resolves a report-only community re-audit without scanning unrelated pendi
 }));
 
 test('resolves a report-only official re-audit', () => withRepository((root) => {
-  addSkill(root, 'pending/official-skill', { slug: 'official-skill', sourceType: 'official' });
+  const pendingDir = 'pending/official-skill';
+  addSkill(root, pendingDir, { slug: 'official-skill', sourceType: 'official', sourceRef: '1'.repeat(40) });
+  const { baseCommit, mergeCommit } = commitReportOnlyHistory(root, pendingDir);
   const plan = resolveApprovedSubmission({
     repositoryRoot: root,
-    changedFiles: ['pending/official-skill/skill-report.json'],
+    changedFiles: [`${pendingDir}/skill-report.json`],
+    reportOnlyBaseCommit: baseCommit,
+    reportOnlyMergeCommit: mergeCommit,
   });
   assert.equal(plan.skills[0].targetDir, 'skills/official-skill');
   assert.equal(plan.skills[0].publicationMode, 'report-only');
+}));
+
+test('report-only CLI accepts the exact workflow commit arguments', () => withRepository((root) => {
+  const pendingDir = 'pending/owner/skill';
+  addSkill(root, pendingDir, { slug: 'owner-skill', sourceRef: '1'.repeat(40) });
+  const { baseCommit, mergeCommit } = commitReportOnlyHistory(root, pendingDir);
+  const filesPath = join(root, 'pr-files.txt');
+  const outputPath = join(root, 'approval-plan.json');
+  writeFileSync(filesPath, `${pendingDir}/skill-report.json\n`);
+  const result = spawnSync(process.execPath, [
+    join(process.cwd(), 'scripts/resolve-approved-submission.mjs'),
+    '--repo-root', root,
+    '--files', filesPath,
+    '--output', outputPath,
+    '--report-only-base-commit', baseCommit,
+    '--report-only-merge-commit', mergeCommit,
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(readFileSync(outputPath, 'utf8')).skills[0].publicationMode, 'report-only');
+}));
+
+test('report-only re-audit is admitted only when the exact prior pending content and provenance are unchanged', () => withRepository((root) => {
+  const pendingDir = 'pending/owner/skill';
+  const oldRef = '1'.repeat(40);
+  const newRef = '2'.repeat(40);
+  addSkill(root, pendingDir, { slug: 'owner-skill', sourceRef: oldRef, withReference: true });
+  const { baseCommit, mergeCommit, reportPath } = commitReportOnlyHistory(root, pendingDir, { oldRef, newRef });
+
+  const plan = resolveApprovedSubmission({
+    repositoryRoot: root,
+    changedFiles: [`${pendingDir}/skill-report.json`],
+    reportOnlyBaseCommit: baseCommit,
+    reportOnlyMergeCommit: mergeCommit,
+  });
+  assert.equal(plan.skills[0].publicationMode, 'report-only');
+
+  git(root, 'checkout', '-q', '--detach', baseCommit);
+  git(root, 'checkout', '-qb', 'untrusted-reaudit');
+  const untrustedReport = JSON.parse(readFileSync(reportPath, 'utf8'));
+  untrustedReport.meta.source_ref = newRef;
+  untrustedReport.meta.source_url = `https://github.com/other/repo/tree/${newRef}/skills/skill`;
+  writeFileSync(reportPath, `${JSON.stringify(untrustedReport)}\n`);
+  git(root, 'add', reportPath);
+  git(root, 'commit', '-qm', 'untrusted provenance change');
+  git(root, 'checkout', '-q', '--detach', baseCommit);
+  git(root, 'merge', '--no-ff', '-qm', 'merge untrusted re-audit', 'untrusted-reaudit');
+  const untrustedMergeCommit = git(root, 'rev-parse', 'HEAD');
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: [`${pendingDir}/skill-report.json`],
+      reportOnlyBaseCommit: baseCommit,
+      reportOnlyMergeCommit: untrustedMergeCommit,
+    }),
+    /source provenance does not match the trusted prior pending report/,
+  );
+}));
+
+test('report-only re-audit rejects a changed pending payload even when the report is valid', () => withRepository((root) => {
+  const pendingDir = 'pending/owner/skill';
+  addSkill(root, pendingDir, { slug: 'owner-skill' });
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'add', '.');
+  git(root, 'commit', '-qm', 'prior pending submission');
+  const baseBranch = git(root, 'branch', '--show-current');
+  const baseCommit = git(root, 'rev-parse', 'HEAD');
+  git(root, 'checkout', '-qb', 'payload-drift');
+  writeFileSync(join(root, pendingDir, 'SKILL.md'), '# Drifted\n');
+  git(root, 'add', '.');
+  git(root, 'commit', '-qm', 'unexpected payload change');
+  git(root, 'checkout', '-q', baseBranch);
+  git(root, 'merge', '--no-ff', '-qm', 'merge payload drift', 'payload-drift');
+  const mergeCommit = git(root, 'rev-parse', 'HEAD');
+  assert.throws(
+    () => resolveApprovedSubmission({
+      repositoryRoot: root,
+      changedFiles: [`${pendingDir}/skill-report.json`],
+      reportOnlyBaseCommit: baseCommit,
+      reportOnlyMergeCommit: mergeCommit,
+    }),
+    /prior pending SKILL\.md content changed/,
+  );
 }));
 
 test('report-only re-audit rejects additional changed payload files', () => withRepository((root) => {
@@ -160,25 +273,31 @@ test('report-only re-audit rejects additional changed payload files', () => with
   );
 }));
 
-test('report-only re-audit requires a regular SKILL.md bound by report hashes', () => withRepository((root) => {
-  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
-  rmSync(join(root, 'pending/owner/skill/SKILL.md'));
+test('report-only re-audit requires a regular SKILL.md bound by exact merged history', () => withRepository((root) => {
+  const pendingDir = 'pending/owner/skill';
+  addSkill(root, pendingDir, { slug: 'owner-skill', sourceRef: '1'.repeat(40), withReference: true });
+  const { baseCommit, mergeCommit } = commitReportOnlyHistory(root, pendingDir);
+  rmSync(join(root, pendingDir, 'SKILL.md'));
   assert.throws(
     () => resolveApprovedSubmission({
       repositoryRoot: root,
-      changedFiles: ['pending/owner/skill/skill-report.json'],
+      changedFiles: [`${pendingDir}/skill-report.json`],
+      reportOnlyBaseCommit: baseCommit,
+      reportOnlyMergeCommit: mergeCommit,
     }),
     /SKILL\.md is missing/,
   );
 
-  addSkill(root, 'pending/owner/skill', { slug: 'owner-skill', withReference: true });
-  write(root, 'pending/owner/skill/SKILL.md', '# Drifted\n');
+  git(root, 'checkout', '--force', mergeCommit);
+  write(root, `${pendingDir}/SKILL.md`, '# Drifted\n');
   assert.throws(
     () => resolveApprovedSubmission({
       repositoryRoot: root,
-      changedFiles: ['pending/owner/skill/skill-report.json'],
+      changedFiles: [`${pendingDir}/skill-report.json`],
+      reportOnlyBaseCommit: baseCommit,
+      reportOnlyMergeCommit: mergeCommit,
     }),
-    /content_hash does not match/,
+    /prior pending SKILL\.md content changed/,
   );
 }));
 


### PR DESCRIPTION
## Goal
Restore publication for trusted merged re-audit PRs that changed only `skill-report.json`, while preserving exact scope and durable retry safety.

## Changes
- accept canonical report-only pending roots without scanning shared pending
- authenticate unchanged `SKILL.md` and assets through report content/tree hashes
- reject mixed/unrelated paths and post-merge subtree drift
- bind each recovery dispatch to an exact immutable outbox attempt
- allow a fresh exact attempt only after correlation failure; refuse same-attempt duplicates, success, and in-flight/unknown replay

## Acceptance criteria
- [x] canonical community and official report-only roots resolve
- [x] missing/drifted Skill and additional/unrelated files fail closed
- [x] existing full-artifact freeze behavior remains
- [x] workflow keeps exact merged-PR scope and post-merge drift check
- [x] failed correlation can use a fresh exact attempt without weakening idempotency
- [x] PR #3335 real pending fixture resolves as report-only

## Evidence
`CI=true node --test scripts/tests/resolve-approved-submission.test.mjs scripts/tests/publication-receiver-workflow.test.mjs scripts/tests/submission-scope-workflows.test.mjs`

59 tests passed, 0 failed.

## Boundary
This PR does not retry publication, move pending entries, sync providers, merge itself, or change audit/risk policy.