### PR TITLE
fix: stop continuation on failed downstream sync

### DIFF
--- a/scripts/continue-merged-publications.mjs
+++ b/scripts/continue-merged-publications.mjs
@@ -88,6 +88,13 @@ export function main(request = api) {
   // close before creating the next publication push, including Cody's dispatches.
   const syncRuns = request(`repos/${repo}/actions/workflows/sync-to-supabase.yml/runs?per_page=100`).workflow_runs;
   if (syncRuns.some(r => r.status !== 'completed')) return console.log('Waiting for provider sync');
+  const lastPush = syncRuns.filter(r => r.event === 'push')
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+  // Publication already removed its pending report before provider/cache work.
+  // Its absence cannot hide a failed downstream run and release the next item.
+  if (lastPush && !['success', 'skipped'].includes(lastPush.conclusion)) {
+    throw new Error(`Previous push sync ${lastPush.id} is ${lastPush.conclusion}; reconcile before continuing`);
+  }
   const publicationRuns = request(`repos/${repo}/actions/workflows/on-pr-merge.yml/runs?per_page=100`).workflow_runs;
   if (publicationRuns.some(r => r.status !== 'completed')) return console.log('Waiting for publication receiver');
   for (const candidate of candidates) {

--- a/scripts/tests/publication-continuation.test.mjs
+++ b/scripts/tests/publication-continuation.test.mjs
@@ -49,6 +49,7 @@ test('current pending inventory stops after its exact owners; fresh A prevents d
   const b = makePr(2, '2026-09-02T00:00:00Z', 'c');
   const { digest } = publicationIdentity(a);
   const calls = [];
+  let syncRuns = [];
   const request = (endpoint, data) => {
     calls.push(endpoint);
     assert.equal(data, undefined, 'fresh earlier outbox must prevent every write');
@@ -60,7 +61,7 @@ test('current pending inventory stops after its exact owners; fresh A prevents d
     }
     if (endpoint.includes('/pulls/1/files')) return [{ filename: 'pending/owner/a/skill-report.json', sha: 'ra' }];
     if (endpoint.includes('/pulls/2/files')) return [{ filename: 'pending/owner/b/skill-report.json', sha: 'rb' }];
-    if (endpoint.includes('/actions/workflows/')) return { workflow_runs: [] };
+    if (endpoint.includes('/actions/workflows/')) return { workflow_runs: endpoint.includes('sync-to-supabase') ? syncRuns : [] };
     if (endpoint.endsWith('/pulls/1')) return a;
     if (endpoint.includes('/git/matching-refs/')) return [{ ref: `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/${Date.now()}-1`, object: { type: 'commit', sha: a.merge_commit_sha } }];
     if (endpoint.includes('/statuses?')) return [];
@@ -68,4 +69,6 @@ test('current pending inventory stops after its exact owners; fresh A prevents d
   };
   main(request);
   assert.ok(!calls.some(p => p.endsWith('/pulls/2')));
+  syncRuns = [{ id: 12, event: 'push', status: 'completed', conclusion: 'failure', created_at: '2026-09-08T00:00:00Z' }];
+  assert.throws(() => main(request), /Previous push sync 12 is failure/);
 });


### PR DESCRIPTION
A successful publication removes its pending report before provider/cache completion. If that downstream push run fails, the pending-only inventory could otherwise advance to the next skill. Stop on the latest failed/cancelled push sync even after the old report has moved, preserving the existing requirement to reconcile partial effects before later publication.

Validation: CI=true node --test scripts/tests/publication-continuation.test.mjs (4 passed), including a completed failed sync after pending ownership discovery.
