### PR TITLE
fix: avoid commit negotiation for exact blob prefetch

### DIFF
--- a/scripts/materialize-changed-skills.mjs
+++ b/scripts/materialize-changed-skills.mjs
@@ -145,7 +145,7 @@ export function materializeChangedSkills({ repositoryRoot = '.', commit, skills 
   // only the exact selected tree's objects in one native request before removal.
   const promisor = git(repositoryRoot, ['config', '--type=bool', '--default=false', '--get', 'remote.origin.promisor'], { encoding: 'utf8' }).trim();
   if (promisor === 'true') {
-    git(repositoryRoot, ['fetch', '--no-tags', '--no-write-fetch-head', '--recurse-submodules=no', '--stdin', 'origin'], {
+    git(repositoryRoot, ['-c', 'fetch.negotiationAlgorithm=noop', 'fetch', '--no-tags', '--no-write-fetch-head', '--recurse-submodules=no', '--stdin', 'origin'], {
       input: `${[...blobs].join('\n')}\n`, encoding: 'utf8',
     });
   }

--- a/scripts/tests/materialize-changed-skills.test.mjs
+++ b/scripts/tests/materialize-changed-skills.test.mjs
@@ -171,6 +171,8 @@ test('partial clone prefetches selected blobs together and preserves unrelated s
     git(clone, ['clone', '--filter=blob:none', '--no-checkout', `file://${source}`, '.']);
     git(clone, ['sparse-checkout', 'set', '--no-cone', '/README.md']);
     git(clone, ['checkout', 'main']);
+    // Frozen preflight may have already downloaded some selected blobs.
+    git(clone, ['cat-file', '-p', `${commit}:skills/owner/demo/SKILL.md`]);
     const beforeHead = git(clone, ['rev-parse', 'HEAD']);
     const trace = join(tmpdir(), `materialize-fetch-${process.pid}.jsonl`);
     const previous = process.env.GIT_TRACE2_EVENT;
@@ -179,6 +181,7 @@ test('partial clone prefetches selected blobs together and preserves unrelated s
     finally { if(previous === undefined)delete process.env.GIT_TRACE2_EVENT;else process.env.GIT_TRACE2_EVENT=previous; }
     const commands=readFileSync(trace,'utf8').trim().split('\n').map(JSON.parse).filter(e=>e.event==='start').map(e=>e.argv);
     rmSync(trace,{force:true});
+    assert.ok(commands.find(args=>args.includes('fetch'))?.includes('fetch.negotiationAlgorithm=noop'), 'blob wants must not enter commit negotiation');
     assert.equal(commands.filter(args=>args.includes('fetch')).length,1,'one bulk fetch; restore must not trigger per-blob fetches');
     assert.equal(readFileSync(join(clone,'skills/owner/demo/SKILL.md'),'utf8'),'# Demo v2\n');
     assert.equal(existsSync(join(clone,'skills/owner/untouched/SKILL.md')),false);


### PR DESCRIPTION
Git 2.43 on production runners rejects a direct batch of blob wants during commit negotiation with `fatal: bad revision`. Disable commit negotiation only for the exact blob-prefetch command.

Verified against the actual second-batch 398 objects in fresh isolated Git 2.43 repositories on the runner host: default failed, explicit noop succeeded, filter-only failed. Local focused tests pass, including partial-clone object fetch with already materialized content and an assertion that blob wants use noop negotiation. Source/hash and publication gates are unchanged.
