### PR TITLE
fix: drain approved pending skills in atomic bounded batches

### DIFF
--- a/.github/workflows/continue-merged-publications.yml
+++ b/.github/workflows/continue-merged-publications.yml
@@ -36,7 +36,7 @@ jobs:
           permission-pull-requests: read
           permission-actions: write
           permission-statuses: read
-      - name: Continue one trusted merged publication
+      - name: Continue a bounded batch of trusted merged publications
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: node scripts/continue-merged-publications.mjs --apply

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -23,7 +23,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: publication-${{ inputs.correlation_id }}
+  group: marketplace-publication-writer
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-approved-batch.yml
+++ b/.github/workflows/publish-approved-batch.yml
@@ -1,0 +1,50 @@
+name: Publish approved Skill batch
+run-name: Publication batch ${{ inputs.batch_id }}
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: Comma-separated exact merged trusted PRs (at most 25 Skills)
+        type: string
+        required: true
+      batch_id:
+        description: SHA256 of sorted exact correlation IDs joined with newline
+        type: string
+        required: true
+permissions:
+  contents: read
+concurrency:
+  group: marketplace-publication-writer
+  cancel-in-progress: false
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+          permission-actions: read
+          permission-statuses: write
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.sha }}
+          token: ${{ steps.token.outputs.token }}
+          persist-credentials: false
+          sparse-checkout: scripts
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '24'
+      - name: Verify every approval and publish one atomic batch
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+          BATCH_ID: ${{ inputs.batch_id }}
+          SKILLSTORE_API_URL: ${{ secrets.SKILLSTORE_API_URL }}
+          SKILLSTORE_CALLBACK_TOKEN: ${{ secrets.SKILLSTORE_CALLBACK_TOKEN }}
+        run: node scripts/publish-approved-batch.mjs

--- a/.github/workflows/sync-to-supabase.yml
+++ b/.github/workflows/sync-to-supabase.yml
@@ -332,20 +332,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PUSH_MESSAGE: ${{ github.event.head_commit.message }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          [[ "$PUSH_BEFORE" =~ ^[0-9a-f]{40}$ ]] && [[ "$PUSH_SHA" =~ ^[0-9a-f]{40}$ ]]
+          git merge-base --is-ancestor "$PUSH_BEFORE" "$PUSH_SHA"
+          # One atomic batch push contains one original submission per commit.
+          PUSH_MESSAGE=$(git log --format=%B "$PUSH_BEFORE..$PUSH_SHA")
           mapfile -t CORRELATIONS < <(
             sed -nE 's/^AgentCrew-Publication: (submission-pr-[1-9][0-9]*-[0-9a-f]{40}-[0-9a-f]{40})$/\1/p' <<< "$PUSH_MESSAGE"
           )
           if [ "${#CORRELATIONS[@]}" -eq 0 ]; then
             exit 0
           fi
-          [ "${#CORRELATIONS[@]}" -eq 1 ] || {
-            echo "::error::Publication push has multiple correlation trailers"
+          [ "${#CORRELATIONS[@]}" -le 25 ] || {
+            echo "::error::Publication push exceeds 25 correlation limit"
             exit 1
           }
-          CORRELATION_ID="${CORRELATIONS[0]}"
+          [ "$(printf '%s\n' "${CORRELATIONS[@]}" | sort -u | wc -l)" -eq "${#CORRELATIONS[@]}" ]
+          CORRELATIONS_JSON=$(printf '%s\n' "${CORRELATIONS[@]}" | jq -Rsc 'split("\n")[:-1]')
+          echo "correlations=$CORRELATIONS_JSON" >> "$GITHUB_OUTPUT"
+          BATCH_DIGEST=$(jq -jr 'sort | join("\n")' <<< "$CORRELATIONS_JSON" | sha256sum | awk '{print $1}')
+          for CORRELATION_ID in "${CORRELATIONS[@]}"; do
           [[ "$CORRELATION_ID" =~ ^submission-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$ ]]
           MERGE_COMMIT_SHA="${BASH_REMATCH[3]}"
           echo "correlation_id=$CORRELATION_ID" >> "$GITHUB_OUTPUT"
@@ -359,15 +369,19 @@ jobs:
           }
           OWNER_RUN_ID="${BASH_REMATCH[1]}"
           PUBLICATION_RUN=''
-          for attempt in {1..60}; do
+          # Batch callbacks finish after the atomic push. Match the publisher's
+          # 30-minute wall-clock budget instead of failing after five minutes.
+          for attempt in {1..360}; do
             PUBLICATION_RUN=$(gh api "repos/$REPOSITORY/actions/runs/$OWNER_RUN_ID")
             if [ "$(jq -r '.status // ""' <<< "$PUBLICATION_RUN")" = completed ]; then
               break
             fi
-            [ "$attempt" -eq 60 ] || sleep 5
+            [ "$attempt" -eq 360 ] || sleep 5
           done
-          jq -e --arg title "Publication $CORRELATION_ID" --arg repository "$REPOSITORY" '
-            .display_title == $title and .head_branch == "main" and .head_repository.full_name == $repository
+          jq -e --arg title "Publication $CORRELATION_ID" --arg batch_title "Publication batch $BATCH_DIGEST" --arg repository "$REPOSITORY" '
+            ((.display_title == $title and .path == ".github/workflows/on-pr-merge.yml") or
+             (.display_title == $batch_title and .path == ".github/workflows/publish-approved-batch.yml")) and
+            .head_branch == "main" and .head_repository.full_name == $repository
           ' <<< "$PUBLICATION_RUN" >/dev/null || {
             echo "::error::Publication reservation owner does not match the exact correlation"
             exit 1
@@ -377,6 +391,7 @@ jobs:
               echo "::error::Correlated publication failed or completion is unknown"
               exit 1
             }
