### PR TITLE
fix: fetch selected publication blobs together before restore

### DIFF
--- a/scripts/materialize-changed-skills.mjs
+++ b/scripts/materialize-changed-skills.mjs
@@ -83,6 +83,7 @@ function selectedEntriesAtCommit(repositoryRoot, commit, skillPaths) {
     '--',
     ...skillPaths.map((skillPath) => `skills/${skillPath}`),
   ]).toString('utf8');
+  const expectedReports = new Set(skillPaths.map(p => `skills/${p}/skill-report.json`));
   const reports = new Map();
   const blobs = new Set();
 
@@ -94,7 +95,7 @@ function selectedEntriesAtCommit(repositoryRoot, commit, skillPaths) {
     const [mode, type, oid] = record.slice(0, tabIndex).split(' ');
     const treePath = record.slice(tabIndex + 1);
     if (type === 'blob') blobs.add(oid);
-    if (treePath.endsWith('/skill-report.json')) {
+    if (expectedReports.has(treePath)) {
       publishedSkillDirectory(treePath);
       reports.set(treePath, { mode, type, oid });
     }

--- a/scripts/materialize-changed-skills.mjs
+++ b/scripts/materialize-changed-skills.mjs
@@ -73,7 +73,7 @@ function resolveExactCommit(repositoryRoot, commit) {
   return resolvedCommit;
 }
 
-function reportEntriesAtCommit(repositoryRoot, commit, skillPaths) {
+function selectedEntriesAtCommit(repositoryRoot, commit, skillPaths) {
   const output = git(repositoryRoot, [
     'ls-tree',
     '-r',
@@ -81,9 +81,10 @@ function reportEntriesAtCommit(repositoryRoot, commit, skillPaths) {
     '--full-tree',
     commit,
     '--',
-    ...skillPaths.map((skillPath) => `skills/${skillPath}/skill-report.json`),
+    ...skillPaths.map((skillPath) => `skills/${skillPath}`),
   ]).toString('utf8');
   const reports = new Map();
+  const blobs = new Set();
 
   for (const record of output.split('\0')) {
     if (!record) continue;
@@ -92,13 +93,14 @@ function reportEntriesAtCommit(repositoryRoot, commit, skillPaths) {
 
     const [mode, type, oid] = record.slice(0, tabIndex).split(' ');
     const treePath = record.slice(tabIndex + 1);
+    if (type === 'blob') blobs.add(oid);
     if (treePath.endsWith('/skill-report.json')) {
       publishedSkillDirectory(treePath);
       reports.set(treePath, { mode, type, oid });
     }
   }
 
-  return reports;
+  return { reports, blobs };
 }
 
 function assertSafeRemoval(repositoryRoot, repositoryPath) {
@@ -125,7 +127,7 @@ function hashMaterializedReports(repositoryRoot, reportPaths) {
 export function materializeChangedSkills({ repositoryRoot = '.', commit, skills }) {
   const exactCommit = resolveExactCommit(repositoryRoot, commit);
   const skillPaths = Array.isArray(skills) ? parseChangedSkillPaths(skills.join(' ')) : parseChangedSkillPaths(skills);
-  const treeReports = reportEntriesAtCommit(repositoryRoot, exactCommit, skillPaths);
+  const { reports: treeReports, blobs } = selectedEntriesAtCommit(repositoryRoot, exactCommit, skillPaths);
   const targets = skillPaths.map((skillPath) => {
     const directory = `skills/${skillPath}`;
     const reportPath = `${directory}/skill-report.json`;
@@ -137,6 +139,15 @@ export function materializeChangedSkills({ repositoryRoot = '.', commit, skills 
 
     return { directory, reportPath, reportOid: report.oid };
   });
+
+  // Partial-clone restore otherwise fetches missing blobs one at a time. Fetch
+  // only the exact selected tree's objects in one native request before removal.
+  const promisor = git(repositoryRoot, ['config', '--type=bool', '--default=false', '--get', 'remote.origin.promisor'], { encoding: 'utf8' }).trim();
+  if (promisor === 'true') {
+    git(repositoryRoot, ['fetch', '--no-tags', '--no-write-fetch-head', '--recurse-submodules=no', '--stdin', 'origin'], {
+      input: `${[...blobs].join('\n')}\n`, encoding: 'utf8',
+    });
+  }
 
   // Remove only the selected directories first so stale untracked files from a
   // mutable self-hosted workspace cannot leak into the sync payload.

--- a/scripts/tests/materialize-changed-skills.test.mjs
+++ b/scripts/tests/materialize-changed-skills.test.mjs
@@ -33,6 +33,7 @@ function makeRepository() {
   git(repositoryRoot, ['config', 'user.email', 'test@skillstore.local']);
 
   write(repositoryRoot, 'skills/owner/demo/SKILL.md', '# Demo v1\n');
+  write(repositoryRoot, 'skills/owner/demo/examples/skill-report.json', '{"example":true}\n');
   write(repositoryRoot, 'skills/owner/demo/skill-report.json', '{"revision":1}\n');
   write(repositoryRoot, 'skills/owner/untouched/SKILL.md', '# Untouched\n');
   write(repositoryRoot, 'skills/owner/untouched/skill-report.json', '{"revision":1}\n');

--- a/scripts/tests/materialize-changed-skills.test.mjs
+++ b/scripts/tests/materialize-changed-skills.test.mjs
@@ -160,3 +160,27 @@ test('selected report lookup does not enumerate or validate unrelated report tre
     assert.equal(readFileSync(join(repositoryRoot, 'skills/owner/demo/skill-report.json'), 'utf8'), '{"revision":2}\n');
   } finally { rmSync(repositoryRoot, { recursive: true, force: true }); }
 });
+
+test('partial clone prefetches selected blobs together and preserves unrelated sparse content', () => {
+  const { repositoryRoot: source, commit } = makeRepository();
+  const clone = mkdtempSync(join(tmpdir(), 'materialize-partial-'));
+  try {
+    git(source, ['config', 'uploadpack.allowFilter', 'true']);
+    git(source, ['config', 'uploadpack.allowAnySHA1InWant', 'true']);
+    git(clone, ['clone', '--filter=blob:none', '--no-checkout', `file://${source}`, '.']);
+    git(clone, ['sparse-checkout', 'set', '--no-cone', '/README.md']);
+    git(clone, ['checkout', 'main']);
+    const beforeHead = git(clone, ['rev-parse', 'HEAD']);
+    const trace = join(tmpdir(), `materialize-fetch-${process.pid}.jsonl`);
+    const previous = process.env.GIT_TRACE2_EVENT;
+    process.env.GIT_TRACE2_EVENT = trace;
+    try { materializeChangedSkills({repositoryRoot:clone,commit,skills:['owner/demo']}); }
+    finally { if(previous === undefined)delete process.env.GIT_TRACE2_EVENT;else process.env.GIT_TRACE2_EVENT=previous; }
+    const commands=readFileSync(trace,'utf8').trim().split('\n').map(JSON.parse).filter(e=>e.event==='start').map(e=>e.argv);
+    rmSync(trace,{force:true});
+    assert.equal(commands.filter(args=>args.includes('fetch')).length,1,'one bulk fetch; restore must not trigger per-blob fetches');
+    assert.equal(readFileSync(join(clone,'skills/owner/demo/SKILL.md'),'utf8'),'# Demo v2\n');
+    assert.equal(existsSync(join(clone,'skills/owner/untouched/SKILL.md')),false);
+    assert.equal(git(clone,['rev-parse','HEAD']),beforeHead);
+  } finally { rmSync(source,{recursive:true,force:true});rmSync(clone,{recursive:true,force:true}); }
+});


### PR DESCRIPTION
A 25-Skill publication containing 1,309 files spends minutes in partial-clone restore because Git fetches missing blobs individually. Fetch the exact selected tree blobs in one native Git request before removing or restoring any selected directory.

Keep the pinned commit, selected-path boundary, root report blob verification, and unrelated sparse content intact. Embedded example reports are ordinary bundled files. This changes only object download batching; it does not change publication decisions or database writes.

Validation: 7 focused tests pass, including a real partial clone with Git trace asserting exactly one fetch and unchanged HEAD. A read-only GitHub probe confirmed bulk fetching selected blob OIDs works against this repository.
