### PR TITLE
fix: continue merged skill publications safely

### DIFF
--- a/.github/workflows/continue-merged-publications.yml
+++ b/.github/workflows/continue-merged-publications.yml
@@ -1,0 +1,40 @@
+name: Continue merged Skill publications
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: merged-publication-continuation
+  cancel-in-progress: false
+jobs:
+  continue:
+    if: github.event_name != 'pull_request_target' || (github.event.pull_request.merged == true && github.event.pull_request.user.id == 254047988 && startsWith(github.event.pull_request.head.ref, 'submission/'))
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: scripts
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '24'
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+          permission-actions: write
+          permission-statuses: read
+      - name: Continue one trusted merged publication
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node scripts/continue-merged-publications.mjs --apply

--- a/.github/workflows/continue-merged-publications.yml
+++ b/.github/workflows/continue-merged-publications.yml
@@ -1,7 +1,6 @@
 name: Continue merged Skill publications
 on:
-  pull_request_target:
-    types: [closed]
+  push:
     branches: [main]
   schedule:
     - cron: '*/5 * * * *'
@@ -13,7 +12,6 @@ concurrency:
   cancel-in-progress: false
 jobs:
   continue:
-    if: github.event_name != 'pull_request_target' || (github.event.pull_request.merged == true && github.event.pull_request.user.id == 254047988 && startsWith(github.event.pull_request.head.ref, 'submission/'))
     runs-on: self-hosted
     timeout-minutes: 15
     steps:

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -427,7 +427,13 @@ jobs:
             fi
             echo "::error::Previous provider sync run $run_id lacks closed provider evidence ($SYNC_CONCLUSION); inspection is required before replay"
             exit 1