+          done
 
       - name: Generate GitHub App Token
         id: app-token
@@ -1144,6 +1159,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CORRELATION_ID: ${{ steps.publication-correlation.outputs.correlation_id }}
+          CORRELATION_IDS: ${{ steps.publication-correlation.outputs.correlations }}
           MERGE_COMMIT_SHA: ${{ steps.publication-correlation.outputs.merge_commit_sha }}
           REPOSITORY: ${{ github.repository }}
           JOB_STATUS: ${{ job.status }}
@@ -1152,6 +1168,10 @@ jobs:
           if [ -z "$CORRELATION_ID" ] || [ -z "$MERGE_COMMIT_SHA" ]; then
             exit 0
           fi
+          mapfile -t CORRELATIONS < <(jq -r '.[]' <<< "$CORRELATION_IDS")
+          for CORRELATION_ID in "${CORRELATIONS[@]}"; do
+          [[ "$CORRELATION_ID" =~ ^submission-pr-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$ ]]
+          MERGE_COMMIT_SHA="${BASH_REMATCH[3]}"
           CONTEXT="agentcrew/publication/$(printf '%s' "$CORRELATION_ID" | sha256sum | awk '{print $1}')"
           STATUSES=$(gh api --paginate "repos/$REPOSITORY/commits/$MERGE_COMMIT_SHA/statuses?per_page=100" | jq -s 'add')
           CURRENT=$(jq -c --arg context "$CONTEXT" '[.[] | select(.context == $context)][0] // {}' <<< "$STATUSES")
@@ -1163,9 +1183,9 @@ jobs:
             exit 1
           }
           if [ "$CURRENT_STATE" = failure ] \
-            && [ "$CURRENT_DESCRIPTION" = 'Correlated publication failed; inspection required' ]; then
+            && { [ "$CURRENT_DESCRIPTION" = 'Correlated publication failed; inspection required' ] || [[ "$CURRENT_DESCRIPTION" == 'Batch publication '* ]]; }; then
             echo "::notice::Upstream publication failure is authoritative; refusing to overwrite it"
-            exit 0
+            continue
           fi
           STATE=failure
           DESCRIPTION='Correlated provider sync failed; inspection required'
@@ -1176,6 +1196,7 @@ jobs:
           gh api --method POST "repos/$REPOSITORY/statuses/$MERGE_COMMIT_SHA" \
             -f state="$STATE" -f context="$CONTEXT" -f description="$DESCRIPTION" \
             -f target_url="$CURRENT_TARGET_URL"
+          done
 
       - name: Record durable correlated manual sync result
         if: >-

--- a/scripts/continue-merged-publications.mjs
+++ b/scripts/continue-merged-publications.mjs
@@ -15,6 +15,12 @@ export function publicationIdentity(pr) {
   return { correlation, digest: createHash('sha256').update(correlation).digest('hex') };
 }
 
