### PR TITLE
fix(publication): complete duplicate-only batches and test runtime changes

### DIFF
--- a/.github/workflows/test-recalculate-scores.yml
+++ b/.github/workflows/test-recalculate-scores.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "scripts/publish-approved-batch.mjs"
+      - "scripts/continue-merged-publications.mjs"
+      - "scripts/resolve-approved-submission.mjs"
+      - ".github/workflows/publish-approved-batch.yml"
+      - ".github/workflows/continue-merged-publications.yml"
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"
@@ -38,6 +43,11 @@ on:
   push:
     branches: [main]
     paths:
+      - "scripts/publish-approved-batch.mjs"
+      - "scripts/continue-merged-publications.mjs"
+      - "scripts/resolve-approved-submission.mjs"
+      - ".github/workflows/publish-approved-batch.yml"
+      - ".github/workflows/continue-merged-publications.yml"
       - "scripts/check-cache-invalidation-aggregate.sh"
       - "scripts/detect-changed-skills.mjs"
       - "scripts/materialize-changed-skills.mjs"

--- a/scripts/publish-approved-batch.mjs
+++ b/scripts/publish-approved-batch.mjs
@@ -43,8 +43,12 @@ function assertDirectoryAncestors(path) {
 }
 async function callback(row) {
   if (!row.submissionId) return;
-  const payload = { submission_id: row.submissionId, event: 'merged', pr_number: row.pr.number,
-    pr_url: row.pr.html_url, merged_by: row.pr.merged_by.login,
+  const duplicateOnly = row.plan.skills.every(skill => skill.duplicate);
+  const payload = { submission_id: row.submissionId, event: duplicateOnly ? 'rejected' : 'merged', pr_number: row.pr.number,
+    pr_url: row.pr.html_url,
+    ...(duplicateOnly ? { rejected_by: row.pr.merged_by.login,
+      reason: 'All reviewed skills already exist at the same immutable source and canonical tree.' }
+      : { merged_by: row.pr.merged_by.login }),
     workflow_run_id: Number(process.env.GITHUB_RUN_ID), workflow_run_url: row.owner };
   for (let attempt = 0; attempt < 3; attempt++) {
     const response = await fetch(`${process.env.SKILLSTORE_API_URL}/api/submit/callback`, {
@@ -117,7 +121,7 @@ export async function main() {
       for (const skill of row.plan.skills) {
         assertDirectoryAncestors(skill.pendingDir); assertDirectoryAncestors(skill.targetDir);
         if (skill.duplicate) {
-          // The reviewed snapshot is byte-identical to the published target.
+          // Canonical content and immutable source match the published target.
           // Resolve the submission by deleting its pending evidence only.
           rmSync(skill.pendingDir, { recursive: true });
           continue;
@@ -132,6 +136,7 @@ export async function main() {
         '-m', `AgentCrew-Publication: ${row.correlation}`]);
     }
     const published = git(['rev-parse', 'HEAD']);
+    const providerSyncRequired = git(['diff', '--name-only', base, published, '--', 'skills/']) !== '';
     // No rebase/force: any concurrent main change rejects the whole atomic push.
     if (git(['ls-remote', 'origin', 'refs/heads/main']).split(/\s/)[0] !== base) throw new Error('Main advanced; re-preflight required');
     git(['push', 'origin', 'HEAD:main']);
@@ -140,6 +145,11 @@ export async function main() {
     pushed = true;
     for (const row of rows) await callback(row);
     for (const row of rows) setStatus(row, row.attemptContext, 'success', 'Exact publication attempt completed');
+    // Pending-only deletion cannot trigger the skills/** push workflow. Match
+    // the single receiver's terminal no-provider-change result in that case.
+    if (!providerSyncRequired) for (const row of rows) {
+      setStatus(row, row.context, 'success', 'Publication completed; no provider changes required');
+    }
     console.log(JSON.stringify({ published, batch: process.env.BATCH_ID, prs: numbers, skills: rows.flatMap(r => r.plan.skills.map(s => s.reportSlug)) }));
   } catch (error) {
     for (const row of claimed) {

--- a/scripts/tests/publish-approved-batch.test.mjs
+++ b/scripts/tests/publish-approved-batch.test.mjs
@@ -19,10 +19,10 @@ test('batch identity and distinct Skill limits fail closed', () => {
   assert.throws(() => batchIdentity([correlation(1), correlation(1)]));
   assert.throws(() => batchIdentity(Array.from({length:26}, (_, i) => correlation(i + 1))));
   assert.throws(() => validateBatchPlans([{plan:{skills:[{targetDir:'skills/a'}, {targetDir:'skills/a/b'}]}}]));
-  assert.throws(() => validateBatchPlans([{plan:{skills:[{targetDir:'skills/a',duplicate:true}]}}]));
+  assert.equal(validateBatchPlans([{plan:{skills:[{targetDir:'skills/a',duplicate:true}]}}]).size, 1);
 });
 
-test('two frozen approvals publish together once, retaining exact commits, callbacks, and reservations', async () => {
+for (const duplicates of [[], [1], [1, 2]]) test(`two frozen approvals publish once with duplicate skills ${duplicates.join(',') || 'none'}`, async () => {
   const temp = mkdtempSync(join(tmpdir(), 'publish-batch-'));
   const root = join(temp, 'work'), remote = join(temp, 'remote.git'), bin = join(temp, 'bin');
   mkdirSync(root); mkdirSync(bin);
@@ -33,7 +33,15 @@ test('two frozen approvals publish together once, retaining exact commits, callb
   try {
     git(['init','-b','main']);git(['config','user.name','Test']);git(['config','user.email','test@example.com']);
     writeFileSync(join(root,'README.md'),'fixture');git(['add','.']);git(['commit','-m','base']);
-    const prs=[],files={};
+    const prs=[],files={},publishedReports={};
+    for (const n of duplicates) {
+      const target=`skills/owner/skill${n}`;mkdirSync(join(root,target),{recursive:true});
+      const content=`# Skill ${n}\n`;writeFileSync(join(root,target,'SKILL.md'),content);
+      const report=JSON.stringify({meta:{slug:`owner-skill${n}`,source_type:'community',source_ref:'a'.repeat(40),source_url:`https://github.com/owner/source/tree/${'a'.repeat(40)}/skill${n}`,content_hash:createHash('sha256').update(content).digest('hex'),tree_hash:calculateCanonicalTreeHash(root,target)},security_audit:{safe_to_publish:false},publishedEvidence:'preserve this report'});
+      writeFileSync(join(root,target,'skill-report.json'),report);publishedReports[n]=report;
+    }
+    if (duplicates.length) {git(['add','.']);git(['commit','-m','already published immutable skills']);}
+
     for (const number of [1,2]) {
       const base=git(['rev-parse','HEAD']), pending=`pending/owner/skill${number}`;
       git(['checkout','-b',`submission/${number}`]);mkdirSync(join(root,pending),{recursive:true});
@@ -68,12 +76,18 @@ fs.writeFileSync(process.env.TEST_STATE,JSON.stringify(state));process.stdout.wr
     assert.equal(git(['ls-remote','origin','refs/heads/main']).split(/\s/)[0],git(['rev-parse','HEAD']));
     assert.equal(git(['rev-list','--count',`${before}..HEAD`]),'2');
     for(const n of [1,2]){assert.equal(existsSync(join(root,`pending/owner/skill${n}`)),false);assert.ok(existsSync(join(root,`skills/owner/skill${n}/skill-report.json`)));}
+    for (const n of duplicates) {
+      assert.equal(readFileSync(join(root,`skills/owner/skill${n}/skill-report.json`),'utf8'),publishedReports[n],'duplicate cleanup preserves the published report');
+      assert.equal(git(['diff', '--name-only', before, 'HEAD', '--', `skills/owner/skill${n}`]), '');
+    }
     assert.equal(callbacks.length,2);
+    assert.deepEqual(callbacks.map(c=>c.body.event),[1,2].map(n=>duplicates.includes(n)?'rejected':'merged'));
+    for (const c of callbacks.filter(c=>c.body.event==='rejected')) assert.match(c.body.reason,/same immutable source/);
     assert.deepEqual(callbacks.map(c=>c.body.pr_number),[1,2]);
     const evidence=JSON.parse(readFileSync(state));
     assert.equal(Object.keys(evidence.refs).length,2);
     assert.equal(evidence.writes.filter(w=>w.body.context?.startsWith('agentcrew/publication-attempt/')&&w.body.state==='success').length,2);
-    assert.equal(evidence.writes.filter(w=>w.body.context?.startsWith('agentcrew/publication/')&&w.body.state==='success').length,0,'only provider may complete correlation');
+    assert.equal(evidence.writes.filter(w=>w.body.context?.startsWith('agentcrew/publication/')&&w.body.state==='success').length,duplicates.length===2?2:0,'only pending-only batches may close without provider sync');
     const prior=git(['rev-parse','HEAD']);const replay=await run();assert.notEqual(replay.code,0);assert.equal(git(['ls-remote','origin','refs/heads/main']).split(/\s/)[0],prior,'replay cannot change main');
   } finally { server.close();rmSync(temp,{recursive:true,force:true}); }
 });


### PR DESCRIPTION
Duplicate-only submissions remove pending files without changing skills/**, so no provider sync runs. The batch receiver must finish their callback and durable status itself, using the existing single-receiver behavior: reject the redundant submission with an explicit same-source/tree reason, and complete the correlation only when the whole push has no provider changes. Mixed batches still leave provider completion to the unique sync run and preserve existing published reports.

Validation: 44 focused tests passed locally (one Linux Bash test skipped on macOS). Real Git integration covers new-only, mixed duplicate/new, and all-duplicate batches, preserved report bytes, exact commits, callbacks, reservations, and replay refusal. CI now triggers when publication runtime scripts or workflows change; previously publisher-only edits skipped these tests.