-          done < <(jq -r '.workflow_runs[] | [.id, .head_sha, .created_at, .conclusion] | @tsv' <<< "$RUNS")
+          # The API does not guarantee that the returned collection is ordered
+          # by creation time. Always inspect newest first; otherwise an older
+          # successful run can move the baseline backwards and replay every
+          # later publication.
+          done < <(jq -r '.workflow_runs
+            | sort_by(.created_at) | reverse[]
+            | [.id, .head_sha, .created_at, .conclusion] | @tsv' <<< "$RUNS")
 
           if [ -z "$LAST_SHA" ] || [ -z "$LAST_CREATED_AT" ]; then
             echo "::error::No provider-complete push sync baseline found; refusing an incomplete fallback"

--- a/scripts/continue-merged-publications.mjs
+++ b/scripts/continue-merged-publications.mjs
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const repo = 'aiskillstore/marketplace';
+export function trustedMerged(pr) {
+  return pr.merged_at && pr.base?.ref === 'main'
+    && pr.user?.id === 254047988 && pr.user?.login === 'ai-skill-store[bot]'
+    && pr.head?.repo?.full_name === repo && pr.head?.ref?.startsWith('submission/')
+    && [pr.head.sha, pr.merge_commit_sha].every(s => /^[a-f0-9]{40}$/.test(s));
+}
+export function publicationIdentity(pr) {
+  if (!trustedMerged(pr)) throw new Error('Untrusted or unmerged submission');
+  const correlation = `submission-pr-${pr.number}-${pr.head.sha}-${pr.merge_commit_sha}`;
+  return { correlation, digest: createHash('sha256').update(correlation).digest('hex') };
+}
+
+// This continuation never merges PRs or interprets advisory audit risk fields.
+// Existing receiver remains the authority for immutable source/tree validation.
+export function chooseAttempt({ refs, statuses, digest, merge, now }) {
+  const prefix = `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/`;
+  if (refs.length >= 8) return { wait: 'outbox attempt limit; inspection required' };
+  for (const ref of refs) {
+    if (!ref.ref.startsWith(prefix) || !/^\d{13}-[1-9]\d*$/.test(ref.ref.slice(prefix.length))
+      || ref.object.type !== 'commit' || ref.object.sha !== merge) throw new Error('Invalid publication outbox');
+  }
+  const context = `agentcrew/publication/${digest}`;
+  // Any prior receiver reservation is authoritative. Failure may include partial
+  // effects; automatic continuation must not invent a safe retry from it.
+  if (statuses.some(s => s.context === context || s.context.startsWith(`agentcrew/publication-attempt/${digest}/`))) {
+    return { wait: 'receiver has durable evidence; reconcile before replay' };
+  }
+  const newest = Math.max(0, ...refs.map(r => Number(r.ref.slice(prefix.length).split('-')[0])));
+  if (newest > now - 15 * 60_000) return { wait: 'fresh dispatch awaiting receiver' };
+  return { attempt: `${now}-${refs.length + 1}` };
+}
+
+function api(endpoint, data) {
+  const args = ['api', endpoint];
+  if (data) args.push('--method', 'POST', '--input', '-');
+  const output = execFileSync('gh', args, {
+    input: data ? JSON.stringify(data) : undefined, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024,
+  });
+  return output.trim() ? JSON.parse(output) : null;
+}
+function pages(endpoint) {
+  const values = [];
+  // ponytail: bounded GitHub inventory; fail visibly at 1000 rather than silently
+  // omit older pending work. Increase pagination only if this ceiling is reached.
+  for (let page = 1; page <= 10; page++) {
+    const batch = api(`${endpoint}${endpoint.includes('?') ? '&' : '?'}per_page=100&page=${page}`);
+    values.push(...batch);
+    if (batch.length < 100) return values;
+  }
+  throw new Error(`Inventory limit reached: ${endpoint}`);
+}
+export function main() {
+  const live = process.argv.includes('--apply');
+  const prs = pages(`repos/${repo}/pulls?state=closed&sort=updated&direction=desc`).filter(trustedMerged);
+  const tree = api(`repos/${repo}/git/trees/main`);
+  const pending = tree.tree.find(t => t.path === 'pending');
+  if (!pending) return console.log('No pending skills');
+  const inventory = api(`repos/${repo}/git/trees/${pending.sha}?recursive=1`);
+  if (inventory.truncated) throw new Error('Truncated pending inventory');
+  const reports = new Map(inventory.tree.filter(t => t.path.endsWith('/skill-report.json'))
+    .map(t => [`pending/${t.path}`, t.sha]));
+  const owners = new Map();
+  for (const pr of prs.sort((a, b) => b.merged_at.localeCompare(a.merged_at))) {
+    const files = pages(`repos/${repo}/pulls/${pr.number}/files`);
+    for (const file of files) {
+      if (reports.has(file.filename) && reports.get(file.filename) === file.sha && !owners.has(file.filename)) {
+        owners.set(file.filename, pr);
+      }
+    }
+  }
+  const unmatched = [...reports.keys()].filter(p => !owners.has(p));
+  if (unmatched.length) console.error(`::warning::Pending reports need provenance inspection: ${unmatched.join(', ')}`);
+  const candidates = [...new Set(owners.values())].sort((a, b) => a.merged_at.localeCompare(b.merged_at));
+  console.log(JSON.stringify({ pending: reports.size, candidates: candidates.map(p => p.number), unmatched }));
+  // GitHub's concurrency group only preserves one pending run. Let each push sync
+  // close before creating the next publication push, including Cody's dispatches.
+  const syncRuns = api(`repos/${repo}/actions/workflows/sync-to-supabase.yml/runs?per_page=100`).workflow_runs;
+  if (syncRuns.some(r => r.status !== 'completed')) return console.log('Waiting for provider sync');
+  const publicationRuns = api(`repos/${repo}/actions/workflows/on-pr-merge.yml/runs?per_page=100`).workflow_runs;
+  if (publicationRuns.some(r => r.status !== 'completed')) return console.log('Waiting for publication receiver');
+  for (const candidate of candidates) {
+    const pr = api(`repos/${repo}/pulls/${candidate.number}`);
+    const { correlation, digest } = publicationIdentity(pr);
+    const refs = api(`repos/${repo}/git/matching-refs/tags/agentcrew-dispatch-outbox/publication/${digest}/`);
+    const statuses = pages(`repos/${repo}/commits/${pr.merge_commit_sha}/statuses`);
+    const choice = chooseAttempt({ refs, statuses, digest, merge: pr.merge_commit_sha, now: Date.now() });
+    if (choice.wait) { console.log(`#${pr.number}: ${choice.wait}`); continue; }
+    if (!live) { console.log(`Would dispatch #${pr.number}: ${correlation}`); return; }
+    const ref = `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/${choice.attempt}`;
+    api(`repos/${repo}/git/refs`, { ref, sha: pr.merge_commit_sha });
+    const readback = api(`repos/${repo}/git/ref/${ref.slice(5)}`);
+    if (readback.object.sha !== pr.merge_commit_sha) throw new Error('Outbox readback mismatch');
+    api(`repos/${repo}/actions/workflows/on-pr-merge.yml/dispatches`, {
+      ref: 'main', inputs: { pr_number: String(pr.number), correlation_id: correlation, outbox_attempt: choice.attempt },
+    });
+    console.log(`Dispatched #${pr.number}: ${correlation}; receiver status is the completion evidence`);
+    return;
+  }
+  if (reports.size) throw new Error('Remaining pending skills require inspection; no safe fresh dispatch');
+}
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main();

--- a/scripts/continue-merged-publications.mjs
+++ b/scripts/continue-merged-publications.mjs
@@ -89,7 +89,11 @@ export function main() {
     const refs = api(`repos/${repo}/git/matching-refs/tags/agentcrew-dispatch-outbox/publication/${digest}/`);
     const statuses = pages(`repos/${repo}/commits/${pr.merge_commit_sha}/statuses`);
     const choice = chooseAttempt({ refs, statuses, digest, merge: pr.merge_commit_sha, now: Date.now() });
-    if (choice.wait) { console.log(`#${pr.number}: ${choice.wait}`); continue; }
+    if (choice.wait) {
+      // Oldest-first is a safety boundary: a missing or non-terminal effect
+      // blocks later publications until its exact correlation is reconciled.
+      return console.log(`#${pr.number}: ${choice.wait}`);
+    }
     if (!live) { console.log(`Would dispatch #${pr.number}: ${correlation}`); return; }
     const ref = `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/${choice.attempt}`;
     api(`repos/${repo}/git/refs`, { ref, sha: pr.merge_commit_sha });

--- a/scripts/tests/publication-continuation.test.mjs
+++ b/scripts/tests/publication-continuation.test.mjs
@@ -27,7 +27,7 @@ test('only authoritative merged submissions continue; unknown effects never auto
 test('merged-only continuation runs trusted main code and reuses the existing receiver', () => {
   const source = readFileSync('.github/workflows/continue-merged-publications.yml', 'utf8');
   const workflow = parse(source);
-  assert.deepEqual(workflow.on.pull_request_target.types, ['closed']);
+  assert.deepEqual(workflow.on.push.branches, ['main']);
   assert.ok(workflow.on.schedule.length);
   assert.equal(workflow.jobs.continue.steps[0].with.ref, 'main');
   assert.equal(workflow.jobs.continue.steps[0].with['persist-credentials'], false);

--- a/scripts/tests/publication-continuation.test.mjs
+++ b/scripts/tests/publication-continuation.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { parse } from 'yaml';
+import { trustedMerged, publicationIdentity, chooseAttempt } from '../continue-merged-publications.mjs';
+
+test('only authoritative merged submissions continue; unknown effects never auto-replay', () => {
+  const pr = { number: 12, merged_at: '2026-09-08T00:00:00Z', base: { ref: 'main' }, user: { id: 254047988, login: 'ai-skill-store[bot]' }, head: { repo: { full_name: 'aiskillstore/marketplace' }, ref: 'submission/test', sha: 'a'.repeat(40) }, merge_commit_sha: 'b'.repeat(40) };
+  assert.ok(trustedMerged(pr));
+  assert.equal(Boolean(trustedMerged({ ...pr, merged_at: null })), false);
+  assert.equal(Boolean(trustedMerged({ ...pr, user: { id: 1 } })), false);
+  const { digest, correlation } = publicationIdentity(pr);
+  assert.equal(correlation, `submission-pr-12-${'a'.repeat(40)}-${'b'.repeat(40)}`);
+  const input = { refs: [], statuses: [], digest, merge: pr.merge_commit_sha, now: 1788800000000 };
+  assert.equal(chooseAttempt(input).attempt, '1788800000000-1');
+  for (const state of ['pending', 'success', 'failure', 'error']) {
+    assert.ok(chooseAttempt({ ...input, statuses: [{ context: `agentcrew/publication/${digest}`, state }] }).wait);
+  }
+  assert.ok(chooseAttempt({ ...input, statuses: [{ context: `agentcrew/publication-attempt/${digest}/1`, state: 'pending' }] }).wait);
+  const ref = { ref: `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/${input.now}-1`, object: { type: 'commit', sha: input.merge } };
+  assert.ok(chooseAttempt({ ...input, refs: [ref] }).wait);
+  assert.ok(chooseAttempt({ ...input, refs: [ref], now: input.now + 900001 }).attempt);
+  assert.throws(() => chooseAttempt({ ...input, refs: [{ ...ref, object: { type: 'commit', sha: 'c'.repeat(40) } }] }));
+  assert.ok(chooseAttempt({ ...input, refs: Array(8).fill(ref) }).wait);
+});
+
+test('merged-only continuation runs trusted main code and reuses the existing receiver', () => {
+  const source = readFileSync('.github/workflows/continue-merged-publications.yml', 'utf8');
+  const workflow = parse(source);
+  assert.deepEqual(workflow.on.pull_request_target.types, ['closed']);
+  assert.ok(workflow.on.schedule.length);
+  assert.equal(workflow.jobs.continue.steps[0].with.ref, 'main');
+  assert.equal(workflow.jobs.continue.steps[0].with['persist-credentials'], false);
+  const script = readFileSync('scripts/continue-merged-publications.mjs', 'utf8');
+  assert.match(script, /on-pr-merge.yml\/dispatches/);
+  assert.match(script, /syncRuns.some\(r => r.status !== 'completed'\)/);
+  assert.doesNotMatch(script, /\/merge['`"]|update-branch|safe_to_publish|is_blocked|risk_level/);
+});
+
+test('sync baseline selection sorts workflow runs newest first', () => {
+  const source = readFileSync('.github/workflows/sync-to-supabase.yml', 'utf8');
+  assert.match(source, /sort_by\(\.created_at\) \| reverse\[\]/);
+});


### PR DESCRIPTION
Merged trusted Skill PRs can leave pending entries because the retired native executor had no replacement trigger. Add a deterministic post-merge/scheduled continuation that reuses the existing publication receiver and durable outbox, waits for active sync, refuses unknown-effect replay, and processes one exact correlation at a time. Also sort sync workflow runs newest-first so the baseline cannot regress on API response order.

Validation: CI=true node --test scripts/tests/publication-continuation.test.mjs scripts/tests/publication-receiver-workflow.test.mjs scripts/tests/trusted-auto-merge-executor-retired.test.mjs