+export function batchIdentity(correlations) {
+  if (!correlations.length || correlations.length > 25 || new Set(correlations).size !== correlations.length) throw new Error('Batch requires 1..25 unique correlations');
+  for (const value of correlations) if (!/^submission-pr-[1-9][0-9]*-[a-f0-9]{40}-[a-f0-9]{40}$/.test(value)) throw new Error('Invalid batch correlation');
+  return createHash('sha256').update([...correlations].sort().join('\n')).digest('hex');
+}
+
 // This continuation never merges PRs or interprets advisory audit risk fields.
 // Existing receiver remains the authority for immutable source/tree validation.
 export function chooseAttempt({ refs, statuses, digest, merge, now }) {
@@ -65,12 +71,14 @@ export function main(request = api) {
     .map(t => [`pending/${t.path}`, t.sha]));
   if (!reports.size) return console.log('No pending skills');
   const owners = new Map();
+  const skillCounts = new Map();
   // Stop when every CURRENT pending report has an exact merged owner. Scanning
   // the entire closed-PR history first always hits the 1000-item bound here.
   for (let page = 1; page <= 10 && owners.size < reports.size; page++) {
     const batch = request(`repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=${page}`);
     for (const pr of batch.filter(trustedMerged).sort((a, b) => b.merged_at.localeCompare(a.merged_at))) {
       const files = pages(`repos/${repo}/pulls/${pr.number}/files`, request);
+      skillCounts.set(pr.number, files.filter(f => f.filename.endsWith('/skill-report.json')).length);
       for (const file of files) {
         if (reports.get(file.filename) === file.sha && !owners.has(file.filename)) {
           owners.set(file.filename, pr);
@@ -97,7 +105,14 @@ export function main(request = api) {
   }
   const publicationRuns = request(`repos/${repo}/actions/workflows/on-pr-merge.yml/runs?per_page=100`).workflow_runs;
   if (publicationRuns.some(r => r.status !== 'completed')) return console.log('Waiting for publication receiver');
+  const batchRuns = request(`repos/${repo}/actions/workflows/publish-approved-batch.yml/runs?per_page=100`).workflow_runs;
+  if (batchRuns.some(r => r.status !== 'completed')) return console.log('Waiting for batch publication receiver');
+  const selected = [];
+  let skillCount = 0;
   for (const candidate of candidates) {
+    const count = skillCounts.get(candidate.number);
+    if (!count || count > 25) throw new Error('Submission exceeds bounded batch capacity');
+    if (skillCount + count > 25 || selected.length === 25) break;
     const pr = request(`repos/${repo}/pulls/${candidate.number}`);
     const { correlation, digest } = publicationIdentity(pr);
     const refs = request(`repos/${repo}/git/matching-refs/tags/agentcrew-dispatch-outbox/publication/${digest}/`);
@@ -108,15 +123,13 @@ export function main(request = api) {
       // blocks later publications until its exact correlation is reconciled.
       return console.log(`#${pr.number}: ${choice.wait}`);
     }
-    if (!live) { console.log(`Would dispatch #${pr.number}: ${correlation}`); return; }
-    const ref = `refs/tags/agentcrew-dispatch-outbox/publication/${digest}/${choice.attempt}`;
-    request(`repos/${repo}/git/refs`, { ref, sha: pr.merge_commit_sha });
-    const readback = request(`repos/${repo}/git/ref/${ref.slice(5)}`);
-    if (readback.object.sha !== pr.merge_commit_sha) throw new Error('Outbox readback mismatch');
-    request(`repos/${repo}/actions/workflows/on-pr-merge.yml/dispatches`, {
-      ref: 'main', inputs: { pr_number: String(pr.number), correlation_id: correlation, outbox_attempt: choice.attempt },
-    });
-    console.log(`Dispatched #${pr.number}: ${correlation}; receiver status is the completion evidence`);
+    selected.push({ number: pr.number, correlation });
+    skillCount += count;
+  }
+  if (selected.length) {
+    const inputs = { pr_numbers: selected.map(p => p.number).join(','), batch_id: batchIdentity(selected.map(p => p.correlation)) };
+    if (live) request(`repos/${repo}/actions/workflows/publish-approved-batch.yml/dispatches`, { ref: 'main', inputs });
+    console.log(`${live ? 'Dispatched' : 'Would dispatch'} ${skillCount} skills: ${JSON.stringify(inputs)}; receiver owns durable reservations`);
     return;
   }
   if (reports.size) throw new Error('Remaining pending skills require inspection; no safe fresh dispatch');

--- a/scripts/publish-approved-batch.mjs
+++ b/scripts/publish-approved-batch.mjs
@@ -1,17 +1,13 @@
-import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { existsSync, lstatSync, mkdirSync, renameSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { publicationIdentity, chooseAttempt } from './continue-merged-publications.mjs';
+import { publicationIdentity, chooseAttempt, batchIdentity } from './continue-merged-publications.mjs';
 import { resolveApprovedSubmission } from './resolve-approved-submission.mjs';
 
+export { batchIdentity } from './continue-merged-publications.mjs';
+
 const repository = 'aiskillstore/marketplace';
-export function batchIdentity(correlations) {
-  if (!correlations.length || correlations.length > 25 || new Set(correlations).size !== correlations.length) throw new Error('Batch requires 1..25 unique correlations');
-  for (const value of correlations) if (!/^submission-pr-[1-9][0-9]*-[a-f0-9]{40}-[a-f0-9]{40}$/.test(value)) throw new Error('Invalid batch correlation');
-  return createHash('sha256').update([...correlations].sort().join('\n')).digest('hex');
-}
 export function validateBatchPlans(rows) {
   const roots = new Set();
   for (const { plan } of rows) for (const skill of plan.skills) {

--- a/scripts/publish-approved-batch.mjs
+++ b/scripts/publish-approved-batch.mjs
@@ -1,0 +1,151 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, renameSync, rmSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { publicationIdentity, chooseAttempt } from './continue-merged-publications.mjs';
+import { resolveApprovedSubmission } from './resolve-approved-submission.mjs';
+
+const repository = 'aiskillstore/marketplace';
+export function batchIdentity(correlations) {
+  if (!correlations.length || correlations.length > 25 || new Set(correlations).size !== correlations.length) throw new Error('Batch requires 1..25 unique correlations');
+  for (const value of correlations) if (!/^submission-pr-[1-9][0-9]*-[a-f0-9]{40}-[a-f0-9]{40}$/.test(value)) throw new Error('Invalid batch correlation');
+  return createHash('sha256').update([...correlations].sort().join('\n')).digest('hex');
+}
+export function validateBatchPlans(rows) {
+  const roots = new Set();
+  for (const { plan } of rows) for (const skill of plan.skills) {
+    if ([...roots].some(root => root === skill.targetDir || root.startsWith(`${skill.targetDir}/`) || skill.targetDir.startsWith(`${root}/`))) throw new Error(`Overlapping batch target: ${skill.targetDir}`);
+    if (skill.duplicate) throw new Error('Duplicate-only cleanup must be reconciled separately');
+    roots.add(skill.targetDir);
+  }
+  if (roots.size < 1 || roots.size > 25) throw new Error('Batch must contain 1..25 distinct skills');
+  return roots;
+}
+function git(args, input) {
+  return execFileSync('git', args, { encoding: 'utf8', input, maxBuffer: 32 * 1024 * 1024, env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } }).trim();
+}
+function api(path, data) {
+  const args = ['api', `repos/${repository}/${path}`];
+  if (data) args.push('--method', 'POST', '--input', '-');
+  const result = execFileSync('gh', args, { encoding: 'utf8', input: data ? JSON.stringify(data) : undefined, maxBuffer: 32 * 1024 * 1024 });
+  return result.trim() ? JSON.parse(result) : null;
+}
+function all(path) {
+  return JSON.parse(execFileSync('gh', ['api', '--paginate', '--slurp', `repos/${repository}/${path}`], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })).flat();
+}
+function assertDirectoryAncestors(path) {
+  const pieces = path.split('/');
+  for (let i = 1; i <= pieces.length; i++) {
+    const partial = pieces.slice(0, i).join('/');
+    if (existsSync(partial)) {
+      const stat = lstatSync(partial);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`Unsafe publication ancestor: ${partial}`);
+    }
+    const entry = git(['ls-tree', 'HEAD', '--', partial]);
+    if (entry && !/^040000 tree /.test(entry)) throw new Error(`Unsafe Git publication ancestor: ${partial}`);
+  }
+}
+async function callback(row) {
+  if (!row.submissionId) return;
+  const payload = { submission_id: row.submissionId, event: 'merged', pr_number: row.pr.number,
+    pr_url: row.pr.html_url, merged_by: row.pr.merged_by.login,
+    workflow_run_id: Number(process.env.GITHUB_RUN_ID), workflow_run_url: row.owner };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const response = await fetch(`${process.env.SKILLSTORE_API_URL}/api/submit/callback`, {
+      method: 'POST', headers: { Authorization: `Bearer ${process.env.SKILLSTORE_CALLBACK_TOKEN}`,
+        'Content-Type': 'application/json', 'X-Skillstore-Callback': 'true', 'User-Agent': 'GitHub-Actions/SkillstoreBot',
+        'Idempotency-Key': `publication-resolved-${row.correlation}` }, body: JSON.stringify(payload), signal: AbortSignal.timeout(30000),
+    });
+    if (response.ok) return;
+    if (attempt === 2) throw new Error(`Merged callback failed for #${row.pr.number}: HTTP ${response.status}`);
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+}
+export async function main() {
+  const numbers = String(process.env.PR_NUMBERS || '').split(',').map(x => x.trim());
+  if (!numbers.length || numbers.length > 25 || new Set(numbers).size !== numbers.length || numbers.some(n => !/^[1-9]\d*$/.test(n))) throw new Error('Expected 1..25 unique PR numbers');
+  if (process.env.GITHUB_REF !== 'refs/heads/main' || process.env.GITHUB_REPOSITORY !== repository) throw new Error('Batch publication requires trusted main');
+  if (!process.env.SKILLSTORE_API_URL || !process.env.SKILLSTORE_CALLBACK_TOKEN) throw new Error('Missing callback configuration');
+  const rows = numbers.map(number => {
+    const pr = api(`pulls/${number}`);
+    const identity = publicationIdentity(pr);
+    const files = all(`pulls/${number}/files?per_page=100`).map(f => f.filename);
+    const roots = [...new Set(files.filter(f => /\/(SKILL\.md|skill-report\.json)$/.test(f)).map(f => f.slice(0, f.lastIndexOf('/'))))];
+    if (!roots.length || roots.some(r => !/^pending\/[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)?$/.test(r) || r.split('/').some(s => s === '.' || s === '..'))) throw new Error('Invalid batch pending roots');
+    return { pr, ...identity, files, roots, submissionId: pr.body?.match(/Submission ID.*`([0-9a-f-]{36})`/)?.[1],
+      owner: `https://github.com/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}` };
+  });
+  if (batchIdentity(rows.map(r => r.correlation)) !== process.env.BATCH_ID) throw new Error('Batch identity does not bind exact merged PRs');
+  const syncs = api('actions/workflows/sync-to-supabase.yml/runs?per_page=100').workflow_runs;
+  if (syncs.some(r => r.status !== 'completed')) throw new Error('Previous provider sync remains active');
+  const last = syncs.filter(r => r.event === 'push').sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+  if (!last || last.conclusion !== 'success') throw new Error('Previous push sync is not fully successful');
+  git(['config', 'credential.helper', '!gh auth git-credential']);
+  git(['fetch', '--depth=1', 'origin', 'main', ...new Set(rows.flatMap(r => [r.pr.base.sha, r.pr.merge_commit_sha]))]);
+  const base = git(['rev-parse', 'origin/main']);
+  // Runtime code is already imported from the immutable workflow checkout.
+  git(['checkout', '--detach', base]);
+  const paths = rows.flatMap(r => r.roots.flatMap(p => [p, p.replace(/^pending\//, 'skills/')]));
+  for (const path of paths) assertDirectoryAncestors(path);
+  git(['sparse-checkout', 'set', '--no-cone', '--stdin'], ['/scripts/', ...paths.map(p => `/${p}/`)].join('\n') + '\n');
+  for (const row of rows) {
+    row.plan = resolveApprovedSubmission({ repositoryRoot: process.cwd(), changedFiles: row.files,
+      reportOnlyBaseCommit: row.pr.base.sha, reportOnlyMergeCommit: row.pr.merge_commit_sha });
+    const refs = api(`git/matching-refs/tags/agentcrew-dispatch-outbox/publication/${row.digest}/`);
+    const statuses = all(`commits/${row.pr.merge_commit_sha}/statuses?per_page=100`);
+    const decision = chooseAttempt({ refs, statuses, digest: row.digest, merge: row.pr.merge_commit_sha, now: Date.now() });
+    if (!decision.attempt) throw new Error(`#${row.pr.number}: ${decision.wait}`);
+    row.attempt = decision.attempt;
+    row.context = `agentcrew/publication/${row.digest}`;
+    row.attemptContext = `agentcrew/publication-attempt/${row.digest}/${row.attempt}`;
+  }
+  validateBatchPlans(rows);
+  const claimed = [];
+  let pushed = false;
+  const setStatus = (row, context, state, description) => api(`statuses/${row.pr.merge_commit_sha}`, { context, state, description, target_url: row.owner });
+  try {
+    for (const row of rows) {
+      const ref = `refs/tags/agentcrew-dispatch-outbox/publication/${row.digest}/${row.attempt}`;
+      api('git/refs', { ref, sha: row.pr.merge_commit_sha });
+      if (api(`git/ref/${ref.slice(5)}`).object.sha !== row.pr.merge_commit_sha) throw new Error('Outbox readback mismatch');
+      // Recheck after the durable outbox write, before any business mutation.
+      const statuses = all(`commits/${row.pr.merge_commit_sha}/statuses?per_page=100`);
+      if (statuses.some(s => s.context === row.context || s.context.startsWith(`agentcrew/publication-attempt/${row.digest}/`))) throw new Error('Concurrent receiver reservation');
+      claimed.push(row);
+      setStatus(row, row.attemptContext, 'pending', 'Exact publication attempt is running');
+      setStatus(row, row.context, 'pending', 'Correlated publication is running');
+    }
+    git(['config', 'user.name', 'ai-skill-store[bot]']);
+    git(['config', 'user.email', '2628292+ai-skill-store[bot]@users.noreply.github.com']);
+    for (const row of rows) {
+      for (const skill of row.plan.skills) {
+        assertDirectoryAncestors(skill.pendingDir); assertDirectoryAncestors(skill.targetDir);
+        if (skill.update) rmSync(skill.targetDir, { recursive: true });
+        else if (existsSync(skill.targetDir)) throw new Error('Unexpected published target');
+        mkdirSync(dirname(skill.targetDir), { recursive: true });
+        renameSync(skill.pendingDir, skill.targetDir);
+      }
+      git(['add', '-A', '-f', '--', ...row.plan.skills.flatMap(s => [s.pendingDir, s.targetDir])]);
+      git(['commit', '-m', `Approve reviewed skills for PR #${row.pr.number}${row.submissionId ? ` [submission: ${row.submissionId}]` : ''}`,
+        '-m', `AgentCrew-Publication: ${row.correlation}`]);
+    }
+    const published = git(['rev-parse', 'HEAD']);
+    // No rebase/force: any concurrent main change rejects the whole atomic push.
+    if (git(['ls-remote', 'origin', 'refs/heads/main']).split(/\s/)[0] !== base) throw new Error('Main advanced; re-preflight required');
+    git(['push', 'origin', 'HEAD:main']);
+    const remote = git(['ls-remote', 'origin', 'refs/heads/main']).split(/\s/)[0];
+    if (remote !== published) throw new Error('Publication push outcome requires inspection');
+    pushed = true;
+    for (const row of rows) await callback(row);
+    for (const row of rows) setStatus(row, row.attemptContext, 'success', 'Exact publication attempt completed');
+    console.log(JSON.stringify({ published, batch: process.env.BATCH_ID, prs: numbers, skills: rows.flatMap(r => r.plan.skills.map(s => s.reportSlug)) }));
+  } catch (error) {
+    for (const row of claimed) {
+      setStatus(row, row.attemptContext, 'failure', 'Exact publication attempt failed');
+      setStatus(row, row.context, 'failure', `Batch publication ${pushed ? 'partially completed' : 'requires inspection'}; no automatic replay`);
+    }
+    throw error;
+  }
+}
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main().catch(error => { console.error(error.message); process.exitCode = 1; });

--- a/scripts/tests/publication-continuation.test.mjs
+++ b/scripts/tests/publication-continuation.test.mjs
@@ -32,7 +32,7 @@ test('merged-only continuation runs trusted main code and reuses the existing re
   assert.equal(workflow.jobs.continue.steps[0].with.ref, 'main');
   assert.equal(workflow.jobs.continue.steps[0].with['persist-credentials'], false);
   const script = readFileSync('scripts/continue-merged-publications.mjs', 'utf8');
-  assert.match(script, /on-pr-merge.yml\/dispatches/);
+  assert.match(script, /publish-approved-batch.yml\/dispatches/);
   assert.match(script, /syncRuns.some\(r => r.status !== 'completed'\)/);
   assert.doesNotMatch(script, /\/merge['`"]|update-branch|safe_to_publish|is_blocked|risk_level/);
 });
@@ -71,4 +71,28 @@ test('current pending inventory stops after its exact owners; fresh A prevents d
   assert.ok(!calls.some(p => p.endsWith('/pulls/2')));
   syncRuns = [{ id: 12, event: 'push', status: 'completed', conclusion: 'failure', created_at: '2026-09-08T00:00:00Z' }];
   assert.throws(() => main(request), /Previous push sync 12 is failure/);
+});
+
+test('automatic continuation dispatches at most 25 skills and leaves reservations to the receiver', async () => {
+  const { main, batchIdentity } = await import('../continue-merged-publications.mjs');
+  const prs = Array.from({length:26}, (_,i) => ({number:i+1, merged_at:`2026-09-01T00:00:${String(i).padStart(2,'0')}Z`, base:{ref:'main'}, user:{id:254047988,login:'ai-skill-store[bot]'}, head:{repo:{full_name:'aiskillstore/marketplace'},ref:'submission/test',sha:'a'.repeat(40)},merge_commit_sha:(i+1).toString(16).padStart(40,'0')}));
+  const writes=[];
+  const request=(endpoint,data)=>{
+    if(data){writes.push({endpoint,data});return;}
+    if(endpoint.endsWith('/git/trees/main'))return {tree:[{path:'pending',sha:'tree'}]};
+    if(endpoint.includes('/git/trees/tree?'))return {tree:prs.map(p=>({path:`owner/s${p.number}/skill-report.json`,sha:`r${p.number}`}))};
+    if(endpoint.includes('/pulls?'))return prs;
+    const file=endpoint.match(/\/pulls\/(\d+)\/files/);
+    if(file)return [{filename:`pending/owner/s${file[1]}/skill-report.json`,sha:`r${file[1]}`}];
+    const pr=endpoint.match(/\/pulls\/(\d+)$/);
+    if(pr)return prs[Number(pr[1])-1];
+    if(endpoint.includes('/actions/workflows/'))return {workflow_runs:[]};
+    if(endpoint.includes('/git/matching-refs/')||endpoint.includes('/statuses?'))return [];
+    throw new Error(`Unexpected ${endpoint}`);
+  };
+  process.argv.push('--apply');
+  try{main(request);}finally{process.argv.pop();}
+  assert.equal(writes.length,1);
+  assert.match(writes[0].endpoint,/publish-approved-batch.yml\/dispatches$/);
+  assert.deepEqual(writes[0].data,{ref:'main',inputs:{pr_numbers:prs.slice(0,25).map(p=>p.number).join(','),batch_id:batchIdentity(prs.slice(0,25).map(p=>publicationIdentity(p).correlation))}});
 });

--- a/scripts/tests/publication-receiver-workflow.test.mjs
+++ b/scripts/tests/publication-receiver-workflow.test.mjs
@@ -17,7 +17,7 @@ test('post-merge publication accepts the exact bot merger and binds dispatch cor
 });
 
 test('publication receiver serializes one correlation and verifies the exact durable outbox attempt before writes', () => {
-  assert.equal(workflow.concurrency.group, 'publication-${{ inputs.correlation_id }}');
+  assert.equal(workflow.concurrency.group, 'marketplace-publication-writer');
   assert.equal(workflow.concurrency['cancel-in-progress'], false);
   assert.equal(workflow.on.workflow_dispatch.inputs.outbox_attempt.required, true);
   const outboxGuard = source.indexOf('Verify durable publication dispatch outbox');

--- a/scripts/tests/publish-approved-batch.test.mjs
+++ b/scripts/tests/publish-approved-batch.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { once } from 'node:events';
+import { parse } from 'yaml';
+import { batchIdentity, validateBatchPlans } from '../publish-approved-batch.mjs';
+import { publicationIdentity } from '../continue-merged-publications.mjs';
+import { calculateCanonicalTreeHash } from '../resolve-approved-submission.mjs';
+
+const script = resolve('scripts/publish-approved-batch.mjs');
+const correlation = n => `submission-pr-${n}-${'a'.repeat(40)}-${'b'.repeat(40)}`;
+test('batch identity and distinct Skill limits fail closed', () => {
+  assert.equal(batchIdentity([correlation(1), correlation(2)]), batchIdentity([correlation(2), correlation(1)]));
+  assert.throws(() => batchIdentity([correlation(1), correlation(1)]));
+  assert.throws(() => batchIdentity(Array.from({length:26}, (_, i) => correlation(i + 1))));
+  assert.throws(() => validateBatchPlans([{plan:{skills:[{targetDir:'skills/a'}, {targetDir:'skills/a/b'}]}}]));
+  assert.throws(() => validateBatchPlans([{plan:{skills:[{targetDir:'skills/a',duplicate:true}]}}]));
+});
+
+test('two frozen approvals publish together once, retaining exact commits, callbacks, and reservations', async () => {
+  const temp = mkdtempSync(join(tmpdir(), 'publish-batch-'));
+  const root = join(temp, 'work'), remote = join(temp, 'remote.git'), bin = join(temp, 'bin');
+  mkdirSync(root); mkdirSync(bin);
+  const git = args => execFileSync('git', args, { cwd: root, encoding:'utf8', stdio:['pipe','pipe','pipe'] }).trim();
+  const callbacks=[];
+  const server = createServer((req,res) => { let body=''; req.on('data', x=>body+=x); req.on('end',()=> { callbacks.push({headers:req.headers,body:JSON.parse(body)});res.writeHead(200);res.end('{}'); }); });
+  server.listen(0,'127.0.0.1'); await once(server,'listening');
+  try {
+    git(['init','-b','main']);git(['config','user.name','Test']);git(['config','user.email','test@example.com']);
+    writeFileSync(join(root,'README.md'),'fixture');git(['add','.']);git(['commit','-m','base']);
+    const prs=[],files={};
+    for (const number of [1,2]) {
+      const base=git(['rev-parse','HEAD']), pending=`pending/owner/skill${number}`;
+      git(['checkout','-b',`submission/${number}`]);mkdirSync(join(root,pending),{recursive:true});
+      const content=`# Skill ${number}\n`;writeFileSync(join(root,pending,'SKILL.md'),content);
+      writeFileSync(join(root,pending,'skill-report.json'),JSON.stringify({meta:{slug:`owner-skill${number}`,source_type:'community',source_ref:'a'.repeat(40),source_url:`https://github.com/owner/source/tree/${'a'.repeat(40)}/skill${number}`,content_hash:createHash('sha256').update(content).digest('hex'),tree_hash:calculateCanonicalTreeHash(root,pending)},security_audit:{safe_to_publish:false}}));
+      git(['add','.']);git(['commit','-m','audited skill']);const head=git(['rev-parse','HEAD']);
+      git(['checkout','main']);git(['merge','--no-ff','-m','merge approval',`submission/${number}`]);const merge=git(['rev-parse','HEAD']);
+      prs.push({number,merged_at:'2026-09-08T00:00:00Z',base:{ref:'main',sha:base},user:{id:254047988,login:'ai-skill-store[bot]'},head:{ref:`submission/${number}`,sha:head,repo:{full_name:'aiskillstore/marketplace'}},merge_commit_sha:merge,html_url:`https://github.com/aiskillstore/marketplace/pull/${number}`,merged_by:{login:'test'},body:`Submission ID: \`${number.toString().padStart(8,'0')}-0000-0000-0000-000000000000\``});
+      files[number]=git(['diff','--name-only',base,merge]).split('\n').map(filename=>({filename}));
+    }
+    const before=git(['rev-parse','HEAD']);git(['clone','--bare',root,remote]);git(['remote','add','origin',remote]);
+    const state=join(temp,'state.json');writeFileSync(state,JSON.stringify({prs,files,refs:{},statuses:{},writes:[]}));
+    writeFileSync(join(bin,'gh'),`#!${process.execPath}\n`+`
+const fs=require('node:fs');const args=process.argv.slice(2);const endpoint=args.find(a=>a.startsWith('repos/')).replace('repos/aiskillstore/marketplace/','');
+const state=JSON.parse(fs.readFileSync(process.env.TEST_STATE));const post=args.includes('--method');let out;
+if(post){const body=JSON.parse(fs.readFileSync(0,'utf8'));state.writes.push({endpoint,body});
+ if(endpoint==='git/refs'){state.refs[body.ref]={ref:body.ref,object:{type:'commit',sha:body.sha}};out=state.refs[body.ref];}
+ else if(endpoint.startsWith('statuses/')){(state.statuses[endpoint.slice(9)]??=[]).unshift(body);out=body;}else throw new Error(endpoint);
+}else if(endpoint.startsWith('pulls/')){const n=Number(endpoint.split('/')[1]);out=endpoint.includes('/files')?state.files[n]:state.prs.find(p=>p.number===n);}
+else if(endpoint.startsWith('actions/workflows/'))out={workflow_runs:[{event:'push',status:'completed',conclusion:'success',created_at:'2026-09-08T00:00:00Z'}]};
+else if(endpoint.startsWith('git/matching-refs/'))out=Object.values(state.refs).filter(r=>r.ref.startsWith('refs/'+endpoint.slice('git/matching-refs/'.length)));
+else if(endpoint.startsWith('git/ref/'))out=state.refs['refs/'+endpoint.slice(8)];
+else if(endpoint.startsWith('commits/'))out=state.statuses[endpoint.split('/')[1]]??[];
+else throw new Error(endpoint);
+fs.writeFileSync(process.env.TEST_STATE,JSON.stringify(state));process.stdout.write(JSON.stringify(args.includes('--slurp')?[out]:out));
+`,{mode:0o755});
+    const run = () => new Promise(resolveRun => {
+      const child=spawn(process.execPath,[script],{cwd:root,env:{...process.env,PATH:`${bin}:${process.env.PATH}`,TEST_STATE:state,PR_NUMBERS:'1,2',BATCH_ID:batchIdentity(prs.map(p=>publicationIdentity(p).correlation)),GITHUB_REF:'refs/heads/main',GITHUB_REPOSITORY:'aiskillstore/marketplace',GITHUB_RUN_ID:'123',SKILLSTORE_API_URL:`http://127.0.0.1:${server.address().port}`,SKILLSTORE_CALLBACK_TOKEN:'test-only'}});
+      let output='';child.stdout.on('data',s=>output+=s);child.stderr.on('data',s=>output+=s);child.on('close',code=>resolveRun({code,output}));
+    });
+    const result=await run();assert.equal(result.code,0,result.output);
+    assert.equal(git(['ls-remote','origin','refs/heads/main']).split(/\s/)[0],git(['rev-parse','HEAD']));
+    assert.equal(git(['rev-list','--count',`${before}..HEAD`]),'2');
+    for(const n of [1,2]){assert.equal(existsSync(join(root,`pending/owner/skill${n}`)),false);assert.ok(existsSync(join(root,`skills/owner/skill${n}/skill-report.json`)));}
+    assert.equal(callbacks.length,2);
+    assert.deepEqual(callbacks.map(c=>c.body.pr_number),[1,2]);
+    const evidence=JSON.parse(readFileSync(state));
+    assert.equal(Object.keys(evidence.refs).length,2);
+    assert.equal(evidence.writes.filter(w=>w.body.context?.startsWith('agentcrew/publication-attempt/')&&w.body.state==='success').length,2);
+    assert.equal(evidence.writes.filter(w=>w.body.context?.startsWith('agentcrew/publication/')&&w.body.state==='success').length,0,'only provider may complete correlation');
+    const prior=git(['rev-parse','HEAD']);const replay=await run();assert.notEqual(replay.code,0);assert.equal(git(['ls-remote','origin','refs/heads/main']).split(/\s/)[0],prior,'replay cannot change main');
+  } finally { server.close();rmSync(temp,{recursive:true,force:true}); }
+});
+
+test('batch and individual receivers share one writer lock and sync reads the exact push range', () => {
+  const single=parse(readFileSync('.github/workflows/on-pr-merge.yml','utf8'));
+  const batch=parse(readFileSync('.github/workflows/publish-approved-batch.yml','utf8'));
+  assert.equal(batch.concurrency.group,single.concurrency.group);
+  assert.equal(batch.jobs.publish.if,"github.ref == 'refs/heads/main'");
+  const sync=readFileSync('.github/workflows/sync-to-supabase.yml','utf8');
+  assert.match(sync,/git log --format=%B "\$PUSH_BEFORE\.\.\$PUSH_SHA"/);
+  assert.match(sync,/Publication batch \$BATCH_DIGEST/);
+  assert.match(sync,/\[ "\$\{#CORRELATIONS\[@\]\}" -le 25 \]/);
+});
+
+const bashMajor=Number(execFileSync('bash',['--version'],{encoding:'utf8'}).match(/version (\d+)/)?.[1]);
+test('actual sync shell validates every batch owner and closes every provider correlation', {skip:bashMajor<4?'Workflow requires Linux Bash 4+; exercised in CI':false}, () => {
+  const temp=mkdtempSync(join(tmpdir(),'batch-provider-'));
+  const config=parse(readFileSync('.github/workflows/sync-to-supabase.yml','utf8'));
+  const wait=config.jobs.sync.steps.find(s=>s.id==='publication-correlation').run;
+  const finish=config.jobs.sync.steps.find(s=>s.name==='Record durable publication provider result').run;
+  const ids=[correlation(1),correlation(2)], digest=batchIdentity(ids);
+  const state=join(temp,'writes.jsonl'), output=join(temp,'output');writeFileSync(output,'');
+  try {
+    writeFileSync(join(temp,'git'), '#!/bin/sh\nif [ "$1" = log ]; then printf "%s\\n" "$TEST_MESSAGES"; fi\n',{mode:0o755});
+    writeFileSync(join(temp,'gh'),`#!${process.execPath}\n`+`
+const fs=require('node:fs');const args=process.argv.slice(2);const endpoint=args.find(a=>a.startsWith('repos/'));
+if(args.includes('--method')){fs.appendFileSync(process.env.TEST_WRITES,JSON.stringify(args)+'\\n');process.stdout.write('{}');}
+else if(endpoint.includes('/statuses')){
+ process.stdout.write(JSON.stringify(JSON.parse(process.env.TEST_IDS).map(id=>({context:'agentcrew/publication/'+require('node:crypto').createHash('sha256').update(id).digest('hex'),state:'pending',target_url:'https://github.com/aiskillstore/marketplace/actions/runs/123'}))));
+}else process.stdout.write(JSON.stringify({display_title:process.env.TEST_TITLE,path:'.github/workflows/publish-approved-batch.yml',head_branch:'main',head_repository:{full_name:'aiskillstore/marketplace'},status:'completed',conclusion:'success'}));
+`,{mode:0o755});
+    const env={...process.env,PATH:`${temp}:${process.env.PATH}`,TEST_WRITES:state,TEST_IDS:JSON.stringify(ids),TEST_MESSAGES:ids.map(id=>`AgentCrew-Publication: ${id}`).join('\n'),TEST_TITLE:`Publication batch ${digest}`,PUSH_BEFORE:'c'.repeat(40),PUSH_SHA:'d'.repeat(40),REPOSITORY:'aiskillstore/marketplace',GITHUB_OUTPUT:output};
+    execFileSync('bash',['-c',wait],{env,encoding:'utf8'});
+    const result=readFileSync(output,'utf8');assert.ok(result.includes(`correlations=${JSON.stringify(ids)}`));
+    execFileSync('bash',['-c',finish],{env:{...env,CORRELATION_ID:ids[1],MERGE_COMMIT_SHA:'b'.repeat(40),CORRELATION_IDS:JSON.stringify(ids),JOB_STATUS:'success'},encoding:'utf8'});
+    const writes=readFileSync(state,'utf8').trim().split('\n').map(JSON.parse);assert.equal(writes.length,2);assert.ok(writes.every(args=>args.includes('state=success')));
+    assert.throws(()=>execFileSync('bash',['-c',wait],{env:{...env,TEST_TITLE:'Publication batch '+ '0'.repeat(64)},encoding:'utf8',stdio:'pipe'}));
+  }finally{rmSync(temp,{recursive:true,force:true});}
+});

--- a/scripts/tests/publish-approved-batch.test.mjs
+++ b/scripts/tests/publish-approved-batch.test.mjs
@@ -89,6 +89,10 @@ test('batch and individual receivers share one writer lock and sync reads the ex
   assert.match(sync,/\[ "\$\{#CORRELATIONS\[@\]\}" -le 25 \]/);
 });
 
+test('owner wait covers the batch callback wall-clock budget', () => {
+  assert.match(readFileSync('.github/workflows/sync-to-supabase.yml', 'utf8'), /for attempt in \{1\.\.360\}/);
+});
+
 const bashMajor=Number(execFileSync('bash',['--version'],{encoding:'utf8'}).match(/version (\d+)/)?.[1]);
 test('actual sync shell validates every batch owner and closes every provider correlation', {skip:bashMajor<4?'Workflow requires Linux Bash 4+; exercised in CI':false}, () => {
   const temp=mkdtempSync(join(tmpdir(),'batch-provider-'));


### PR DESCRIPTION
Merged approved submissions remained in Pending because publication execution was retired and later recovery processed only one Skill per provider run. Publish up to 25 independently validated Skills in one atomic push, and let the native continuation drain subsequent batches after successful provider sync.

Each PR keeps its frozen source and tree validation, durable outbox and attempt status, original publication commit, submission callback, and provider correlation. Single and batch receivers share one writer lock. A main race rejects the push, and uncertain or failed effects require reconciliation before replay. Advisory risk fields remain advisory.

Sync validates every publication owner in the push range and closes every correlation after provider/cache completion. The owner wait now matches the publisher's 30-minute timeout.

Validation: focused Node tests pass locally (38 passed across updated focused suites; one Bash 4+ shell integration requires Linux CI). Includes real Git two-approval atomic publication, replay refusal, 25-Skill automatic continuation limit, and per-correlation shell verification in Linux CI.
