### PR TITLE
fix: keep sync discovery current and materialization scoped

### DIFF
--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -396,7 +396,10 @@ jobs:
           # Advance the baseline when the provider step itself succeeded, even if a
           # later callback/status step failed. Conversely, a failed provider step is
           # an unknown partial effect and blocks automatic replay for inspection.
-          RUNS=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?status=completed&event=push&per_page=100")
+          # The server-side status filter can omit newly completed runs. Fetch
+          # the recent collection and filter locally before sorting; sorting an
+          # incomplete response alone still regresses the baseline.
+          RUNS=$(gh api "repos/${{ github.repository }}/actions/workflows/sync-to-supabase.yml/runs?per_page=100")
           LAST_SHA=''
           LAST_CREATED_AT=''
           while IFS=$'\t' read -r run_id head_sha created_at run_conclusion; do
@@ -432,6 +435,7 @@ jobs:
           # successful run can move the baseline backwards and replay every
           # later publication.
           done < <(jq -r '.workflow_runs
+            | map(select(.event == "push" and .status == "completed"))
             | sort_by(.created_at) | reverse[]
             | [.id, .head_sha, .created_at, .conclusion] | @tsv' <<< "$RUNS")
 

--- a/scripts/materialize-changed-skills.mjs
+++ b/scripts/materialize-changed-skills.mjs
@@ -73,7 +73,7 @@ function resolveExactCommit(repositoryRoot, commit) {
   return resolvedCommit;
 }
 
-function reportEntriesAtCommit(repositoryRoot, commit) {
+function reportEntriesAtCommit(repositoryRoot, commit, skillPaths) {
   const output = git(repositoryRoot, [
     'ls-tree',
     '-r',
@@ -81,7 +81,7 @@ function reportEntriesAtCommit(repositoryRoot, commit) {
     '--full-tree',
     commit,
     '--',
-    'skills',
+    ...skillPaths.map((skillPath) => `skills/${skillPath}/skill-report.json`),
   ]).toString('utf8');
   const reports = new Map();
 
@@ -125,7 +125,7 @@ function hashMaterializedReports(repositoryRoot, reportPaths) {
 export function materializeChangedSkills({ repositoryRoot = '.', commit, skills }) {
   const exactCommit = resolveExactCommit(repositoryRoot, commit);
   const skillPaths = Array.isArray(skills) ? parseChangedSkillPaths(skills.join(' ')) : parseChangedSkillPaths(skills);
-  const treeReports = reportEntriesAtCommit(repositoryRoot, exactCommit);
+  const treeReports = reportEntriesAtCommit(repositoryRoot, exactCommit, skillPaths);
   const targets = skillPaths.map((skillPath) => {
     const directory = `skills/${skillPath}`;
     const reportPath = `${directory}/skill-report.json`;

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -202,7 +202,8 @@ test('incremental detection subtracts only verified successful manual recovery a
   const detect = section(workflow, '      - name: Detect changed skills', '      - name: Download skillstore-cli');
 
   assert.match(lastSync, /if: inputs\.slugs == ''/);
-  assert.match(lastSync, /status=completed&event=push/);
+  assert.doesNotMatch(lastSync, /status=completed&event=push/);
+  assert.match(lastSync, /map\(select\(\.event == "push" and \.status == "completed"\)\)/);
   assert.match(lastSync, /Sync skills to Supabase/);
   assert.match(lastSync, /SYNC_CONCLUSION.*success/);
   assert.match(lastSync, /lacks closed provider evidence/);

--- a/scripts/tests/cache-invalidation-workflow.test.mjs
+++ b/scripts/tests/cache-invalidation-workflow.test.mjs
@@ -58,7 +58,8 @@ test('publication provider writes use push as the only automatic trigger', () =>
   assert.match(workflow, /Ignoring conclusively non-owning duplicate recovery run/);
   assert.match(workflow, /Idempotency-Key: publication-published-/);
   assert.match(workflow, /Record durable correlated manual sync result/);
-  assert.match(workflow, /status=completed&event=push/);
+  assert.doesNotMatch(workflow, /status=completed&event=push/);
+  assert.match(workflow, /map\(select\(\.event == "push" and \.status == "completed"\)\)/);
   assert.match(workflow, /actions\/runs\/\$run_id\/jobs/);
   assert.match(workflow, /Previous provider sync run .* lacks closed provider evidence/);
 

--- a/scripts/tests/invalidate-cache.test.mjs
+++ b/scripts/tests/invalidate-cache.test.mjs
@@ -688,7 +688,8 @@ test('sync workflow uses an artifact-backed bounded invalidator and preserves do
   assert.doesNotMatch(invalidationJob, /needs\.sync\.outputs\.synced_slugs/);
   assert.match(finalizerJob, /needs: \[sync, calculate-scores, cache-invalidate\]/);
   assert.match(finalizerJob, /needs\.cache-invalidate\.result == 'success'/);
-  assert.match(workflow, /runs\?status=completed&event=push&per_page=100/);
+  assert.match(workflow, /runs\?per_page=100/);
+  assert.match(workflow, /map\(select\(\.event == "push" and \.status == "completed"\)\)/);
   assert.match(workflow, /actions\/runs\/\$run_id\/jobs\?per_page=100/);
   assert.match(workflow, /Previous provider sync run .* lacks closed provider evidence/);
   assert.match(triggerJob, /needs: \[sync, cache-invalidate, finalize-english-cache\]/);

--- a/scripts/tests/materialize-changed-skills.test.mjs
+++ b/scripts/tests/materialize-changed-skills.test.mjs
@@ -148,3 +148,15 @@ test('rejects reserved published identities before materialization', () => {
     rmSync(repositoryRoot, { recursive: true, force: true });
   }
 });
+
+test('selected report lookup does not enumerate or validate unrelated report trees', () => {
+  const { repositoryRoot } = makeRepository();
+  try {
+    write(repositoryRoot, 'skills/unrelated/nested/invalid/skill-report.json', '{}\n');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'unrelated report outside canonical roots']);
+    const commit = git(repositoryRoot, ['rev-parse', 'HEAD']);
+    assert.deepEqual(materializeChangedSkills({ repositoryRoot, commit, skills: ['owner/demo'] }), ['skills/owner/demo']);
+    assert.equal(readFileSync(join(repositoryRoot, 'skills/owner/demo/skill-report.json'), 'utf8'), '{"revision":2}\n');
+  } finally { rmSync(repositoryRoot, { recursive: true, force: true }); }
+});

--- a/scripts/tests/sync-baseline-discovery.test.mjs
+++ b/scripts/tests/sync-baseline-discovery.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { parse } from 'yaml';
+
+test('baseline uses unfiltered collection, newest completed push, and blocks newer partial effects', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sync-baseline-'));
+  try {
+    const step = parse(readFileSync('.github/workflows/sync-to-supabase.yml', 'utf8')).jobs.sync.steps
+      .find(s => s.name === 'Find last successful sync commit');
+    const script = step.run.replaceAll('${{ github.repository }}', 'aiskillstore/marketplace')
+      .replaceAll('${{ github.sha }}', 'f'.repeat(40));
+    writeFileSync(join(dir, 'gh'), `#!${process.execPath}\n` + `
+const fs = require('node:fs');
+const endpoint = process.argv[3];
+if (endpoint.includes('/runs?')) {
+  if (endpoint !== 'repos/aiskillstore/marketplace/actions/workflows/sync-to-supabase.yml/runs?per_page=100') process.exit(9);
+  process.stdout.write(fs.readFileSync(process.env.FIXTURE));
+} else {
+  process.stdout.write(JSON.stringify({jobs:[{steps:[{name:'Wait for authoritative publication completion',conclusion:'success'},{name:'Sync skills to Supabase',conclusion:'success'}]}]}));
+}
+`, { mode: 0o755 });
+    writeFileSync(join(dir, 'git'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const run = (id, day, extras = {}) => ({ id, head_sha: String(id).repeat(40), created_at: `2026-09-0${day}T00:00:00Z`, event: 'push', status: 'completed', conclusion: 'success', ...extras });
+    const fixture = join(dir, 'runs.json'), output = join(dir, 'output');
+    const execute = runs => {
+      writeFileSync(fixture, JSON.stringify({ workflow_runs: runs }));
+      writeFileSync(output, '');
+      return spawnSync('bash', ['-c', script], { encoding: 'utf8', env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, FIXTURE: fixture, GITHUB_OUTPUT: output } });
+    };
+    let result = execute([run(1, 1), run(4, 4, { status: 'in_progress' }), run(3, 3, { event: 'workflow_dispatch' }), run(2, 2)]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(readFileSync(output, 'utf8'), new RegExp(`base_sha=${'2'.repeat(40)}`));
+    result = execute([run(1, 1), run(2, 2, { conclusion: 'failure' })]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /downstream effects are incomplete/);
+    assert.equal(readFileSync(output, 'utf8'), '');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
The server-filtered Workflow Runs endpoint intermittently omits today's successful syncs: at 13:02 UTC its newest completed push was Sep 7's b1ef8011, while the unfiltered collection included completed runs 34228565592, 34222729905, and 34220454740. Sorting the incomplete collection cannot prevent baseline regression and repeated provider writes.

Fetch the unfiltered recent collection, locally select completed push runs, then inspect newest-first with the existing provider/downstream failure gates. A shell-level regression test executes the actual workflow step against shuffled, in-progress, manual, and partially failed run evidence; it also rejects the server-filtered endpoint.

Validation: CI=true node --test scripts/tests/sync-baseline-discovery.test.mjs scripts/tests/publication-continuation.test.mjs (5 passed).

Materialization now queries only selected report paths instead of enumerating the entire skills tree. Exact commit, regular-file, and Git blob verification remain unchanged. Regression includes an unrelated malformed report tree that must not affect the selected skill. Targeted baseline/cache tests: 43 passed; materialization/baseline tests: 7 passed.
